### PR TITLE
build mq from the local source instead of fetching from Git in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
             owner = "harehare";
             repo = "mq";
             rev = "main";
-            sha256 = "sha256-4cQjQnPNgPKtnyVR46Hu9G5sn5QbmQqFhHK4DZfHlKo=";
+            sha256 = "sha256-JWrfHqId/N/tAw46QxE3v5qtjs01Ew1V22mfKytZvxw=";
           };
 
           cargoLock = {

--- a/flake.nix
+++ b/flake.nix
@@ -65,17 +65,8 @@
           pname = "mq";
           version = "unstable";
 
-          src = pkgs.fetchFromGitHub {
-            owner = "harehare";
-            repo = "mq";
-            rev = "main";
-            sha256 = "sha256-JWrfHqId/N/tAw46QxE3v5qtjs01Ew1V22mfKytZvxw=";
-          };
-
-          cargoLock = {
-            lockFile = null;
-            lockFileContents = builtins.readFile ./Cargo.lock;
-          };
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
 
           meta = with pkgs.lib; {
             description = "jq-like command-line tool for markdown processing";


### PR DESCRIPTION
Sorry, forgot to update it before the merge.

if we don't change it any nix build will get this error:
```bash
i $ nix build .#mq
error: Cannot build '/nix/store/v90zzbnyn3hbsldwi5izkjvjv2zy0892-mq-unstable.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/d4vj4z927vawrdxd2d1y2amxyvk6pcga-mq-unstable
       Last 25 log lines:
       > ---
       > > version = "4.5.39"
       > 325c325
       > < checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
       > ---
       > > checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
       > 333c333
       > < version = "4.5.38"
       > ---
       > > version = "4.5.39"
       > 335c335
       > < checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
       > ---
       > > checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
       >
       > ERROR: cargoHash or cargoSha256 is out of date
       >
       > Cargo.lock is not the same in /build/cargo-vendor-dir
       >
       > To fix the issue:
       > 1. Set cargoHash/cargoSha256 to an empty string: `cargoHash = "";`
       > 2. Build the derivation and wait for it to fail with a hash mismatch
       > 3. Copy the "got: sha256-..." value back into the cargoHash field
       >    You should have: cargoHash = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=";
       >
       For full logs, run:
         nix log /nix/store/v90zzbnyn3hbsldwi5izkjvjv2zy0892-mq-unstable.drv
```