### PR TITLE
Refactor string operations and loops for performance

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -296,6 +296,7 @@ impl Evaluator {
         env: Rc<RefCell<Env>>,
     ) -> Result<RuntimeValue, EvalError> {
         if let ast::Expr::InterpolatedString(segments) = &*node.expr {
+            use std::fmt::Write;
             segments
                 .iter()
                 .try_fold(String::with_capacity(100), |mut acc, segment| {
@@ -304,10 +305,14 @@ impl Evaluator {
                         ast::StringSegment::Ident(ident) => {
                             let value =
                                 self.eval_ident(ident, Rc::clone(&node), Rc::clone(&env))?;
-                            acc.push_str(&value.to_string());
+                            // Use write! to avoid intermediate string allocation for value.to_string()
+                            write!(&mut acc, "{}", value)
+                                .map_err(|_| EvalError::InternalError((*self.token_arena.borrow()[node.token_id]).clone()))?;
                         }
                         ast::StringSegment::Self_ => {
-                            acc.push_str(&runtime_value.to_string());
+                            // Use write! to avoid intermediate string allocation for runtime_value.to_string()
+                            write!(&mut acc, "{}", runtime_value)
+                                .map_err(|_| EvalError::InternalError((*self.token_arena.borrow()[node.token_id]).clone()))?;
                         }
                     }
 
@@ -383,18 +388,14 @@ impl Evaluator {
         if let ast::Expr::Foreach(ident, values, body) = &*node.expr {
             let values = self.eval_expr(runtime_value, Rc::clone(values), Rc::clone(&env))?;
             let values = if let RuntimeValue::Array(values) = values {
-                let runtime_values: Vec<RuntimeValue> = Vec::with_capacity(values.len());
                 let env = Rc::new(RefCell::new(Env::with_parent(Rc::downgrade(&env))));
-
                 values
                     .into_iter()
-                    .try_fold(runtime_values, |mut acc, value| {
+                    .map(|value| {
                         env.borrow_mut().define(ident, value);
-                        let result =
-                            self.eval_program(body, runtime_value.clone(), Rc::clone(&env))?;
-                        acc.push(result);
-                        Ok::<Vec<RuntimeValue>, EvalError>(acc)
-                    })?
+                        self.eval_program(body, runtime_value.clone(), Rc::clone(&env))
+                    })
+                    .collect::<Result<Vec<RuntimeValue>, EvalError>>()?
             } else {
                 return Err(EvalError::InvalidTypes {
                     token: (*self.token_arena.borrow()[node.token_id]).clone(),

--- a/crates/mq-lang/src/value_macros.rs
+++ b/crates/mq-lang/src/value_macros.rs
@@ -46,24 +46,39 @@ macro_rules! impl_value_string {
                     Self::Number(n) => n.to_string(),
                     Self::Bool(b) => b.to_string(),
                     Self::String(s) => format!(r#""{}""#, s),
-                    Self::Array(a) => format!(
-                        "[{}]",
-                        a.iter()
-                            .map(|v| format!("{:?}", v))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    ),
+                    Self::Array(a) => {
+                        let mut s = String::new();
+                        s.push('[');
+                        for (i, v) in a.iter().enumerate() {
+                            if i > 0 {
+                                s.push_str(", ");
+                            }
+                            // This assumes that the Debug trait is implemented for the items
+                            // and that it produces the desired string representation.
+                            // If specific formatting is needed, this might need adjustment.
+                            std::fmt::write(&mut s, format_args!("{:?}", v)).unwrap();
+                        }
+                        s.push(']');
+                        s
+                    }
                     Self::Markdown(m, ..) => m.to_string(),
                     Self::None => "".to_string(),
                     Self::Function(..) => "function".to_string(),
                     Self::NativeFunction(_) => "native_function".to_string(),
                     Self::Dict(map) => {
-                        let items = map
-                            .iter()
-                            .map(|(k, v)| format!("\"{}\": {}", k, v.string()))
-                            .collect::<Vec<String>>()
-                            .join(", ");
-                        format!("{{{}}}", items)
+                        let mut s = String::new();
+                        s.push('{');
+                        for (i, (k, v)) in map.iter().enumerate() {
+                            if i > 0 {
+                                s.push_str(", ");
+                            }
+                            // Similar to Array, this assumes `string()` method on `v`
+                            // produces the desired output.
+                            // Also, k is directly used, ensure it doesn't need escaping if it can contain special chars.
+                            std::fmt::write(&mut s, format_args!("\"{}\": {}", k, v.string())).unwrap();
+                        }
+                        s.push('}');
+                        s
                     }
                 }
             }


### PR DESCRIPTION
This commit introduces several changes to improve performance in non-optimizer code paths:

1.  **Optimized String Formatting:**
    - Refactored the `impl_value_string!` macro in `value_macros.rs` to use `write!` for `Array` and `Dict` stringification, reducing intermediate string allocations.
    - Modified `eval_interpolated_string` in `eval.rs` to use `write!` for constructing interpolated strings, avoiding unnecessary allocations.

2.  **Optimized `eval_foreach`:**
    - Refactored the `eval_foreach` function in `eval.rs` to use `map().collect()` instead of manual `Vec` pushing with `try_fold`, potentially improving conciseness and leveraging iterator optimizations.

Analysis of `RuntimeValue`/`Value` conversions and `Env` lookups did not reveal immediate major bottlenecks, so significant changes in those areas were deferred.

These changes are expected to improve performance, especially in scenarios involving heavy string manipulation or frequent iteration in `foreach` loops. Benchmarks were run successfully, and further detailed performance analysis will be observed via CodSpeed reports.