### PR TITLE
✨ feat(lsp): Add AST JSON conversion command

### DIFF
--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.14.0"
 miette = {version = "7.6.0", features = ["fancy"]}
 mq-formatter.workspace = true
 mq-hir.workspace = true
-mq-lang.workspace = true
+mq-lang = {workspace = true, features = ["ast-json"]}
 mq-markdown.workspace = true
 serde_json = "1.0.140"
 tokio = {version = "1.46", features = ["macros", "io-std", "rt-multi-thread"]}


### PR DESCRIPTION
Add new LSP command `mq/to_ast_json` that converts mq code to AST JSON format. Enable ast-json feature in mq-lang dependency to support JSON serialization.

🤖 Generated with [Claude Code](https://claude.ai/code)