### PR TITLE
feat: Add support for parentheses to prioritize evaluation

### DIFF
--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -90,6 +90,7 @@ impl Node {
                     arena[self.token_id].range.clone()
                 }
             }
+            Expr::Paren(node) => node.range(Rc::clone(&arena)),
             Expr::Literal(_)
             | Expr::Ident(_)
             | Expr::Selector(_)
@@ -232,6 +233,7 @@ pub enum Expr {
     Include(Literal),
     Self_,
     Nodes,
+    Paren(Rc<Node>),
 }
 #[cfg(test)]
 mod tests {

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -362,6 +362,7 @@ impl Evaluator {
                 self.eval_include(module_id.to_owned())?;
                 Ok(runtime_value.clone())
             }
+            ast::Expr::Paren(expr) => self.eval_expr(runtime_value, Rc::clone(expr), env),
         }
     }
 

--- a/crates/mq-lang/src/optimizer.rs
+++ b/crates/mq-lang/src/optimizer.rs
@@ -92,6 +92,9 @@ impl Optimizer {
                     }
                 }
             }
+            ast::Expr::Paren(node) => {
+                Self::collect_used_identifiers_in_node(node, used_idents);
+            }
             ast::Expr::Literal(_)
             | ast::Expr::Selector(_)
             | ast::Expr::Nodes
@@ -207,6 +210,9 @@ impl Optimizer {
                 for node in program {
                     self.optimize_node(node);
                 }
+            }
+            ast::Expr::Paren(expr) => {
+                self.optimize_node(expr);
             }
             _ => {}
         }


### PR DESCRIPTION
This change introduces the ability to use parentheses in expressions to control the order of evaluation. The parser has been updated to recognize parentheses and represent them as a `Paren` node in the AST. The evaluator has been updated to handle this new node type by recursively evaluating the expression within the parentheses.

- Added `Expr::Paren(Rc<Node>)` to the AST to represent parenthesized expressions.
- Modified the parser to handle `LParen` and `RParen` tokens, creating `Paren` nodes.
- Updated the evaluator to correctly evaluate `Paren` nodes.
- Added tests to ensure that expressions with parentheses are parsed and evaluated correctly.