### PR TITLE
🐛 fix(docs,lsp): Update heading level API reference and improve LSP document symbol handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You can chain multiple operations to perform complex transformations:
 
 ```sh
 # Markdown TOC
-$ mq '.h | let link = to_link("#" + to_text(self), to_text(self), "") | let level = .h.depth | if (not(is_none(level))): to_md_list(link, to_number(level))' docs/books/**/*.md
+$ mq '.h | let link = to_link("#" + to_text(self), to_text(self), "") | let level = .h.level | if (not(is_none(level))): to_md_list(link, to_number(level))' docs/books/**/*.md
 # String Interpolation
 $ mq 'let name = "Alice" | let age = 30 | s"Hello, my name is ${name} and I am ${age} years old."'
 # Merging Multiple Files

--- a/crates/mq-lsp/src/document_symbol.rs
+++ b/crates/mq-lsp/src/document_symbol.rs
@@ -28,33 +28,39 @@ pub fn response(
                         _ => return None,
                     };
 
-                    symbol.value.as_ref().map(|name| DocumentSymbol {
-                        name: name.to_string(),
-                        detail: None,
-                        kind,
-                        tags: None,
-                        range: Range {
-                            start: Position {
-                                line: text_range.start.line - 1,
-                                character: (text_range.start.column - 1) as u32,
-                            },
-                            end: Position {
-                                line: text_range.end.line - 1,
-                                character: (text_range.end.column - 1) as u32,
-                            },
-                        },
-                        selection_range: Range {
-                            start: Position {
-                                line: text_range.start.line - 1,
-                                character: (text_range.start.column - 1) as u32,
-                            },
-                            end: Position {
-                                line: text_range.start.line - 1,
-                                character: (text_range.start.column - 1) as u32,
-                            },
-                        },
-                        children: None,
-                        deprecated: None,
+                    symbol.value.as_ref().and_then(|name| {
+                        if name.is_empty() {
+                            None
+                        } else {
+                            Some(DocumentSymbol {
+                                name: name.to_string(),
+                                detail: None,
+                                kind,
+                                tags: None,
+                                range: Range {
+                                    start: Position {
+                                        line: text_range.start.line - 1,
+                                        character: (text_range.start.column - 1) as u32,
+                                    },
+                                    end: Position {
+                                        line: text_range.end.line - 1,
+                                        character: (text_range.end.column - 1) as u32,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: text_range.start.line - 1,
+                                        character: (text_range.start.column - 1) as u32,
+                                    },
+                                    end: Position {
+                                        line: text_range.start.line - 1,
+                                        character: (text_range.start.column - 1) as u32,
+                                    },
+                                },
+                                children: None,
+                                deprecated: None,
+                            })
+                        }
                     })
                 })
             })


### PR DESCRIPTION
- Update README.md example to use .h.level instead of .h.depth
- Improve LSP document symbol handling by filtering empty names
- Use and_then instead of map for better error handling in document_symbol.rs

🤖 Generated with [Claude Code](https://claude.ai/code)