### PR TITLE
✨ feat(lang): add print builtin function

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -103,6 +103,18 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
             }),
         );
         map.insert(
+            CompactString::new("print"),
+            BuiltinFunction::new(ParamNum::Fixed(1), |_, current_value, args| {
+                match args.as_slice() {
+                    [a] => {
+                        println!("{}", a);
+                        Ok(current_value.clone())
+                    }
+                    _ => unreachable!(),
+                }
+            }),
+        );
+        map.insert(
             CompactString::new("stderr"),
             BuiltinFunction::new(ParamNum::Fixed(1), |_, current_value, args| {
                 match args.as_slice() {
@@ -2348,6 +2360,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             BuiltinFunctionDoc {
             description: "Asserts that two values are equal, returns the value if true, otherwise raises an error.",
             params: &["value1", "value2"],
+            },
+        );
+        map.insert(
+            CompactString::new("print"),
+            BuiltinFunctionDoc {
+                description: "Prints a message to standard output and returns the current value.",
+                params: &["message"],
             },
         );
         map.insert(


### PR DESCRIPTION
Add a new print builtin function that outputs a message to standard output and returns the current value. This provides a convenient way to debug and inspect values in mq queries.

🤖 Generated with [Claude Code](https://claude.ai/code)