### PR TITLE
📦 build(mcp): update rmcp dependency to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,8 +949,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -968,12 +978,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -2071,7 +2106,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3498,6 +3533,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+checksum = "b008b927a85d514699ff304be84c5084598596e6cad4a6f5bc67207715fafe5f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3634,11 +3689,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+checksum = "7465280d5f73f2c5c99017a04af407b2262455a149f255ad22f2b0b29087695c"
 dependencies = [
- "darling",
+ "darling 0.21.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3821,12 +3876,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -3834,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/mq-mcp/Cargo.toml
+++ b/crates/mq-mcp/Cargo.toml
@@ -10,7 +10,7 @@ miette.workspace = true
 mq-hir.workspace = true
 mq-lang.workspace = true
 mq-markdown.workspace = true
-rmcp = {version = "0.2.1", features = ["server"]}
+rmcp = {version = "0.3.0", features = ["server"]}
 serde = {workspace = true, features = ["derive"]}
 serde_json.workspace = true
 tokio = {version = "1.46.1", features = ["macros", "rt-multi-thread", "io-std"]}

--- a/crates/mq-mcp/src/server.rs
+++ b/crates/mq-mcp/src/server.rs
@@ -1,12 +1,12 @@
 use miette::miette;
 use rmcp::{
-    Error as McpError, ServerHandler, ServiceExt,
+    ErrorData, ServerHandler, ServiceExt,
     handler::server::tool::{Parameters, ToolRouter},
     model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router,
 };
 use tokio::io::{stdin, stdout};
-type McpResult = Result<CallToolResult, McpError>;
+type McpResult = Result<CallToolResult, ErrorData>;
 
 #[derive(Debug, Clone, Default)]
 pub struct Server {
@@ -74,7 +74,7 @@ impl Server {
         engine.load_builtin_module();
 
         let markdown = mq_markdown::Markdown::from_html_str(&html).map_err(|e| {
-            McpError::parse_error(
+            ErrorData::parse_error(
                 "Failed to parse html",
                 Some(serde_json::Value::String(e.to_string())),
             )
@@ -85,7 +85,7 @@ impl Server {
                 markdown.nodes.clone().into_iter().map(mq_lang::Value::from),
             )
             .map_err(|e| {
-                McpError::invalid_request(
+                ErrorData::invalid_request(
                     "Failed to query",
                     Some(serde_json::Value::String(e.to_string())),
                 )
@@ -111,12 +111,12 @@ impl Server {
     fn extract_markdown(
         &self,
         Parameters(QueryForMarkdown { markdown, query }): Parameters<QueryForMarkdown>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         let mut engine = mq_lang::Engine::default();
         engine.load_builtin_module();
 
         let markdown = mq_markdown::Markdown::from_html_str(&markdown).map_err(|e| {
-            McpError::parse_error(
+            ErrorData::parse_error(
                 "Failed to parse markdown",
                 Some(serde_json::Value::String(e.to_string())),
             )
@@ -127,7 +127,7 @@ impl Server {
                 markdown.nodes.clone().into_iter().map(mq_lang::Value::from),
             )
             .map_err(|e| {
-                McpError::invalid_request(
+                ErrorData::invalid_request(
                     "Failed to query",
                     Some(serde_json::Value::String(e.to_string())),
                 )


### PR DESCRIPTION
- Update rmcp from 0.2.1 to 0.3.0 in mq-mcp crate
- Replace deprecated McpError with ErrorData in error handling
- Update Cargo.lock with new dependency versions and transitive dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)