### PR TITLE
✨ feat(lang): add unary operator support with NOT operator

### DIFF
--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -240,6 +240,9 @@ impl Hir {
             mq_lang::CstNodeKind::BinaryOp(_) => {
                 self.add_binary_op_expr(node, source_id, scope_id, parent);
             }
+            mq_lang::CstNodeKind::UnaryOp(_) => {
+                self.add_unary_op_expr(node, source_id, scope_id, parent);
+            }
             mq_lang::CstNodeKind::Call => {
                 self.add_call_expr(node, source_id, scope_id, parent);
             }
@@ -305,6 +308,33 @@ impl Hir {
             let symbol_id = self.add_symbol(Symbol {
                 value: node.name(),
                 kind: SymbolKind::BinaryOp,
+                source: SourceInfo::new(Some(source_id), Some(node.range())),
+                scope: scope_id,
+                doc: node.comments(),
+                parent,
+            });
+
+            for child in node.children_without_token() {
+                self.add_expr(&child, source_id, scope_id, Some(symbol_id));
+            }
+        }
+    }
+
+    fn add_unary_op_expr(
+        &mut self,
+        node: &Arc<mq_lang::CstNode>,
+        source_id: SourceId,
+        scope_id: ScopeId,
+        parent: Option<SymbolId>,
+    ) {
+        if let mq_lang::CstNode {
+            kind: mq_lang::CstNodeKind::UnaryOp(_),
+            ..
+        } = &**node
+        {
+            let symbol_id = self.add_symbol(Symbol {
+                value: node.name(),
+                kind: SymbolKind::UnaryOp,
                 source: SourceInfo::new(Some(source_id), Some(node.range())),
                 scope: scope_id,
                 doc: node.comments(),
@@ -1045,6 +1075,8 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
     #[case::array_nested("[[1], [2]]", "1", SymbolKind::Number)]
     #[case::dict_simple("{\"a\": 1, \"b\": 2}", "a", SymbolKind::String)]
     #[case::dict_nested("{\"a\": {\"b\": 2}}", "b", SymbolKind::String)]
+    #[case::not_unary("!true", "!", SymbolKind::UnaryOp)]
+    #[case::not_variable("!x", "!", SymbolKind::UnaryOp)]
     fn test_add_code(
         #[case] code: &str,
         #[case] expected_name: &str,

--- a/crates/mq-hir/src/symbol.rs
+++ b/crates/mq-hir/src/symbol.rs
@@ -44,6 +44,7 @@ pub enum SymbolKind {
     Keyword,
     Selector,
     BinaryOp,
+    UnaryOp,
 }
 
 impl Symbol {

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -98,6 +98,7 @@ pub enum NodeKind {
     Selector,
     Self_,
     Token,
+    UnaryOp(UnaryOp),
     Until,
     While,
 }
@@ -118,6 +119,11 @@ pub enum BinaryOp {
     Or,
     Plus,
     RangeOp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum UnaryOp {
+    Not,
 }
 
 impl Display for Node {
@@ -218,6 +224,15 @@ impl Node {
             let left = non_token_children.next()?;
             let right = non_token_children.next()?;
             Some((Arc::clone(left), Arc::clone(right)))
+        } else {
+            None
+        }
+    }
+
+    pub fn unary_op(&self) -> Option<Arc<Node>> {
+        if let NodeKind::UnaryOp(_) = self.kind {
+            let operand = self.children.iter().find(|child| !child.is_token())?;
+            Some(Arc::clone(operand))
         } else {
             None
         }

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -216,6 +216,7 @@ define_token_parser!(gt, ">", TokenKind::Gt);
 define_token_parser!(gte, ">=", TokenKind::Gte);
 define_token_parser!(and, "&&", TokenKind::And);
 define_token_parser!(or, "||", TokenKind::Or);
+define_token_parser!(not, "!", TokenKind::Not);
 
 fn punctuations(input: Span) -> IResult<Span, Token> {
     alt((
@@ -230,6 +231,10 @@ fn binary_op(input: Span) -> IResult<Span, Token> {
         eq_eq, ne_eq, lte, gte, lt, gt, equal, plus, minus, asterisk, slash, percent, range_op,
     ))
     .parse(input)
+}
+
+fn unary_op(input: Span) -> IResult<Span, Token> {
+    alt((not,)).parse(input)
 }
 
 fn keywords(input: Span) -> IResult<Span, Token> {
@@ -488,6 +493,7 @@ fn token(input: Span) -> IResult<Span, Token> {
         literals,
         punctuations,
         binary_op,
+        unary_op,
         ident,
     ))
     .parse(input)
@@ -504,6 +510,7 @@ fn token_include_spaces(input: Span) -> IResult<Span, Token> {
         literals,
         punctuations,
         binary_op,
+        unary_op,
         ident,
     ))
     .parse(input)

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -96,6 +96,7 @@ pub enum TokenKind {
     LBrace,
     And,
     Or,
+    Not,
 }
 
 impl Token {
@@ -115,6 +116,7 @@ impl Display for TokenKind {
         match &self {
             TokenKind::And => write!(f, "&&"),
             TokenKind::Or => write!(f, "||"),
+            TokenKind::Not => write!(f, "!"),
             TokenKind::Asterisk => write!(f, "*"),
             TokenKind::BoolLiteral(b) => write!(f, "{}", b),
             TokenKind::Colon => write!(f, ":"),

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -97,6 +97,8 @@ pub use cst::node::NodeKind as CstNodeKind;
 #[cfg(feature = "cst")]
 pub use cst::node::Trivia as CstTrivia;
 #[cfg(feature = "cst")]
+pub use cst::node::UnaryOp as CstUnaryOp;
+#[cfg(feature = "cst")]
 pub use cst::parser::ErrorReporter as CstErrorReporter;
 #[cfg(feature = "cst")]
 pub use cst::parser::Parser as CstParser;

--- a/crates/mq-lsp/src/semantic_tokens.rs
+++ b/crates/mq-lsp/src/semantic_tokens.rs
@@ -66,7 +66,7 @@ pub fn response(hir: Arc<RwLock<mq_hir::Hir>>, url: Url) -> Vec<SemanticToken> {
                 mq_hir::SymbolKind::Argument => {
                     token_type(tower_lsp::lsp_types::SemanticTokenType::PARAMETER)
                 }
-                mq_hir::SymbolKind::BinaryOp => {
+                mq_hir::SymbolKind::BinaryOp | mq_hir::SymbolKind::UnaryOp => {
                     token_type(tower_lsp::lsp_types::SemanticTokenType::OPERATOR)
                 }
                 mq_hir::SymbolKind::Dict

--- a/editors/vscode/mq.tmLanguage.json
+++ b/editors/vscode/mq.tmLanguage.json
@@ -47,7 +47,7 @@
                 },
                 {
                     "name": "keyword.operator.mq",
-                    "match": "(->|=|\\||:|;|\\?)"
+                    "match": "(->|=|\\||:|;|\\?|!|\\+|\\-|\\*|\\/|%|<|>|<=|>=|==|!=|&&)"
                 },
                 {
                     "name": "constant.language.boolean.mq",

--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -615,7 +615,7 @@ export const Playground = () => {
             "keyword",
           ],
           [/;/, "delimiter"],
-          [/\|/, "operator"],
+          [/(->|=|\||:|;|\?|!|\+|-|\*|\/|%|<=|>=|==|!=|<|>|&&)/, "operator"],
           [/"/, { token: "string", next: "@multilineString" }],
           [/"s"/, { token: "string", next: "@multilineString" }],
           [/\d+/, "number"],


### PR DESCRIPTION
Implements comprehensive unary operator support across the mq language stack:

- Add UnaryOp enum with Not variant to CST and HIR
- Implement unary operator parsing in AST and CST parsers
- Add formatter support for unary operations
- Include HIR symbol handling for unary operators
- Add LSP semantic token support for unary operators
- Add comprehensive test coverage for NOT operator functionality

The NOT operator (\!) can now be used with boolean literals and variables, following standard logical negation semantics.