### PR TITLE
📝 docs(conditionals): add shorthand operator syntax examples

### DIFF
--- a/docs/books/src/reference/conditionals.md
+++ b/docs/books/src/reference/conditionals.md
@@ -2,18 +2,21 @@
 
 mq supports standard conditional operations through the following functions:
 
-- `and(a, b)` - Returns true if both `a` and `b` are true
-- `or(a, b)` - Returns true if either `a` or `b` is true
-- `not(a)` - Returns true if `a` is false
+- `and(a, b)`, `a && b` - Returns true if both `a` and `b` are true
+- `or(a, b), a || b` - Returns true if either `a` or `b` is true
+- `not(a), !a` - Returns true if `a` is false
 
 ### Examples
 
 ```python
 # Basic comparisons
 and(true, true, true)
+true && true && true
 # => true
 or(true, false, true)
+true || false || true
 # => true
 not(false)
+!false
 # => true
 ```


### PR DESCRIPTION
Update conditionals documentation to include shorthand operator syntax (&&, ||, \!) alongside existing function syntax, with examples showing both approaches for better user understanding.