### PR TITLE
✨ feat(vscode): Add configurable CodeLens toggle

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -106,6 +106,12 @@
           "type": "boolean",
           "default": true,
           "description": "Show examples when creating a new file"
+        },
+        "mq.enableCodeLens": {
+          "title": "Enable Code Lens",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable Code Lens for mq queries"
         }
       }
     }


### PR DESCRIPTION
Add mq.enableCodeLens setting to allow users to enable/disable CodeLens functionality in the VSCode extension. Includes dynamic provider management with proper cleanup and configuration change watching.