### PR TITLE
🐛 fix(formatter): enhance indentation for pipe-let expressions with conditionals

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -307,7 +307,13 @@ impl Formatter {
         append_space_after_keyword: bool,
     ) {
         let is_prev_pipe = self.is_prev_pipe();
-        let indent_adjustment = if self.is_let_line() { 1 } else { 0 };
+        let indent_adjustment = if self.is_let_line() {
+            1
+        } else if self.is_pipe_and_let_line() {
+            2
+        } else {
+            0
+        };
 
         if node.has_new_line() {
             self.append_indent(indent_level);
@@ -1094,6 +1100,34 @@ test2
       test
     else:
       test2"#
+    )]
+    #[case::let_with_until_multiline(
+        r#"let x = until(condition()):
+process();"#,
+        r#"let x = until (condition()):
+  process();"#
+    )]
+    #[case::let_with_until_multiline(
+        r#""test"
+| let x = until(condition()):
+process();"#,
+        r#""test"
+| let x = until (condition()):
+      process();"#
+    )]
+    #[case::let_with_while_multiline(
+        r#"let x = while(condition()):
+process();"#,
+        r#"let x = while (condition()):
+  process();"#
+    )]
+    #[case::let_with_while_multiline(
+        r#""test"
+| let x = while(condition()):
+process();"#,
+        r#""test"
+| let x = while (condition()):
+      process();"#
     )]
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);


### PR DESCRIPTION
Improved indentation handling by adding is_pipe_and_let_line() check that provides proper 2-space indentation adjustment for pipe-let expressions in until() and while() conditionals. Added comprehensive tests for multiline let expressions with conditionals.