### PR TITLE
🐛 fix(formatter): Improve End token handling and code organization

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -79,7 +79,9 @@ impl Formatter {
 
         if !matches!(
             node.kind,
-            mq_lang::CstNodeKind::Token | mq_lang::CstNodeKind::BinaryOp(_)
+            mq_lang::CstNodeKind::Token
+                | mq_lang::CstNodeKind::BinaryOp(_)
+                | mq_lang::CstNodeKind::End
         ) {
             self.append_leading_trivia(&node, indent_level_consider_new_line);
         }
@@ -125,6 +127,7 @@ impl Formatter {
             }
             mq_lang::CstNodeKind::Env => self.append_env(&node, indent_level_consider_new_line),
             mq_lang::CstNodeKind::Nodes
+            | mq_lang::CstNodeKind::End
             | mq_lang::CstNodeKind::Self_
             | mq_lang::CstNodeKind::Break
             | mq_lang::CstNodeKind::Continue => {
@@ -588,8 +591,22 @@ impl Formatter {
             token: Some(token), ..
         } = &**node
         {
-            self.append_indent(indent_level);
-            self.output.push_str(&token.to_string());
+            match token.kind {
+                mq_lang::TokenKind::End => {
+                    if node.has_new_line() {
+                        let indent_level = indent_level.saturating_sub(1);
+                        self.append_leading_trivia(node, indent_level);
+                        self.append_indent(indent_level);
+                        self.output.push_str(&token.to_string());
+                    } else {
+                        self.output.push_str(&token.to_string());
+                    }
+                }
+                _ => {
+                    self.append_indent(indent_level);
+                    self.output.push_str(&token.to_string());
+                }
+            }
         }
     }
 
@@ -622,16 +639,6 @@ impl Formatter {
                     }
                 }
                 mq_lang::TokenKind::RParen => {
-                    if node.has_new_line() {
-                        let indent_level = indent_level.saturating_sub(1);
-                        self.append_leading_trivia(node, indent_level);
-                        self.append_indent(indent_level);
-                        self.output.push_str(&token.to_string());
-                    } else {
-                        self.output.push_str(&token.to_string());
-                    }
-                }
-                mq_lang::TokenKind::End => {
                     if node.has_new_line() {
                         let indent_level = indent_level.saturating_sub(1);
                         self.append_leading_trivia(node, indent_level);

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -290,6 +290,7 @@ impl Hir {
             }
             mq_lang::CstNodeKind::Self_
             | mq_lang::CstNodeKind::Nodes
+            | mq_lang::CstNodeKind::End
             | mq_lang::CstNodeKind::Break
             | mq_lang::CstNodeKind::Continue => {
                 self.add_keyword(node, source_id, scope_id, parent);

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -84,6 +84,7 @@ pub enum NodeKind {
     Continue,
     Def,
     Dict,
+    End,
     Elif,
     Else,
     Env,


### PR DESCRIPTION
- Move End token handling logic to append_token method for consistency
- Add End variant to CstNodeKind enum in mq-lang
- Update pattern matches to include End token in formatter and HIR
- Consolidate End token formatting logic for better maintainability