### PR TITLE
✨ feat(parser): Add bracket access syntax for arrays and dictionaries

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -1126,6 +1126,13 @@ process();"#,
 | let x = while (condition()):
       process();"#
     )]
+    #[case::array_index_access("let arr = [1, 2, 3]\n|arr[1]", "let arr = [1, 2, 3]\n| arr[1]")]
+    #[case::array_index_access_inline("arr[0]", "arr[0]")]
+    #[case::dict_index_access(
+        "let d = {\"key\": \"value\"}\n|d[\"key\"]",
+        "let d = {\"key\": \"value\"}\n| d[\"key\"]"
+    )]
+    #[case::dict_index_access_inline("d[\"key\"]", "d[\"key\"]")]
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);
         assert_eq!(result.unwrap(), expected);

--- a/crates/mq-lang/src/ast/error.rs
+++ b/crates/mq-lang/src/ast/error.rs
@@ -17,4 +17,6 @@ pub enum ParseError {
     ExpectedClosingParen(Token),
     #[error("Expected a closing brace `}}` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     ExpectedClosingBrace(Token),
+    #[error("Expected a closing bracket `]` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
+    ExpectedClosingBracket(Token),
 }

--- a/crates/mq-lang/src/cst/error.rs
+++ b/crates/mq-lang/src/cst/error.rs
@@ -12,4 +12,6 @@ pub enum ParseError {
     UnexpectedEOFDetected,
     #[error("Insufficient tokens `{0}`")]
     InsufficientTokens(Arc<Token>),
+    #[error("Expected a closing bracket `]` but got `{0}` delimiter")]
+    ExpectedClosingBracket(Arc<Token>),
 }

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -49,6 +49,7 @@ impl Error {
                 ParseError::InsufficientTokens(token) => Some(token),
                 ParseError::ExpectedClosingParen(token) => Some(token),
                 ParseError::ExpectedClosingBrace(token) => Some(token),
+                ParseError::ExpectedClosingBracket(token) => Some(token),
             },
             InnerError::Eval(err) => match err {
                 EvalError::UserDefined { token, .. } => Some(token),
@@ -80,6 +81,7 @@ impl Error {
                     ParseError::InsufficientTokens(token) => Some(token),
                     ParseError::ExpectedClosingParen(token) => Some(token),
                     ParseError::ExpectedClosingBrace(token) => Some(token),
+                    ParseError::ExpectedClosingBracket(token) => Some(token),
                 },
                 ModuleError::InvalidModule => None,
             },
@@ -206,6 +208,9 @@ impl Diagnostic for Error {
             InnerError::Parse(ParseError::ExpectedClosingBrace(_)) => {
                 "ParseError::ExpectedClosingBrace".to_string()
             }
+            InnerError::Parse(ParseError::ExpectedClosingBracket(_)) => {
+                "ParseError::ExpectedClosingBracket".to_string()
+            }
             InnerError::Eval(EvalError::RecursionError(_)) => {
                 "EvalError::RecursionError".to_string()
             }
@@ -270,6 +275,9 @@ impl Diagnostic for Error {
             }
             InnerError::Module(ModuleError::ParseError(ParseError::ExpectedClosingBrace(_))) => {
                 "ModuleError::ExpectedClosingBrace".to_string()
+            }
+            InnerError::Module(ModuleError::ParseError(ParseError::ExpectedClosingBracket(_))) => {
+                "ModuleError::ExpectedClosingBracket".to_string()
             }
         };
 

--- a/docs/books/src/reference/types_and_values.md
+++ b/docs/books/src/reference/types_and_values.md
@@ -20,6 +20,60 @@
 | **Dict**     | Represents key-value mappings (dictionaries).                                                                     | `{"a": 1, "b": 2}`, `dict(["a", 1], ["b", 2])` |
 | **Function** | Represents executable code.                                                                                       | `def foo(): 42; let name = def foo(): 42;`     |
 
+## Accessing Values
+
+### Array Index Access
+
+Arrays can be accessed using square bracket notation with zero-based indexing:
+
+```mq
+let arr = [1, 2, 3, 4, 5]
+
+arr[0]     # Returns 1 (first element)
+arr[2]     # Returns 3 (third element)
+arr[6]     # Returns None
+```
+
+You can also use the `get` function explicitly:
+
+```mq
+get(arr, 0)    # Same as arr[0]
+arr | get(2)    # Same as arr[2]
+```
+
+### Dictionary Key Access
+
+Dictionaries can be accessed using square bracket notation with keys:
+
+```mq
+let d = {"name": "Alice", "age": 30, "city": "Tokyo"}
+
+d["name"]   # Returns "Alice"
+d["age"]    # Returns 30
+d["city"]   # Returns "Tokyo"
+```
+
+You can also use the `get` function explicitly:
+
+```mq
+get(d, "name")   # Same as di["name"]
+d | get("age")    # Same as d["age"]
+```
+
+### Dynamic Access
+
+Both arrays and dictionaries support dynamic access using variables:
+
+```mq
+let arr = [10, 20, 30]
+| let index = 1
+| arr[index]     # Returns 20
+
+let d = {"x": 100, "y": 200}
+| let key = "x"
+| d[key]      # Returns 100
+```
+
 ## Environment Variables
 
 A module handling environment-specific functionality.


### PR DESCRIPTION
- Implement bracket access syntax `ident[key]` transformation to `get(ident, key)` calls
- Add support for both AST and CST parsers
- Include comprehensive error handling for missing closing brackets
- Add extensive test coverage for array index access and dictionary key access
- Update documentation with bracket access examples and usage patterns