### PR TITLE
♻️ refactor(lang): Remove nth function and integrate functionality into get

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -95,7 +95,7 @@ def filter(v, f):
       let fileted = foreach (x, entries(v)): select(x, f(x)); | dict(compact(fileted));
 
   | let _filter = fn(v, f):
-  foreach (x, v): select(x, f(x)); | compact();
+      foreach (x, v): select(x, f(x)); | compact();
 
   | if (is_dict(v)):
     filter_dict(v, f)
@@ -108,7 +108,7 @@ def first(arr):
   if (is_empty(arr)):
     None
   else:
-    nth(arr, 0)
+    get(arr, 0)
 end
 
 # Returns the last element of an array
@@ -116,7 +116,7 @@ def last(arr):
   if (is_empty(arr)):
     None
   else:
-    nth(arr, sub(len(arr), 1))
+    get(arr, sub(len(arr), 1))
 end
 
 # Returns the second element of an array
@@ -124,7 +124,7 @@ def second(arr):
   if (len(arr) < 2):
     None
   else:
-    nth(arr, 1)
+    get(arr, 1)
 end
 
 # Checks if markdown is h1 heading
@@ -318,7 +318,7 @@ def find_index(arr, f):
   let _find_index_impl = fn(arr, f, idx):
       if (idx == len(arr)):
         -1
-      elif (f(nth(arr, idx))):
+      elif (f(get(arr, idx))):
         idx
       else:
         _find_index_impl(arr, f, idx + 1);
@@ -338,7 +338,7 @@ def skip_while(arr, f):
   elif (is_empty(arr)):
     0
   else:
-    until (and(i < len(arr), f(nth(arr, i)))):
+    until (and(i < len(arr), f(get(arr, i)))):
       let i = i + 1 | i;
   | if (is_none(si)): []
   else:
@@ -354,7 +354,7 @@ def take_while(arr, f):
   elif (is_empty(arr)):
     0
   else:
-    until (and(i < len(arr), f(nth(arr, i)))):
+    until (and(i < len(arr), f(get(arr, i)))):
       let i = i + 1 | i;
   | if (is_none(ti)): []
   else:
@@ -414,7 +414,7 @@ def fold(arr, init, f):
     init
   else:
     until (i != len(arr)):
-      let acc = f(acc, nth(arr, i))
+      let acc = f(acc, get(arr, i))
       | let i = i + 1
       | acc
     end
@@ -430,7 +430,7 @@ def unique_by(arr, f):
   elif (is_empty(arr)): []
   else:
     until (i != len(arr)):
-      let item = nth(arr, i)
+      let item = get(arr, i)
       | let key = to_string(f(item))
       | let already_seen = get(seen, key)
       | let result = if (is_none(already_seen)): result + item else: result
@@ -446,15 +446,15 @@ def identity(x): x;
 # Returns an array of sections, each section is an array of markdown nodes between the specified header and the next header of the same level.
 def sections(md_nodes, level):
   let indices = foreach (i, range(sub(len(md_nodes), 1))):
-      let n = nth(md_nodes, i)
+      let n = get(md_nodes, i)
       | if (is_h_level(n, level)): i;
   | let indices = compact(indices)
   | let indices_with_end = indices + len(md_nodes)
   | let result = []
   | let i = 0
   | until (i < len(indices)):
-      let start_node = nth(indices, i)
-      | let end_node = nth(indices_with_end, i + 1)
+      let start_node = get(indices, i)
+      | let end_node = get(indices_with_end, i + 1)
       | let section = slice(md_nodes, start_node, end_node)
       | let result = result + [section]
       | let i = i + 1

--- a/crates/mq-lang/examples/rule110.rs
+++ b/crates/mq-lang/examples/rule110.rs
@@ -19,7 +19,7 @@ def rule110(left, center, right):
 
 def safe_get(arr, index):
   if (and(index >= 0, index < len(arr))):
-    nth(arr, index)
+    get(arr, index)
   else:
     0;
 
@@ -28,7 +28,7 @@ def next_generation(current_gen):
   | map(range(0, width, 1),
   fn(i):
     let left = safe_get(current_gen, sub(i, 1))
-    | let center = nth(current_gen, i)
+    | let center = get(current_gen, i)
     | let right = safe_get(current_gen, add(i, 1))
     | rule110(left, center, right);
 );

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -2678,27 +2678,27 @@ mod tests {
              ast_call("get_title", SmallVec::new())
         ],
         Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Empty, None)]))]
-    #[case::nth_string(vec![RuntimeValue::String("test1".to_string())],
+    #[case::get_string(vec![RuntimeValue::String("test1".to_string())],
         vec![
-            ast_call("nth", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(0.into())))])
+            ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(0.into())))])
         ],
         Ok(vec![RuntimeValue::String("t".to_string())]))]
-    #[case::nth_string(vec![RuntimeValue::String("test1".to_string())],
+    #[case::get_string(vec![RuntimeValue::String("test1".to_string())],
         vec![
-            ast_call("nth", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(5.into())))])
+            ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(5.into())))])
         ],
         Ok(vec![RuntimeValue::NONE]))]
-    #[case::nth_array(vec![RuntimeValue::Array(vec!["test1".to_string().into()])],
+    #[case::get_array(vec![RuntimeValue::Array(vec!["test1".to_string().into()])],
         vec![
-            ast_call("nth", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(2.into())))])
+            ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(2.into())))])
         ],
         Ok(vec![RuntimeValue::NONE]))]
-    #[case::nth(vec![RuntimeValue::TRUE],
+    #[case::get(vec![RuntimeValue::TRUE],
         vec![
-            ast_call("nth", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(0.into())))])
+            ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(0.into())))])
         ],
         Err(InnerError::Eval(EvalError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
-                                                     name: "nth".to_string(),
+                                                     name: "get".to_string(),
                                                      args: vec![true.to_string().into(), 0.to_string().into()]})))]
     #[case::to_date(vec![RuntimeValue::Number(1609459200000_i64.into())],
         vec![

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -807,33 +807,6 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
             }),
         );
         map.insert(
-            CompactString::new("nth"),
-            BuiltinFunction::new(ParamNum::Fixed(2), |ident, _, args| match args.as_slice() {
-                [RuntimeValue::Array(array), RuntimeValue::Number(index)] => {
-                    let index = index.value() as usize;
-                    Ok(array.get(index).cloned().unwrap_or(RuntimeValue::None))
-                }
-                [RuntimeValue::String(s), RuntimeValue::Number(n)] => {
-                    match s.chars().nth(n.value() as usize) {
-                        Some(o) => Ok(o.to_string().into()),
-                        None => Ok(RuntimeValue::None),
-                    }
-                }
-                [RuntimeValue::Markdown(node, _), RuntimeValue::Number(i)] => {
-                    Ok(RuntimeValue::Markdown(
-                        node.clone(),
-                        Some(runtime_value::Selector::Index(i.value() as usize)),
-                    ))
-                }
-                [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::NONE),
-                [a, b] => Err(Error::InvalidTypes(
-                    ident.to_string(),
-                    vec![a.clone(), b.clone()],
-                )),
-                _ => unreachable!(),
-            }),
-        );
-        map.insert(
             CompactString::new("range"),
             BuiltinFunction::new(ParamNum::Range(1, 3), |ident, _, args| {
                 match args.as_slice() {
@@ -1857,6 +1830,19 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
                     let index = index.value() as usize;
                     Ok(array.get(index).cloned().unwrap_or(RuntimeValue::None))
                 }
+                [RuntimeValue::String(s), RuntimeValue::Number(n)] => {
+                    match s.chars().nth(n.value() as usize) {
+                        Some(o) => Ok(o.to_string().into()),
+                        None => Ok(RuntimeValue::None),
+                    }
+                }
+                [RuntimeValue::Markdown(node, _), RuntimeValue::Number(i)] => {
+                    Ok(RuntimeValue::Markdown(
+                        node.clone(),
+                        Some(runtime_value::Selector::Index(i.value() as usize)),
+                    ))
+                }
+                [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::NONE),
                 [a, b] => Err(Error::InvalidTypes(
                     ident.to_string(),
                     vec![a.clone(), b.clone()],
@@ -2605,13 +2591,6 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             BuiltinFunctionDoc {
                 description: "Finds the last occurrence of a substring in the given string.",
                 params: &["string", "substring"],
-            },
-        );
-        map.insert(
-            CompactString::new("nth"),
-            BuiltinFunctionDoc {
-                description: "Gets the element at the specified index in the array or string.",
-                params: &["array_or_string", "index"],
             },
         );
         map.insert(

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-mq",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mq",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",
         "which": "^5.0.0"

--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -41,7 +41,7 @@ Hello world
   },
   {
     name: "Update child node",
-    code: `.h1 | nth(1) | add("text")`,
+    code: `.h1 | get(1) | add("text")`,
     markdown: `# *h1* text
 
 - item1


### PR DESCRIPTION
- Remove nth builtin function from eval/builtin.rs
- Extend get function to support all nth functionality (arrays, strings, markdown)
- Update all nth() calls to get() in builtin.mq library functions
- Update rule110 example to use get() instead of nth()
- Update test cases from nth_* to get_* naming
- Update playground example to use get() syntax
- Bump VSCode extension version to 0.2.14