### PR TITLE
🐛 fix(parser): fix parser for 'Not' token in function calls

### DIFF
--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -4497,6 +4497,28 @@ mod tests {
                     token(TokenKind::Eof)
                 ],
                 Err(ParseError::UnexpectedEOFDetected(Module::TOP_LEVEL_MODULE_ID)))]
+    #[case::break_(
+                    vec![
+                        token(TokenKind::Break),
+                        token(TokenKind::Eof)
+                    ],
+                    Ok(vec![
+                        Rc::new(Node {
+                            token_id: 0.into(),
+                            expr: Rc::new(Expr::Break),
+                        })
+                    ]))]
+    #[case::continue_(
+                    vec![
+                        token(TokenKind::Continue),
+                        token(TokenKind::Eof)
+                    ],
+                    Ok(vec![
+                        Rc::new(Node {
+                            token_id: 0.into(),
+                            expr: Rc::new(Expr::Continue),
+                        })
+                    ]))]
     fn test_parse(#[case] input: Vec<Token>, #[case] expected: Result<Program, ParseError>) {
         let arena = Arena::new(10);
         assert_eq!(

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -3961,13 +3961,84 @@ mod tests {
                 value: "Not a heading".to_string(),
                 position: None
             }), None)],
+            vec![
+                ast_call("decrease_header_level", SmallVec::new())
+            ],
+            Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text {
+                value: "Not a heading".to_string(),
+                position: None
+            }), None)]))]
+    #[case::break_in_foreach(
+       vec![RuntimeValue::Array(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(2.into()),
+            RuntimeValue::Number(3.into()),
+        ])],
+            vec![
+                ast_node(ast::Expr::Foreach(
+                    ast::Ident::new("x"),
+                    ast_node(ast::Expr::Self_),
+                    vec![
+                        ast_node(ast::Expr::If(smallvec![
+                            (
+                                Some(ast_node(ast::Expr::Call(
+                                    ast::Ident::new("eq"),
+                                    smallvec![
+                                        ast_node(ast::Expr::Ident(ast::Ident::new("x"))),
+                                        ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
+                                    ],
+                                    false,
+                                ))),
+                                ast_node(ast::Expr::Break),
+                            ),
+                            (
+                                None,
+                                ast_node(ast::Expr::Ident(ast::Ident::new("x"))),
+                            ),
+                        ])),
+                    ],
+                )),
+            ],
+            Ok(vec![RuntimeValue::Array(vec![
+                RuntimeValue::Number(1.into()),
+            ])])
+        )]
+    #[case::continue_in_foreach(
+        vec![RuntimeValue::Array(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(2.into()),
+            RuntimeValue::Number(3.into()),
+        ])],
+        vec![
+            ast_node(ast::Expr::Foreach(
+                ast::Ident::new("x"),
+                ast_node(ast::Expr::Self_),
                 vec![
-                    ast_call("decrease_header_level", SmallVec::new())
+                    ast_node(ast::Expr::If(smallvec![
+                        (
+                            Some(ast_node(ast::Expr::Call(
+                                ast::Ident::new("eq"),
+                                smallvec![
+                                    ast_node(ast::Expr::Ident(ast::Ident::new("x"))),
+                                    ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
+                                ],
+                                false,
+                            ))),
+                            ast_node(ast::Expr::Continue),
+                        ),
+                        (
+                            None,
+                            ast_node(ast::Expr::Ident(ast::Ident::new("x"))),
+                        ),
+                    ])),
                 ],
-                Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text {
-                    value: "Not a heading".to_string(),
-                    position: None
-                }), None)]))]
+            )),
+        ],
+        Ok(vec![RuntimeValue::Array(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(3.into()),
+        ])])
+    )]
     fn test_eval(
         token_arena: Rc<RefCell<Arena<Rc<Token>>>>,
         #[case] runtime_values: Vec<RuntimeValue>,

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -177,3 +177,26 @@ impl Display for TokenKind {
         }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        StringSegment::Text("hello".to_string(), Range::default()),
+        "hello"
+    )]
+    #[case(
+        StringSegment::Ident(CompactString::new("world"), Range::default()),
+        "${world}"
+    )]
+    #[case(
+        StringSegment::Text("".to_string(), Range::default()),
+        ""
+    )]
+    #[case(StringSegment::Ident(CompactString::new(""), Range::default()), "${}")]
+    fn string_segment_display_works(#[case] segment: StringSegment, #[case] expected: &str) {
+        assert_eq!(segment.to_string(), expected);
+    }
+}


### PR DESCRIPTION
Fix CST parser to properly handle Not tokens as unary operators in function call arguments. Previously the parser would fail to recognize Not tokens in function call contexts.

- Add Not token to primary expression parsing in CST parser
- Add comprehensive test case for function calls with Not operator arguments
- Include additional test coverage for break/continue statements in AST parser
- Add evaluator tests for break/continue control flow in foreach loops