### PR TITLE
🐛 fix(playground): improve multiline string escape handling in Monaco syntax highlighting

### DIFF
--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -629,9 +629,8 @@ export const Playground = () => {
         ],
         multilineString: [
           [/\$\{[^}]*\}/, "variable"],
-          [/[^"$]+/, "string"],
-          [/\$(?!\{)/, "string"],
-          [/\n/, "string"],
+          [/\\./, "string.escape"], // handle escaped characters (including \")
+          [/[^\\"]+/, "string"], // match all except backslash and quote
           [/"/, { token: "string", next: "@pop" }],
         ],
       },


### PR DESCRIPTION
- Add proper handling for escaped characters including \"
- Simplify string pattern matching by consolidating rules
- Remove redundant newline and dollar sign patterns