### PR TITLE
👷 ci(npm-publish): update workflow to use OIDC authentication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@ name: Publish npm package
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -25,5 +29,3 @@ jobs:
       - name: Publish to npm
         working-directory: packages/mq-web
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Add id-token write and contents read permissions
- Remove NODE_AUTH_TOKEN environment variable
- Modernize npm publishing workflow for enhanced security