### PR TITLE
🐛 fix(parser): add group expression parsing support

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -101,6 +101,7 @@ impl Formatter {
             }
             mq_lang::CstNodeKind::Call => self.format_call(&node, indent_level_consider_new_line),
             mq_lang::CstNodeKind::Def
+            | mq_lang::CstNodeKind::Group
             | mq_lang::CstNodeKind::Foreach
             | mq_lang::CstNodeKind::While
             | mq_lang::CstNodeKind::Until

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -91,6 +91,7 @@ pub enum NodeKind {
     Eof,
     Fn,
     Foreach,
+    Group,
     Ident,
     If,
     Include,


### PR DESCRIPTION
Add Group node kind and parsing logic for parenthesized expressions. Includes formatter support and comprehensive test coverage.