### PR TITLE
📦 build(mcp): update rmcp dependency to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3668,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
+checksum = "9a04b2d9da174d72bc0511410242eb3e8f47a02d9e23868e4b076c7c70208eb4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3689,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
+checksum = "651b4292f292d4a4ba191e64f0ce553aef5455b8ddf831dc6a8cd328dd68d721"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/crates/mq-mcp/Cargo.toml
+++ b/crates/mq-mcp/Cargo.toml
@@ -10,7 +10,7 @@ miette.workspace = true
 mq-hir.workspace = true
 mq-lang.workspace = true
 mq-markdown.workspace = true
-rmcp = {version = "0.3.2", features = ["server"]}
+rmcp = {version = "0.4.0", features = ["server"]}
 serde = {workspace = true, features = ["derive"]}
 serde_json.workspace = true
 tokio = {version = "1.47.1", features = ["macros", "rt-multi-thread", "io-std"]}

--- a/crates/mq-mcp/src/server.rs
+++ b/crates/mq-mcp/src/server.rs
@@ -289,10 +289,14 @@ mod tests {
                 assert!(!result.is_error.unwrap_or_default());
                 let actual = result
                     .content
-                    .iter()
-                    .map(|c| c.raw.as_text().map(|t| t.text.clone()).unwrap_or_default())
-                    .collect::<Vec<_>>()
-                    .join("\n\n");
+                    .map(|c| {
+                        c.iter()
+                            .map(|c| c.as_text().map(|t| t.text.clone()).unwrap_or_default())
+                            .collect::<Vec<_>>()
+                            .join("\n\n")
+                    })
+                    .unwrap_or_default();
+
                 assert_eq!(actual, expected_text);
             }
             Err(expected_err) => {
@@ -354,10 +358,13 @@ mod tests {
                 assert!(!result.is_error.unwrap_or_default());
                 let actual = result
                     .content
-                    .iter()
-                    .map(|c| c.raw.as_text().map(|t| t.text.clone()).unwrap_or_default())
-                    .collect::<Vec<_>>()
-                    .join("\n\n");
+                    .map(|c| {
+                        c.iter()
+                            .map(|c| c.raw.as_text().map(|t| t.text.clone()).unwrap_or_default())
+                            .collect::<Vec<_>>()
+                            .join("\n\n")
+                    })
+                    .unwrap_or_default();
                 assert_eq!(actual, expected_text);
             }
             Err(expected_err) => {
@@ -376,7 +383,7 @@ mod tests {
         let server = Server::new().expect("Failed to create server");
         let result = server.available_functions().unwrap();
         assert!(!result.is_error.unwrap_or_default());
-        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.content.map(|c| c.len()).unwrap_or_default(), 1);
     }
 
     #[test]
@@ -384,7 +391,7 @@ mod tests {
         let server = Server::new().expect("Failed to create server");
         let result = server.available_selectors().unwrap();
         assert!(!result.is_error.unwrap_or_default());
-        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.content.map(|c| c.len()).unwrap_or_default(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Update rmcp from 0.3.2 to 0.4.0 and adapt test code to handle API changes in content structure handling.