### PR TITLE
🐛 fix(formatter): improve spacing condition to check for trailing space

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -552,7 +552,10 @@ impl Formatter {
                         self.append_indent(indent_level);
                     }
 
-                    if !self.output.is_empty() && !self.output.ends_with('\n') {
+                    if !self.output.is_empty()
+                        && !self.output.ends_with('\n')
+                        && !self.output.ends_with(' ')
+                    {
                         self.append_space();
                     }
 


### PR DESCRIPTION
Add check for trailing space in addition to newline to prevent unnecessary space insertion in formatter output.