### PR TITLE
✨ feat(parser): add support for loop keywords in argument parsing

### DIFF
--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -821,6 +821,21 @@ impl<'a> Parser<'a> {
             }
             | Token {
                 range: _,
+                kind: TokenKind::Until,
+                ..
+            }
+            | Token {
+                range: _,
+                kind: TokenKind::Foreach,
+                ..
+            }
+            | Token {
+                range: _,
+                kind: TokenKind::While,
+                ..
+            }
+            | Token {
+                range: _,
                 kind: TokenKind::LParen,
                 ..
             } => self.parse_expr(leading_trivia, false, false),


### PR DESCRIPTION
Extend parse_arg function to recognize Until, Foreach, and While token kinds as valid argument patterns, enabling loop constructs to be parsed correctly in argument contexts.