### PR TITLE
✨ feat(lsp): implement did_close method with resource cleanup

### DIFF
--- a/crates/mq-lsp/src/server.rs
+++ b/crates/mq-lsp/src/server.rs
@@ -272,11 +272,7 @@ impl Backend {
                         let hir = self.hir.read().unwrap();
                         let has_error_in_this_file = hir.symbols().any(|(_, symbol)| {
                             symbol.source.source_id == Some(*source_id)
-                                && symbol
-                                    .source
-                                    .text_range
-                                    .as_ref()
-                                    .map_or(false, |range| range == &item)
+                                && symbol.source.text_range.as_ref() == Some(&item)
                         });
 
                         if has_error_in_this_file {


### PR DESCRIPTION
- Add did_close method to properly clean up resources when files are closed
- Remove error information, CST nodes, and source map entries for closed files
- Clear diagnostics for closed files to prevent stale error reporting
- Improve diagnostics method to filter errors by specific file
- Add comprehensive test coverage for did_close functionality

🤖 Generated with [Claude Code](https://claude.ai/code)