### PR TITLE
✨ feat(editor): add include snippet support for VSCode and playground

### DIFF
--- a/editors/vscode/snippets/mq.json
+++ b/editors/vscode/snippets/mq.json
@@ -1,4 +1,11 @@
 {
+    "include": {
+        "prefix": "include",
+        "body": [
+            "include \"${1:module}\""
+        ],
+        "description": "Include a module"
+    },
     "foreach": {
         "prefix": "foreach",
         "body": [

--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -558,6 +558,22 @@ export const Playground = () => {
             },
           },
           {
+            label: "include",
+            kind: monaco.languages.CompletionItemKind.Snippet,
+            insertText: 'include "${1:path}"',
+            insertTextRules:
+              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+            detail: "Include a module",
+            documentation:
+              "Includes the contents of an external module for processing.",
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: wordRange.startColumn,
+              endLineNumber: position.lineNumber,
+              endColumn: wordRange.endColumn,
+            },
+          },
+          {
             label: "while",
             kind: monaco.languages.CompletionItemKind.Snippet,
             insertText: "while (${1:condition}): ${0:body};",


### PR DESCRIPTION
- Add include snippet to VSCode snippets with module parameter placeholder
- Add include autocomplete suggestion in playground editor with documentation
- Ensure consistent snippet behavior across both editors