### PR TITLE
⚡ perf(lang): optimize CSV parsing and reduce unnecessary cloning

### DIFF
--- a/crates/mq-lang/modules/csv.mq
+++ b/crates/mq-lang/modules/csv.mq
@@ -23,14 +23,13 @@ end
 def _parse_unquoted_field(input, delimiter, pos):
   let end_pos = pos
   | let current_input = input[end_pos]
-  | let result = until (end_pos < len(input) && current_input != delimiter && current_input != "\n" && current_input != "\r"):
+  | let end_pos = until (end_pos < len(input) && current_input != delimiter && current_input != "\n" && current_input != "\r"):
         let end_pos = end_pos + 1
         | let current_input = input[end_pos]
         | end_pos
       end
-  | let result = if (is_none(result)): end_pos else: result
-  | let field_content = join(input[pos:result], "")
-  | [field_content, result]
+  | let end_pos = if (is_none(end_pos)): pos else: end_pos
+  | [join(input[pos:end_pos], ""), end_pos]
 end
 
 def _parse_csv_field(input, delimiter, pos):


### PR DESCRIPTION
- Streamline CSV field parsing by removing redundant variables in csv.mq
- Replace .clone() with .to_owned() for better memory efficiency in eval.rs
- Use iterators instead of cloning collections in function argument handling
- Simplify control flow in until/while loop evaluation