### PR TITLE
📦 build: integrate cargo-nextest for improved test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,13 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install cargo-readme
         run: cargo install cargo-readme
+      - uses: taiki-e/install-action@nextest
       - name: Build
         run: just build
       - name: Run tests
         run: just test
+        env:
+          NEXTEST_RETRIES: 3
       - name: Check docs
         run: just docs
       - name: Check for diffs in docs

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
             cargo-llvm-cov
             cargo-readme
             cargo-udeps
+            cargo-nextest
             cargo-watch
             just
             maturin

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ test-mq:
 
 # Run formatting, linting and all tests
 test: fmt lint test-mq
-    cargo test --workspace --all-features
+    cargo nextest run --workspace --all-features
 
 # Run tests with code coverage reporting
 test-cov:


### PR DESCRIPTION
- Add cargo-nextest installation to CI workflow with retry configuration
- Include cargo-nextest in Nix flake development dependencies
- Replace cargo test with cargo nextest run in justfile for faster, more reliable testing