### PR TITLE
📦 build(mcp): upgrade rmcp dependency from 0.5.0 to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faf35b7d3c4b7f8c21c45bb014011b32a0ce6444bf6094da04daab01a8c3c34"
+checksum = "1f521fbd040eba82684b17d787d423f43afb6e97974029b51f679157a589592a"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3651,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9720d9d2a943779f1dc3d47fa9072c7eeffaff4e1a82f67eb9f7ea52696091"
+checksum = "c162bf8a2846f70464ded6dda6430b60d1e2fb4b0e371f0906e39f63916641b9"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/crates/mq-mcp/Cargo.toml
+++ b/crates/mq-mcp/Cargo.toml
@@ -10,7 +10,7 @@ miette.workspace = true
 mq-hir.workspace = true
 mq-lang.workspace = true
 mq-markdown.workspace = true
-rmcp = {version = "0.5.0", features = ["server"]}
+rmcp = {version = "0.6.1", features = ["server"]}
 serde = {workspace = true, features = ["derive"]}
 serde_json.workspace = true
 tokio = {version = "1.47.1", features = ["macros", "rt-multi-thread", "io-std"]}

--- a/crates/mq-mcp/src/server.rs
+++ b/crates/mq-mcp/src/server.rs
@@ -1,7 +1,7 @@
 use miette::miette;
 use rmcp::{
     ErrorData, ServerHandler, ServiceExt,
-    handler::server::tool::{Parameters, ToolRouter},
+    handler::server::{tool::ToolRouter, wrapper::Parameters},
     model::{CallToolResult, Content, ProtocolVersion, ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router,
 };
@@ -289,13 +289,10 @@ mod tests {
                 assert!(!result.is_error.unwrap_or_default());
                 let actual = result
                     .content
-                    .map(|c| {
-                        c.iter()
-                            .map(|c| c.as_text().map(|t| t.text.clone()).unwrap_or_default())
-                            .collect::<Vec<_>>()
-                            .join("\n\n")
-                    })
-                    .unwrap_or_default();
+                    .into_iter()
+                    .map(|c| c.as_text().map(|t| t.text.clone()).unwrap_or_default())
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
 
                 assert_eq!(actual, expected_text);
             }
@@ -358,13 +355,10 @@ mod tests {
                 assert!(!result.is_error.unwrap_or_default());
                 let actual = result
                     .content
-                    .map(|c| {
-                        c.iter()
-                            .map(|c| c.raw.as_text().map(|t| t.text.clone()).unwrap_or_default())
-                            .collect::<Vec<_>>()
-                            .join("\n\n")
-                    })
-                    .unwrap_or_default();
+                    .into_iter()
+                    .map(|c| c.as_text().map(|c| c.text.clone()).unwrap_or_default())
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
                 assert_eq!(actual, expected_text);
             }
             Err(expected_err) => {
@@ -383,7 +377,7 @@ mod tests {
         let server = Server::new().expect("Failed to create server");
         let result = server.available_functions().unwrap();
         assert!(!result.is_error.unwrap_or_default());
-        assert_eq!(result.content.map(|c| c.len()).unwrap_or_default(), 1);
+        assert_eq!(result.content.into_iter().len(), 1);
     }
 
     #[test]
@@ -391,7 +385,7 @@ mod tests {
         let server = Server::new().expect("Failed to create server");
         let result = server.available_selectors().unwrap();
         assert!(!result.is_error.unwrap_or_default());
-        assert_eq!(result.content.map(|c| c.len()).unwrap_or_default(), 1);
+        assert_eq!(result.content.into_iter().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
- Update rmcp dependency to version 0.6.1 in mq-mcp crate
- Fix import path: tool::Parameters -> wrapper::Parameters
- Update content handling to work with new rmcp API
- Simplify iterator patterns in test code