### PR TITLE
✨ feat(repl): add comprehensive syntax highlighting with keywords, commands, and operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "mq-lang",
  "mq-markdown",
  "mq-test",
+ "regex-lite",
  "rstest",
  "rustyline",
  "strum 0.27.2",

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -19,6 +19,7 @@ miette.workspace = true
 mq-hir.workspace = true
 mq-lang.workspace = true
 mq-markdown.workspace = true
+regex-lite = "0.1"
 rustyline = "17.0.1"
 strum = {version = "0.27.2", features = ["derive"]}
 


### PR DESCRIPTION
- Add regex-lite dependency for lightweight pattern matching
- Implement highlight_mq_syntax function with support for:
  - Keywords (def, let, if, else, etc.) in bright blue
  - Commands (/help, /copy, etc.) in bright green
  - Strings in bright green
  - Numbers in bright magenta
  - Operators (=, +, ->, etc.) in bright yellow
- Replace MatchingBracketHighlighter with custom syntax highlighter
- Add comprehensive tests for syntax highlighting functionality
- Improve REPL user experience with visual syntax differentiation