### PR TITLE
✨ feat(cli): add streaming mode for processing large files line by line

### DIFF
--- a/crates/mq-cli/tests/integration_tests.rs
+++ b/crates/mq-cli/tests/integration_tests.rs
@@ -148,6 +148,11 @@ In {year}, the snowfall was above average.
     "ok",
     Some("ok\n")
 )]
+#[case::test_stream(
+    vec!["--unbuffered", "-I", "text", "--stream", ".h"],
+    "# title\n",
+    None
+)]
 fn test_cli_commands(
     #[case] args: Vec<&str>,
     #[case] input: &str,


### PR DESCRIPTION
- Add --stream flag to enable line-by-line processing of large files
- Refactor CLI execution logic to support both batch and streaming modes
- Implement process_streaming() and process_lines() methods for efficient memory usage
- Add integration test for streaming functionality
- Maintain backward compatibility with existing batch processing mode