### PR TITLE
✨ feat(cli): add --xml flag to include built-in XML module

### DIFF
--- a/crates/mq-cli/src/cli.rs
+++ b/crates/mq-cli/src/cli.rs
@@ -141,6 +141,10 @@ struct InputArgs {
     #[arg(long = "toml", default_value_t = false)]
     include_toml: bool,
 
+    /// Include the built-in XML module
+    #[arg(long = "xml", default_value_t = false)]
+    include_xml: bool,
+
     /// Include the built-in test module
     #[arg(long = "test", default_value_t = false)]
     include_test: bool,
@@ -384,6 +388,7 @@ impl Cli {
             ("json", self.input.include_json),
             ("toml", self.input.include_toml),
             ("yaml", self.input.include_yaml),
+            ("xml", self.input.include_xml),
             ("test", self.input.include_test),
         ]
         .iter()

--- a/crates/mq-cli/tests/integration_tests.rs
+++ b/crates/mq-cli/tests/integration_tests.rs
@@ -143,6 +143,25 @@ In {year}, the snowfall was above average.
 "#,
     )
 )]
+#[case::xml_output(
+    vec!["--unbuffered", "-I", "raw", "--xml", "xml_parse() | xml_stringify()"],
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <type>Heading</type>
+    <value>title1</value>
+  </item>
+  <item>
+    <type>Heading</type>
+    <value>title2</value>
+  </item>
+</root>
+"#,
+    Some(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<root><item><type>Heading</type><value>title1</value></item><item><type>Heading</type><value>title2</value></item></root>\n\n",
+    )
+)]
 #[case::test_option_success(
     vec!["--unbuffered", "-I", "text", "--test", "assert(true)"],
     "ok",

--- a/crates/mq-lang/modules/xml.mq
+++ b/crates/mq-lang/modules/xml.mq
@@ -215,8 +215,7 @@ def xml_parse(input):
   | result[0]
 end
 
-# Serializes a value to an XML string.
-def xml_stringify(data):
+def _xml_stringify(data):
   def _format_attributes(attributes):
     if (is_empty(keys(attributes))):
       ""
@@ -242,7 +241,7 @@ def xml_stringify(data):
     else:
       ""
     | let child_content = if (!is_empty(children)):
-          join(map(children, xml_stringify), "")
+          join(map(children, _xml_stringify), "")
         else:
           ""
     | let all_content = content + child_content
@@ -253,6 +252,11 @@ def xml_stringify(data):
       _format_xml_element(data)
     else:
       to_string(data)
+end
+
+# Serializes a value to an XML string.
+def xml_stringify(data):
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + _xml_stringify(data) + "\n"
 end
 
 def _xml_to_markdown_table(data, depth):

--- a/scripts/tests/xml_tests.mq
+++ b/scripts/tests/xml_tests.mq
@@ -10,7 +10,7 @@ include "xml"
 
 | def test_xml_stringify():
     let result = xml_stringify(xml_parse(input))
-    | assert_eq(result, "<users><user id=\"1\"><name>Alice</name><email>alice@example.com</email><roles><role>admin</role><role>user</role></roles></user><user id=\"2\"><name>Bob</name><email>bob@example.com</email><roles><role>user</role></roles></user><user id=\"3\"><name>Charlie</name><email>charlie@example.com</email><roles><role>editor</role><role>user</role></roles></user></users>")
+    | assert_eq(result, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<users><user id=\"1\"><name>Alice</name><email>alice@example.com</email><roles><role>admin</role><role>user</role></roles></user><user id=\"2\"><name>Bob</name><email>bob@example.com</email><roles><role>user</role></roles></user><user id=\"3\"><name>Charlie</name><email>charlie@example.com</email><roles><role>editor</role><role>user</role></roles></user></users>\n")
   end
 
 | def test_xml_to_markdown_table():


### PR DESCRIPTION
Add support for including the XML module in mq CLI with the --xml flag. This enables XML parsing and stringification functionality with proper XML declaration formatting.

- Add --xml CLI argument to InputArgs struct
- Include xml module in module loading logic
- Add integration test for XML parsing and stringification
- Improve xml_stringify to include XML declaration and proper formatting
- Update XML tests to match new output format