### PR TITLE
✨ feat(lang): add read_file builtin function with file-io feature

### DIFF
--- a/crates/mq-cli/Cargo.toml
+++ b/crates/mq-cli/Cargo.toml
@@ -28,7 +28,7 @@ itertools.workspace = true
 miette = {workspace = true, features = ["fancy"]}
 mq-formatter.workspace = true
 mq-hir.workspace = true
-mq-lang.workspace = true
+mq-lang = {workspace = true, features = ["file-io"]}
 mq-lsp.workspace = true
 mq-markdown = {workspace = true, features = ["json", "html-to-markdown"]}
 mq-mcp.workspace = true

--- a/crates/mq-cli/tests/integration_tests.rs
+++ b/crates/mq-cli/tests/integration_tests.rs
@@ -437,3 +437,28 @@ Content of section 3.
 
     Ok(())
 }
+
+#[test]
+fn test_read_file() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = mq_test::create_file("test_read_file.md", "test");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = Command::cargo_bin("mq")?;
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg(format!(
+            r#"read_file("{}")"#,
+            temp_file_path.to_string_lossy(),
+        ))
+        .arg(temp_file_path.to_string_lossy().to_string())
+        .assert();
+
+    assert.success().code(0).stdout("test\n");
+    Ok(())
+}

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -34,6 +34,7 @@ thiserror.workspace = true
 ast-json = ["dep:serde", "dep:serde_json", "smallvec/serde", "compact_str/serde"]
 cst = []
 default = ["std"]
+file-io = []
 std = []
 
 [dev-dependencies]

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -94,7 +94,7 @@ def filter(v, f):
       let fileted = foreach (x, entries(v)): select(x, f(x)); | dict(compact(fileted));
 
   | let _filter = fn(v, f):
-        foreach (x, v): select(x, f(x)); | compact();
+      foreach (x, v): select(x, f(x)); | compact();
 
   | if (is_dict(v)):
       filter_dict(v, f)

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3249,6 +3249,16 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             params: &["heading_node"],
             },
         );
+
+        #[cfg(feature = "file-io")]
+        map.insert(
+            CompactString::new("read_file"),
+            BuiltinFunctionDoc {
+            description: "Reads the contents of a file at the given path and returns it as a string.",
+            params: &["path"],
+            },
+        );
+
         map
     });
 

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2201,6 +2201,24 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
             }),
         );
 
+        #[cfg(feature = "file-io")]
+        map.insert(
+            CompactString::new("read_file"),
+            BuiltinFunction::new(ParamNum::Fixed(1), |ident, _, mut args| {
+                match args.as_mut_slice() {
+                    [RuntimeValue::String(path)] => match std::fs::read_to_string(path) {
+                        Ok(content) => Ok(RuntimeValue::String(content)),
+                        Err(e) => Err(Error::Runtime(format!("Failed to read file: {}", e))),
+                    },
+                    [a] => Err(Error::InvalidTypes(
+                        ident.to_string(),
+                        vec![std::mem::take(a)],
+                    )),
+                    _ => unreachable!(),
+                }
+            }),
+        );
+
         map
     });
 

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2206,9 +2206,9 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
             CompactString::new("read_file"),
             BuiltinFunction::new(ParamNum::Fixed(1), |ident, _, mut args| {
                 match args.as_mut_slice() {
-                    [RuntimeValue::String(path)] => match std::fs::read_to_string(path) {
+                    [RuntimeValue::String(path)] => match std::fs::read_to_string(&path) {
                         Ok(content) => Ok(RuntimeValue::String(content)),
-                        Err(e) => Err(Error::Runtime(format!("Failed to read file: {}", e))),
+                        Err(_) => Err(Error::Runtime(format!("Failed to read file: {}", path))),
                     },
                     [a] => Err(Error::InvalidTypes(
                         ident.to_string(),

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2208,7 +2208,10 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
                 match args.as_mut_slice() {
                     [RuntimeValue::String(path)] => match std::fs::read_to_string(&path) {
                         Ok(content) => Ok(RuntimeValue::String(content)),
-                        Err(_) => Err(Error::Runtime(format!("Failed to read file: {}", path))),
+                        Err(e) => Err(Error::Runtime(format!(
+                            "Failed to read file {}: {}",
+                            path, e
+                        ))),
                     },
                     [a] => Err(Error::InvalidTypes(
                         ident.to_string(),


### PR DESCRIPTION
Add file I/O capability to mq language with a new read_file builtin function that allows reading file contents from the filesystem. The functionality is gated behind a file-io feature flag to keep the core language minimal.

Changes:
- Add read_file builtin function in mq-lang with file-io feature guard
- Enable file-io feature in mq-cli for CLI usage
- Add integration test for read_file functionality
- Fix indentation in builtin.mq filter function