### PR TITLE
✨ feat(lang): add string multiplication support to mul builtin function

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1572,10 +1572,10 @@ mod tests {
        vec![
             ast_call("mul", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("te".to_string()))),
-                    ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
+                    ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
                 ]),
        ],
-       Err(InnerError::Eval(EvalError::RuntimeError(Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()}, "invalid float literal".to_string()))))]
+       Ok(vec![RuntimeValue::String("tete".to_string())]))]
     #[case::mod_(vec![RuntimeValue::String("testString".to_string())],
        vec![
             ast_call("mod", smallvec![

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1425,6 +1425,9 @@ pub static BUILTIN_FUNCTIONS: LazyLock<FxHashMap<CompactString, BuiltinFunction>
             BuiltinFunction::new(ParamNum::Fixed(2), |_, _, mut args| {
                 match args.as_mut_slice() {
                     [RuntimeValue::Number(n1), RuntimeValue::Number(n2)] => Ok((*n1 * *n2).into()),
+                    [RuntimeValue::String(s), RuntimeValue::Number(n)] => {
+                        Ok(s.repeat(n.value() as usize).into())
+                    }
                     [a, b] => match (to_number(a)?, to_number(b)?) {
                         (RuntimeValue::Number(n1), RuntimeValue::Number(n2)) => {
                             Ok((n1 * n2).into())


### PR DESCRIPTION
- Extended mul function to handle string × number operations (e.g., "te" * 2 = "tete")
- Updated test case to verify string multiplication functionality
- Maintains backward compatibility with existing number multiplication