### PR TITLE
📦 build: add debug binary support to release workflow and optimize Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Rename artifact
         run: |
           mv target/${{ matrix.target }}/release/mq${{ matrix.ext }} target/${{ matrix.target }}/release/mq-${{ matrix.asset_name}}${{ matrix.ext }}
+          mv target/${{ matrix.target }}/release/mq-dbg${{ matrix.ext }} target/${{ matrix.target }}/release/mq-dbg-${{ matrix.asset_name}}${{ matrix.ext }}
           mv target/${{ matrix.target }}/release/mq-lsp${{ matrix.ext }} target/${{ matrix.target }}/release/mq-lsp-${{ matrix.asset_name}}${{ matrix.ext }}
           mv target/${{ matrix.target }}/release/mq-mcp${{ matrix.ext }} target/${{ matrix.target }}/release/mq-mcp-${{ matrix.asset_name}}${{ matrix.ext }}
           mv target/${{ matrix.target }}/release/mqcr${{ matrix.ext }} target/${{ matrix.target }}/release/mqcr-${{ matrix.asset_name}}${{ matrix.ext }}
@@ -50,6 +51,7 @@ jobs:
           name: mq-${{ matrix.asset_name }}
           path: |
             target/${{ matrix.target }}/release/mq-${{ matrix.asset_name}}${{ matrix.ext }}
+            target/${{ matrix.target }}/release/mq-dbg-${{ matrix.asset_name}}${{ matrix.ext }}
             target/${{ matrix.target }}/release/mq-lsp-${{ matrix.asset_name }}${{ matrix.ext }}
             target/${{ matrix.target }}/release/mq-mcp-${{ matrix.asset_name }}${{ matrix.ext }}
             target/${{ matrix.target }}/release/mqcr-${{ matrix.asset_name }}${{ matrix.ext }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM rust:1.85-slim AS builder
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 
-RUN cargo build -p mq-cli --release
+RUN cargo build -p mq-cli --bin mq --release
 
 FROM gcr.io/distroless/cc:nonroot
 
 COPY --from=builder --chown=nonroot:nonroot /usr/src/app/target/release/mq /usr/local/bin/mq
 
-CMD ["mq"]
+ENTRYPOINT [ "mq" ]


### PR DESCRIPTION
- Include mq-dbg binary in GitHub release artifacts for debugging support
- Optimize Dockerfile to build only the mq binary specifically
- Change Docker CMD to ENTRYPOINT for better container usage