### PR TITLE
♻️ refactor: migrate from CompactString to SmolStr for better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,21 +720,6 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
  "static_assertions",
 ]
 
@@ -2563,12 +2557,12 @@ dependencies = [
 name = "mq-hir"
 version = "0.2.22"
 dependencies = [
- "compact_str 0.9.0",
  "itertools 0.14.0",
  "mq-lang",
  "rstest",
  "rustc-hash",
  "slotmap",
+ "smol_str",
  "strsim",
  "thiserror 2.0.16",
  "url",
@@ -2581,7 +2575,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "codspeed-divan-compat",
- "compact_str 0.9.0",
  "dirs",
  "itertools 0.14.0",
  "miette",
@@ -2596,6 +2589,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "smol_str",
  "thiserror 2.0.16",
 ]
 
@@ -2641,7 +2635,6 @@ dependencies = [
 name = "mq-markdown"
 version = "0.2.22"
 dependencies = [
- "compact_str 0.9.0",
  "ego-tree",
  "itertools 0.14.0",
  "markdown",
@@ -2652,6 +2645,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "smol_str",
 ]
 
 [[package]]
@@ -3443,7 +3437,7 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.9.1",
  "cassowary",
- "compact_str 0.8.1",
+ "compact_str",
  "crossterm 0.28.1",
  "indoc",
  "instability",
@@ -4133,6 +4127,16 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ resolver = "3"
 arboard = "3.6.1"
 clap = {version = "4.5.47", features = ["derive"]}
 colored = "3.0.0"
-compact_str = "0.9.0"
 dirs = "6.0.0"
 itertools = "0.14.0"
 miette = {version = "7.6.0"}
@@ -42,6 +41,7 @@ rstest = "0.26.1"
 rustc-hash = "2.1.1"
 serde = "1.0"
 serde_json = "1.0"
+smol_str = "0.3.2"
 thiserror = "2.0.16"
 url = "2.5.7"
 

--- a/crates/mq-hir/Cargo.toml
+++ b/crates/mq-hir/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/harehare/mq"
 version = "0.2.22"
 
 [dependencies]
-compact_str.workspace = true
 itertools.workspace = true
 mq-lang = {workspace = true, features = ["cst"]}
 rustc-hash.workspace = true
 slotmap = "1.0.7"
+smol_str.workspace = true
 strsim = "0.11.1"
 thiserror.workspace = true
 url.workspace = true

--- a/crates/mq-hir/src/builtin.rs
+++ b/crates/mq-hir/src/builtin.rs
@@ -1,14 +1,14 @@
-use compact_str::CompactString;
 use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
 
 use crate::{scope::ScopeId, source::SourceId};
 
 #[derive(Debug, Default)]
 pub struct Builtin {
     pub disabled: bool,
-    pub functions: FxHashMap<CompactString, mq_lang::BuiltinFunctionDoc>,
-    pub internal_functions: FxHashMap<CompactString, mq_lang::BuiltinFunctionDoc>,
-    pub selectors: FxHashMap<CompactString, mq_lang::BuiltinSelectorDoc>,
+    pub functions: FxHashMap<SmolStr, mq_lang::BuiltinFunctionDoc>,
+    pub internal_functions: FxHashMap<SmolStr, mq_lang::BuiltinFunctionDoc>,
+    pub selectors: FxHashMap<SmolStr, mq_lang::BuiltinSelectorDoc>,
     pub source_id: SourceId,
     pub scope_id: ScopeId,
     pub loaded: bool,

--- a/crates/mq-hir/src/error.rs
+++ b/crates/mq-hir/src/error.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactString;
+use smol_str::SmolStr;
 use thiserror::Error;
 
 use crate::{Hir, Symbol, SymbolKind};
@@ -14,12 +14,12 @@ pub enum HirError {
     )]
     UnresolvedSymbol {
         symbol: Symbol,
-        similar_name: Option<Vec<CompactString>>,
+        similar_name: Option<Vec<SmolStr>>,
     },
     #[error("Included module not found: {module_name}")]
     ModuleNotFound {
         symbol: Symbol,
-        module_name: CompactString,
+        module_name: SmolStr,
     },
 }
 
@@ -49,7 +49,7 @@ impl Hir {
                     let module_name = symbol
                         .clone()
                         .value
-                        .unwrap_or(CompactString::new("unknown"))
+                        .unwrap_or(SmolStr::new("unknown"))
                         .clone();
                     match self.module_loader.read_file(&module_name) {
                         Ok(_) => None,
@@ -145,8 +145,8 @@ impl Hir {
             .collect::<Vec<_>>()
     }
 
-    fn find_similar_names(&self, target: &str) -> Option<Vec<CompactString>> {
-        let similar_names: Vec<CompactString> = self
+    fn find_similar_names(&self, target: &str) -> Option<Vec<SmolStr>> {
+        let similar_names: Vec<SmolStr> = self
             .symbols
             .iter()
             .filter_map(|(_, symbol)| {

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use compact_str::CompactString;
 use mq_lang::{Token, TokenKind};
 use rustc_hash::FxHashMap;
 use slotmap::SlotMap;
+use smol_str::SmolStr;
 use url::Url;
 
 use crate::{
@@ -185,7 +185,7 @@ impl Hir {
                     mq_lang::BUILTIN_FUNCTION_DOC[name]
                         .params
                         .iter()
-                        .map(|p| CompactString::new(p))
+                        .map(SmolStr::new)
                         .collect::<Vec<_>>(),
                 ),
                 source: SourceInfo::new(Some(self.builtin.source_id), None),
@@ -209,7 +209,7 @@ impl Hir {
                         mq_lang::INTERNAL_FUNCTION_DOC[name]
                             .params
                             .iter()
-                            .map(|p| CompactString::new(p))
+                            .map(SmolStr::new)
                             .collect::<Vec<_>>(),
                     ),
                     source: SourceInfo::new(Some(self.builtin.source_id), None),

--- a/crates/mq-hir/src/resolve.rs
+++ b/crates/mq-hir/src/resolve.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactString;
+use smol_str::SmolStr;
 
 use crate::{Hir, ScopeId, SourceId, Symbol, SymbolId, SymbolKind};
 
@@ -62,7 +62,7 @@ impl Hir {
     fn resolve_ref_symbol_of_source(
         &self,
         source_ids: Vec<SourceId>,
-        ref_name: &CompactString,
+        ref_name: &SmolStr,
     ) -> Option<(SymbolId, Symbol)> {
         let mut candidates = Vec::new();
 
@@ -102,7 +102,7 @@ impl Hir {
     fn resolve_ref_symbol_of_scope(
         &self,
         scope_id: ScopeId,
-        ref_name: &CompactString,
+        ref_name: &SmolStr,
         ref_symbol_id: SymbolId,
     ) -> Option<(SymbolId, Symbol)> {
         // Find all matching symbols in current scope with priority order

--- a/crates/mq-hir/src/symbol.rs
+++ b/crates/mq-hir/src/symbol.rs
@@ -2,19 +2,19 @@ use std::fmt;
 
 use crate::source::SourceInfo;
 use crate::{SourceId, scope::ScopeId};
-use compact_str::CompactString;
 use itertools::Itertools;
+use smol_str::SmolStr;
 
 slotmap::new_key_type! { pub struct SymbolId; }
 
-type Params = Vec<CompactString>;
+type Params = Vec<SmolStr>;
 pub type Doc = (mq_lang::Range, String);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Symbol {
     pub doc: Vec<Doc>,
     pub kind: SymbolKind,
-    pub value: Option<CompactString>,
+    pub value: Option<SmolStr>,
     pub scope: ScopeId,
     pub source: SourceInfo,
     pub parent: Option<SymbolId>,
@@ -99,7 +99,7 @@ mod tests {
         Symbol {
             doc: Vec::new(),
             kind,
-            value: value.map(CompactString::from),
+            value: value.map(SmolStr::from),
             scope: ScopeId::default(),
             source: SourceInfo::new(None, None),
             parent: None,
@@ -108,7 +108,7 @@ mod tests {
 
     #[rstest]
     #[case(SymbolKind::Function(Vec::new()), true)]
-    #[case(SymbolKind::Function(vec![CompactString::from("param")]), true)]
+    #[case(SymbolKind::Function(vec![SmolStr::from("param")]), true)]
     #[case(SymbolKind::Variable, false)]
     #[case(SymbolKind::Call, false)]
     fn test_is_function(#[case] kind: SymbolKind, #[case] expected: bool) {

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -15,7 +15,6 @@ version = "0.2.22"
 [dependencies]
 base64 = "0.22.1"
 chrono = "0.4.42"
-compact_str.workspace = true
 dirs.workspace = true
 itertools.workspace = true
 miette.workspace = true
@@ -28,10 +27,11 @@ rustc-hash.workspace = true
 serde = {workspace = true, features = ["derive", "rc"], optional = true}
 serde_json = {workspace = true, optional = true}
 smallvec = "1.15.1"
+smol_str.workspace = true
 thiserror.workspace = true
 
 [features]
-ast-json = ["dep:serde", "dep:serde_json", "smallvec/serde", "compact_str/serde"]
+ast-json = ["dep:serde", "dep:serde_json", "smallvec/serde", "smol_str/serde"]
 cst = []
 debugger = []
 default = ["std"]

--- a/crates/mq-lang/src/ast.rs
+++ b/crates/mq-lang/src/ast.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
-use compact_str::CompactString;
 use node::Node;
+use smol_str::SmolStr;
 
 use crate::{Token, arena::ArenaId};
 
@@ -11,7 +11,7 @@ pub mod node;
 pub mod parser;
 
 pub type Program = Vec<Rc<Node>>;
-pub type IdentName = CompactString;
+pub type IdentName = SmolStr;
 pub type TokenId = ArenaId<Rc<Token>>;
 
 /// Serializes an AST `Program` to a JSON string.

--- a/crates/mq-lang/src/ast/error.rs
+++ b/crates/mq-lang/src/ast/error.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactString;
+use smol_str::SmolStr;
 use thiserror::Error;
 
 use crate::{Token, eval::module::ModuleId};
@@ -6,7 +6,7 @@ use crate::{Token, eval::module::ModuleId};
 #[derive(Error, Debug, PartialEq)]
 pub enum ParseError {
     #[error("Not found env `{1}`")]
-    EnvNotFound(Token, CompactString),
+    EnvNotFound(Token, SmolStr),
     #[error("Unexpected token `{}`", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     UnexpectedToken(Token),
     #[error("Unexpected EOF detected")]

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -2,10 +2,10 @@ use super::{IdentName, Program, TokenId};
 #[cfg(feature = "ast-json")]
 use crate::arena::ArenaId;
 use crate::{Token, arena::Arena, lexer, number::Number, range::Range};
-use compact_str::CompactString;
 #[cfg(feature = "ast-json")]
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use smol_str::SmolStr;
 use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
@@ -14,7 +14,7 @@ use std::{
 
 type Depth = u8;
 type Index = usize;
-type Lang = CompactString;
+type Lang = SmolStr;
 pub type Params = SmallVec<[Rc<Node>; 4]>;
 pub type Args = SmallVec<[Rc<Node>; 4]>;
 pub type Cond = (Option<Rc<Node>>, Rc<Node>);
@@ -143,7 +143,7 @@ impl Ident {
 
     pub fn new_with_token(name: &str, token: Option<Rc<Token>>) -> Self {
         Self {
-            name: CompactString::from(name),
+            name: SmolStr::from(name),
             token,
         }
     }
@@ -194,7 +194,7 @@ pub enum Selector {
 pub enum StringSegment {
     Text(String),
     Ident(Ident),
-    Env(CompactString),
+    Env(SmolStr),
     Self_,
 }
 
@@ -204,7 +204,7 @@ impl From<&lexer::token::StringSegment> for StringSegment {
             lexer::token::StringSegment::Text(text, _) => StringSegment::Text(text.to_owned()),
             lexer::token::StringSegment::Ident(ident, _) if ident == "self" => StringSegment::Self_,
             lexer::token::StringSegment::Ident(ident, _) if ident.starts_with("$") => {
-                StringSegment::Env(CompactString::from(&ident[1..]))
+                StringSegment::Env(SmolStr::from(&ident[1..]))
             }
             lexer::token::StringSegment::Ident(ident, _) => StringSegment::Ident(Ident::new(ident)),
         }

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use compact_str::CompactString;
+use smol_str::SmolStr;
 
 use crate::TokenKind;
 use crate::{Range, Token};
@@ -169,7 +169,7 @@ impl Node {
         }
     }
 
-    pub fn name(&self) -> Option<CompactString> {
+    pub fn name(&self) -> Option<SmolStr> {
         self.token.as_ref().map(|token| token.to_string().into())
     }
 

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -1730,9 +1730,7 @@ impl<'a> Parser<'a> {
         let tokens = &mut self.tokens.clone();
         Self::try_parse_leading_trivia(tokens);
 
-        let token = tokens
-            .peek()
-            .ok_or_else(|| ParseError::UnexpectedEOFDetected);
+        let token = tokens.peek().ok_or(ParseError::UnexpectedEOFDetected);
 
         if token.is_err() {
             return false;
@@ -1788,7 +1786,7 @@ impl<'a> Parser<'a> {
             .tokens
             .peek()
             .cloned()
-            .ok_or_else(|| ParseError::UnexpectedEOFDetected)?;
+            .ok_or(ParseError::UnexpectedEOFDetected)?;
 
         if match_token_kind(&token.kind) {
             self.tokens.next();

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3,11 +3,11 @@ use crate::ast::{constants, node as ast};
 use crate::number::Number;
 use crate::{AstIdentName, Token};
 use base64::prelude::*;
-use compact_str::CompactString;
 use itertools::Itertools;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use regex_lite::{Regex, RegexBuilder};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::process::exit;
@@ -2406,12 +2406,12 @@ pub struct BuiltinSelectorDoc {
     pub params: &'static [&'static str],
 }
 
-pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelectorDoc>> =
+pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<SmolStr, BuiltinSelectorDoc>> =
     LazyLock::new(|| {
         let mut map = FxHashMap::with_capacity_and_hasher(100, FxBuildHasher);
 
         map.insert(
-            CompactString::new(".h"),
+            SmolStr::new(".h"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the specified depth.",
                 params: &["depth"],
@@ -2419,7 +2419,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".text"),
+            SmolStr::new(".text"),
             BuiltinSelectorDoc {
                 description: "Selects a text node.",
                 params: &[],
@@ -2427,7 +2427,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h1"),
+            SmolStr::new(".h1"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 1 depth.",
                 params: &[],
@@ -2435,7 +2435,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h2"),
+            SmolStr::new(".h2"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 2 depth.",
                 params: &[],
@@ -2443,7 +2443,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h3"),
+            SmolStr::new(".h3"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 3 depth.",
                 params: &[],
@@ -2451,7 +2451,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h4"),
+            SmolStr::new(".h4"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 4 depth.",
                 params: &[],
@@ -2459,7 +2459,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h5"),
+            SmolStr::new(".h5"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 5 depth.",
                 params: &[],
@@ -2467,7 +2467,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".h6"),
+            SmolStr::new(".h6"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the 6 depth.",
                 params: &[],
@@ -2475,7 +2475,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".code"),
+            SmolStr::new(".code"),
             BuiltinSelectorDoc {
                 description: "Selects a code block node with the specified language.",
                 params: &["lang"],
@@ -2483,7 +2483,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".code_inline"),
+            SmolStr::new(".code_inline"),
             BuiltinSelectorDoc {
                 description: "Selects an inline code node.",
                 params: &[],
@@ -2491,7 +2491,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".inline_math"),
+            SmolStr::new(".inline_math"),
             BuiltinSelectorDoc {
                 description: "Selects an inline math node.",
                 params: &[],
@@ -2499,7 +2499,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".strong"),
+            SmolStr::new(".strong"),
             BuiltinSelectorDoc {
                 description: "Selects a strong (bold) node.",
                 params: &[],
@@ -2507,7 +2507,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".emphasis"),
+            SmolStr::new(".emphasis"),
             BuiltinSelectorDoc {
                 description: "Selects an emphasis (italic) node.",
                 params: &[],
@@ -2515,7 +2515,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".delete"),
+            SmolStr::new(".delete"),
             BuiltinSelectorDoc {
                 description: "Selects a delete (strikethrough) node.",
                 params: &[],
@@ -2523,7 +2523,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".link"),
+            SmolStr::new(".link"),
             BuiltinSelectorDoc {
                 description: "Selects a link node.",
                 params: &[],
@@ -2531,7 +2531,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".link_ref"),
+            SmolStr::new(".link_ref"),
             BuiltinSelectorDoc {
                 description: "Selects a link reference node.",
                 params: &[],
@@ -2539,7 +2539,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".image"),
+            SmolStr::new(".image"),
             BuiltinSelectorDoc {
                 description: "Selects an image node.",
                 params: &[],
@@ -2547,7 +2547,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".heading"),
+            SmolStr::new(".heading"),
             BuiltinSelectorDoc {
                 description: "Selects a heading node with the specified depth.",
                 params: &[],
@@ -2555,7 +2555,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".horizontal_rule"),
+            SmolStr::new(".horizontal_rule"),
             BuiltinSelectorDoc {
                 description: "Selects a horizontal rule node.",
                 params: &[],
@@ -2563,7 +2563,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".blockquote"),
+            SmolStr::new(".blockquote"),
             BuiltinSelectorDoc {
                 description: "Selects a blockquote node.",
                 params: &[],
@@ -2571,7 +2571,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".[][]"),
+            SmolStr::new(".[][]"),
             BuiltinSelectorDoc {
                 description: "Selects a table cell node with the specified row and column.",
                 params: &["row", "column"],
@@ -2579,7 +2579,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".html"),
+            SmolStr::new(".html"),
             BuiltinSelectorDoc {
                 description: "Selects an HTML node.",
                 params: &[],
@@ -2587,7 +2587,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".<>"),
+            SmolStr::new(".<>"),
             BuiltinSelectorDoc {
                 description: "Selects an HTML node.",
                 params: &[],
@@ -2595,7 +2595,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".footnote"),
+            SmolStr::new(".footnote"),
             BuiltinSelectorDoc {
                 description: "Selects a footnote node.",
                 params: &[],
@@ -2603,7 +2603,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".mdx_jsx_flow_element"),
+            SmolStr::new(".mdx_jsx_flow_element"),
             BuiltinSelectorDoc {
                 description: "Selects an MDX JSX flow element node.",
                 params: &[],
@@ -2611,7 +2611,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".list"),
+            SmolStr::new(".list"),
             BuiltinSelectorDoc {
                 description: "Selects a list node with the specified index and checked state.",
                 params: &["indent", "checked"],
@@ -2619,7 +2619,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".mdx_js_esm"),
+            SmolStr::new(".mdx_js_esm"),
             BuiltinSelectorDoc {
                 description: "Selects an MDX JS ESM node.",
                 params: &[],
@@ -2627,7 +2627,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".toml"),
+            SmolStr::new(".toml"),
             BuiltinSelectorDoc {
                 description: "Selects a TOML node.",
                 params: &[],
@@ -2635,7 +2635,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".yaml"),
+            SmolStr::new(".yaml"),
             BuiltinSelectorDoc {
                 description: "Selects a YAML node.",
                 params: &[],
@@ -2643,7 +2643,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".break"),
+            SmolStr::new(".break"),
             BuiltinSelectorDoc {
                 description: "Selects a break node.",
                 params: &[],
@@ -2651,7 +2651,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".mdx_text_expression"),
+            SmolStr::new(".mdx_text_expression"),
             BuiltinSelectorDoc {
                 description: "Selects an MDX text expression node.",
                 params: &[],
@@ -2659,7 +2659,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".footnote_ref"),
+            SmolStr::new(".footnote_ref"),
             BuiltinSelectorDoc {
                 description: "Selects a footnote reference node.",
                 params: &[],
@@ -2667,7 +2667,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".image_ref"),
+            SmolStr::new(".image_ref"),
             BuiltinSelectorDoc {
                 description: "Selects an image reference node.",
                 params: &[],
@@ -2675,7 +2675,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".mdx_jsx_text_element"),
+            SmolStr::new(".mdx_jsx_text_element"),
             BuiltinSelectorDoc {
                 description: "Selects an MDX JSX text element node.",
                 params: &[],
@@ -2683,7 +2683,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".math"),
+            SmolStr::new(".math"),
             BuiltinSelectorDoc {
                 description: "Selects a math node.",
                 params: &[],
@@ -2691,7 +2691,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".math_inline"),
+            SmolStr::new(".math_inline"),
             BuiltinSelectorDoc {
                 description: "Selects a math inline node.",
                 params: &[],
@@ -2699,7 +2699,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".mdx_flow_expression"),
+            SmolStr::new(".mdx_flow_expression"),
             BuiltinSelectorDoc {
                 description: "Selects an MDX flow expression node.",
                 params: &[],
@@ -2707,7 +2707,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         );
 
         map.insert(
-            CompactString::new(".definition"),
+            SmolStr::new(".definition"),
             BuiltinSelectorDoc {
                 description: "Selects a definition node.",
                 params: &[],
@@ -2717,12 +2717,12 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<CompactString, BuiltinSelect
         map
     });
 
-pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFunctionDoc>> =
-    LazyLock::new(|| {
+pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>> = LazyLock::new(
+    || {
         let mut map = FxHashMap::default();
 
         map.insert(
-            CompactString::new("_sort_by_impl"),
+            SmolStr::new("_sort_by_impl"),
             BuiltinFunctionDoc{
                 description: "Internal implementation of sort_by functionality that sorts arrays of arrays using the first element as the key.",
                 params: &[],
@@ -2730,7 +2730,8 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFunct
         );
 
         map
-    });
+    },
+);
 
 #[derive(Clone, Debug)]
 pub struct BuiltinFunctionDoc {
@@ -2738,285 +2739,285 @@ pub struct BuiltinFunctionDoc {
     pub params: &'static [&'static str],
 }
 
-pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFunctionDoc>> =
-    LazyLock::new(|| {
+pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>> = LazyLock::new(
+    || {
         let mut map = FxHashMap::with_capacity_and_hasher(100, FxBuildHasher);
 
         map.insert(
-            CompactString::new("halt"),
+            SmolStr::new("halt"),
             BuiltinFunctionDoc {
                 description: "Terminates the program with the given exit code.",
                 params: &["exit_code"],
             },
         );
         map.insert(
-            CompactString::new("error"),
+            SmolStr::new("error"),
             BuiltinFunctionDoc {
                 description: "Raises a user-defined error with the specified message.",
                 params: &["message"],
             },
         );
         map.insert(
-            CompactString::new("assert"),
+            SmolStr::new("assert"),
             BuiltinFunctionDoc {
             description: "Asserts that two values are equal, returns the value if true, otherwise raises an error.",
             params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new("print"),
+            SmolStr::new("print"),
             BuiltinFunctionDoc {
                 description: "Prints a message to standard output and returns the current value.",
                 params: &["message"],
             },
         );
         map.insert(
-            CompactString::new("stderr"),
+            SmolStr::new("stderr"),
             BuiltinFunctionDoc {
                 description: "Prints a message to standard error and returns the current value.",
                 params: &["message"],
             },
         );
         map.insert(
-            CompactString::new("type"),
+            SmolStr::new("type"),
             BuiltinFunctionDoc {
                 description: "Returns the type of the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new(constants::ARRAY),
+            SmolStr::new(constants::ARRAY),
             BuiltinFunctionDoc {
                 description: "Creates an array from the given values.",
                 params: &["values"],
             },
         );
         map.insert(
-            CompactString::new("flatten"),
+            SmolStr::new("flatten"),
             BuiltinFunctionDoc {
                 description: "Flattens a nested array into a single level array.",
                 params: &["array"],
             },
         );
         map.insert(
-            CompactString::new("from_date"),
+            SmolStr::new("from_date"),
             BuiltinFunctionDoc {
                 description: "Converts a date string to a timestamp.",
                 params: &["date_str"],
             },
         );
         map.insert(
-            CompactString::new("to_date"),
+            SmolStr::new("to_date"),
             BuiltinFunctionDoc {
                 description: "Converts a timestamp to a date string with the given format.",
                 params: &["timestamp", "format"],
             },
         );
         map.insert(
-            CompactString::new("now"),
+            SmolStr::new("now"),
             BuiltinFunctionDoc {
                 description: "Returns the current timestamp.",
                 params: &[],
             },
         );
         map.insert(
-            CompactString::new("base64"),
+            SmolStr::new("base64"),
             BuiltinFunctionDoc {
                 description: "Encodes the given string to base64.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new("base64d"),
+            SmolStr::new("base64d"),
             BuiltinFunctionDoc {
                 description: "Decodes the given base64 string.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new("min"),
+            SmolStr::new("min"),
             BuiltinFunctionDoc {
                 description: "Returns the minimum of two values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new("max"),
+            SmolStr::new("max"),
             BuiltinFunctionDoc {
                 description: "Returns the maximum of two values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new("to_html"),
+            SmolStr::new("to_html"),
             BuiltinFunctionDoc {
                 description: "Converts the given markdown string to HTML.",
                 params: &["markdown"],
             },
         );
         map.insert(
-            CompactString::new("to_string"),
+            SmolStr::new("to_string"),
             BuiltinFunctionDoc {
                 description: "Converts the given value to a string.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_markdown_string"),
+            SmolStr::new("to_markdown_string"),
             BuiltinFunctionDoc {
                 description: "Converts the given value(s) to a markdown string representation.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_number"),
+            SmolStr::new("to_number"),
             BuiltinFunctionDoc {
                 description: "Converts the given value to a number.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_array"),
+            SmolStr::new("to_array"),
             BuiltinFunctionDoc {
                 description: "Converts the given value to an array.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("url_encode"),
+            SmolStr::new("url_encode"),
             BuiltinFunctionDoc {
                 description: "URL-encodes the given string.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new("to_text"),
+            SmolStr::new("to_text"),
             BuiltinFunctionDoc {
                 description: "Converts the given markdown node to plain text.",
                 params: &["markdown"],
             },
         );
         map.insert(
-            CompactString::new("ends_with"),
+            SmolStr::new("ends_with"),
             BuiltinFunctionDoc {
                 description: "Checks if the given string ends with the specified substring.",
                 params: &["string", "substring"],
             },
         );
         map.insert(
-            CompactString::new("starts_with"),
+            SmolStr::new("starts_with"),
             BuiltinFunctionDoc {
                 description: "Checks if the given string starts with the specified substring.",
                 params: &["string", "substring"],
             },
         );
         map.insert(
-            CompactString::new("match"),
+            SmolStr::new("match"),
             BuiltinFunctionDoc {
                 description: "Finds all matches of the given pattern in the string.",
                 params: &["string", "pattern"],
             },
         );
         map.insert(
-            CompactString::new("downcase"),
+            SmolStr::new("downcase"),
             BuiltinFunctionDoc {
                 description: "Converts the given string to lowercase.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new("gsub"),
+            SmolStr::new("gsub"),
             BuiltinFunctionDoc {
                 description: "Replaces all occurrences matching a regular expression pattern with the replacement string.",
                 params: &["from","pattern",  "to"],
             },
         );
         map.insert(
-            CompactString::new("replace"),
+            SmolStr::new("replace"),
             BuiltinFunctionDoc {
                 description: "Replaces all occurrences of a substring with another substring.",
                 params: &["from", "pattern", "to"],
             },
         );
         map.insert(
-            CompactString::new("repeat"),
+            SmolStr::new("repeat"),
             BuiltinFunctionDoc {
                 description: "Repeats the given string a specified number of times.",
                 params: &["string", "count"],
             },
         );
         map.insert(
-            CompactString::new("explode"),
+            SmolStr::new("explode"),
             BuiltinFunctionDoc {
                 description: "Splits the given string into an array of characters.",
                 params: &["string"],
             },
         );
         map.insert(
-            CompactString::new("implode"),
+            SmolStr::new("implode"),
             BuiltinFunctionDoc {
                 description: "Joins an array of characters into a string.",
                 params: &["array"],
             },
         );
         map.insert(
-            CompactString::new("trim"),
+            SmolStr::new("trim"),
             BuiltinFunctionDoc {
                 description: "Trims whitespace from both ends of the given string.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new("upcase"),
+            SmolStr::new("upcase"),
             BuiltinFunctionDoc {
                 description: "Converts the given string to uppercase.",
                 params: &["input"],
             },
         );
         map.insert(
-            CompactString::new(constants::SLICE),
+            SmolStr::new(constants::SLICE),
             BuiltinFunctionDoc {
                 description: "Extracts a substring from the given string.",
                 params: &["string", "start", "end"],
             },
         );
         map.insert(
-            CompactString::new("update"),
+            SmolStr::new("update"),
             BuiltinFunctionDoc {
                 description: "Update the value with specified value.",
                 params: &["target_value", "source_value"],
             },
         );
         map.insert(
-            CompactString::new("pow"),
+            SmolStr::new("pow"),
             BuiltinFunctionDoc {
                 description: "Raises the base to the power of the exponent.",
                 params: &["base", "exponent"],
             },
         );
         map.insert(
-            CompactString::new("index"),
+            SmolStr::new("index"),
             BuiltinFunctionDoc {
                 description: "Finds the first occurrence of a substring in the given string.",
                 params: &["string", "substring"],
             },
         );
         map.insert(
-            CompactString::new("len"),
+            SmolStr::new("len"),
             BuiltinFunctionDoc {
                 description: "Returns the length of the given string or array.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("rindex"),
+            SmolStr::new("rindex"),
             BuiltinFunctionDoc {
                 description: "Finds the last occurrence of a substring in the given string.",
                 params: &["string", "substring"],
             },
         );
         map.insert(
-            CompactString::new("join"),
+            SmolStr::new("join"),
             BuiltinFunctionDoc {
                 description:
                     "Joins the elements of an array into a string with the given separator.",
@@ -3024,63 +3025,63 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             },
         );
         map.insert(
-            CompactString::new("reverse"),
+            SmolStr::new("reverse"),
             BuiltinFunctionDoc {
                 description: "Reverses the given string or array.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("sort"),
+            SmolStr::new("sort"),
             BuiltinFunctionDoc {
                 description: "Sorts the elements of the given array.",
                 params: &["array"],
             },
         );
         map.insert(
-            CompactString::new("compact"),
+            SmolStr::new("compact"),
             BuiltinFunctionDoc {
                 description: "Removes None values from the given array.",
                 params: &["array"],
             },
         );
         map.insert(
-            CompactString::new("split"),
+            SmolStr::new("split"),
             BuiltinFunctionDoc {
                 description: "Splits the given string by the specified separator.",
                 params: &["string", "separator"],
             },
         );
         map.insert(
-            CompactString::new("uniq"),
+            SmolStr::new("uniq"),
             BuiltinFunctionDoc {
                 description: "Removes duplicate elements from the given array.",
                 params: &["array"],
             },
         );
         map.insert(
-            CompactString::new(constants::EQ),
+            SmolStr::new(constants::EQ),
             BuiltinFunctionDoc {
                 description: "Checks if two values are equal.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::NE),
+            SmolStr::new(constants::NE),
             BuiltinFunctionDoc {
                 description: "Checks if two values are not equal.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::GT),
+            SmolStr::new(constants::GT),
             BuiltinFunctionDoc {
                 description: "Checks if the first value is greater than the second value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::GTE),
+            SmolStr::new(constants::GTE),
             BuiltinFunctionDoc {
                 description:
                     "Checks if the first value is greater than or equal to the second value.",
@@ -3088,70 +3089,70 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             },
         );
         map.insert(
-            CompactString::new(constants::LT),
+            SmolStr::new(constants::LT),
             BuiltinFunctionDoc {
                 description: "Checks if the first value is less than the second value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::LTE),
+            SmolStr::new(constants::LTE),
             BuiltinFunctionDoc {
                 description: "Checks if the first value is less than or equal to the second value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::ADD),
+            SmolStr::new(constants::ADD),
             BuiltinFunctionDoc {
                 description: "Adds two values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::SUB),
+            SmolStr::new(constants::SUB),
             BuiltinFunctionDoc {
                 description: "Subtracts the second value from the first value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::DIV),
+            SmolStr::new(constants::DIV),
             BuiltinFunctionDoc {
                 description: "Divides the first value by the second value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::MUL),
+            SmolStr::new(constants::MUL),
             BuiltinFunctionDoc {
                 description: "Multiplies two values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::MOD),
+            SmolStr::new(constants::MOD),
             BuiltinFunctionDoc {
                 description: "Calculates the remainder of the division of the first value by the second value.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::AND),
+            SmolStr::new(constants::AND),
             BuiltinFunctionDoc {
                 description: "Performs a logical AND operation on two boolean values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::OR),
+            SmolStr::new(constants::OR),
             BuiltinFunctionDoc {
                 description: "Performs a logical OR operation on two boolean values.",
                 params: &["value1", "value2"],
             },
         );
         map.insert(
-            CompactString::new(constants::NOT),
+            SmolStr::new(constants::NOT),
             BuiltinFunctionDoc {
                 description: "Performs a logical NOT operation on a boolean value.",
                 params: &["value"],
@@ -3159,14 +3160,14 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
         );
 
         map.insert(
-            CompactString::new("round"),
+            SmolStr::new("round"),
             BuiltinFunctionDoc {
                 description: "Rounds the given number to the nearest integer.",
                 params: &["number"],
             },
         );
         map.insert(
-            CompactString::new("trunc"),
+            SmolStr::new("trunc"),
             BuiltinFunctionDoc {
                 description:
                     "Truncates the given number to an integer by removing the fractional part.",
@@ -3174,70 +3175,70 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             },
         );
         map.insert(
-            CompactString::new("ceil"),
+            SmolStr::new("ceil"),
             BuiltinFunctionDoc {
                 description: "Rounds the given number up to the nearest integer.",
                 params: &["number"],
             },
         );
         map.insert(
-            CompactString::new("floor"),
+            SmolStr::new("floor"),
             BuiltinFunctionDoc {
                 description: "Rounds the given number down to the nearest integer.",
                 params: &["number"],
             },
         );
         map.insert(
-            CompactString::new("del"),
+            SmolStr::new("del"),
             BuiltinFunctionDoc {
                 description: "Deletes the element at the specified index in the array or string.",
                 params: &["array_or_string", "index"],
             },
         );
         map.insert(
-            CompactString::new("abs"),
+            SmolStr::new("abs"),
             BuiltinFunctionDoc {
                 description: "Returns the absolute value of the given number.",
                 params: &["number"],
             },
         );
         map.insert(
-            CompactString::new(constants::ATTR),
+            SmolStr::new(constants::ATTR),
             BuiltinFunctionDoc {
                 description: "Retrieves the value of the specified attribute from a markdown node.",
                 params: &["markdown", "attribute"],
             },
         );
         map.insert(
-            CompactString::new("set_attr"),
+            SmolStr::new("set_attr"),
             BuiltinFunctionDoc {
                 description: "Sets the value of the specified attribute on a markdown node.",
                 params: &["markdown", "attribute", "value"],
             },
         );
         map.insert(
-            CompactString::new("to_md_name"),
+            SmolStr::new("to_md_name"),
             BuiltinFunctionDoc {
                 description: "Returns the name of the given markdown node.",
                 params: &["markdown"],
             },
         );
         map.insert(
-            CompactString::new("set_list_ordered"),
+            SmolStr::new("set_list_ordered"),
             BuiltinFunctionDoc {
                 description: "Sets the ordered property of a markdown list node.",
                 params: &["list", "ordered"],
             },
         );
         map.insert(
-            CompactString::new("to_md_text"),
+            SmolStr::new("to_md_text"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown text node with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_image"),
+            SmolStr::new("to_image"),
             BuiltinFunctionDoc {
                 description:
                     "Creates a markdown image node with the given URL, alt text, and title.",
@@ -3245,175 +3246,175 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             },
         );
         map.insert(
-            CompactString::new("to_code"),
+            SmolStr::new("to_code"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown code block with the given value and language.",
                 params: &["value", "language"],
             },
         );
         map.insert(
-            CompactString::new("to_code_inline"),
+            SmolStr::new("to_code_inline"),
             BuiltinFunctionDoc {
                 description: "Creates an inline markdown code node with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_h"),
+            SmolStr::new("to_h"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown heading node with the given value and depth.",
                 params: &["value", "depth"],
             },
         );
         map.insert(
-            CompactString::new("to_math"),
+            SmolStr::new("to_math"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown math block with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_math_inline"),
+            SmolStr::new("to_math_inline"),
             BuiltinFunctionDoc {
                 description: "Creates an inline markdown math node with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_strong"),
+            SmolStr::new("to_strong"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown strong (bold) node with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_em"),
+            SmolStr::new("to_em"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown emphasis (italic) node with the given value.",
                 params: &["value"],
             },
         );
         map.insert(
-            CompactString::new("to_hr"),
+            SmolStr::new("to_hr"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown horizontal rule node.",
                 params: &[],
             },
         );
         map.insert(
-            CompactString::new("to_link"),
+            SmolStr::new("to_link"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown link node  with the given  url and title.",
                 params: &["url", "value", "title"],
             },
         );
         map.insert(
-            CompactString::new("to_md_list"),
+            SmolStr::new("to_md_list"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown list node with the given value and indent level.",
                 params: &["value", "indent"],
             },
         );
         map.insert(
-            CompactString::new("to_md_table_row"),
+            SmolStr::new("to_md_table_row"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown table row node with the given values.",
                 params: &["cells"],
             },
         );
         map.insert(
-            CompactString::new("get_title"),
+            SmolStr::new("get_title"),
             BuiltinFunctionDoc {
                 description: "Returns the title of a markdown node.",
                 params: &["node"],
             },
         );
         map.insert(
-            CompactString::new("get_url"),
+            SmolStr::new("get_url"),
             BuiltinFunctionDoc {
                 description: "Returns the url of a markdown node.",
                 params: &["node"],
             },
         );
         map.insert(
-            CompactString::new("set_check"),
+            SmolStr::new("set_check"),
             BuiltinFunctionDoc {
                 description: "Creates a markdown list node with the given checked state.",
                 params: &["list", "checked"],
             },
         );
         map.insert(
-            CompactString::new("set_ref"),
+            SmolStr::new("set_ref"),
             BuiltinFunctionDoc {
             description: "Sets the reference identifier for markdown nodes that support references (e.g., Definition, LinkRef, ImageRef, Footnote, FootnoteRef).",
             params: &["node", "reference_id"],
             },
         );
         map.insert(
-            CompactString::new("set_code_block_lang"),
+            SmolStr::new("set_code_block_lang"),
             BuiltinFunctionDoc {
                 description: "Sets the language of a markdown code block node.",
                 params: &["code_block", "language"],
             },
         );
         map.insert(
-            CompactString::new(constants::DICT),
+            SmolStr::new(constants::DICT),
             BuiltinFunctionDoc {
                 description: "Creates a new, empty dict.",
                 params: &[],
             },
         );
         map.insert(
-            CompactString::new(constants::GET),
+            SmolStr::new(constants::GET),
             BuiltinFunctionDoc {
                 description: "Retrieves a value from a dict by its key. Returns None if the key is not found.",
                 params: &["obj", "key"],
             },
         );
         map.insert(
-            CompactString::new("set"),
+            SmolStr::new("set"),
             BuiltinFunctionDoc {
                 description: "Sets a key-value pair in a dict. If the key exists, its value is updated. Returns the modified map.",
                 params: &["obj", "key", "value"],
             },
         );
         map.insert(
-            CompactString::new("keys"),
+            SmolStr::new("keys"),
             BuiltinFunctionDoc {
                 description: "Returns an array of keys from the dict.",
                 params: &["dict"],
             },
         );
         map.insert(
-            CompactString::new("values"),
+            SmolStr::new("values"),
             BuiltinFunctionDoc {
                 description: "Returns an array of values from the dict.",
                 params: &["dict"],
             },
         );
         map.insert(
-            CompactString::new("entries"),
+            SmolStr::new("entries"),
             BuiltinFunctionDoc {
                 description: "Returns an array of key-value pairs from the dict as arrays.",
                 params: &["dict"],
             },
         );
         map.insert(
-            CompactString::new(constants::RANGE),
+            SmolStr::new(constants::RANGE),
             BuiltinFunctionDoc {
                 description: "Creates an array from start to end with an optional step.",
                 params: &["start", "end", "step"],
             },
         );
         map.insert(
-            CompactString::new("insert"),
+            SmolStr::new("insert"),
             BuiltinFunctionDoc {
             description: "Inserts a value into an array or string at the specified index, or into a dict with the specified key.",
             params: &["target", "index_or_key", "value"],
             },
         );
         map.insert(
-            CompactString::new("increase_header_level"),
+            SmolStr::new("increase_header_level"),
             BuiltinFunctionDoc {
                 description:
                     "Increases the level of a markdown heading node by one, up to a maximum of 6.",
@@ -3421,7 +3422,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
             },
         );
         map.insert(
-            CompactString::new("decrease_header_level"),
+            SmolStr::new("decrease_header_level"),
             BuiltinFunctionDoc {
             description: "Decreases the level of a markdown heading node by one, down to a minimum of 1.",
             params: &["heading_node"],
@@ -3430,7 +3431,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
 
         #[cfg(feature = "file-io")]
         map.insert(
-            CompactString::new("read_file"),
+            SmolStr::new("read_file"),
             BuiltinFunctionDoc {
             description: "Reads the contents of a file at the given path and returns it as a string.",
             params: &["path"],
@@ -3438,7 +3439,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
         );
 
         map.insert(
-            CompactString::new(constants::BREAKPOINT),
+            SmolStr::new(constants::BREAKPOINT),
             BuiltinFunctionDoc {
             description: "Sets a breakpoint for debugging; execution will pause at this point if a debugger is attached.",
             params: &[],
@@ -3446,7 +3447,8 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<CompactString, BuiltinFuncti
         );
 
         map
-    });
+    },
+);
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
@@ -3918,7 +3920,7 @@ mod tests {
         #[case] expected: Result<RuntimeValue, Error>,
     ) {
         let ident = ast::Ident {
-            name: CompactString::new(func_name),
+            name: SmolStr::new(func_name),
             token: None,
         };
 
@@ -3937,7 +3939,7 @@ mod tests {
         #[case] expected_error: Error,
     ) {
         let ident = ast::Ident {
-            name: CompactString::new(func_name),
+            name: SmolStr::new(func_name),
             token: None,
         };
 
@@ -3949,7 +3951,7 @@ mod tests {
     #[test]
     fn test_implicit_first_arg() {
         let ident = ast::Ident {
-            name: CompactString::new("starts_with"),
+            name: SmolStr::new("starts_with"),
             token: None,
         };
 
@@ -4181,7 +4183,7 @@ mod tests {
     #[test]
     fn test_eval_builtin_new_dict() {
         let ident = ast::Ident {
-            name: CompactString::new("dict"),
+            name: SmolStr::new("dict"),
             token: None,
         };
         let result = eval_builtin(&RuntimeValue::None, &ident, vec![]);
@@ -4214,7 +4216,7 @@ mod tests {
     #[test]
     fn test_eval_builtin_set_dict() {
         let ident_set = ast::Ident {
-            name: CompactString::new("set"),
+            name: SmolStr::new("set"),
             token: None,
         };
         let initial_map = RuntimeValue::new_dict();
@@ -4330,7 +4332,7 @@ mod tests {
     #[test]
     fn test_eval_builtin_get_map() {
         let ident_get = ast::Ident {
-            name: CompactString::new("get"),
+            name: SmolStr::new("get"),
             token: None,
         };
         let mut map_data = BTreeMap::default();
@@ -4376,7 +4378,7 @@ mod tests {
     #[test]
     fn test_eval_builtin_keys_dict() {
         let ident_keys = ast::Ident {
-            name: CompactString::new("keys"),
+            name: SmolStr::new("keys"),
             token: None,
         };
 
@@ -4428,7 +4430,7 @@ mod tests {
     #[test]
     fn test_eval_builtin_values_dict() {
         let ident_values = ast::Ident {
-            name: CompactString::new("values"),
+            name: SmolStr::new("values"),
             token: None,
         };
 

--- a/crates/mq-lang/src/eval/error.rs
+++ b/crates/mq-lang/src/eval/error.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactString;
+use smol_str::SmolStr;
 use thiserror::Error;
 
 use crate::{Token, number::Number};
@@ -6,7 +6,7 @@ use crate::{Token, number::Number};
 use super::module::ModuleError;
 
 type FunctionName = String;
-type ArgType = Vec<CompactString>;
+type ArgType = Vec<SmolStr>;
 type ErrorToken = Token;
 
 #[derive(Error, Debug, PartialEq)]
@@ -48,5 +48,5 @@ pub enum EvalError {
     #[error("Unexpected token continue")]
     Continue(ErrorToken),
     #[error("Not found env `{1}`")]
-    EnvNotFound(Token, CompactString),
+    EnvNotFound(Token, SmolStr),
 }

--- a/crates/mq-lang/src/eval/module.rs
+++ b/crates/mq-lang/src/eval/module.rs
@@ -5,8 +5,8 @@ use crate::{
     lexer::{self, Lexer, error::LexerError},
     optimizer::{OptimizationLevel, Optimizer},
 };
-use compact_str::CompactString;
 use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
 use std::{cell::RefCell, fs, path::PathBuf, rc::Rc, sync::LazyLock};
 use thiserror::Error;
 
@@ -33,8 +33,8 @@ pub enum ModuleError {
 
 pub type ModuleId = ArenaId<ModuleName>;
 
-type ModuleName = CompactString;
-type StandardModules = FxHashMap<CompactString, fn() -> &'static str>;
+type ModuleName = SmolStr;
+type StandardModules = FxHashMap<SmolStr, fn() -> &'static str>;
 
 #[derive(Debug, Clone)]
 pub struct ModuleLoader {
@@ -67,7 +67,7 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
                 include_str!(concat!("../../modules/", stringify!($name), ".mq"))
             }
             map.insert(
-                CompactString::new(stringify!($name)),
+                SmolStr::new(stringify!($name)),
                 $name as fn() -> &'static str,
             );
         };
@@ -80,12 +80,12 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
     std_module!(toml);
     std_module!(xml);
 
-    map.insert(CompactString::new("csv"), csv as fn() -> &'static str);
-    map.insert(CompactString::new("yaml"), yaml as fn() -> &'static str);
-    map.insert(CompactString::new("json"), json as fn() -> &'static str);
-    map.insert(CompactString::new("test"), test as fn() -> &'static str);
-    map.insert(CompactString::new("toml"), toml as fn() -> &'static str);
-    map.insert(CompactString::new("xml"), xml as fn() -> &'static str);
+    map.insert(SmolStr::new("csv"), csv as fn() -> &'static str);
+    map.insert(SmolStr::new("yaml"), yaml as fn() -> &'static str);
+    map.insert(SmolStr::new("json"), json as fn() -> &'static str);
+    map.insert(SmolStr::new("test"), test as fn() -> &'static str);
+    map.insert(SmolStr::new("toml"), toml as fn() -> &'static str);
+    map.insert(SmolStr::new("xml"), xml as fn() -> &'static str);
     map
 });
 
@@ -111,11 +111,11 @@ impl ModuleLoader {
     }
 
     #[inline(always)]
-    pub fn module_name(&self, module_id: ModuleId) -> CompactString {
+    pub fn module_name(&self, module_id: ModuleId) -> SmolStr {
         self.loaded_modules
             .get(module_id)
             .map(|s| s.to_owned())
-            .unwrap_or_else(|| CompactString::new("<unknown>"))
+            .unwrap_or_else(|| SmolStr::new("<unknown>"))
     }
 
     #[cfg(feature = "debugger")]
@@ -283,9 +283,9 @@ impl ModuleLoader {
 mod tests {
     use std::{cell::RefCell, rc::Rc};
 
-    use compact_str::CompactString;
     use rstest::{fixture, rstest};
     use smallvec::{SmallVec, smallvec};
+    use smol_str::SmolStr;
 
     use crate::{
         Token, TokenKind,
@@ -309,7 +309,7 @@ mod tests {
         vars: vec![
             Rc::new(ast::Node{token_id: 0.into(), expr: Rc::new(ast::Expr::Let(
                 ast::Ident::new_with_token("test", Some(Rc::new(Token{
-                    kind: TokenKind::Ident(CompactString::new("test")),
+                    kind: TokenKind::Ident(SmolStr::new("test")),
                     range: Range{start: Position{line: 1, column: 5}, end: Position{line: 1, column: 9}},
                     module_id: 1.into()
                 }))),
@@ -322,7 +322,7 @@ mod tests {
         functions: vec![
             Rc::new(ast::Node{token_id: 0.into(), expr: Rc::new(ast::Expr::Def(
             ast::Ident::new_with_token("test", Some(Rc::new(Token{
-                kind: TokenKind::Ident(CompactString::new("test")),
+                kind: TokenKind::Ident(SmolStr::new("test")),
                 range: Range{start: Position{line: 1, column: 5}, end: Position{line: 1, column: 9}},
                 module_id: 1.into()
             }))),
@@ -338,28 +338,28 @@ mod tests {
         modules: Vec::new(),
         functions: vec![
             Rc::new(ast::Node{token_id: 0.into(), expr: Rc::new(ast::Expr::Def(
-                ast::Ident::new_with_token("test", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("test")), range: Range{start: Position{line: 1, column: 5}, end: Position{line: 1, column: 9}}, module_id: 1.into()}))),
+                ast::Ident::new_with_token("test", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("test")), range: Range{start: Position{line: 1, column: 5}, end: Position{line: 1, column: 9}}, module_id: 1.into()}))),
                 smallvec![
                     Rc::new(ast::Node{token_id: 1.into(), expr:
                         Rc::new(
-                            ast::Expr::Ident(ast::Ident::new_with_token("a", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("a")), range: Range{start: Position{line: 1, column: 10}, end: Position{line: 1, column: 11}}, module_id: 1.into()})))
+                            ast::Expr::Ident(ast::Ident::new_with_token("a", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("a")), range: Range{start: Position{line: 1, column: 10}, end: Position{line: 1, column: 11}}, module_id: 1.into()})))
                         ))}),
                     Rc::new(ast::Node{token_id: 2.into(), expr:
                         Rc::new(
-                            ast::Expr::Ident(ast::Ident::new_with_token("b", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("b")), range: Range{start: Position{line: 1, column: 13}, end: Position{line: 1, column: 14}}, module_id: 1.into()})))
+                            ast::Expr::Ident(ast::Ident::new_with_token("b", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("b")), range: Range{start: Position{line: 1, column: 13}, end: Position{line: 1, column: 14}}, module_id: 1.into()})))
                         ))})
                 ],
                 vec![
                     Rc::new(ast::Node{token_id: 6.into(), expr: Rc::new(ast::Expr::Call(
-                    ast::Ident::new_with_token("add", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("add")), range: Range{start: Position{line: 1, column: 17}, end: Position{line: 1, column: 20}}, module_id: 1.into()}))),
+                    ast::Ident::new_with_token("add", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("add")), range: Range{start: Position{line: 1, column: 17}, end: Position{line: 1, column: 20}}, module_id: 1.into()}))),
                     smallvec![
                         Rc::new(ast::Node{token_id: 4.into(),
                             expr: Rc::new(
-                                ast::Expr::Ident(ast::Ident::new_with_token("a", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("a")), range: Range{start: Position{line: 1, column: 21}, end: Position{line: 1, column: 22}}, module_id: 1.into()}))))
+                                ast::Expr::Ident(ast::Ident::new_with_token("a", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("a")), range: Range{start: Position{line: 1, column: 21}, end: Position{line: 1, column: 22}}, module_id: 1.into()}))))
                                 )}),
                         Rc::new(ast::Node{token_id: 5.into(),
                             expr: Rc::new(
-                                ast::Expr::Ident(ast::Ident::new_with_token("b", Some(Rc::new(Token{kind: TokenKind::Ident(CompactString::new("b")), range: Range{start: Position{line: 1, column: 24}, end: Position{line: 1, column: 25}}, module_id: 1.into()}))))
+                                ast::Expr::Ident(ast::Ident::new_with_token("b", Some(Rc::new(Token{kind: TokenKind::Ident(SmolStr::new("b")), range: Range{start: Position{line: 1, column: 24}, end: Position{line: 1, column: 25}}, module_id: 1.into()}))))
                             )})
                     ],
                 ))})]

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -1,7 +1,6 @@
 pub mod error;
 pub mod token;
 
-use compact_str::CompactString;
 use error::LexerError;
 use nom::Parser;
 use nom::bytes::complete::{is_not, take_until};
@@ -17,6 +16,7 @@ use nom::{
     sequence::{delimited, pair, preceded},
 };
 use nom_locate::{LocatedSpan, position};
+use smol_str::SmolStr;
 use token::{StringSegment, Token, TokenKind};
 
 use crate::eval::module::ModuleId;
@@ -503,14 +503,14 @@ fn ident(input: Span) -> IResult<Span, Token> {
                 let fragment = span.fragment();
 
                 if fragment.starts_with(".") {
-                    let kind = TokenKind::Selector(CompactString::new(span.fragment()));
+                    let kind = TokenKind::Selector(SmolStr::new(span.fragment()));
                     Token {
                         range: span.into(),
                         kind,
                         module_id,
                     }
                 } else {
-                    let kind = TokenKind::Ident(CompactString::new(span.fragment()));
+                    let kind = TokenKind::Ident(SmolStr::new(span.fragment()));
                     Token {
                         range: span.into(),
                         kind,
@@ -529,7 +529,7 @@ fn env(input: Span) -> IResult<Span, Token> {
         map(
             recognize(many1(alt((alphanumeric1, tag("_"))))),
             |span: Span| {
-                let kind = TokenKind::Env(CompactString::new(span.fragment()));
+                let kind = TokenKind::Env(SmolStr::new(span.fragment()));
                 let module_id = span.extra;
                 Token {
                     range: span.into(),
@@ -592,9 +592,9 @@ mod tests {
     #[case("and(contains(\"test\"))",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(CompactString::new("and")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("and")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 13} }, kind: TokenKind::Ident(CompactString::new("contains")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 13} }, kind: TokenKind::Ident(SmolStr::new("contains")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 13}, end: Position {line: 1, column: 14} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 20} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 20}, end: Position {line: 1, column: 21} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -603,17 +603,17 @@ mod tests {
     #[case("and(contains(\"test\")) | or(endswith(\"test\"))",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(CompactString::new("and")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("and")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 13} }, kind: TokenKind::Ident(CompactString::new("contains")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 13} }, kind: TokenKind::Ident(SmolStr::new("contains")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 13}, end: Position {line: 1, column: 14} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 20} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 20}, end: Position {line: 1, column: 21} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 21}, end: Position {line: 1, column: 22} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 23}, end: Position {line: 1, column: 24} }, kind: TokenKind::Pipe, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 25}, end: Position {line: 1, column: 27} }, kind: TokenKind::Ident(CompactString::new("or")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 25}, end: Position {line: 1, column: 27} }, kind: TokenKind::Ident(SmolStr::new("or")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 27}, end: Position {line: 1, column: 28} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 28}, end: Position {line: 1, column: 36} }, kind: TokenKind::Ident(CompactString::new("endswith")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 28}, end: Position {line: 1, column: 36} }, kind: TokenKind::Ident(SmolStr::new("endswith")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 36}, end: Position {line: 1, column: 37} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 37}, end: Position {line: 1, column: 43} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 43}, end: Position {line: 1, column: 44} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -622,9 +622,9 @@ mod tests {
     #[case("eq(length(), 10)",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(CompactString::new("eq")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(SmolStr::new("eq")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 10} }, kind: TokenKind::Ident(CompactString::new("length")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 10} }, kind: TokenKind::Ident(SmolStr::new("length")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 10}, end: Position {line: 1, column: 11} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 12} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 12}, end: Position {line: 1, column: 13} }, kind: TokenKind::Comma, module_id: 1.into()},
@@ -634,25 +634,25 @@ mod tests {
     #[case("or(.h1, .**)",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(CompactString::new("or")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(SmolStr::new("or")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 7} }, kind: TokenKind::Selector(CompactString::new(".h1")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 7} }, kind: TokenKind::Selector(SmolStr::new(".h1")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 8} }, kind: TokenKind::Comma, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 12} }, kind: TokenKind::Selector(CompactString::new(".**")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 12} }, kind: TokenKind::Selector(SmolStr::new(".**")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 12}, end: Position {line: 1, column: 13} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 13}, end: Position {line: 1, column: 13} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case("or(.[][], .[])",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(CompactString::new("or")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Ident(SmolStr::new("or")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::Selector(CompactString::new(".")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::Selector(SmolStr::new(".")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::LBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 6}, end: Position {line: 1, column: 7} }, kind: TokenKind::RBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 8} }, kind: TokenKind::LBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 8}, end: Position {line: 1, column: 9} }, kind: TokenKind::RBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 10} }, kind: TokenKind::Comma, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 12} }, kind: TokenKind::Selector(CompactString::new(".")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 12} }, kind: TokenKind::Selector(SmolStr::new(".")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 12}, end: Position {line: 1, column: 13} }, kind: TokenKind::LBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 13}, end: Position {line: 1, column: 14} }, kind: TokenKind::RBracket, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 15} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -660,7 +660,7 @@ mod tests {
     #[case("startswith(\"\\u{0061}\")",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 11} }, kind: TokenKind::Ident(CompactString::new("startswith")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 11} }, kind: TokenKind::Ident(SmolStr::new("startswith")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 12} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 12}, end: Position {line: 1, column: 22} }, kind: TokenKind::StringLiteral("a".to_string()), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 22}, end: Position {line: 1, column: 23} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -668,23 +668,23 @@ mod tests {
     #[case("endswith($ENV)",
         Options::default(),
         Ok(vec![
-          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 9} }, kind: TokenKind::Ident(CompactString::new("endswith")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 9} }, kind: TokenKind::Ident(SmolStr::new("endswith")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 10} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 14} }, kind: TokenKind::Env(CompactString::new("ENV")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 14} }, kind: TokenKind::Env(SmolStr::new("ENV")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 15} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 15}, end: Position {line: 1, column: 15} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case("def check(arg1, arg2): startswith(\"\\u{0061}\")",
         Options::default(),
         Ok(vec![
           Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Def, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 10} }, kind: TokenKind::Ident(CompactString::new("check")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 10} }, kind: TokenKind::Ident(SmolStr::new("check")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 10}, end: Position {line: 1, column: 11} }, kind: TokenKind::LParen, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 15} }, kind: TokenKind::Ident(CompactString::new("arg1")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 15} }, kind: TokenKind::Ident(SmolStr::new("arg1")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 15}, end: Position {line: 1, column: 16} }, kind: TokenKind::Comma, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 17}, end: Position {line: 1, column: 21} }, kind: TokenKind::Ident(CompactString::new("arg2")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 17}, end: Position {line: 1, column: 21} }, kind: TokenKind::Ident(SmolStr::new("arg2")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 21}, end: Position {line: 1, column: 22} }, kind: TokenKind::RParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 22}, end: Position {line: 1, column: 23} }, kind: TokenKind::Colon, module_id: 1.into()},
-          Token{range: Range { start: Position {line: 1, column: 24}, end: Position {line: 1, column: 34} }, kind: TokenKind::Ident(CompactString::new("startswith")), module_id: 1.into()},
+          Token{range: Range { start: Position {line: 1, column: 24}, end: Position {line: 1, column: 34} }, kind: TokenKind::Ident(SmolStr::new("startswith")), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 34}, end: Position {line: 1, column: 35} }, kind: TokenKind::LParen, module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 35}, end: Position {line: 1, column: 45} }, kind: TokenKind::StringLiteral("a".to_string()), module_id: 1.into()},
           Token{range: Range { start: Position {line: 1, column: 45}, end: Position {line: 1, column: 46} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -695,10 +695,10 @@ mod tests {
     #[case::new_line("and(\ncontains(\"test\"))",
             Options{include_spaces: true, ignore_errors: true},
             Ok(vec![
-              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(CompactString::new("and")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("and")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::NewLine, module_id: 1.into()},
-              Token{range: Range { start: Position {line: 2, column: 1}, end: Position {line: 2, column: 9} }, kind: TokenKind::Ident(CompactString::new("contains")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 2, column: 1}, end: Position {line: 2, column: 9} }, kind: TokenKind::Ident(SmolStr::new("contains")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 9}, end: Position {line: 2, column: 10} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 10}, end: Position {line: 2, column: 16} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 16}, end: Position {line: 2, column: 17} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -707,10 +707,10 @@ mod tests {
     #[case("and(\ncontains(\"test\")) | or(\nendswith(\"test\"))",
             Options{include_spaces: true, ignore_errors: true},
             Ok(vec![
-              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(CompactString::new("and")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("and")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::NewLine, module_id: 1.into()},
-              Token{range: Range { start: Position {line: 2, column: 1}, end: Position {line: 2, column: 9} }, kind: TokenKind::Ident(CompactString::new("contains")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 2, column: 1}, end: Position {line: 2, column: 9} }, kind: TokenKind::Ident(SmolStr::new("contains")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 9}, end: Position {line: 2, column: 10} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 10}, end: Position {line: 2, column: 16} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 16}, end: Position {line: 2, column: 17} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -718,10 +718,10 @@ mod tests {
               Token{range: Range { start: Position {line: 2, column: 18}, end: Position {line: 2, column: 19} }, kind: TokenKind::Whitespace(1), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 19}, end: Position {line: 2, column: 20} }, kind: TokenKind::Pipe, module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 20}, end: Position {line: 2, column: 21} }, kind: TokenKind::Whitespace(1), module_id: 1.into()},
-              Token{range: Range { start: Position {line: 2, column: 21}, end: Position {line: 2, column: 23} }, kind: TokenKind::Ident(CompactString::new("or")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 2, column: 21}, end: Position {line: 2, column: 23} }, kind: TokenKind::Ident(SmolStr::new("or")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 23}, end: Position {line: 2, column: 24} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 2, column: 24}, end: Position {line: 2, column: 25} }, kind: TokenKind::NewLine, module_id: 1.into()},
-              Token{range: Range { start: Position {line: 3, column: 1}, end: Position {line: 3, column: 9} }, kind: TokenKind::Ident(CompactString::new("endswith")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 3, column: 1}, end: Position {line: 3, column: 9} }, kind: TokenKind::Ident(SmolStr::new("endswith")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 3, column: 9}, end: Position {line: 3, column: 10} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 3, column: 10}, end: Position {line: 3, column: 16} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
               Token{range: Range { start: Position {line: 3, column: 16}, end: Position {line: 3, column: 17} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -730,10 +730,10 @@ mod tests {
     #[case::tab("and(\tcontains(\"test\"))",
             Options{include_spaces: true, ignore_errors: true},
             Ok(vec![
-              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(CompactString::new("and")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("and")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::Tab(1), module_id: 1.into()},
-              Token{range: Range { start: Position {line: 1, column: 6}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(CompactString::new("contains")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 6}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(SmolStr::new("contains")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 15} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 15}, end: Position {line: 1, column: 21} }, kind: TokenKind::StringLiteral("test".to_string()), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 21}, end: Position {line: 1, column: 22} }, kind: TokenKind::RParen, module_id: 1.into()},
@@ -769,7 +769,7 @@ mod tests {
               Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::RParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::Colon, module_id: 1.into()},
-              Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(CompactString::new("program")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(SmolStr::new("program")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 15} }, kind: TokenKind::SemiColon, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 15}, end: Position {line: 1, column: 15} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::end_keyword("end",
@@ -784,7 +784,7 @@ mod tests {
               Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::LParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::RParen, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::Colon, module_id: 1.into()},
-              Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(CompactString::new("program")), module_id: 1.into()},
+              Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 14} }, kind: TokenKind::Ident(SmolStr::new("program")), module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 15}, end: Position {line: 1, column: 18} }, kind: TokenKind::End, module_id: 1.into()},
               Token{range: Range { start: Position {line: 1, column: 18}, end: Position {line: 1, column: 18} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::eq_eq1("==",
@@ -856,9 +856,9 @@ mod tests {
             Options::default(),
             Ok(vec![
                 Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 2} }, kind: TokenKind::LBrace, module_id: 1.into()},
-                Token{range: Range { start: Position {line: 1, column: 2}, end: Position {line: 1, column: 5} }, kind: TokenKind::Ident(CompactString::new("key")), module_id: 1.into()},
+                Token{range: Range { start: Position {line: 1, column: 2}, end: Position {line: 1, column: 5} }, kind: TokenKind::Ident(SmolStr::new("key")), module_id: 1.into()},
                 Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 6} }, kind: TokenKind::Colon, module_id: 1.into()},
-                Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 12} }, kind: TokenKind::Ident(CompactString::new("value")), module_id: 1.into()},
+                Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 12} }, kind: TokenKind::Ident(SmolStr::new("value")), module_id: 1.into()},
                 Token{range: Range { start: Position {line: 1, column: 12}, end: Position {line: 1, column: 13} }, kind: TokenKind::RBrace, module_id: 1.into()},
                 Token{range: Range { start: Position {line: 1, column: 13}, end: Position {line: 1, column: 13} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::selector_with_dot_h_text(".h.text",
@@ -866,7 +866,7 @@ mod tests {
             Ok(vec![
                     Token {
                         range: Range { start: Position { line: 1, column: 1 }, end: Position { line: 1, column: 8 } },
-                        kind: TokenKind::Selector(CompactString::new(".h.text")),
+                        kind: TokenKind::Selector(SmolStr::new(".h.text")),
                         module_id: 1.into(),
                     },
                     Token {
@@ -881,7 +881,7 @@ mod tests {
             Ok(vec![
                     Token {
                         range: Range { start: Position { line: 1, column: 1 }, end: Position { line: 1, column: 6 } },
-                        kind: TokenKind::Ident(CompactString::new("print")),
+                        kind: TokenKind::Ident(SmolStr::new("print")),
                         module_id: 1.into(),
                     },
                     Token {
@@ -909,17 +909,17 @@ mod tests {
     #[case::keyword_boundary_def("definition",
         Options::default(),
         Ok(vec![
-            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 11} }, kind: TokenKind::Ident(CompactString::new("definition")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 11} }, kind: TokenKind::Ident(SmolStr::new("definition")), module_id: 1.into()},
             Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 11} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::keyword_boundary_end("ending",
         Options::default(),
         Ok(vec![
-            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 7} }, kind: TokenKind::Ident(CompactString::new("ending")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 7} }, kind: TokenKind::Ident(SmolStr::new("ending")), module_id: 1.into()},
             Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 7} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::keyword_boundary_if("ifconfig",
         Options::default(),
         Ok(vec![
-            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 9} }, kind: TokenKind::Ident(CompactString::new("ifconfig")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 9} }, kind: TokenKind::Ident(SmolStr::new("ifconfig")), module_id: 1.into()},
             Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 9} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case::keyword_proper_def("def ",
         Options::default(),

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
-use compact_str::CompactString;
 use itertools::Itertools;
+use smol_str::SmolStr;
 
 #[cfg(feature = "ast-json")]
 use crate::ArenaId;
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub enum StringSegment {
     Text(String, Range),
-    Ident(CompactString, Range),
+    Ident(SmolStr, Range),
 }
 
 impl Display for StringSegment {
@@ -56,7 +56,7 @@ pub enum TokenKind {
     Elif,
     Else,
     End,
-    Env(CompactString),
+    Env(SmolStr),
     Eof,
     Equal,
     EqEq,
@@ -64,7 +64,7 @@ pub enum TokenKind {
     Foreach,
     Gt,
     Gte,
-    Ident(CompactString),
+    Ident(SmolStr),
     If,
     Include,
     InterpolatedString(Vec<StringSegment>),
@@ -86,7 +86,7 @@ pub enum TokenKind {
     RBracket,
     RBrace,
     RParen,
-    Selector(CompactString),
+    Selector(SmolStr),
     Self_,
     SemiColon,
     StringLiteral(String),
@@ -186,14 +186,14 @@ mod tests {
         "hello"
     )]
     #[case(
-        StringSegment::Ident(CompactString::new("world"), Range::default()),
+        StringSegment::Ident(SmolStr::new("world"), Range::default()),
         "${world}"
     )]
     #[case(
         StringSegment::Text("".to_string(), Range::default()),
         ""
     )]
-    #[case(StringSegment::Ident(CompactString::new(""), Range::default()), "${}")]
+    #[case(StringSegment::Ident(SmolStr::new(""), Range::default()), "${}")]
     fn string_segment_display_works(#[case] segment: StringSegment, #[case] expected: &str) {
         assert_eq!(segment.to_string(), expected);
     }

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/harehare/mq"
 version = "0.2.22"
 
 [dependencies]
-compact_str.workspace = true
 ego-tree = {version = "0.10.0", optional = true}
 itertools.workspace = true
 markdown = "1.0.0"
@@ -21,6 +20,7 @@ scraper = {version = "0.24.0", optional = true}
 serde = {workspace = true, features = ["derive"], optional = true}
 serde_json = {workspace = true, optional = true}
 serde_yaml = {version = "0.9", optional = true}
+smol_str.workspace = true
 
 [dev-dependencies]
 rstest = "0.26.1"
@@ -28,5 +28,5 @@ rstest = "0.26.1"
 [features]
 default = ["std"]
 html-to-markdown = ["dep:scraper", "dep:ego-tree", "dep:serde_yaml"]
-json = ["dep:serde", "dep:serde_json", "compact_str/serde"]
+json = ["dep:serde", "dep:serde_json", "smol_str/serde"]
 std = []

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Display};
 
-use compact_str::CompactString;
 use itertools::Itertools;
 use markdown::mdast::{self};
+use smol_str::SmolStr;
 
 type Level = u8;
 
@@ -387,7 +387,7 @@ pub struct Yaml {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct CodeInline {
-    pub value: CompactString,
+    pub value: SmolStr,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
 }
@@ -399,7 +399,7 @@ pub struct CodeInline {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct MathInline {
-    pub value: CompactString,
+    pub value: SmolStr,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
 }
@@ -423,7 +423,7 @@ pub struct Math {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct MdxFlowExpression {
-    pub value: CompactString,
+    pub value: SmolStr,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
 }
@@ -449,7 +449,7 @@ pub struct MdxJsxFlowElement {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub enum MdxAttributeContent {
-    Expression(CompactString),
+    Expression(SmolStr),
     Property(MdxJsxAttribute),
 }
 
@@ -460,7 +460,7 @@ pub enum MdxAttributeContent {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct MdxJsxAttribute {
-    pub name: CompactString,
+    pub name: SmolStr,
     pub value: Option<MdxAttributeValue>,
 }
 
@@ -471,8 +471,8 @@ pub struct MdxJsxAttribute {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub enum MdxAttributeValue {
-    Expression(CompactString),
-    Literal(CompactString),
+    Expression(SmolStr),
+    Literal(SmolStr),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -485,7 +485,7 @@ pub struct MdxJsxTextElement {
     pub children: Vec<Node>,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
-    pub name: Option<CompactString>,
+    pub name: Option<SmolStr>,
     pub attributes: Vec<MdxAttributeContent>,
 }
 
@@ -496,7 +496,7 @@ pub struct MdxJsxTextElement {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct MdxTextExpression {
-    pub value: CompactString,
+    pub value: SmolStr,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
 }
@@ -508,7 +508,7 @@ pub struct MdxTextExpression {
     serde(rename_all = "camelCase", tag = "type")
 )]
 pub struct MdxJsEsm {
-    pub value: CompactString,
+    pub value: SmolStr,
     #[cfg_attr(feature = "json", serde(skip))]
     pub position: Option<Position>,
 }
@@ -1104,7 +1104,7 @@ impl Node {
         }
     }
 
-    pub fn name(&self) -> CompactString {
+    pub fn name(&self) -> SmolStr {
         match self {
             Self::Blockquote(_) => "blockquote".into(),
             Self::Break { .. } => "break".into(),
@@ -1375,7 +1375,7 @@ impl Node {
         matches!(self, Self::Definition(_))
     }
 
-    pub fn is_code(&self, lang: Option<CompactString>) -> bool {
+    pub fn is_code(&self, lang: Option<SmolStr>) -> bool {
         if let Self::Code(Code {
             lang: node_lang, ..
         }) = &self
@@ -2574,7 +2574,7 @@ impl Node {
             .collect()
     }
 
-    fn mdx_attribute_content_to_string(attr: MdxAttributeContent) -> CompactString {
+    fn mdx_attribute_content_to_string(attr: MdxAttributeContent) -> SmolStr {
         match attr {
             MdxAttributeContent::Expression(value) => format!("{{{}}}", value).into(),
             MdxAttributeContent::Property(property) => match property.value {
@@ -3061,11 +3061,7 @@ mod tests {
     #[case(Node::Code(Code{value: "code".to_string(), lang: None, fence: true, meta: None, position: None}), true, None)]
     #[case(Node::Code(Code{value: "code".to_string(), lang: None, fence: false, meta: None, position: None}), true, None)]
     #[case(Node::Text(Text{value: "test".to_string(), position: None}), false, None)]
-    fn test_is_code(
-        #[case] node: Node,
-        #[case] expected: bool,
-        #[case] lang: Option<CompactString>,
-    ) {
+    fn test_is_code(#[case] node: Node, #[case] expected: bool, #[case] lang: Option<SmolStr>) {
         assert_eq!(node.is_code(lang), expected);
     }
 


### PR DESCRIPTION
Replace compact_str::CompactString with smol_str::SmolStr across all crates:
- Updated dependencies in workspace Cargo.toml files
- Migrated string handling in tokens, identifiers, and selectors
- Updated AST parser, HIR symbols, and builtin function implementations
- Maintained API compatibility while improving memory efficiency