### PR TITLE
♻️ refactor: add conditional sync support with Shared and SharedCell type aliases

### DIFF
--- a/crates/mq-cli/src/cli.rs
+++ b/crates/mq-cli/src/cli.rs
@@ -376,9 +376,10 @@ impl Cli {
             let handler = DebuggerHandler::new(engine.clone());
             engine
                 .debugger()
-                .borrow_mut()
+                .write()
+                .unwrap()
                 .set_handler(Box::new(handler));
-            engine.debugger().borrow_mut().activate();
+            engine.debugger().write().unwrap().activate();
         }
 
         Ok(engine)

--- a/crates/mq-cli/src/debugger.rs
+++ b/crates/mq-cli/src/debugger.rs
@@ -1,6 +1,6 @@
 use colored::*;
 use miette::IntoDiagnostic;
-use mq_lang::DebugContext;
+use mq_lang::{DebugContext, Shared};
 use rustyline::{
     At, Cmd, CompletionType, Config, EditMode, Editor, Helper, KeyCode, KeyEvent, Modifiers,
     Movement, Word,
@@ -10,7 +10,7 @@ use rustyline::{
     hint::Hinter,
     validate::{ValidationContext, ValidationResult, Validator},
 };
-use std::{borrow::Cow, cmp::max, fmt, rc::Rc};
+use std::{borrow::Cow, cmp::max, fmt};
 use strum::IntoEnumIterator;
 
 type LineNo = usize;
@@ -60,19 +60,59 @@ impl fmt::Display for Command {
 impl Command {
     pub fn help(&self) -> String {
         match self {
-            Command::Backtrace => "Print the current backtrace".to_string(),
-            Command::Breakpoint(_) => "Set a breakpoint at the specified line".to_string(),
-            Command::Continue => "Continue execution".to_string(),
-            Command::Clear(_) => "Clear breakpoints at a specific identifier".to_string(),
+            Command::Backtrace => {
+                format!(
+                    "{:<20}{}",
+                    "backtrace or bt",
+                    "Print the current backtrace".to_string()
+                )
+            }
+            Command::Breakpoint(_) => format!(
+                "{:<20}{}",
+                "b[reakpoint]",
+                "Set a breakpoint at the specified line".to_string()
+            ),
+            Command::Continue => {
+                format!("{:<20}{}", "c[ontinue]", "Continue execution".to_string())
+            }
+            Command::Clear(_) => format!(
+                "{:<20}{}",
+                "cl[ear]",
+                "Clear breakpoints at a specific identifier".to_string()
+            ),
             Command::Eval(_) | Command::Error(_) => "".to_string(),
-            Command::Finish => "Finish execution and return to the caller".to_string(),
-            Command::Help => "Print command help".to_string(),
-            Command::Info => "Print information about the current context".to_string(),
-            Command::List => "List source code around the current line".to_string(),
-            Command::LongList => "List all source code lines".to_string(),
-            Command::Next => "Step over the next function call".to_string(),
-            Command::Quit => "Quit evaluation and exit".to_string(),
-            Command::Step => "Step into the next function call".to_string(),
+            Command::Finish => format!(
+                "{:<20}{}",
+                "f[inish]",
+                "Finish execution and return to the caller".to_string()
+            ),
+            Command::Help => format!("{:<20}{}", "h[elp]", "Print command help".to_string()),
+            Command::Info => format!(
+                "{:<20}{}",
+                "i[nfo]",
+                "Print information about the current context".to_string()
+            ),
+            Command::List => format!(
+                "{:<20}{}",
+                "l[ist]",
+                "List source code around the current line".to_string()
+            ),
+            Command::LongList => format!(
+                "{:<20}{}",
+                "long-list or ll",
+                "List all source code lines".to_string()
+            ),
+            Command::Next => format!(
+                "{:<20}{}",
+                "n[ext]",
+                "Step over the next function call".to_string()
+            ),
+            Command::Quit => format!("{:<20}{}", "q[uit]", "Quit evaluation and exit".to_string()),
+            Command::Step => format!(
+                "{:<20}{}",
+                "s[tep]",
+                "Step into the next function call".to_string()
+            ),
         }
     }
 }
@@ -183,7 +223,7 @@ impl DebuggerHandler {
                         .call_stack
                         .iter()
                         .filter_map(|frame| {
-                            let range = self.engine.token_arena().borrow()[frame.token_id]
+                            let range = self.engine.token_arena().read().unwrap()[frame.token_id]
                                 .range
                                 .clone();
 
@@ -227,11 +267,11 @@ impl DebuggerHandler {
                     Self::print_source_code(0, context.token.range.start.line as usize + 1, lines);
                 }
                 Command::Info => {
-                    println!("{}", context.env.borrow());
+                    println!("{}", context.env.read().unwrap());
                 }
                 Command::Eval(expr) => {
                     let value: mq_lang::Value = context.current_value.clone().into();
-                    let mut engine = self.engine.switch_env(Rc::clone(&context.env));
+                    let mut engine = self.engine.switch_env(Shared::clone(&context.env));
                     let values = match engine.eval(&expr, vec![value].into_iter()) {
                         Ok(v) => v,
                         Err(e) => {
@@ -260,7 +300,7 @@ impl DebuggerHandler {
                 Command::Help => {
                     let commands: Vec<String> = Command::iter()
                         .filter_map(|c| {
-                            if matches!(c, Command::Eval(_)) {
+                            if matches!(c, Command::Eval(_) | Command::Error(_)) {
                                 None
                             } else {
                                 Some(c.help().to_string())
@@ -471,7 +511,6 @@ impl Validator for DebuggerLineHelper {
 mod tests {
     use mq_lang::ModuleId;
     use mq_lang::{self, DebugContext};
-    use std::rc::Rc;
 
     use super::*;
 
@@ -602,7 +641,7 @@ mod tests {
     fn test_get_source_code_with_context_basic() {
         let context = DebugContext {
             source_code: "a\nb\nc\nd\ne\nf\ng\nh\ni\nj".to_string(),
-            token: Rc::new(mq_lang::Token {
+            token: Shared::new(mq_lang::Token {
                 range: mq_lang::Range {
                     start: mq_lang::Position { line: 4, column: 0 },
                     end: mq_lang::Position { line: 4, column: 1 },

--- a/crates/mq-cli/src/debugger.rs
+++ b/crates/mq-cli/src/debugger.rs
@@ -61,58 +61,45 @@ impl Command {
     pub fn help(&self) -> String {
         match self {
             Command::Backtrace => {
-                format!(
-                    "{:<20}{}",
-                    "backtrace or bt",
-                    "Print the current backtrace".to_string()
-                )
+                format!("{:<20}{}", "backtrace or bt", "Print the current backtrace")
             }
             Command::Breakpoint(_) => format!(
                 "{:<20}{}",
-                "b[reakpoint]",
-                "Set a breakpoint at the specified line".to_string()
+                "b[reakpoint]", "Set a breakpoint at the specified line"
             ),
             Command::Continue => {
-                format!("{:<20}{}", "c[ontinue]", "Continue execution".to_string())
+                format!("{:<20}{}", "c[ontinue]", "Continue execution")
             }
             Command::Clear(_) => format!(
                 "{:<20}{}",
-                "cl[ear]",
-                "Clear breakpoints at a specific identifier".to_string()
+                "cl[ear]", "Clear breakpoints at a specific identifier"
             ),
             Command::Eval(_) | Command::Error(_) => "".to_string(),
             Command::Finish => format!(
                 "{:<20}{}",
-                "f[inish]",
-                "Finish execution and return to the caller".to_string()
+                "f[inish]", "Finish execution and return to the caller"
             ),
-            Command::Help => format!("{:<20}{}", "h[elp]", "Print command help".to_string()),
+            Command::Help => format!("{:<20}{}", "h[elp]", "Print command help"),
             Command::Info => format!(
                 "{:<20}{}",
-                "i[nfo]",
-                "Print information about the current context".to_string()
+                "i[nfo]", "Print information about the current context"
             ),
             Command::List => format!(
                 "{:<20}{}",
-                "l[ist]",
-                "List source code around the current line".to_string()
+                "l[ist]", "List source code around the current line"
             ),
-            Command::LongList => format!(
-                "{:<20}{}",
-                "long-list or ll",
-                "List all source code lines".to_string()
-            ),
-            Command::Next => format!(
-                "{:<20}{}",
-                "n[ext]",
-                "Step over the next function call".to_string()
-            ),
-            Command::Quit => format!("{:<20}{}", "q[uit]", "Quit evaluation and exit".to_string()),
-            Command::Step => format!(
-                "{:<20}{}",
-                "s[tep]",
-                "Step into the next function call".to_string()
-            ),
+            Command::LongList => {
+                format!("{:<20}{}", "long-list or ll", "List all source code lines")
+            }
+            Command::Next => {
+                format!("{:<20}{}", "n[ext]", "Step over the next function call")
+            }
+            Command::Quit => {
+                format!("{:<20}{}", "q[uit]", "Quit evaluation and exit")
+            }
+            Command::Step => {
+                format!("{:<20}{}", "s[tep]", "Step into the next function call")
+            }
         }
     }
 }

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -34,10 +34,11 @@ thiserror.workspace = true
 [features]
 ast-json = ["dep:serde", "dep:serde_json", "smallvec/serde", "smol_str/serde"]
 cst = []
-debugger = []
+debugger = ["sync"]
 default = ["std"]
 file-io = []
 std = []
+sync = []
 
 [dev-dependencies]
 divan = {version = "2.8.1", package = "codspeed-divan-compat"}

--- a/crates/mq-lang/README.md
+++ b/crates/mq-lang/README.md
@@ -16,12 +16,10 @@ let mut engine = mq_lang::Engine::default();
 assert!(matches!(engine.eval(&code, input).unwrap(), mq_lang::Value::String("Hello,world!".to_string())));
 
 // Parse code into AST nodes
-use mq_lang::{tokenize, LexerOptions, AstParser, Arena};
-use std::rc::Rc;
-use std::cell::RefCell;
+use mq_lang::{tokenize, LexerOptions, AstParser, Arena, Shared, SharedCell};
 
 let code = "1 + 2";
-let token_arena = Rc::new(RefCell::new(Arena::new()));
+let token_arena = Shared::new(SharedCell::new(Arena::new()));
 let ast = mq_lang::parse(code, token_arena).unwrap();
 
 assert_eq!(ast.nodes.len(), 1);

--- a/crates/mq-lang/benches/benchmark.rs
+++ b/crates/mq-lang/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use mq_lang::{Shared, SharedCell};
 
 fn main() {
     divan::main();
@@ -149,8 +149,8 @@ fn eval_dead_code_elimination_benchmark() -> mq_lang::Values {
 }
 
 #[divan::bench]
-fn parse_fibonacci() -> Vec<Rc<mq_lang::AstNode>> {
-    let token_arena = Rc::new(RefCell::new(mq_lang::Arena::new(100)));
+fn parse_fibonacci() -> Vec<Shared<mq_lang::AstNode>> {
+    let token_arena = Shared::new(SharedCell::new(mq_lang::Arena::new(100)));
     mq_lang::parse(
         "
      def fibonacci(x):
@@ -160,7 +160,7 @@ fn parse_fibonacci() -> Vec<Rc<mq_lang::AstNode>> {
         1
       else:
         fibonacci(sub(x, 1)) + fibonacci(sub(x, 2)); | fibonacci(20)",
-        Rc::clone(&token_arena),
+        Shared::clone(&token_arena),
     )
     .unwrap()
 }

--- a/crates/mq-lang/src/ast.rs
+++ b/crates/mq-lang/src/ast.rs
@@ -1,16 +1,14 @@
-use std::rc::Rc;
-
 use node::Node;
 
-use crate::{Token, arena::ArenaId};
+use crate::{Shared, Token, arena::ArenaId};
 
 pub mod constants;
 pub mod error;
 pub mod node;
 pub mod parser;
 
-pub type Program = Vec<Rc<Node>>;
-pub type TokenId = ArenaId<Rc<Token>>;
+pub type Program = Vec<Shared<Node>>;
+pub type TokenId = ArenaId<Shared<Token>>;
 
 /// Serializes an AST `Program` to a JSON string.
 ///
@@ -44,9 +42,9 @@ mod tests {
     fn test_ast_to_json_and_from_json_roundtrip() {
         use crate::{AstExpr, ast::node::IdentWithToken};
 
-        let ident = Rc::new(Node {
+        let ident = Shared::new(Node {
             token_id: TokenId::new(1),
-            expr: Rc::new(AstExpr::Ident(IdentWithToken::new("foo"))),
+            expr: Shared::new(AstExpr::Ident(IdentWithToken::new("foo"))),
         });
         let program = vec![ident.clone()];
 

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -1326,9 +1326,9 @@ impl<'a> Parser<'a> {
                     token_id: token_alloc(&self.token_arena, &token),
                     expr: Shared::new(Expr::Selector(Selector::Text)),
                 })),
-                ".table" => Ok(Rc::new(Node {
-                    token_id: self.token_arena.borrow_mut().alloc(Rc::clone(&token)),
-                    expr: Rc::new(Expr::Selector(Selector::Table(None, None))),
+                ".table" => Ok(Shared::new(Node {
+                    token_id: token_alloc(&self.token_arena, &token),
+                    expr: Shared::new(Expr::Selector(Selector::Table(None, None))),
                 })),
                 // Handles table/array indexing selectors like `.[index]` or `.[index1][index2]`.
                 "." => self.parse_selector_table_args(Shared::clone(&token)),

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -403,4 +403,24 @@ mod tests {
         assert_eq!(values.len(), 1);
         assert_eq!(values[0], "hello".to_string().into());
     }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_engine_thread_usage_with_sync_feature() {
+        use std::sync::{Arc, Mutex};
+
+        let engine = Arc::new(Mutex::new(Engine::default()));
+        let engine_clone = Arc::clone(&engine);
+
+        let handle = std::thread::spawn(move || {
+            let mut engine = engine_clone.lock().unwrap();
+            let result = engine.eval("2 + 3", vec!["".to_string().into()].into_iter());
+            assert!(result.is_ok());
+            let values = result.unwrap();
+            assert_eq!(values.len(), 1);
+            assert_eq!(values[0], 5.into());
+        });
+
+        handle.join().expect("Threaded engine usage failed");
+    }
 }

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -393,13 +393,11 @@ impl Diagnostic for Error {
 
 #[cfg(test)]
 mod test {
-    use std::{cell::RefCell, rc::Rc};
-
     use mq_test::defer;
     use rstest::{fixture, rstest};
 
     use super::*;
-    use crate::{Arena, Range, Token, TokenKind, arena::ArenaId};
+    use crate::{Arena, Range, Shared, SharedCell, Token, TokenKind, arena::ArenaId};
 
     #[fixture]
     fn module_loader() -> ModuleLoader {
@@ -603,7 +601,7 @@ mod test {
             }
         }
 
-        let token_arena = Rc::new(RefCell::new(Arena::new(10)));
+        let token_arena = Shared::new(SharedCell::new(Arena::new(10)));
         let mut loader = ModuleLoader::new(Some(vec![temp_dir.clone()]));
         loader
             .load_from_file("test_from_error_with_module_source", token_arena)
@@ -623,7 +621,7 @@ mod test {
 
     #[test]
     fn test_from_error_with_builtin_module() {
-        let token_arena = Rc::new(RefCell::new(Arena::new(10)));
+        let token_arena = Shared::new(SharedCell::new(Arena::new(10)));
         let mut loader = ModuleLoader::default();
         loader.load_builtin(token_arena).unwrap();
         let token = Token {

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -330,8 +330,7 @@ impl Evaluator {
         env: Shared<SharedCell<Env>>,
     ) {
         let current_call_stack = self.debugger.read().unwrap().current_call_stack();
-        let token = self.token_arena.read().unwrap()[node.token_id].clone();
-
+        let token = get_token(Shared::clone(&self.token_arena), node.token_id);
         self.debugger.write().unwrap().breakpoint_hit(
             &DebugContext {
                 current_value: runtime_value.clone(),
@@ -473,7 +472,7 @@ impl Evaluator {
 
             let _ = self.debugger.write().unwrap().should_break(
                 &debug_context,
-                Shared::clone(&self.token_arena.read().unwrap()[node.token_id]),
+                get_token(Shared::clone(&self.token_arena), node.token_id),
             );
         }
 

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -70,7 +70,7 @@ impl Default for Evaluator {
             call_stack_depth: 0,
             options: Options::default(),
             module_loader: module::ModuleLoader::default(),
-            #[allow(clippy::arc_with_non_send_sync)]
+            #[cfg_attr(feature = "sync", allow(clippy::arc_with_non_send_sync))]
             #[cfg(feature = "debugger")]
             debugger: Shared::new(SharedCell::new(Debugger::new())),
         }

--- a/crates/mq-lang/src/eval/debugger.rs
+++ b/crates/mq-lang/src/eval/debugger.rs
@@ -416,7 +416,7 @@ impl From<DebuggerAction> for DebuggerCommand {
     }
 }
 
-pub trait DebuggerHandler: std::fmt::Debug {
+pub trait DebuggerHandler: std::fmt::Debug + Send + Sync {
     // Called when a breakpoint is hit.
     fn on_breakpoint_hit(
         &mut self,

--- a/crates/mq-lang/src/eval/debugger.rs
+++ b/crates/mq-lang/src/eval/debugger.rs
@@ -1,13 +1,11 @@
 use itertools::Itertools;
 
 use super::runtime_value::RuntimeValue;
-use crate::Token;
 use crate::ast::node as ast;
 use crate::eval::Evaluator;
 use crate::eval::env::Env;
+use crate::{Shared, SharedCell, Token};
 
-use std::cell::RefCell;
-use std::rc::Rc;
 use std::{collections::HashSet, fmt::Debug};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Hash)]
@@ -46,13 +44,13 @@ pub struct DebugContext {
     /// Current runtime value being evaluated
     pub current_value: RuntimeValue,
     /// Current AST node being evaluated
-    pub current_node: Rc<ast::Node>,
+    pub current_node: Shared<ast::Node>,
     /// Current token being evaluated
-    pub token: Rc<Token>,
+    pub token: Shared<Token>,
     /// Call stack of AST nodes representing the current execution path
-    pub call_stack: Vec<Rc<ast::Node>>,
+    pub call_stack: Vec<Shared<ast::Node>>,
     /// Current evaluation environment info
-    pub env: Rc<RefCell<Env>>,
+    pub env: Shared<SharedCell<Env>>,
     /// Source code being executed
     pub source_code: String,
 }
@@ -61,17 +59,17 @@ impl Default for DebugContext {
     fn default() -> Self {
         Self {
             current_value: RuntimeValue::NONE,
-            current_node: Rc::new(ast::Node {
+            current_node: Shared::new(ast::Node {
                 token_id: crate::ast::TokenId::new(0),
-                expr: Rc::new(ast::Expr::Literal(ast::Literal::Number(0.0.into()))),
+                expr: Shared::new(ast::Expr::Literal(ast::Literal::Number(0.0.into()))),
             }),
-            token: Rc::new(Token {
+            token: Shared::new(Token {
                 kind: crate::TokenKind::Eof,
                 range: crate::Range::default(),
                 module_id: crate::eval::module::ModuleId::new(0),
             }),
             call_stack: Vec::new(),
-            env: Rc::new(RefCell::new(Env::default())),
+            env: Shared::new(SharedCell::new(Env::default())),
             source_code: String::new(),
         }
     }
@@ -83,7 +81,7 @@ pub struct Debugger {
     /// Set of active breakpoints
     breakpoints: HashSet<Breakpoint>,
     /// Call stack of AST nodes representing the current execution path
-    call_stack: Vec<Rc<ast::Node>>,
+    call_stack: Vec<Shared<ast::Node>>,
     /// Next breakpoint ID to assign
     next_breakpoint_id: usize,
     /// Current debugger command
@@ -149,7 +147,7 @@ impl Debugger {
         id
     }
 
-    pub fn push_call_stack(&mut self, node: Rc<ast::Node>) {
+    pub fn push_call_stack(&mut self, node: Shared<ast::Node>) {
         self.call_stack.push(node);
     }
 
@@ -157,7 +155,7 @@ impl Debugger {
         self.call_stack.pop();
     }
 
-    pub fn current_call_stack(&self) -> Vec<Rc<ast::Node>> {
+    pub fn current_call_stack(&self) -> Vec<Shared<ast::Node>> {
         self.call_stack.clone()
     }
 
@@ -192,7 +190,7 @@ impl Debugger {
     pub fn should_break(
         &mut self,
         context: &DebugContext,
-        token: Rc<Token>,
+        token: Shared<Token>,
     ) -> (bool, Option<DebuggerAction>) {
         if !self.active {
             return (false, None);
@@ -441,8 +439,8 @@ pub struct DefaultDebuggerHandler;
 impl DebuggerHandler for DefaultDebuggerHandler {}
 
 impl Evaluator {
-    pub fn debugger(&self) -> Rc<RefCell<Debugger>> {
-        Rc::clone(&self.debugger)
+    pub fn debugger(&self) -> Shared<SharedCell<Debugger>> {
+        Shared::clone(&self.debugger)
     }
 }
 
@@ -454,8 +452,8 @@ mod tests {
 
     use super::*;
 
-    fn make_token(line: usize, column: usize) -> Rc<Token> {
-        Rc::new(Token {
+    fn make_token(line: usize, column: usize) -> Shared<Token> {
+        Shared::new(Token {
             kind: TokenKind::Ident("dummy".into()),
             range: Range {
                 start: crate::Position {
@@ -471,23 +469,23 @@ mod tests {
         })
     }
 
-    fn make_node(token_id: TokenId) -> Rc<ast::Node> {
-        Rc::new(ast::Node {
+    fn make_node(token_id: TokenId) -> Shared<ast::Node> {
+        Shared::new(ast::Node {
             token_id,
-            expr: Rc::new(ast::Expr::Literal(ast::Literal::Number(42.0.into()))),
+            expr: Shared::new(ast::Expr::Literal(ast::Literal::Number(42.0.into()))),
         })
     }
 
     fn make_debug_context(line: usize, column: usize) -> DebugContext {
         let mut arena = Arena::new(10);
         let token = make_token(line, column);
-        let token_id = arena.alloc(Rc::clone(&token));
+        let token_id = arena.alloc(Shared::clone(&token));
         let node = make_node(token_id);
-        let env = Rc::new(RefCell::new(Env::default()));
+        let env = Shared::new(SharedCell::new(Env::default()));
         DebugContext {
             current_value: RuntimeValue::NONE,
             current_node: node,
-            token: Rc::clone(&token),
+            token: Shared::clone(&token),
             call_stack: Vec::new(),
             env,
             source_code: String::new(),

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -223,27 +223,29 @@ pub fn raw_input(input: &str) -> Vec<Value> {
 }
 
 #[inline(always)]
-#[cfg(not(feature = "sync"))]
 pub(crate) fn token_alloc(arena: &TokenArena, token: &Shared<Token>) -> TokenId {
-    arena.borrow_mut().alloc(Shared::clone(token))
+    #[cfg(not(feature = "sync"))]
+    {
+        arena.borrow_mut().alloc(Shared::clone(token))
+    }
+
+    #[cfg(feature = "sync")]
+    {
+        arena.write().unwrap().alloc(Shared::clone(token))
+    }
 }
 
 #[inline(always)]
-#[cfg(feature = "sync")]
-pub(crate) fn token_alloc(arena: &TokenArena, token: &Shared<Token>) -> TokenId {
-    arena.write().unwrap().alloc(Shared::clone(token))
-}
-
-#[inline(always)]
-#[cfg(not(feature = "sync"))]
 pub(crate) fn get_token(arena: TokenArena, token_id: TokenId) -> Shared<Token> {
-    Shared::clone(&arena.borrow()[token_id])
-}
+    #[cfg(not(feature = "sync"))]
+    {
+        Shared::clone(&arena.borrow()[token_id])
+    }
 
-#[inline(always)]
-#[cfg(feature = "sync")]
-pub(crate) fn get_token(arena: TokenArena, token_id: TokenId) -> Shared<Token> {
-    Shared::clone(&arena.read().unwrap()[token_id])
+    #[cfg(feature = "sync")]
+    {
+        Shared::clone(&arena.read().unwrap()[token_id])
+    }
 }
 
 #[cfg(test)]

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -15,11 +15,11 @@
 //!
 //! // Parse code into AST nodes
 //! use mq_lang::{tokenize, LexerOptions, AstParser, Arena};
-//! use std::rc::Rc;
-//! use std::cell::RefCell;
+//! use std::rc::Shared;
+//! use std::cell::SharedCell;
 //!
 //! let code = "1 + 2";
-//! let token_arena = Rc::new(RefCell::new(Arena::new()));
+//! let token_arena = Shared::new(SharedCell::new(Arena::new()));
 //! let ast = mq_lang::parse(code, token_arena).unwrap();
 //!
 //! assert_eq!(ast.nodes.len(), 1);
@@ -57,10 +57,14 @@ mod value;
 mod value_macros;
 
 use lexer::Lexer;
+#[cfg(not(feature = "sync"))]
 use std::cell::RefCell;
+#[cfg(not(feature = "sync"))]
 use std::rc::Rc;
 #[cfg(feature = "cst")]
 use std::sync::Arc;
+#[cfg(feature = "sync")]
+use std::sync::RwLock;
 
 pub use arena::Arena;
 #[cfg(feature = "ast-json")]
@@ -108,7 +112,23 @@ pub use eval::debugger::{
     Breakpoint, DebugContext, Debugger, DebuggerAction, DebuggerCommand, DebuggerHandler,
 };
 
+use crate::ast::TokenId;
+
 pub type MqResult = Result<Values, Box<Error>>;
+
+/// Type alias for reference-counted pointer, switches between Shared and Arc depending on "sync" feature.
+#[cfg(not(feature = "sync"))]
+pub type Shared<T> = Rc<T>;
+#[cfg(feature = "sync")]
+pub type Shared<T> = Arc<T>;
+
+/// Type alias for interior mutability, switches between SharedCell and RwLock depending on "sync" feature.
+#[cfg(not(feature = "sync"))]
+pub type SharedCell<T> = RefCell<T>;
+#[cfg(feature = "sync")]
+pub type SharedCell<T> = RwLock<T>;
+
+pub(crate) type TokenArena = Shared<SharedCell<Arena<Shared<Token>>>>;
 
 #[cfg(feature = "cst")]
 pub fn parse_recovery(code: &str) -> (Vec<Arc<CstNode>>, CstErrorReporter) {
@@ -132,10 +152,7 @@ pub fn parse_recovery(code: &str) -> (Vec<Arc<CstNode>>, CstErrorReporter) {
     (cst_nodes, errors)
 }
 
-pub fn parse(
-    code: &str,
-    token_arena: Rc<RefCell<Arena<Rc<Token>>>>,
-) -> Result<Program, Box<error::Error>> {
+pub fn parse(code: &str, token_arena: TokenArena) -> Result<Program, Box<error::Error>> {
     let tokens = Lexer::new(lexer::Options::default())
         .tokenize(code, Module::TOP_LEVEL_MODULE_ID)
         .map_err(|e| {
@@ -147,7 +164,11 @@ pub fn parse(
         })?;
 
     AstParser::new(
-        tokens.into_iter().map(Rc::new).collect::<Vec<_>>().iter(),
+        tokens
+            .into_iter()
+            .map(Shared::new)
+            .collect::<Vec<_>>()
+            .iter(),
         token_arena,
         Module::TOP_LEVEL_MODULE_ID,
     )
@@ -201,6 +222,30 @@ pub fn raw_input(input: &str) -> Vec<Value> {
     vec![input.to_string().into()]
 }
 
+#[inline(always)]
+#[cfg(not(feature = "sync"))]
+pub(crate) fn token_alloc(arena: &TokenArena, token: &Shared<Token>) -> TokenId {
+    arena.borrow_mut().alloc(Shared::clone(token))
+}
+
+#[inline(always)]
+#[cfg(feature = "sync")]
+pub(crate) fn token_alloc(arena: &TokenArena, token: &Shared<Token>) -> TokenId {
+    arena.write().unwrap().alloc(Shared::clone(token))
+}
+
+#[inline(always)]
+#[cfg(not(feature = "sync"))]
+pub(crate) fn get_token(arena: TokenArena, token_id: TokenId) -> Shared<Token> {
+    Shared::clone(&arena.borrow()[token_id])
+}
+
+#[inline(always)]
+#[cfg(feature = "sync")]
+pub(crate) fn get_token(arena: TokenArena, token_id: TokenId) -> Shared<Token> {
+    Shared::clone(&arena.read().unwrap()[token_id])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,7 +281,7 @@ mod tests {
     #[test]
     fn test_parse_error_syntax() {
         let code = "add(1,";
-        let token_arena = Rc::new(RefCell::new(Arena::new(10)));
+        let token_arena = Shared::new(SharedCell::new(Arena::new(10)));
         let result = parse(code, token_arena);
 
         assert!(result.is_err());
@@ -245,7 +290,7 @@ mod tests {
     #[test]
     fn test_parse_error_lexer() {
         let code = "add(1, `unclosed string)";
-        let token_arena = Rc::new(RefCell::new(Arena::new(10)));
+        let token_arena = Shared::new(SharedCell::new(Arena::new(10)));
         let result = parse(code, token_arena);
 
         assert!(result.is_err());

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -1484,48 +1484,47 @@ fn test_eval_error(mut engine_no_opt: Engine, #[case] program: &str, #[case] inp
 
 #[cfg(feature = "ast-json")]
 mod ast_json {
-    use mq_lang::{ArenaId, AstExpr, AstLiteral, AstNode, Program};
+    use mq_lang::{ArenaId, AstExpr, AstLiteral, AstNode, Program, Shared};
     use rstest::rstest;
     use smallvec::smallvec;
-    use std::rc::Rc;
 
-    fn default_token_id() -> ArenaId<Rc<mq_lang::Token>> {
+    fn default_token_id() -> ArenaId<Shared<mq_lang::Token>> {
         ArenaId::new(0)
     }
 
     #[rstest]
     #[case(
-    Rc::new(AstNode {
+    Shared::new(AstNode {
         token_id: default_token_id(),
-        expr: Rc::new(AstExpr::Literal(AstLiteral::String("hello".to_string()))),
+        expr: Shared::new(AstExpr::Literal(AstLiteral::String("hello".to_string()))),
     }),
     Some(vec!["Literal", "String", "hello"]),
     true
 )]
     #[case(
-    Rc::new(AstNode {
+    Shared::new(AstNode {
         token_id: default_token_id(),
-        expr: Rc::new(AstExpr::Literal(AstLiteral::Number(123.45.into()))),
+        expr: Shared::new(AstExpr::Literal(AstLiteral::Number(123.45.into()))),
     }),
     Some(vec!["Literal", "Number", "123.45"]),
     true
 )]
     #[case(
-    Rc::new(AstNode {
+    Shared::new(AstNode {
         token_id: default_token_id(),
-        expr: Rc::new(AstExpr::Ident(mq_lang::IdentWithToken::new("my_var"))),
+        expr: Shared::new(AstExpr::Ident(mq_lang::IdentWithToken::new("my_var"))),
     }),
     Some(vec!["Ident", "my_var"]),
     true
 )]
     #[case(
-    Rc::new(AstNode {
+    Shared::new(AstNode {
         token_id: default_token_id(),
-        expr: Rc::new(AstExpr::Call(
+        expr: Shared::new(AstExpr::Call(
             mq_lang::IdentWithToken::new("my_func"),
-            smallvec![Rc::new(AstNode {
+            smallvec![Shared::new(AstNode {
                 token_id: default_token_id(),
-                expr: Rc::new(AstExpr::Literal(AstLiteral::Number(1.into()))),
+                expr: Shared::new(AstExpr::Literal(AstLiteral::Number(1.into()))),
             })],
         )),
     }),
@@ -1533,17 +1532,17 @@ mod ast_json {
     true
 )]
     #[case(
-    Rc::new(AstNode {
+    Shared::new(AstNode {
         token_id: default_token_id(),
-        expr: Rc::new(AstExpr::If(smallvec![
+        expr: Shared::new(AstExpr::If(smallvec![
             (
-                Some(Rc::new(AstNode {
+                Some(Shared::new(AstNode {
                     token_id: default_token_id(),
-                    expr: Rc::new(AstExpr::Literal(AstLiteral::Bool(true))),
+                    expr: Shared::new(AstExpr::Literal(AstLiteral::Bool(true))),
                 })),
-                Rc::new(AstNode {
+                Shared::new(AstNode {
                     token_id: default_token_id(),
-                    expr: Rc::new(AstExpr::Literal(AstLiteral::String("then_branch".to_string()))),
+                    expr: Shared::new(AstExpr::Literal(AstLiteral::String("then_branch".to_string()))),
                 })
             )
         ])),
@@ -1552,7 +1551,7 @@ mod ast_json {
     false
 )]
     fn test_astnode_serialization_deserialization(
-        #[case] original_node: Rc<AstNode>,
+        #[case] original_node: Shared<AstNode>,
         #[case] expected_json_parts: Option<Vec<&str>>,
         #[case] check_token_id: bool,
     ) {
@@ -1578,13 +1577,13 @@ mod ast_json {
 
     #[test]
     fn test_program_serialization_deserialization() {
-        let node1 = Rc::new(AstNode {
+        let node1 = Shared::new(AstNode {
             token_id: default_token_id(),
-            expr: Rc::new(AstExpr::Literal(AstLiteral::String("first".to_string()))),
+            expr: Shared::new(AstExpr::Literal(AstLiteral::String("first".to_string()))),
         });
-        let node2 = Rc::new(AstNode {
+        let node2 = Shared::new(AstNode {
             token_id: default_token_id(),
-            expr: Rc::new(AstExpr::Literal(AstLiteral::Number(10.into()))),
+            expr: Shared::new(AstExpr::Literal(AstLiteral::Number(10.into()))),
         });
         let original_program: Program = vec![node1, node2];
 

--- a/crates/mq-lsp/src/execute_command.rs
+++ b/crates/mq-lsp/src/execute_command.rs
@@ -1,5 +1,4 @@
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
-
+use std::borrow::Cow;
 use tower_lsp::jsonrpc::Result;
 
 pub fn response(
@@ -39,7 +38,8 @@ pub fn response(
             .as_slice()
         {
             [Some(code)] => {
-                let token_arena = Rc::new(RefCell::new(mq_lang::Arena::new(1024)));
+                let token_arena =
+                    mq_lang::Shared::new(mq_lang::SharedCell::new(mq_lang::Arena::new(1024)));
                 let program =
                     mq_lang::parse(code, token_arena).map_err(|e| tower_lsp::jsonrpc::Error {
                         code: tower_lsp::jsonrpc::ErrorCode::InvalidParams,

--- a/crates/mq-wasm/src/script.rs
+++ b/crates/mq-wasm/src/script.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, str::FromStr};
+use std::str::FromStr;
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -248,7 +248,7 @@ pub fn run(code: &str, content: &str, options: JsValue) -> Result<String, JsValu
 
 #[wasm_bindgen(js_name=toAst)]
 pub fn to_ast(code: &str) -> Result<String, JsValue> {
-    let token_arena = Rc::new(RefCell::new(mq_lang::Arena::new(10240)));
+    let token_arena = mq_lang::Shared::new(mq_lang::SharedCell::new(mq_lang::Arena::new(10240)));
     mq_lang::parse(code, token_arena)
         .map_err(|e| JsValue::from_str(&format!("Failed to parse code: {}", e)))
         .and_then(|json| {

--- a/justfile
+++ b/justfile
@@ -83,7 +83,9 @@ test-mq:
 
 # Run formatting, linting and all tests
 test: fmt lint test-mq
+    cargo nextest run --workspace
     cargo nextest run --workspace --all-features
+    cargo test --doc --workspace
 
 # Run tests with code coverage reporting
 test-cov:

--- a/justfile
+++ b/justfile
@@ -81,11 +81,15 @@ test-mq:
     cargo run -p mq-cli --bin mq -- -f crates/mq-lang/modules/xml_tests.mq
     cargo run -p mq-cli --bin mq -- -f crates/mq-lang/modules/fuzzy_tests.mq
 
-# Run formatting, linting and all tests
-test: fmt lint test-mq
-    cargo nextest run --workspace
-    cargo nextest run --workspace --all-features
+test-doc:
     cargo test --doc --workspace
+
+test-all-features:
+    cargo nextest run --workspace --all-features
+
+# Run formatting, linting and all tests
+test: fmt lint test-mq test-doc test-all-features
+    cargo nextest run --workspace
 
 # Run tests with code coverage reporting
 test-cov:


### PR DESCRIPTION
- Introduce 'sync' feature flag for conditional compilation between single-threaded and multi-threaded modes
- Add Shared<T> type alias that switches between Rc<T> (non-sync) and Arc<T> (sync mode)
- Add SharedCell<T> type alias that switches between RefCell<T> (non-sync) and RwLock<T> (sync mode)
- Refactor all crates to use new type aliases instead of hardcoded Rc/RefCell
- Update debugger feature to depend on sync feature for thread safety
- Add helper functions token_alloc() and get_token() with conditional compilation
- Update documentation and examples to use new type aliases

This enables the mq language to be safely used in both single-threaded and multi-threaded environments depending on feature flags, improving flexibility and thread safety when needed.