### PR TITLE
⚡ perf(dap): optimize logging levels for debug vs release builds

### DIFF
--- a/crates/mq-dap/src/server.rs
+++ b/crates/mq-dap/src/server.rs
@@ -11,8 +11,13 @@ type DynResult<T> = miette::Result<T, Box<dyn std::error::Error>>;
 pub fn start() -> DynResult<()> {
     let (debug_writer, log_rx) = DebugConsoleWriter::new();
 
+    #[cfg(debug_assertions)]
+    let log_level = tracing::Level::DEBUG;
+    #[cfg(not(debug_assertions))]
+    let log_level = tracing::Level::INFO;
+
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
+        .with_max_level(log_level)
         .with_writer(debug_writer)
         .init();
 


### PR DESCRIPTION
Switch from TRACE to conditionally compiled log levels:
- DEBUG level in debug builds for development visibility
- INFO level in release builds for better performance