### PR TITLE
✨ feat(lsp): add module path configuration support

### DIFF
--- a/crates/mq-hir/src/find.rs
+++ b/crates/mq-hir/src/find.rs
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_find_symbol_in_position() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, "let x = 5");
         let pos = mq_lang::Position::new(1, 4);
 
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_find_scope_in_position() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, "def example(): 5;");
         let pos = mq_lang::Position::new(1, 18);
 
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_find_symbols_in_scope() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (_, scope_id) = hir.add_code(None, "let x = 5");
         let symbols = hir.find_symbols_in_scope(scope_id);
 
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_find_symbols_in_source() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, "let x = 5");
         let symbols = hir.find_symbols_in_source(source_id);
 
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_find_scope_by_source() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, scope_id) = hir.add_code(None, "let x = 5");
 
         hir.source_scopes.insert(source_id, scope_id);

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -1,3 +1,5 @@
+use std::{path::PathBuf, vec};
+
 use mq_lang::{Token, TokenKind};
 use rustc_hash::FxHashMap;
 use slotmap::SlotMap;
@@ -24,12 +26,12 @@ pub struct Hir {
 
 impl Default for Hir {
     fn default() -> Self {
-        Self::new()
+        Self::new(vec![])
     }
 }
 
 impl Hir {
-    pub fn new() -> Self {
+    pub fn new(module_paths: Vec<PathBuf>) -> Self {
         let mut sources = SlotMap::default();
         let mut scopes = SlotMap::default();
 
@@ -48,7 +50,7 @@ impl Hir {
             symbols: SlotMap::default(),
             sources,
             scopes,
-            module_loader: mq_lang::ModuleLoader::default(),
+            module_loader: mq_lang::ModuleLoader::new(Some(module_paths)),
             source_scopes,
             references: FxHashMap::default(),
         }
@@ -1095,7 +1097,7 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
         #[case] expected_doc: Vec<String>,
         #[case] expected_kind: Vec<SymbolKind>,
     ) {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
 
         hir.builtin.disabled = true;
         hir.add_code(None, code);
@@ -1171,7 +1173,7 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
         #[case] expected_name: &str,
         #[case] expected_kind: SymbolKind,
     ) {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         hir.builtin.loaded = true;
         hir.add_code(None, code);
 
@@ -1227,7 +1229,7 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
         #[case] expected_name: &str,
         #[case] expected_kind: SymbolKind,
     ) {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, code);
 
         let (_, symbol) = hir.find_symbol_in_position(source_id, pos).unwrap();
@@ -1237,14 +1239,14 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
 
     #[test]
     fn test_builtin() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         hir.add_builtin();
         assert!(hir.builtin.loaded);
     }
 
     #[test]
     fn test_include_function_resolves() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         hir.builtin.loaded = false; // Ensure builtins are loaded by add_code
         let code = r#"include "csv"
 | def test_csv():
@@ -1272,7 +1274,7 @@ end"#;
 
     #[test]
     fn test_unused_functions() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         hir.builtin.disabled = true; // Disable builtins for cleaner test
 
         let code = "def used_function(): 1; def unused_function(): 2; def another_unused(): 3; | used_function()";
@@ -1295,7 +1297,7 @@ end"#;
 
     #[test]
     fn test_unused_functions_empty_when_all_used() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         hir.builtin.disabled = true;
 
         let code = "def func1(): 1; def func2(): 2; | func1() | func2()";

--- a/crates/mq-hir/src/reference.rs
+++ b/crates/mq-hir/src/reference.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[test]
     fn test_references() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let _ = hir.add_code(None, "def func1(): 1; let val1 = func1()");
 
         assert_eq!(

--- a/crates/mq-hir/src/scope.rs
+++ b/crates/mq-hir/src/scope.rs
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn test_add_child() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, "let x = 5");
         let source = SourceInfo::new(Some(source_id), None);
         let mut scope = Scope::new(source, ScopeKind::Module(source_id), None);
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_symbol_id() {
-        let mut hir = Hir::new();
+        let mut hir = Hir::default();
         let (source_id, _) = hir.add_code(None, "let x = 5");
         let source = SourceInfo::new(Some(source_id), None);
         let symbol_id = hir.symbols().collect::<Vec<_>>().first().unwrap().0;

--- a/crates/mq-lsp/src/document_symbol.rs
+++ b/crates/mq-lsp/src/document_symbol.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_response_with_empty_symbols() {
-        let hir = Arc::new(RwLock::new(mq_hir::Hir::new()));
+        let hir = Arc::new(RwLock::new(mq_hir::Hir::default()));
         let url = Url::parse("file:///test.mq").unwrap();
         let source_map = BiMap::new();
         let res = response(hir.clone(), url.clone(), source_map.clone());
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_response_with_various_symbols() {
-        let mut hir = mq_hir::Hir::new();
+        let mut hir = mq_hir::Hir::default();
         let url = Url::parse("file:///test.mq").unwrap();
 
         let (source_id, _) = hir.add_code(Some(url.clone()), "def func1(): 1; let var1 = 2");

--- a/crates/mq-lsp/src/goto_definition.rs
+++ b/crates/mq-lsp/src/goto_definition.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_goto_definition_not_found() {
-        let hir = Arc::new(RwLock::new(mq_hir::Hir::new()));
+        let hir = Arc::new(RwLock::new(mq_hir::Hir::default()));
         let url = Url::parse("file:///test.mq").unwrap();
 
         let result = response(hir, url, Position::new(0, 0));
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_goto_definition_no_text_range() {
-        let mut hir = mq_hir::Hir::new();
+        let mut hir = mq_hir::Hir::default();
         let url = Url::parse("file:///test.mq").unwrap();
         hir.add_code(Some(url.clone()), "let x = 42;");
 

--- a/crates/mq-lsp/src/main.rs
+++ b/crates/mq-lsp/src/main.rs
@@ -1,3 +1,5 @@
+use crate::server::LspConfig;
+
 pub mod capabilities;
 pub mod completions;
 pub mod document_symbol;
@@ -10,5 +12,5 @@ pub mod server;
 
 #[tokio::main]
 async fn main() {
-    server::start().await;
+    server::start(LspConfig::default()).await;
 }

--- a/crates/mq-lsp/src/references.rs
+++ b/crates/mq-lsp/src/references.rs
@@ -61,7 +61,7 @@ mod tests {
     use super::*;
 
     fn setup() -> (Arc<RwLock<Hir>>, BiMap<String, SourceId>) {
-        let hir = Arc::new(RwLock::new(Hir::new()));
+        let hir = Arc::new(RwLock::new(Hir::default()));
         let source_map = BiMap::new();
         (hir, source_map)
     }

--- a/crates/mq-lsp/src/server.rs
+++ b/crates/mq-lsp/src/server.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use bimap::BiMap;
@@ -362,12 +363,24 @@ impl Backend {
     }
 }
 
-pub async fn start() {
+#[derive(Debug, Clone, Default)]
+
+pub struct LspConfig {
+    module_paths: Vec<PathBuf>,
+}
+
+impl LspConfig {
+    pub fn new(module_paths: Vec<PathBuf>) -> Self {
+        Self { module_paths }
+    }
+}
+
+pub async fn start(config: LspConfig) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
     let (service, socket) = LspService::new(|client| Backend {
         client,
-        hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+        hir: Arc::new(RwLock::new(mq_hir::Hir::new(config.module_paths))),
         source_map: RwLock::new(BiMap::new()),
         error_map: DashMap::new(),
         cst_nodes_map: DashMap::new(),
@@ -386,7 +399,7 @@ mod tests {
     async fn test_did_open() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -435,7 +448,7 @@ mod tests {
     async fn test_formatting() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -473,7 +486,7 @@ mod tests {
     async fn test_completion() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -501,7 +514,7 @@ mod tests {
     async fn test_goto_definition() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -528,7 +541,7 @@ mod tests {
     async fn test_hover() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -554,7 +567,7 @@ mod tests {
     async fn test_semantic_tokens() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -612,7 +625,7 @@ mod tests {
     async fn test_references() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -654,7 +667,7 @@ mod tests {
     async fn test_document_symbol() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -700,7 +713,7 @@ mod tests {
     async fn test_did_change() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -743,7 +756,7 @@ mod tests {
     async fn test_did_close() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -800,7 +813,7 @@ mod tests {
     async fn test_did_save() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -839,7 +852,7 @@ mod tests {
     async fn test_initialize_shutdown() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -865,7 +878,7 @@ mod tests {
     async fn test_semantic_tokens_range() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -906,7 +919,7 @@ mod tests {
     async fn test_diagnostics_with_errors() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -932,7 +945,7 @@ mod tests {
     async fn test_unused_function_warnings() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -973,7 +986,7 @@ mod tests {
     async fn test_formatting_with_errors() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),
@@ -1021,7 +1034,7 @@ mod tests {
     async fn test_unreachable_code_warnings() {
         let (service, _) = LspService::new(|client| Backend {
             client,
-            hir: Arc::new(RwLock::new(mq_hir::Hir::new())),
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
             source_map: RwLock::new(BiMap::new()),
             error_map: DashMap::new(),
             cst_nodes_map: DashMap::new(),

--- a/crates/mq-repl/src/command_context.rs
+++ b/crates/mq-repl/src/command_context.rs
@@ -94,7 +94,7 @@ pub struct CommandContext {
 
 impl CommandContext {
     pub fn new(engine: mq_lang::Engine, input: Vec<mq_lang::RuntimeValue>) -> Self {
-        let mut hir = mq_hir::Hir::new();
+        let mut hir = mq_hir::Hir::default();
         let (source_id, scope_id) = hir.add_new_source(None);
 
         hir.add_builtin();


### PR DESCRIPTION
- Add CLI option -M/--module-paths to lsp command for specifying module file paths
- Introduce LspConfig struct to manage LSP server configuration
- Update Hir::new() to accept module paths and pass them to ModuleLoader
- Configure VSCode extension to pass workspace directory as module path
- Update all HIR and LSP test initialization to use new constructor pattern

This enables the LSP server to load modules from specified paths, improving module resolution and IntelliSense capabilities in editor environments.