### PR TITLE
✨ feat(vscode): add mq syntax highlighting in markdown code blocks

### DIFF
--- a/editors/vscode/mq.markdown.tmLanguage.json
+++ b/editors/vscode/mq.markdown.tmLanguage.json
@@ -1,0 +1,34 @@
+{
+  "scopeName": "markdown.mq.codeblock",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#mq-code-block"
+    }
+  ],
+  "repository": {
+    "mq-code-block": {
+      "begin": "(^|\\G)(\\s*)(```)(mq)\\s*$",
+      "end": "(^|\\G)(\\s*)(```)",
+      "contentName": "meta.embedded.block.mq",
+      "patterns": [
+        {
+          "include": "source.mq"
+        }
+      ],
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      }
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -46,6 +46,10 @@
     "languages": [
       {
         "id": "mq",
+        "aliases": [
+          "mq",
+          "MQ"
+        ],
         "extensions": [
           ".mq"
         ],
@@ -61,6 +65,16 @@
         "language": "mq",
         "scopeName": "source.mq",
         "path": "./mq.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.mq.codeblock",
+        "path": "./mq.markdown.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.mq": "mq"
+        }
       }
     ],
     "commands": [


### PR DESCRIPTION
Add TextMate grammar injection to enable mq syntax highlighting within markdown fenced code blocks. This improves the editing experience when working with markdown files containing mq examples.