### PR TITLE
✨ feat(cli): add aggregate option to combine input files into array

### DIFF
--- a/crates/mq-cli/src/cli.rs
+++ b/crates/mq-cli/src/cli.rs
@@ -99,6 +99,10 @@ pub enum LinkUrlStyle {
 
 #[derive(Clone, Debug, clap::Args, Default)]
 struct InputArgs {
+    /// Aggregate all input files/content into a single array
+    #[arg(short = 'A', long, default_value_t = false)]
+    aggregate: bool,
+
     /// load filter from the file
     #[arg(short, long, default_value_t = false)]
     from_file: bool,
@@ -422,12 +426,22 @@ impl Cli {
         .map(|(name, _)| format!(r#"include "{}""#, name))
         .join(" | ");
 
-        Ok(match (includes.is_empty(), query.is_empty()) {
+        let aggregate = if self.input.aggregate {
+            Some("nodes")
+        } else {
+            None
+        };
+
+        let query = match (includes.is_empty(), query.is_empty()) {
             (true, false) => query,
             (false, true) => includes,
             (false, false) => format!("{} | {}", includes, query),
             (true, true) => String::new(),
-        })
+        };
+
+        Ok(aggregate
+            .map(|agg| format!("{} | {}", agg, query))
+            .unwrap_or(query))
     }
 
     fn execute(


### PR DESCRIPTION
Add -A/--aggregate flag to CLI that allows aggregating all input files or content into a single array before processing. When enabled, wraps the query with 'nodes |' to collect all inputs.