### PR TITLE
💄 style(formatter): Improve indentation for function values in dict f…

### DIFF
--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -180,6 +180,10 @@ impl Node {
         matches!(self.kind, NodeKind::Token)
     }
 
+    pub fn is_fn(&self) -> bool {
+        matches!(self.kind, NodeKind::Fn)
+    }
+
     pub fn comments(&self) -> Vec<Comment> {
         self.leading_trivia
             .iter()


### PR DESCRIPTION
…ormatting

- Add CallDynamic to the list of node kinds that skip leading trivia newlines
- Improve dict value formatting to properly indent function values
- Add is_fn() helper method to CstNode for checking function nodes
- Add test case for dict with multiline function values