### PR TITLE
🐛 fix(optimizer): Prevent constant table leakage across function scopes

### DIFF
--- a/crates/mq-lang/src/optimizer.rs
+++ b/crates/mq-lang/src/optimizer.rs
@@ -610,9 +610,15 @@ impl Optimizer {
                 }
             }
             ast::Expr::Def(_, _, program) | ast::Expr::Fn(_, program) => {
+                // Save current constant table to prevent leaking function-local constants
+                let saved_constant_table = std::mem::take(&mut self.constant_table);
+
                 for node in program {
                     self.optimize_node(node);
                 }
+
+                // Restore the outer scope's constant table
+                self.constant_table = saved_constant_table;
             }
             ast::Expr::Paren(expr) => {
                 self.optimize_node(expr);


### PR DESCRIPTION
Save and restore the constant table when entering/exiting function and def blocks to prevent function-local constants from leaking into the outer scope. This ensures proper constant scope isolation during optimization.