### PR TITLE
✨ feat(builtin): Add input function to read from stdin

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2256,7 +2256,7 @@ define_builtin!(INPUT, ParamNum::None, |_, _, _| {
     io::stdin()
         .read_line(&mut input)
         .map_err(|e| Error::Runtime(format!("Failed to read from stdin: {}", e)))?;
-    input = input.trim_end_matches(&['\n', '\r'][..]).to_string();
+    input.truncate(input.trim_end_matches(&['\n', '\r'][..]).len());
 
     Ok(RuntimeValue::String(input))
 });


### PR DESCRIPTION
Adds a new builtin function `input()` that reads a line from standard input and returns it as a string. This enables interactive user input in mq queries.

Changes:
- Add INPUT builtin with ParamNum::None
- Import std::io for stdin reading
- Add function hash and documentation
- Fix NAN and INFINITE to use ParamNum::None instead of Fixed(0)