### PR TITLE
📝 docs(reference): Add Symbol type to types and values documentation

### DIFF
--- a/docs/books/src/reference/types_and_values.md
+++ b/docs/books/src/reference/types_and_values.md
@@ -4,6 +4,7 @@
 
 - `42` (a number)
 - `"Hello, world!"` (a string)
+- `:value` (a symbol)
 - `[1, 2, 3]`, `array(1, 2, 3)` (an array)
 - `{"a": 1, "b": 2, "c": 3}`, `dict(["a", 1], ["b", 2], ["c", 3])` (a dictionary)
 - `true`, `false` (a boolean)
@@ -15,6 +16,7 @@
 | ------------ | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | **Number**   | Represents numeric values.                                                                                        | `1`, `3.14`, `-42`                             |
 | **String**   | Represents sequences of characters, including Unicode code points and escape sequences in the form of `\{0x000}`. | `"hello"`, `"123"`, `"😊"`, `"\u{1F600}"`       |
+| **Symbol**   | Represents immutable, interned identifiers prefixed with `:`. Used for constant values and keys.                  | `:value`, `:success`, `:error`, `:ok`          |
 | **Boolean**  | Represents truth values.                                                                                          | `true`, `false`                                |
 | **Array**    | Represents ordered collections of values.                                                                         | `[1, 2, 3]`, `array(1, 2, 3)`                  |
 | **Dict**     | Represents key-value mappings (dictionaries).                                                                     | `{"a": 1, "b": 2}`, `dict(["a", 1], ["b", 2])` |


### PR DESCRIPTION
Add Symbol type documentation to the reference guide, including:
- Symbol literal syntax example (:value)
- Symbol type description in the types table
- Example symbols (:success, :error, :ok)

This completes the documentation for the symbol literals feature added in #727.