### PR TITLE
✨ feat(builtin): Add to_markdown function for parsing markdown strings

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -5215,6 +5215,17 @@ mod tests {
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
         ].into_iter().collect())])
     )]
+    #[case::to_markdown_string_to_markdown_array(
+        vec![RuntimeValue::String("a\n\nb\n\nc".to_string())],
+        vec![
+            ast_call("to_markdown", SmallVec::new())
+        ],
+        Ok(vec![RuntimeValue::Array(vec![
+            RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "a".to_string(), position: None}), None),
+            RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "b".to_string(), position: None}), None),
+            RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "c".to_string(), position: None}), None),
+        ])]))
+    ]
     fn test_eval(
         token_arena: Shared<SharedCell<Arena<Shared<Token>>>>,
         #[case] runtime_values: Vec<RuntimeValue>,


### PR DESCRIPTION
Implements a new builtin function `to_markdown` that parses a markdown string and returns an array of markdown nodes. This enables users to convert string data into markdown AST structures for further processing.

Changes:
- Added TO_MARKDOWN builtin function with ParamNum::Fixed(1)
- Implemented string-to-markdown parsing using parse_markdown_input
- Added comprehensive test case for to_markdown functionality
- Added function documentation to BUILTIN_FUNCTION_DOC
- Registered function hash for runtime lookup