### PR TITLE
✨ feat(parser): add dedicated dict key validation method

### DIFF
--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -1285,6 +1285,7 @@ impl<'a> Parser<'a> {
         Ok(Shared::new(node))
     }
 
+    #[inline(always)]
     fn parse_node(
         &mut self,
         node_kind: NodeKind,
@@ -1389,6 +1390,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
+    #[inline(always)]
     fn parse_dict_key(&mut self, leading_trivia: Vec<Trivia>) -> Result<Shared<Node>, ParseError> {
         let token = match self.tokens.peek() {
             Some(token) => Shared::clone(token),
@@ -2185,6 +2187,7 @@ impl<'a> Parser<'a> {
         Ok(nodes)
     }
 
+    #[inline(always)]
     fn parse_param(&mut self) -> Result<Shared<Node>, ParseError> {
         let leading_trivia = self.parse_leading_trivia();
 
@@ -2197,6 +2200,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    #[inline(always)]
     fn parse_leading_trivia(&mut self) -> Vec<Trivia> {
         let mut trivia = Vec::with_capacity(100);
 
@@ -2233,6 +2237,7 @@ impl<'a> Parser<'a> {
         trivia
     }
 
+    #[inline(always)]
     fn try_next_token(&mut self, match_token_kind: fn(&TokenKind) -> bool) -> bool {
         let tokens = &mut self.tokens.clone();
         Self::try_parse_leading_trivia(tokens);
@@ -2246,6 +2251,7 @@ impl<'a> Parser<'a> {
         match_token_kind(&token.unwrap().kind)
     }
 
+    #[inline(always)]
     fn parse_trailing_trivia(&mut self) -> Vec<Trivia> {
         let mut trivia = Vec::with_capacity(10);
 
@@ -2261,6 +2267,7 @@ impl<'a> Parser<'a> {
         trivia
     }
 
+    #[inline(always)]
     fn skip_tokens(&mut self) {
         loop {
             let token = match self.tokens.peek() {
@@ -2285,6 +2292,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    #[inline(always)]
     fn next_token(
         &mut self,
         match_token_kind: fn(&TokenKind) -> bool,
@@ -2303,6 +2311,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    #[inline(always)]
     fn next_node(
         &mut self,
         expected_token: fn(&TokenKind) -> bool,


### PR DESCRIPTION
Extracted dictionary key parsing logic into a separate parse_dict_key method to improve type safety and error handling. The new method explicitly validates that dictionary keys are identifiers, colons, or string literals before parsing.