### PR TITLE
✨ feat(build): upgrade to Rust 1.90 and adopt let-chaining syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.85-slim AS builder
+# syntax=docker/dockerfile:1
+FROM rust:1.90-slim AS builder
 
 WORKDIR /usr/src/app
 COPY . /usr/src/app

--- a/crates/mq-dap/src/adapter.rs
+++ b/crates/mq-dap/src/adapter.rs
@@ -620,7 +620,9 @@ impl MqAdapter {
                 server.respond(rsp)?;
             }
             command => {
-                return Err(Box::new(MqAdapterError::UnhandledCommand(command.clone())));
+                return Err(Box::new(MqAdapterError::UnhandledCommand(Box::new(
+                    command.clone(),
+                ))));
             }
         }
         Ok(())

--- a/crates/mq-dap/src/error.rs
+++ b/crates/mq-dap/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum MqAdapterError {
     #[error("Unhandled command: {0:?}")]
-    UnhandledCommand(Command),
+    UnhandledCommand(Box<Command>),
     #[error("Protocol error: {0}")]
     ProtocolError(String),
     #[error("Failed to deserialize launch arguments: {0}")]

--- a/crates/mq-dap/src/log.rs
+++ b/crates/mq-dap/src/log.rs
@@ -19,15 +19,15 @@ impl DebugConsoleWriter {
 impl Write for DebugConsoleWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let message = String::from_utf8_lossy(buf);
-        if let Some(ref sender) = self.sender {
-            if sender.send(message.to_string()).is_err() {
-                // Channel is closed, but we still need to return success
-                // to avoid breaking the logging infrastructure
-                eprintln!(
-                    "Warning: Log channel is closed, message dropped: {}",
-                    message
-                );
-            }
+        if let Some(ref sender) = self.sender
+            && sender.send(message.to_string()).is_err()
+        {
+            // Channel is closed, but we still need to return success
+            // to avoid breaking the logging infrastructure
+            eprintln!(
+                "Warning: Log channel is closed, message dropped: {}",
+                message
+            );
         }
 
         Ok(buf.len())

--- a/crates/mq-dap/src/server.rs
+++ b/crates/mq-dap/src/server.rs
@@ -66,12 +66,11 @@ pub fn start() -> DynResult<()> {
         }
 
         debug!("Waiting for next request or debugger message");
-        if let Some(rx) = adapter.debugger_message_rx() {
-            if let Ok(message) = rx.try_recv() {
-                if let Err(e) = adapter.handle_debugger_message(message, &mut server) {
-                    error!(error = %e, "Failed to handle debugger message");
-                }
-            }
+        if let Some(rx) = adapter.debugger_message_rx()
+            && let Ok(message) = rx.try_recv()
+            && let Err(e) = adapter.handle_debugger_message(message, &mut server)
+        {
+            error!(error = %e, "Failed to handle debugger message");
         }
 
         match server.poll_request()? {
@@ -80,10 +79,9 @@ pub fn start() -> DynResult<()> {
                     error!(error = %e, "Failed to handle DAP request");
                     if let Some(MqAdapterError::ProtocolError(msg)) =
                         e.downcast_ref::<MqAdapterError>()
+                        && msg == "Shutdown"
                     {
-                        if msg == "Shutdown" {
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -768,36 +768,34 @@ impl Formatter {
         }
 
         // 3. Optional guard: if <expr>
-        if let Some(if_token) = children.get(idx) {
-            if let Some(token) = if_token.token.as_ref() {
-                if matches!(token.kind, mq_lang::TokenKind::If) {
-                    self.append_space();
-                    self.output.push_str("if ");
-                    idx += 1;
+        if let Some(if_token) = children.get(idx)
+            && let Some(token) = if_token.token.as_ref()
+            && matches!(token.kind, mq_lang::TokenKind::If)
+        {
+            self.append_space();
+            self.output.push_str("if ");
+            idx += 1;
 
-                    // Guard expression: all nodes until colon
-                    while let Some(expr) = children.get(idx) {
-                        if let Some(t) = expr.token.as_ref() {
-                            if matches!(t.kind, mq_lang::TokenKind::Colon) {
-                                break;
-                            }
-                        }
-                        self.format_node(mq_lang::Shared::clone(expr), 0);
-                        idx += 1;
-                    }
+            // Guard expression: all nodes until colon
+            while let Some(expr) = children.get(idx) {
+                if let Some(t) = expr.token.as_ref()
+                    && matches!(t.kind, mq_lang::TokenKind::Colon)
+                {
+                    break;
                 }
+                self.format_node(mq_lang::Shared::clone(expr), 0);
+                idx += 1;
             }
         }
 
         // 4. Colon
-        if let Some(colon) = children.get(idx) {
-            if let Some(token) = colon.token.as_ref() {
-                if matches!(token.kind, mq_lang::TokenKind::Colon) {
-                    self.output.push_str(&token.to_string());
-                    self.append_space();
-                    idx += 1;
-                }
-            }
+        if let Some(colon) = children.get(idx)
+            && let Some(token) = colon.token.as_ref()
+            && matches!(token.kind, mq_lang::TokenKind::Colon)
+        {
+            self.output.push_str(&token.to_string());
+            self.append_space();
+            idx += 1;
         }
 
         // 5. Body
@@ -829,26 +827,25 @@ impl Formatter {
         // Format children (for complex patterns like arrays, dicts, type patterns)
         if !node.children.is_empty() {
             // Check if this is a type pattern (starts with colon)
-            if let Some(first) = node.children.first() {
-                if let Some(token) = &first.token {
-                    if matches!(token.kind, mq_lang::TokenKind::Colon) {
-                        // Type pattern: :type_name
-                        self.output.push_str(&token.to_string());
-                        if let Some(second) = node.children.get(1) {
-                            if let Some(t) = &second.token {
-                                if let mq_lang::TokenKind::Ident(name) = &t.kind {
-                                    self.output.push_str(name);
-                                }
-                            }
-                        }
-                        return;
-                    } else if matches!(token.kind, mq_lang::TokenKind::LBracket) {
-                        self.format_array_pattern(node);
-                        return;
-                    } else if matches!(token.kind, mq_lang::TokenKind::LBrace) {
-                        self.format_dict_pattern(node);
-                        return;
+            if let Some(first) = node.children.first()
+                && let Some(token) = &first.token
+            {
+                if matches!(token.kind, mq_lang::TokenKind::Colon) {
+                    // Type pattern: :type_name
+                    self.output.push_str(&token.to_string());
+                    if let Some(second) = node.children.get(1)
+                        && let Some(t) = &second.token
+                        && let mq_lang::TokenKind::Ident(name) = &t.kind
+                    {
+                        self.output.push_str(name);
                     }
+                    return;
+                } else if matches!(token.kind, mq_lang::TokenKind::LBracket) {
+                    self.format_array_pattern(node);
+                    return;
+                } else if matches!(token.kind, mq_lang::TokenKind::LBrace) {
+                    self.format_dict_pattern(node);
+                    return;
                 }
             }
 
@@ -896,23 +893,19 @@ impl Formatter {
                         self.output.push_str(name);
 
                         // Check for colon and pattern after the identifier
-                        if let Some(next) = children.get(i + 1) {
-                            if let Some(next_token) = &next.token {
-                                if matches!(next_token.kind, mq_lang::TokenKind::Colon) {
-                                    self.output.push_str(&format!("{} ", next_token));
-                                    i += 2; // Skip colon
+                        if let Some(next) = children.get(i + 1)
+                            && let Some(next_token) = &next.token
+                            && matches!(next_token.kind, mq_lang::TokenKind::Colon)
+                        {
+                            self.output.push_str(&format!("{} ", next_token));
+                            i += 2; // Skip colon
 
-                                    // Format the pattern after colon
-                                    if let Some(pattern_node) = children.get(i) {
-                                        if let Some(pattern_token) = &pattern_node.token {
-                                            if let mq_lang::TokenKind::Ident(pattern_name) =
-                                                &pattern_token.kind
-                                            {
-                                                self.output.push_str(pattern_name);
-                                            }
-                                        }
-                                    }
-                                }
+                            // Format the pattern after colon
+                            if let Some(pattern_node) = children.get(i)
+                                && let Some(pattern_token) = &pattern_node.token
+                                && let mq_lang::TokenKind::Ident(pattern_name) = &pattern_token.kind
+                            {
+                                self.output.push_str(pattern_name);
                             }
                         }
                     }

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -536,35 +536,33 @@ impl Hir {
             token: Some(token),
             ..
         } = &**node
-        {
-            if let Token {
+            && let Token {
                 kind: TokenKind::InterpolatedString(segments),
                 ..
             } = &**token
-            {
-                segments.iter().for_each(|segment| match segment {
-                    mq_lang::StringSegment::Text(text, range) => {
-                        self.add_symbol(Symbol {
-                            value: Some(text.into()),
-                            kind: SymbolKind::String,
-                            source: SourceInfo::new(Some(source_id), Some(range.clone())),
-                            scope: scope_id,
-                            doc: node.comments(),
-                            parent,
-                        });
-                    }
-                    mq_lang::StringSegment::Ident(ident, range) => {
-                        self.symbols.insert(Symbol {
-                            value: Some(ident.clone()),
-                            kind: SymbolKind::Variable,
-                            source: SourceInfo::new(Some(source_id), Some(range.clone())),
-                            scope: scope_id,
-                            doc: node.comments(),
-                            parent,
-                        });
-                    }
-                });
-            }
+        {
+            segments.iter().for_each(|segment| match segment {
+                mq_lang::StringSegment::Text(text, range) => {
+                    self.add_symbol(Symbol {
+                        value: Some(text.into()),
+                        kind: SymbolKind::String,
+                        source: SourceInfo::new(Some(source_id), Some(range.clone())),
+                        scope: scope_id,
+                        doc: node.comments(),
+                        parent,
+                    });
+                }
+                mq_lang::StringSegment::Ident(ident, range) => {
+                    self.symbols.insert(Symbol {
+                        value: Some(ident.clone()),
+                        kind: SymbolKind::Variable,
+                        source: SourceInfo::new(Some(source_id), Some(range.clone())),
+                        scope: scope_id,
+                        doc: node.comments(),
+                        parent,
+                    });
+                }
+            });
         }
     }
 
@@ -1386,10 +1384,10 @@ impl Hir {
 
             // Process pattern (first child after the pipe token)
             // The pattern introduces variables into the arm scope
-            if let Some(pattern) = children.first() {
-                if matches!(pattern.kind, mq_lang::CstNodeKind::Pattern) {
-                    self.add_pattern_expr(pattern, source_id, arm_scope_id, Some(symbol_id));
-                }
+            if let Some(pattern) = children.first()
+                && matches!(pattern.kind, mq_lang::CstNodeKind::Pattern)
+            {
+                self.add_pattern_expr(pattern, source_id, arm_scope_id, Some(symbol_id));
             }
 
             // Process remaining children (guard and body)

--- a/crates/mq-hir/src/resolve.rs
+++ b/crates/mq-hir/src/resolve.rs
@@ -71,18 +71,17 @@ impl Hir {
         let mut candidates = Vec::new();
 
         for (symbol_id, symbol) in &self.symbols {
-            if let Some(source_id) = symbol.source.source_id {
-                if source_ids.contains(&source_id)
-                    && symbol.value.as_ref() == Some(ref_name)
-                    && (symbol.is_function()
-                        || symbol.is_parameter()
-                        || symbol.is_variable()
-                        || symbol.is_argument()
-                        || symbol.is_pattern_variable())
-                {
-                    let priority = self.get_symbol_priority_for_cross_source(&symbol.kind);
-                    candidates.push((priority, symbol_id, symbol.clone()));
-                }
+            if let Some(source_id) = symbol.source.source_id
+                && source_ids.contains(&source_id)
+                && symbol.value.as_ref() == Some(ref_name)
+                && (symbol.is_function()
+                    || symbol.is_parameter()
+                    || symbol.is_variable()
+                    || symbol.is_argument()
+                    || symbol.is_pattern_variable())
+            {
+                let priority = self.get_symbol_priority_for_cross_source(&symbol.kind);
+                candidates.push((priority, symbol_id, symbol.clone()));
             }
         }
 

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -1855,15 +1855,14 @@ impl<'a> Parser<'a> {
         children.push(self.parse_pattern(pattern_leading_trivia)?);
 
         // Check for guard (if condition)
-        if let Some(token) = self.tokens.peek() {
-            if matches!(token.kind, TokenKind::If) {
-                children
-                    .push(self.next_node(|kind| matches!(kind, TokenKind::If), NodeKind::Token)?);
+        if let Some(token) = self.tokens.peek()
+            && matches!(token.kind, TokenKind::If)
+        {
+            children.push(self.next_node(|kind| matches!(kind, TokenKind::If), NodeKind::Token)?);
 
-                // Parse guard expression (as args)
-                let mut guard_args = self.parse_args()?;
-                children.append(&mut guard_args);
-            }
+            // Parse guard expression (as args)
+            let mut guard_args = self.parse_args()?;
+            children.append(&mut guard_args);
         }
 
         // Parse colon
@@ -2039,13 +2038,13 @@ impl<'a> Parser<'a> {
             let _leading_trivia = self.parse_leading_trivia();
 
             // Check for }
-            if let Some(token) = self.tokens.peek() {
-                if matches!(token.kind, TokenKind::RBrace) {
-                    children.push(
-                        self.next_node(|kind| matches!(kind, TokenKind::RBrace), NodeKind::Token)?,
-                    );
-                    break;
-                }
+            if let Some(token) = self.tokens.peek()
+                && matches!(token.kind, TokenKind::RBrace)
+            {
+                children.push(
+                    self.next_node(|kind| matches!(kind, TokenKind::RBrace), NodeKind::Token)?,
+                );
+                break;
             }
 
             // Parse key (identifier)
@@ -2053,15 +2052,15 @@ impl<'a> Parser<'a> {
                 .push(self.next_node(|kind| matches!(kind, TokenKind::Ident(_)), NodeKind::Ident)?);
 
             // Check for colon (key: pattern) or just key
-            if let Some(token) = self.tokens.peek() {
-                if matches!(token.kind, TokenKind::Colon) {
-                    children.push(
-                        self.next_node(|kind| matches!(kind, TokenKind::Colon), NodeKind::Token)?,
-                    );
+            if let Some(token) = self.tokens.peek()
+                && matches!(token.kind, TokenKind::Colon)
+            {
+                children.push(
+                    self.next_node(|kind| matches!(kind, TokenKind::Colon), NodeKind::Token)?,
+                );
 
-                    let pattern_leading_trivia = self.parse_leading_trivia();
-                    children.push(self.parse_pattern(pattern_leading_trivia)?);
-                }
+                let pattern_leading_trivia = self.parse_leading_trivia();
+                children.push(self.parse_pattern(pattern_leading_trivia)?);
             }
 
             // Check for comma or }

--- a/crates/mq-lang/src/eval/debugger.rs
+++ b/crates/mq-lang/src/eval/debugger.rs
@@ -345,10 +345,10 @@ impl Debugger {
             }
 
             if breakpoint.line == line {
-                if let Some(bp_column) = breakpoint.column {
-                    if bp_column != column {
-                        continue;
-                    }
+                if let Some(bp_column) = breakpoint.column
+                    && bp_column != column
+                {
+                    continue;
                 }
 
                 return Some(breakpoint.clone());

--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -82,18 +82,18 @@ fn is_char_available() -> bool {
     }
 
     // Check if we're in a UTF-8 locale
-    if let Ok(lang) = std::env::var("LANG") {
-        if lang.to_lowercase().contains("utf-8") || lang.to_lowercase().contains("utf8") {
-            return true;
-        }
+    if let Ok(lang) = std::env::var("LANG")
+        && (lang.to_lowercase().contains("utf-8") || lang.to_lowercase().contains("utf8"))
+    {
+        return true;
     }
 
     // Check LC_ALL and LC_CTYPE for UTF-8 support
     for var in ["LC_ALL", "LC_CTYPE"] {
-        if let Ok(locale) = std::env::var(var) {
-            if locale.to_lowercase().contains("utf-8") || locale.to_lowercase().contains("utf8") {
-                return true;
-            }
+        if let Ok(locale) = std::env::var(var)
+            && (locale.to_lowercase().contains("utf-8") || locale.to_lowercase().contains("utf8"))
+        {
+            return true;
         }
     }
 

--- a/crates/mq-wasm/Cargo.toml
+++ b/crates/mq-wasm/Cargo.toml
@@ -24,4 +24,4 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-test = "0.3.50"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-O4', '--enable-simd']
+wasm-opt = ['-O4', '--enable-simd', '--enable-bulk-memory', '--enable-nontrapping-float-to-int']

--- a/crates/mq-web-api/src/middleware/rate_limit.rs
+++ b/crates/mq-web-api/src/middleware/rate_limit.rs
@@ -58,19 +58,19 @@ fn extract_identifier(request: &Request) -> String {
     // 3. Connection remote address
     // 4. Fallback to "unknown"
 
-    if let Some(forwarded_for) = request.headers().get("x-forwarded-for") {
-        if let Ok(forwarded_str) = forwarded_for.to_str() {
-            // Take the first IP from the comma-separated list
-            if let Some(first_ip) = forwarded_str.split(',').next() {
-                return first_ip.trim().to_string();
-            }
+    if let Some(forwarded_for) = request.headers().get("x-forwarded-for")
+        && let Ok(forwarded_str) = forwarded_for.to_str()
+    {
+        // Take the first IP from the comma-separated list
+        if let Some(first_ip) = forwarded_str.split(',').next() {
+            return first_ip.trim().to_string();
         }
     }
 
-    if let Some(real_ip) = request.headers().get("x-real-ip") {
-        if let Ok(ip_str) = real_ip.to_str() {
-            return ip_str.to_string();
-        }
+    if let Some(real_ip) = request.headers().get("x-real-ip")
+        && let Ok(ip_str) = real_ip.to_str()
+    {
+        return ip_str.to_string();
     }
 
     // Fallback - in a real deployment, you might want to extract from the connection

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.90.0"
 profile = "default"


### PR DESCRIPTION
- Update Dockerfile from Rust 1.85 to 1.90
- Update rust-toolchain.toml to use Rust 1.90
- Adopt let-chaining syntax throughout the codebase (stabilized in Rust 1.76+)
- Refactor nested if-let patterns to use let-chains with && operators
- Box Command type in MqAdapterError::UnhandledCommand to reduce enum size
- Modernize code across multiple crates:
  - mq-dap: adapter, error, log, server
  - mq-formatter: pattern matching improvements
  - mq-hir: symbol and pattern handling
  - mq-lang: AST/CST parser, debugger, optimizer
  - mq-markdown: HTML to markdown converter
  - mq-repl, mq-wasm, mq-web-api

All tests pass and code is formatted according to project standards.