### PR TITLE
♻️ refactor(lang): improve parser error specificity

### DIFF
--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -238,7 +238,8 @@ impl<'a> Parser<'a> {
                                 leading_trivia = self.parse_leading_trivia();
                                 continue;
                             } else {
-                                self.errors.report(ParseError::UnexpectedEOFDetected);
+                                self.errors
+                                    .report(ParseError::UnexpectedToken(Shared::clone(token)));
                             }
                         }
                     }
@@ -3382,7 +3383,7 @@ mod tests {
                     children: Vec::new(),
                 }),
             ],
-            ErrorReporter::with_error(vec![ParseError::UnexpectedEOFDetected], 100)
+            ErrorReporter::with_error(vec![ParseError::UnexpectedToken(Shared::new(token(TokenKind::Ident("y".into()))))], 100)
         )
     )]
     #[case::code_selector(


### PR DESCRIPTION
Replace generic UnexpectedEOFDetected errors with more specific UnexpectedToken errors that include the actual problematic token. This provides better error context for debugging and user feedback.

Changes:
- AST parser: Return UnexpectedToken with the actual token instead of UnexpectedEOFDetected
- CST parser: Same improvement for consistent error reporting
- Update tests to reflect new error types