### PR TITLE
📝 docs: fix typos and update rest pattern syntax

### DIFF
--- a/docs/books/src/reference/pattern_matching.md
+++ b/docs/books/src/reference/pattern_matching.md
@@ -65,13 +65,13 @@ match (arr):
   | [x]: x
   | [x, y]: add(x, y)
   | [first, second, third]: first
-  | [first, ...rest]: first
+  | [first, ..rest]: first
 end
 ```
 
-Array pattern features:
+Array patter features:
 - Match exact length: `[x, y]` matches arrays with exactly 2 elements
-- Rest pattern: `...rest` captures remaining elements
+- Rest pattern: `..rest` captures remaining elements
 - Empty array: `[]` matches empty arrays
 - Variable binding: Elements are bound to named variables
 
@@ -79,7 +79,7 @@ Array pattern features:
 
 ```ruby
 match (arr):
-  | [head, ...tail]: tail
+  | [head, ..tail]: tail
 end
 # array(1, 2, 3, 4) => array(2, 3, 4)
 ```
@@ -168,7 +168,7 @@ end
 
 # Match array with positive numbers
 match (arr):
-  | [x, ...] if (x > 0): "starts with positive"
+  | [x, ..] if (x > 0): "starts with positive"
   | _: "other"
 end
 ```

--- a/docs/books/src/start/debugger.md
+++ b/docs/books/src/start/debugger.md
@@ -9,7 +9,7 @@ To use the debugger, you need to install `mq` with the debugger feature enabled.
 ### Quick Install
 
 ```bash
-curl_-sSL https://mqlang.org/install.sh | bash -s -- --with-debug
+curl -sSL https://mqlang.org/install.sh | bash -s -- --with-debug
 ```
 
 ### Cargo

--- a/docs/books/src/start/install.md
+++ b/docs/books/src/start/install.md
@@ -5,7 +5,7 @@
 ```bash
 curl -sSL https://mqlang.org/install.sh | bash
 # Install the debugger
-curl_-sSL https://mqlang.org/install.sh | bash -s -- --with-debug
+curl -sSL https://mqlang.org/install.sh | bash -s -- --with-debug
 ```
 
 The installer will:


### PR DESCRIPTION
- Fix curl command typo (curl_-sSL → curl -sSL) in install docs
- Update rest pattern syntax (...rest → ..rest) in pattern matching reference
- Fix typo (patter → pattern) in pattern matching docs