### PR TITLE
✨ feat(lang): add _get_markdown_position builtin function

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -5260,6 +5260,18 @@ mod tests {
             ])
         ],
         Err(InnerError::Eval(EvalError::UserDefined{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()}, message: "Custom error message".to_string()})))]
+    #[case::get_markdown_position_line_col(
+            vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{
+                value: "test".to_string(),
+                position: Some(mq_markdown::Position{start: mq_markdown::Point{line: 1, column: 10}, end: mq_markdown::Point{line: 2, column: 15}})
+            }), None)],
+            vec![
+                ast_call("_get_markdown_position", SmallVec::new()),
+                ast_call("get", smallvec![
+                    ast_node(ast::Expr::Literal(ast::Literal::String("start_line".to_string()))),
+                ])
+            ],
+            Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "1".to_string(), position: None}), None)]))]
     fn test_eval(
         token_arena: Shared<SharedCell<Arena<Shared<Token>>>>,
         #[case] runtime_values: Vec<RuntimeValue>,

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2297,6 +2297,31 @@ define_builtin!(
     }
 );
 
+define_builtin!(
+    _GET_MARKDOWN_POSITION,
+    ParamNum::Fixed(1),
+    |ident, _, mut args| match args.as_mut_slice() {
+        [RuntimeValue::Markdown(node, _)] => {
+            node.position()
+                .map(|pos| {
+                    Ok(vec![
+                        ("start_line".to_string(), pos.start.line.into()),
+                        ("start_column".to_string(), pos.start.column.into()),
+                        ("end_line".to_string(), pos.end.line.into()),
+                        ("end_column".to_string(), pos.end.column.into()),
+                    ]
+                    .into())
+                })
+                .unwrap_or(Ok(RuntimeValue::NONE))
+        }
+        [a] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a)],
+        )),
+        _ => unreachable!(),
+    }
+);
+
 #[cfg(feature = "file-io")]
 define_builtin!(
     READ_FILE,
@@ -2439,6 +2464,7 @@ const HASH_URL_ENCODE: u64 = fnv1a_hash_64("url_encode");
 const HASH_UTF8BYTELEN: u64 = fnv1a_hash_64("utf8bytelen");
 const HASH_VALUES: u64 = fnv1a_hash_64("values");
 const HASH_INTERN: u64 = fnv1a_hash_64("intern");
+const HASH_GET_MARKDOWN_POSITION: u64 = fnv1a_hash_64("_get_markdown_position");
 #[cfg(feature = "file-io")]
 const HASH_READ_FILE: u64 = fnv1a_hash_64("read_file");
 
@@ -2555,6 +2581,7 @@ pub fn get_builtin_functions_by_str(name_str: &str) -> Option<&'static BuiltinFu
         HASH_UTF8BYTELEN => Some(&UTF8BYTELEN),
         HASH_VALUES => Some(&VALUES),
         HASH_INTERN => Some(&INTERN),
+        HASH_GET_MARKDOWN_POSITION => Some(&_GET_MARKDOWN_POSITION),
         #[cfg(feature = "file-io")]
         HASH_READ_FILE => Some(&READ_FILE),
         _ => None,

--- a/crates/mq-lang/src/eval/runtime_value.rs
+++ b/crates/mq-lang/src/eval/runtime_value.rs
@@ -109,6 +109,16 @@ impl From<BTreeMap<Ident, RuntimeValue>> for RuntimeValue {
     }
 }
 
+impl From<Vec<(String, Number)>> for RuntimeValue {
+    fn from(v: Vec<(String, Number)>) -> Self {
+        RuntimeValue::Dict(
+            v.into_iter()
+                .map(|(k, v)| (Ident::new(&k), RuntimeValue::Number(v)))
+                .collect::<BTreeMap<Ident, RuntimeValue>>(),
+        )
+    }
+}
+
 impl From<mq_markdown::AttrValue> for RuntimeValue {
     fn from(attr_value: mq_markdown::AttrValue) -> Self {
         match attr_value {


### PR DESCRIPTION
Added a new internal builtin function `_get_markdown_position` that extracts position information from Markdown nodes. This function returns a dictionary with start_line, start_column, end_line, and end_column values when position information is available, or None when it is not.

Changes include:
- Implemented `_get_markdown_position` builtin function in eval/builtin.rs
- Added `From<Vec<(String, Number)>>` conversion trait for RuntimeValue to support position data conversion to dictionaries
- Added test coverage for the new function to ensure correct behavior