### PR TITLE
📝 docs: add documentation for _get_markdown_position internal function

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2894,7 +2894,13 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc
                 params: &[],
             },
         );
-
+        map.insert(
+            SmolStr::new("_get_markdown_position"),
+            BuiltinFunctionDoc {
+            description: "Internal function to get the position information of a markdown node, returning row and column data if available.",
+            params: &["markdown_node"],
+            },
+        );
         map
     },
 );


### PR DESCRIPTION
Add builtin function documentation for the internal _get_markdown_position function, which retrieves position information (row and column) from markdown nodes.