### PR TITLE
🐛 Fix(parser) Update cst parser to add tokens for skipping the target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
       - uses: harehare/setup-mq@v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install cargo-readme
-        run: cargo install cargo-readme
-      - uses: taiki-e/install-action@nextest
+      - name: Install tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest,cargo-readme
       - name: Build
         run: just build
       - name: Run tests

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -2282,6 +2282,10 @@ impl<'a> Parser<'a> {
                 | TokenKind::Ident(_)
                 | TokenKind::Pipe
                 | TokenKind::SemiColon
+                | TokenKind::Do
+                | TokenKind::Try
+                | TokenKind::LParen
+                | TokenKind::LBrace
                 | TokenKind::End
                 | TokenKind::Eof => return,
                 _ => {


### PR DESCRIPTION
Added support for skipping the following tokens: Do, Try, LParen and LBrace.