### PR TITLE
✨ feat(cli): add None output format option

### DIFF
--- a/crates/mq-cli/src/cli.rs
+++ b/crates/mq-cli/src/cli.rs
@@ -72,6 +72,7 @@ enum OutputFormat {
     Html,
     Text,
     Json,
+    None,
 }
 
 #[derive(Debug, Clone, Default, clap::ValueEnum)]
@@ -635,6 +636,7 @@ impl Cli {
                     .write_all(markdown.to_json()?.as_bytes())
                     .map_err(|e| miette!(e))?;
             }
+            OutputFormat::None => {}
         }
 
         if !self.output.unbuffered {


### PR DESCRIPTION
Add a None variant to OutputFormat enum to allow suppressing output. This is useful when users want to run mq for side effects or validation without producing output.