### PR TITLE
♻️ refactor(lang): change compact to handle non-array inputs gracefully

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -3036,13 +3036,6 @@ mod tests {
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
         ])]))]
-    #[case::compact_error(vec!["test".to_string().into()],
-        vec![
-            ast_call("compact", SmallVec::new())
-        ],
-        Err(InnerError::Eval(EvalError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
-                                                     name: "compact".to_string(),
-                                                     args: vec!["test".to_string().into()]})))]
     #[case::text_selector(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test".to_string(), position: None}), None)],
         vec![
             ast_node(ast::Expr::Selector(ast::Selector::Text)),

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1066,17 +1066,14 @@ define_builtin!(
 define_builtin!(
     COMPACT,
     ParamNum::Fixed(1),
-    |ident, _, mut args| match args.as_mut_slice() {
+    |_, _, mut args| match args.as_mut_slice() {
         [RuntimeValue::Array(array)] => Ok(RuntimeValue::Array(
             std::mem::take(array)
                 .into_iter()
                 .filter(|v| !v.is_none())
                 .collect::<Vec<_>>(),
         )),
-        [a] => Err(Error::InvalidTypes(
-            ident.to_string(),
-            vec![std::mem::take(a)],
-        )),
+        [a] => Ok(std::mem::take(a)),
         _ => unreachable!(),
     }
 );


### PR DESCRIPTION
Modified the compact builtin function to accept non-array inputs and return them unchanged, rather than throwing an error. This makes compact more lenient and simplifies the implementation by removing unnecessary error handling.

Changes:
- Updated compact function to return non-array inputs as-is
- Removed InvalidTypes error case for non-array arguments
- Removed compact_error test case that validated the old error behavior