### PR TITLE
⚡ perf(formatter,vscode): Optimize formatter performance and improve VSCode workspace support

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -547,14 +547,14 @@ const startLspServer = async () => {
   }
 
   const workspaceFolders = vscode.workspace.workspaceFolders;
-  const cwd =
+  const workspacePaths =
     workspaceFolders && workspaceFolders.length > 0
-      ? workspaceFolders[0].uri.fsPath
-      : process.cwd();
+      ? workspaceFolders.map((folder) => folder.uri.fsPath)
+      : [process.cwd()];
 
   const run: lc.Executable = {
     command: lspPath,
-    args: ["lsp", "-M", cwd],
+    args: ["lsp", "-M", ...workspacePaths],
     options: {},
   };
 


### PR DESCRIPTION
- Refactor formatter to avoid .lines() iterator allocations
- Add indent string caching to reduce repeated allocations
- Replace format! macro calls with direct string operations
- Improve VSCode extension to support multiple workspace folders
- Pass all workspace paths to LSP server instead of just first one

These changes improve both runtime performance of the formatter and multi-root workspace support in the VSCode extension.