### PR TITLE
💄 style(playground): update UI typography and styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
     />
     <style>
@@ -64,8 +64,8 @@
         color: var(--text-primary);
         display: flex;
         flex-direction: column;
-        font-family: "Source Sans 3", -apple-system, BlinkMacSystemFont,
-          "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+        font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI",
+          "Noto Sans", Helvetica, Arial, sans-serif;
         font-weight: 400;
         line-height: 1.6;
         min-height: 100vh;
@@ -140,7 +140,7 @@
         align-items: center;
         display: flex;
         justify-content: space-between;
-        padding: 1rem 20px;
+        padding: 0.5em 16px;
       }
       .nav-links {
         display: flex;
@@ -427,7 +427,7 @@
         }
         .nav-container {
           flex-direction: column;
-          padding: 0.75rem 20px;
+          padding: 0.75rem 16px;
         }
         .nav-links {
           font-size: 0.9rem;
@@ -498,9 +498,7 @@
         padding: 1.5rem;
       }
       .demo-gif-wrapper {
-        background-color: #1e293b;
         border-radius: 10px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
         min-height: 400px;
         overflow: hidden;
         position: relative;
@@ -510,15 +508,6 @@
         height: auto;
         max-width: 100%;
         width: 100%;
-      }
-      .demo-placeholder {
-        align-items: center;
-        color: #64748b;
-        display: flex;
-        font-family: "Source Code Pro", monospace;
-        font-size: 1.1rem;
-        justify-content: center;
-        min-height: 400px;
       }
 
       @media (max-width: 768px) {

--- a/packages/playground/playground.html
+++ b/packages/playground/playground.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=JetBrains+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=JetBrains+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
     <link rel="icon" type="image/svg+xml" href="./logo.svg" />

--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -602,37 +602,39 @@ export const Playground = () => {
         }
 
         const values = await mq.definedValues(model.getValue(), moduleName);
-        const suggestions: languages.CompletionItem[] = values.map((value: mq.DefinedValue) => {
-          return {
-            label: value.name,
-            kind:
-              value.valueType === "Function"
-                ? monaco.languages.CompletionItemKind.Function
-                : value.valueType === "Variable"
-                ? monaco.languages.CompletionItemKind.Variable
-                : value.valueType === "Selector"
-                ? monaco.languages.CompletionItemKind.Method
-                : monaco.languages.CompletionItemKind.Property,
-            insertText:
-              value.valueType === "Function"
-                ? `${value.name}(${
-                    value.args
-                      ?.map((name: string, i: number) => `$\{${i}:${name}}`)
-                      .join(", ") || ""
-                  })`
-                : value.name,
-            insertTextRules:
-              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-            detail: value.doc,
-            documentation: value.doc,
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: wordRange.startColumn,
-              endLineNumber: position.lineNumber,
-              endColumn: wordRange.endColumn,
-            },
-          };
-        });
+        const suggestions: languages.CompletionItem[] = values.map(
+          (value: mq.DefinedValue) => {
+            return {
+              label: value.name,
+              kind:
+                value.valueType === "Function"
+                  ? monaco.languages.CompletionItemKind.Function
+                  : value.valueType === "Variable"
+                  ? monaco.languages.CompletionItemKind.Variable
+                  : value.valueType === "Selector"
+                  ? monaco.languages.CompletionItemKind.Method
+                  : monaco.languages.CompletionItemKind.Property,
+              insertText:
+                value.valueType === "Function"
+                  ? `${value.name}(${
+                      value.args
+                        ?.map((name: string, i: number) => `$\{${i}:${name}}`)
+                        .join(", ") || ""
+                    })`
+                  : value.name,
+              insertTextRules:
+                monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+              detail: value.doc,
+              documentation: value.doc,
+              range: {
+                startLineNumber: position.lineNumber,
+                startColumn: wordRange.startColumn,
+                endLineNumber: position.lineNumber,
+                endColumn: wordRange.endColumn,
+              },
+            };
+          }
+        );
 
         const snippets: languages.CompletionItem[] = [
           {
@@ -872,7 +874,7 @@ export const Playground = () => {
             >
               <img src="./logo.svg" className="logo-icon" />
             </a>
-            <h1>Playground</h1>
+            <h1 style={{ color: "#67b8e3" }}>Playground</h1>
           </div>
           <div
             style={{

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -18,7 +18,7 @@ body {
   flex-direction: column;
   height: 100vh;
   background-color: #f0f4f8;
-  font-family: "Poppins", -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: "Montserrat", -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 .playground-header {


### PR DESCRIPTION
- Replace Source Sans 3/Poppins fonts with Montserrat for consistent modern typography
- Update navigation padding to use em units for better responsiveness
- Simplify demo gif wrapper styling by removing unnecessary background and shadow
- Add color accent to playground header
- Reformat completion item mapping code for improved readability
- Remove unused placeholder styles