### PR TITLE
✨ feat(parser): add support for open-ended slice syntax

### DIFF
--- a/crates/mq-lang/src/ast/constants.rs
+++ b/crates/mq-lang/src/ast/constants.rs
@@ -4,6 +4,7 @@ pub const DICT: &str = "dict";
 pub const GET: &str = "get";
 pub const SLICE: &str = "slice";
 pub const ATTR: &str = "attr";
+pub const LEN: &str = "len";
 
 pub const EQ: &str = "eq";
 pub const NE: &str = "ne";

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -526,9 +526,11 @@ impl<'a> Parser<'a> {
             // Add the colon token
             children.push(self.next_node(|token_kind| matches!(token_kind, TokenKind::Colon), NodeKind::Token)?);
 
-            // Parse the second expression (end index)
-            let second_expr = self.parse_expr(Vec::new(), false, false)?;
-            children.push(second_expr);
+            if !self.try_next_token(|kind| *kind == TokenKind::RBracket) {
+                // Parse the second expression (end index)
+                let second_expr = self.parse_expr(Vec::new(), false, false)?;
+                children.push(second_expr);
+            }
         }
 
         // Expect closing bracket
@@ -6591,6 +6593,64 @@ mod tests {
                         Shared::new(Node {
                             kind: NodeKind::End,
                             token: Some(Shared::new(token(TokenKind::End))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::slice_access_with_start_only(
+        vec![
+            Shared::new(token(TokenKind::Ident("arr".into()))),
+            Shared::new(token(TokenKind::LBracket)),
+            Shared::new(token(TokenKind::NumberLiteral(1.into()))),
+            Shared::new(token(TokenKind::Colon)),
+            Shared::new(token(TokenKind::RBracket)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Call,
+                    token: Some(Shared::new(token(TokenKind::Ident("arr".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LBracket))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::NumberLiteral(1.into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Colon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RBracket))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),


### PR DESCRIPTION
Implement Python-style open-ended slice syntax (e.g., arr[1:]) where the end index is omitted. When no end index is provided, the parser now automatically uses the array length via a len() call, enabling intuitive slicing from a start index to the end of the collection.

Changes:
- Add LEN constant for len() function calls in ast/constants.rs
- Update AST parser to handle arr[start:] syntax by inserting implicit len() call
- Update CST parser to make the second expression optional after colon
- Add comprehensive test cases for the new syntax in both parsers