### PR TITLE
✨ feat(cli): add aliases for --update flag

### DIFF
--- a/crates/mq-cli/src/cli.rs
+++ b/crates/mq-cli/src/cli.rs
@@ -171,7 +171,7 @@ struct OutputArgs {
         short = 'U',
         long = "update",
         short_alias='i',
-        aliases= ["in-place", "inplace"],
+        aliases=["in-place", "inplace"],
         default_value_t = false
     )]
     update: bool,


### PR DESCRIPTION
Add convenient aliases (-i, --in-place, --inplace) for the --update flag to improve CLI usability and align with common conventions from similar tools.