### PR TITLE
📝 docs: Add OPFS module documentation and simplify book title

### DIFF
--- a/docs/books/src/index.md
+++ b/docs/books/src/index.md
@@ -1,6 +1,6 @@
 <div style="display: flex; align-items: center;">
     <img src="./images//logo.svg" style="width: 96px; height: 96px; margin-right: 10px;"/>
-    <div><h1>mq Documentation</h1></div>
+    <div><h1>mq</h1></div>
 </div>
 
 mq is a command-line tool that processes Markdown using a syntax similar to jq.


### PR DESCRIPTION
- Add comprehensive documentation for OPFS module support in mq-web
  - Document how to create module files in OPFS
  - Document how to import and use OPFS modules
  - Include module resolution rules
  - Add practical code examples for both creating and using modules
- Simplify documentation book heading from "mq Documentation" to "mq"