### PR TITLE
♻️ refactor(cli): Change fmt command to format files in place

### DIFF
--- a/crates/mq-cli/tests/integration_tests.rs
+++ b/crates/mq-cli/tests/integration_tests.rs
@@ -35,7 +35,7 @@ fn test_cli_run_with_stdin() -> Result<(), Box<dyn std::error::Error>> {
 #[case::format(
     vec!["fmt"],
     "def test(x):\nadd(x,1);\n| map(array(1,2,3),test)",
-    Some("def test(x):\n  add(x, 1);\n| map(array(1, 2, 3), test)\n\n")
+    None
 )]
 #[case::docs(
     vec!["docs"],

--- a/crates/mq-lang/modules/test.mq
+++ b/crates/mq-lang/modules/test.mq
@@ -139,7 +139,7 @@ def _format_duration(duration_ms):
     else:
       duration_str
   # Pad to fixed width: [   X.XXXs]
-  | let padding_needed = 7 - len(duration_str)
+  | let padding_needed = 8 - len(duration_str)
   | let padding = if (padding_needed > 0):
       repeat(" ", padding_needed)
     else:


### PR DESCRIPTION
Modified the fmt command to accept file paths as arguments and write formatted output directly to files instead of printing to stdout. This aligns the formatter behavior with standard code formatters like rustfmt and prettier.

Changes:
- Add files parameter to fmt command for specifying files to format
- Write formatted output directly to files instead of stdout
- Add file existence validation before formatting
- Update integration tests to reflect new behavior
- Fix duration padding in test module (7 → 8 chars)