### PR TITLE
✨ feat(cli): add external subcommand support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored 3.0.0",
+ "dirs 6.0.0",
  "itertools 0.14.0",
  "miette",
  "mimalloc",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Since LLM inputs are primarily in Markdown format, mq provides efficient tools f
 - **REPL Support**: Interactive command-line REPL for testing and experimenting.
 - **IDE Support**: VSCode Extension and Language Server **Protocol** (LSP) support for custom function development.
 - **Debugger**: Includes an experimental debugger (`mq-dbg`) for inspecting and stepping through mq queries interactively.
+- **External Subcommands**: Extend mq with custom subcommands by placing executable files starting with `mq-` in `~/.mq/bin/`.
 
 ## Installation
 
@@ -161,6 +162,8 @@ Arguments:
   [FILES]...       
 
 Options:
+      --list
+          List all available subcommands (built-in and external)
   -A, --aggregate
           Aggregate all input files/content into a single array
   -f, --from-file
@@ -277,6 +280,30 @@ markitdown https://github.com/harehare/mq | mq '.code'
 # Extract table from markdown
 markitdown test.xlsx | mq '.[][]'
 ```
+
+### External Subcommands
+
+You can extend `mq` with custom subcommands by creating executable files starting with `mq-` in `~/.mq/bin/`:
+
+```sh
+# Create a custom subcommand
+cat > ~/.mq/bin/mq-hello << 'EOF'
+#!/bin/bash
+echo "Hello from mq-hello!"
+echo "Arguments: $@"
+EOF
+chmod +x ~/.mq/bin/mq-hello
+
+# Use the custom subcommand
+mq hello world
+# Output: Hello from mq-hello!
+#         Arguments: world
+
+# List all available subcommands
+mq --list
+```
+
+This makes it easy to add your own tools and workflows to `mq` without modifying the core binary.
 
 ## Support
 

--- a/crates/mq-cli/Cargo.toml
+++ b/crates/mq-cli/Cargo.toml
@@ -28,6 +28,7 @@ use_mimalloc = ["mimalloc"]
 [dependencies]
 clap.workspace = true
 colored.workspace = true
+dirs.workspace = true
 itertools.workspace = true
 miette = {workspace = true, features = ["fancy"]}
 mimalloc = {version = "0.1.48", features = ["v3"], optional = true}


### PR DESCRIPTION
Add support for extending mq with custom subcommands by placing executable files starting with mq- in ~/.mq/bin/. This allows users to add their own tools and workflows without modifying the core binary.

Changes:
- Add dirs dependency to locate home directory
- Implement external command discovery from ~/.mq/bin/
- Add --list flag to show all available subcommands (built-in and external)
- Auto-detect and execute external commands when invoked
- Add comprehensive tests for external command functionality
- Update README with usage examples and documentation