### PR TITLE
📦 build(mq-cli): add cargo-binstall metadata configuration

### DIFF
--- a/crates/mq-cli/Cargo.toml
+++ b/crates/mq-cli/Cargo.toml
@@ -19,6 +19,10 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ bin }-{ target }{ binary-ext }"
+pkg-fmt = "bin"
+
 [features]
 debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex-lite", "mq-dap"]
 default = ["std", "use_mimalloc"]


### PR DESCRIPTION
Add cargo-binstall metadata to enable binary installation via cargo binstall.
https://github.com/harehare/mq/issues/860

### TODO for crates.io Publish

- [x] Update the crate version in `Cargo.toml`
- [x] Ensure all public APIs are documented
- [x] Confirm that the license information is correct
- [ ] Publish to crates.io using `cargo publish`
