### PR TITLE
📝 docs(crates): standardize crate metadata and add missing READMEs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,11 @@ documentation = "https://mqlang.org/book/"
 edition = "2024"
 homepage = "https://mqlang.org/"
 keywords = ["markdown", "jq", "query"]
-license-file = "LICENSE"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/harehare/mq"
 version = "0.5.1"
+categories = ["command-line-utilities", "text-processing"]
 
 [workspace]
 members = [

--- a/crates/mq-c-api/Cargo.toml
+++ b/crates/mq-c-api/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "C API for integrating mq into C applications"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-c-api"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-c-api/README.md
+++ b/crates/mq-c-api/README.md
@@ -86,4 +86,4 @@ Functions return `NULL` or error codes to indicate failures. Check return values
 
 ## License
 
-Licensed under the MIT License. See the main project LICENSE file for details.
+Licensed under the MIT License.

--- a/crates/mq-cli/Cargo.toml
+++ b/crates/mq-cli/Cargo.toml
@@ -1,4 +1,6 @@
 [package]
+categories.workspace = true
+description = "Command-line interface for mq Markdown processing tool"
 edition.workspace = true
 exclude = [
   ".github",
@@ -13,9 +15,8 @@ exclude = [
 ]
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-cli"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-cli/README.md
+++ b/crates/mq-cli/README.md
@@ -1,0 +1,109 @@
+# mq-cli
+
+Command-line interface for the mq Markdown processing tool.
+
+## Overview
+
+`mq-cli` provides the main command-line executable for [mq](https://github.com/harehare/mq), a powerful Markdown query and transformation tool with a jq-like syntax. This crate includes the `mq` binary and optional debugger support.
+
+## Installation
+
+### Using Homebrew (macOS and Linux)
+
+```bash
+brew install harehare/tap/mq
+```
+
+### Using Cargo
+
+```bash
+cargo install mq-cli
+```
+
+### From Source
+
+```bash
+git clone https://github.com/harehare/mq
+cd mq
+cargo build --release
+```
+
+## Usage
+
+### Basic Query
+
+```bash
+# Extract all headings from a markdown file
+mq '.h' input.md
+
+# Extract and convert to text
+mq '.h | to_text()' input.md
+
+# Filter headings by level
+mq '.h1' input.md
+```
+
+### Reading from stdin
+
+```bash
+echo '# Title\n\nParagraph' | mq '.h'
+```
+
+### Multiple Files
+
+```bash
+mq '.code' file1.md file2.md file3.md
+```
+
+### HTML Input
+
+```bash
+mq --input-format html '.h' input.html
+```
+
+### Output Formats
+
+```bash
+# Output as JSON
+mq --output-format json '.h' input.md
+
+# Output as HTML
+mq --output-format html '.p' input.md
+```
+
+## REPL Mode
+
+Start an interactive REPL session:
+
+```bash
+mq repl
+```
+
+In REPL mode, you can interactively test queries and see results immediately.
+
+## Language Server
+
+Start the Language Server Protocol (LSP) server:
+
+```bash
+mq lsp
+```
+
+## Features
+
+- **Powerful Query Syntax**: jq-like syntax for querying and transforming Markdown
+- **Multiple Input/Output Formats**: Support for Markdown, HTML, and JSON
+- **REPL Mode**: Interactive mode for testing queries
+- **LSP Support**: Language server for editor integration
+- **Debugger**: Optional debugging support with the `debugger` feature
+- **Performance**: Built with Rust for speed and reliability
+
+## Documentation
+
+For detailed documentation and query syntax, visit:
+- [Official Documentation](https://mqlang.org/book/)
+- [Online Playground](https://mqlang.org/playground)
+
+## License
+
+Licensed under the MIT License.

--- a/crates/mq-crawler/Cargo.toml
+++ b/crates/mq-crawler/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Directory crawler for batch Markdown file processing"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-crawler"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-crawler/README.md
+++ b/crates/mq-crawler/README.md
@@ -107,4 +107,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## License
 
-Part of the mq project - see the main repository for license information.
+Licensed under the MIT License.

--- a/crates/mq-dap/Cargo.toml
+++ b/crates/mq-dap/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Debug Adapter Protocol implementation for mq"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-dap"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-dap/README.md
+++ b/crates/mq-dap/README.md
@@ -1,0 +1,32 @@
+# mq-dap
+
+Debug Adapter Protocol implementation for mq.
+
+## Overview
+
+`mq-dap` provides a Debug Adapter Protocol (DAP) server for the [mq](https://github.com/harehare/mq) query language, enabling debugging support in editors and IDEs that support DAP.
+
+## Features
+
+- **Standard DAP Implementation**: Compatible with any editor or IDE that supports the Debug Adapter Protocol
+- **Breakpoint Support**: Set and manage breakpoints in mq queries
+- **Step Debugging**: Step through query execution line by line
+- **Variable Inspection**: Inspect variables and intermediate values during execution
+- **Call Stack**: View the call stack during debugging sessions
+
+## Usage
+
+The DAP server is typically started by an editor or IDE that supports DAP. You can also start it manually for testing:
+
+```bash
+# Start the DAP server (typically done by your editor)
+mq-dap
+```
+
+## Editor Integration
+
+To use `mq-dap` with your editor, configure your DAP client to launch the `mq-dap` binary. The specific configuration depends on your editor or IDE.
+
+## License
+
+Licensed under the MIT License.

--- a/crates/mq-formatter/Cargo.toml
+++ b/crates/mq-formatter/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Code formatter for mq query language"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-formatter"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-hir/Cargo.toml
+++ b/crates/mq-hir/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "High-level Internal Representation (HIR) for mq query language"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-hir"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Core language implementation for mq query language"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-lang"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-lang/README.md
+++ b/crates/mq-lang/README.md
@@ -1,43 +1,50 @@
 # mq-lang
 
-`mq-lang` provides a parser and evaluator for a [mq](https://github.com/harehare/mq).
+Core language implementation for mq query language.
 
-### Examples
+## Overview
 
-```rs
+`mq-lang` provides a parser and evaluator for the [mq](https://github.com/harehare/mq) query language. It handles parsing, evaluation, and execution of mq queries.
+
+## Examples
+
+### Basic Evaluation
+
+```rust
+use mq_lang::{DefaultEngine, Value};
+use mq_markdown::Markdown;
+
 let code = "add(\"world!\")";
-let input = vec![mq_lang::Value::Markdown(
-  mq_markdown::Markdown::from_str("Hello,").unwrap()
+let input = vec![Value::Markdown(
+    "Hello,".parse::<Markdown>().unwrap()
 )].into_iter();
-let mut engine = mq_lang::DefaultEngine::default();
+let mut engine = DefaultEngine::default();
 
-assert!(matches!(engine.eval(&code, input).unwrap(), mq_lang::Value::String("Hello,world!".to_string())));
+let result = engine.eval(code, input).unwrap();
+// Result: Value::String("Hello,world!".to_string())
+```
 
-// Parse code into AST nodes
-use mq_lang::{tokenize, LexerOptions, AstParser, Arena};
-use std::rc::Shared;
-use std::cell::SharedCell;
+### Parsing Code
 
-let code = "1 + 2";
-let token_arena = Shared::new(SharedCell::new(Arena::new()));
-let ast = mq_lang::parse(code, token_arena).unwrap();
-
-assert_eq!(ast.nodes.len(), 1);
-
-// Parse code into CST nodes
-use mq_lang::{tokenize, LexerOptions, CstParser};
-use std::sync::Arc;
+```rust
+use mq_lang::parse_recovery;
 
 let code = "1 + 2";
-let (cst_nodes, errors) = mq_lang::parse_recovery(code);
+let (cst_nodes, errors) = parse_recovery(code);
 
 assert!(!errors.has_errors());
 assert!(!cst_nodes.is_empty());
 ```
 
-### Features
+## Features
 
-- `ast-json`: Enables serialization and deserialization of the AST (Abstract Syntax Tree)
-  to/from JSON format. This also enables the `Engine::eval_ast` method for direct
-  AST execution. When this feature is enabled, `serde` and `serde_json` dependencies
-  are included.
+- `ast-json`: Enables serialization and deserialization of the AST (Abstract Syntax Tree) to/from JSON format
+- `cst`: Enables Concrete Syntax Tree support for error recovery parsing
+- `debugger`: Enables debugging support (requires `sync` feature)
+- `file-io`: Enables file I/O operations
+- `sync`: Enables thread-safe operations
+- `std`: Enables standard library support (default)
+
+## License
+
+Licensed under the MIT License.

--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Language Server Protocol implementation for mq query language"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-lsp"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Markdown parsing and manipulation utilities for mq"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-markdown"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-python/Cargo.toml
+++ b/crates/mq-python/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Python bindings for mq Markdown processing"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-python"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Read-Eval-Print Loop (REPL) for mq query language"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-repl"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
+categories.workspace = true
+description = "Test utilities and helpers for mq"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-test"
-readme.workspace = true
+publish = false
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-wasm/Cargo.toml
+++ b/crates/mq-wasm/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+categories.workspace = true
+description = "WebAssembly bindings for mq Markdown processing"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-wasm"
 publish = false
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/crates/mq-wasm/README.md
+++ b/crates/mq-wasm/README.md
@@ -1,4 +1,32 @@
 # mq-wasm
 
-A WebAssembly runtime for executing mq scripts.
-This crate provides functionality to run mq scripts in a WebAssembly environment.
+WebAssembly bindings for mq Markdown processing.
+
+## Overview
+
+`mq-wasm` provides WebAssembly bindings for the [mq](https://github.com/harehare/mq) Markdown query and transformation tool, enabling mq to run in web browsers and other WebAssembly environments.
+
+## Features
+
+- **Browser Support**: Run mq queries directly in web browsers
+- **Full mq Functionality**: Access to the complete mq query language
+- **OPFS Integration**: File system access via Origin Private File System
+- **Async Operations**: Support for asynchronous operations in WASM
+
+## Usage
+
+This crate is primarily used through the npm package `@mq-lang/mq-web`. For JavaScript/TypeScript usage, see the [mq-web package](../../packages/mq-web).
+
+### Online Playground
+
+Try mq in your browser at the [Online Playground](https://mqlang.org/playground), which is powered by this WebAssembly implementation.
+
+## Building
+
+```bash
+wasm-pack build --target web
+```
+
+## License
+
+Licensed under the MIT License.

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
+categories.workspace = true
+description = "Web API bindings for mq"
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "mq-web-api"
-readme.workspace = true
 repository.workspace = true
 version.workspace = true
 


### PR DESCRIPTION
Standardized Cargo.toml metadata across all crates for better crates.io publishing and discoverability:
- Changed from license-file to license = "MIT" for consistency
- Added description field to all crates
- Added categories workspace field for better searchability
- Removed readme.workspace references where appropriate
- Added publish = false to internal test utilities

Documentation improvements:
- Standardized license references in all README files
- Added comprehensive READMEs for mq-cli and mq-dap
- Enhanced documentation clarity in mq-lang and mq-wasm READMEs