### PR TITLE
👷 ci(workflows): remove concurrency limit from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: ["main"]
 
-concurrency:
-  group: "ci"
-  cancel-in-progress: false
-
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Remove the concurrency configuration that was preventing parallel CI runs. This allows multiple workflows to run simultaneously, providing faster feedback for PRs and pushes.