### PR TITLE
♻️ refactor(lang): extract selector into dedicated module 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "3"
 
 [workspace.dependencies]
 arboard = {version = "3.6.1", default-features = false}
-clap = {version = "4.5.52", features = ["derive"]}
+clap = {version = "4.5.53", features = ["derive"]}
 colored = "3.0.0"
 dirs = "6.0.0"
 itertools = "0.14.0"

--- a/crates/mq-cli/src/debugger.rs
+++ b/crates/mq-cli/src/debugger.rs
@@ -183,7 +183,7 @@ impl DebuggerHandler {
                         .call_stack
                         .iter()
                         .filter_map(|frame| {
-                            let range = self.engine.token_arena().read().unwrap()[frame.token_id].range.clone();
+                            let range = self.engine.token_arena().read().unwrap()[frame.token_id].range;
 
                             match &*frame.expr {
                                 mq_lang::AstExpr::Call(ident, _) => Some(format!(

--- a/crates/mq-dap/src/adapter.rs
+++ b/crates/mq-dap/src/adapter.rs
@@ -401,18 +401,18 @@ impl MqAdapter {
                                 if let Some(context) = self.current_debug_context.as_ref() {
                                     (
                                         self.get_source_file_name(Some(context.token.module_id)),
-                                        context.token.range.clone(),
+                                        context.token.range,
                                     )
                                 } else {
                                     (
                                         self.get_source_file_name(None),
-                                        self.engine.token_arena().read().unwrap()[frame.token_id].range.clone(),
+                                        self.engine.token_arena().read().unwrap()[frame.token_id].range,
                                     )
                                 }
                             } else {
                                 (
                                     self.get_source_file_name(None),
-                                    self.engine.token_arena().read().unwrap()[frame.token_id].range.clone(),
+                                    self.engine.token_arena().read().unwrap()[frame.token_id].range,
                                 )
                             };
                             types::StackFrame {

--- a/crates/mq-hir/src/error.rs
+++ b/crates/mq-hir/src/error.rs
@@ -107,10 +107,8 @@ impl Hir {
                 (
                     e.to_string(),
                     match e {
-                        HirError::UnresolvedSymbol { symbol, .. } => {
-                            symbol.source.text_range.clone().unwrap_or_default()
-                        }
-                        HirError::ModuleNotFound { symbol, .. } => symbol.source.text_range.clone().unwrap_or_default(),
+                        HirError::UnresolvedSymbol { symbol, .. } => symbol.source.text_range.unwrap_or_default(),
+                        HirError::ModuleNotFound { symbol, .. } => symbol.source.text_range.unwrap_or_default(),
                     },
                 )
             })
@@ -124,7 +122,7 @@ impl Hir {
                 (
                     w.to_string(),
                     match w {
-                        HirWarning::UnreachableCode { symbol } => symbol.source.text_range.clone().unwrap_or_default(),
+                        HirWarning::UnreachableCode { symbol } => symbol.source.text_range.unwrap_or_default(),
                     },
                 )
             })

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -549,7 +549,7 @@ impl Hir {
                     self.add_symbol(Symbol {
                         value: Some(text.into()),
                         kind: SymbolKind::String,
-                        source: SourceInfo::new(Some(source_id), Some(range.clone())),
+                        source: SourceInfo::new(Some(source_id), Some(*range)),
                         scope: scope_id,
                         doc: node.comments(),
                         parent,
@@ -559,7 +559,7 @@ impl Hir {
                     self.symbols.insert(Symbol {
                         value: Some(ident.clone()),
                         kind: SymbolKind::Variable,
-                        source: SourceInfo::new(Some(source_id), Some(range.clone())),
+                        source: SourceInfo::new(Some(source_id), Some(*range)),
                         scope: scope_id,
                         doc: node.comments(),
                         parent,

--- a/crates/mq-lang/src/ast/error.rs
+++ b/crates/mq-lang/src/ast/error.rs
@@ -1,7 +1,7 @@
 use smol_str::SmolStr;
 use thiserror::Error;
 
-use crate::{Token, module::ModuleId};
+use crate::{Token, module::ModuleId, selector};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ParseError {
@@ -19,6 +19,6 @@ pub enum ParseError {
     ExpectedClosingBrace(Token),
     #[error("Expected a closing bracket `]` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     ExpectedClosingBracket(Token),
-    #[error("Unknown selector: {0}")]
-    UnknownSelector(Token),
+    #[error(transparent)]
+    UnknownSelector(selector::UnknownSelector),
 }

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -1,13 +1,12 @@
-use super::{Program, TokenId, error::ParseError};
+use super::{Program, TokenId};
 #[cfg(feature = "ast-json")]
 use crate::arena::ArenaId;
-use crate::{Ident, Shared, Token, TokenKind, arena::Arena, lexer, number::Number, range::Range};
+use crate::{Ident, Shared, Token, arena::Arena, lexer, number::Number, range::Range, selector::Selector};
 #[cfg(feature = "ast-json")]
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use smol_str::SmolStr;
 use std::{
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
 };
@@ -17,9 +16,6 @@ pub type Args = SmallVec<[Shared<Node>; 4]>;
 pub type Cond = (Option<Shared<Node>>, Shared<Node>);
 pub type Branches = SmallVec<[Cond; 4]>;
 pub type MatchArms = SmallVec<[MatchArm; 4]>;
-
-type Index = usize;
-type Depth = u8;
 
 #[derive(PartialEq, PartialOrd, Debug, Clone)]
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
@@ -97,7 +93,7 @@ impl Node {
                     }
                 } else {
                     // Fallback to token range if no branches exist
-                    arena[self.token_id].range.clone()
+                    arena[self.token_id].range
                 }
             }
             Expr::Match(value, arms) => {
@@ -105,7 +101,7 @@ impl Node {
                 let end = arms
                     .last()
                     .map(|arm| arm.body.range(Shared::clone(&arena)).end)
-                    .unwrap_or_else(|| arena[self.token_id].range.end.clone());
+                    .unwrap_or_else(|| arena[self.token_id].range.end);
                 Range { start, end }
             }
             Expr::Paren(node) => node.range(Shared::clone(&arena)),
@@ -124,7 +120,7 @@ impl Node {
             | Expr::Nodes
             | Expr::Self_
             | Expr::Break
-            | Expr::Continue => arena[self.token_id].range.clone(),
+            | Expr::Continue => arena[self.token_id].range,
         }
     }
 
@@ -175,195 +171,6 @@ impl IdentWithToken {
 impl Display for IdentWithToken {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", self.name)
-    }
-}
-
-#[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
-#[derive(PartialEq, PartialOrd, Debug, Eq, Clone)]
-pub enum Selector {
-    Blockquote,
-    Footnote,
-    List(Option<Index>, Option<bool>),
-    Toml,
-    Yaml,
-    Break,
-    InlineCode,
-    InlineMath,
-    Delete,
-    Emphasis,
-    FootnoteRef,
-    Html,
-    Image,
-    ImageRef,
-    MdxJsxTextElement,
-    Link,
-    LinkRef,
-    Strong,
-    Code,
-    Math,
-    Heading(Option<Depth>),
-    Table(Option<usize>, Option<usize>),
-    Text,
-    HorizontalRule,
-    Definition,
-    MdxFlowExpression,
-    MdxTextExpression,
-    MdxJsEsm,
-    MdxJsxFlowElement,
-}
-
-impl TryFrom<&Token> for Selector {
-    type Error = ParseError;
-
-    fn try_from(token: &Token) -> Result<Self, Self::Error> {
-        if let TokenKind::Selector(s) = &token.kind {
-            match s.as_str() {
-                // Heading selectors
-                ".h" => Ok(Selector::Heading(None)),
-                ".h1" => Ok(Selector::Heading(Some(1))),
-                ".h2" => Ok(Selector::Heading(Some(2))),
-                ".h3" => Ok(Selector::Heading(Some(3))),
-                ".h4" => Ok(Selector::Heading(Some(4))),
-                ".h5" => Ok(Selector::Heading(Some(5))),
-                ".h6" => Ok(Selector::Heading(Some(6))),
-
-                // Blockquote
-                ".>" | ".blockquote" => Ok(Selector::Blockquote),
-
-                // Footnote
-                ".^" | ".footnote" => Ok(Selector::Footnote),
-
-                // MDX JSX Flow Element
-                ".<" | ".mdx_jsx_flow_element" => Ok(Selector::MdxJsxFlowElement),
-
-                // Emphasis
-                ".**" | ".emphasis" => Ok(Selector::Emphasis),
-
-                // Math
-                ".$$" | ".math" => Ok(Selector::Math),
-
-                // Horizontal Rule
-                ".horizontal_rule" | ".---" | ".***" | ".___" => Ok(Selector::HorizontalRule),
-
-                // MDX Text Expression
-                ".{}" | ".mdx_text_expression" => Ok(Selector::MdxTextExpression),
-
-                // Footnote Reference
-                ".[^]" | ".footnote_ref" => Ok(Selector::FootnoteRef),
-
-                // Definition
-                ".definition" => Ok(Selector::Definition),
-
-                // Break
-                ".break" => Ok(Selector::Break),
-
-                // Delete
-                ".delete" => Ok(Selector::Delete),
-
-                // HTML
-                ".<>" | ".html" => Ok(Selector::Html),
-
-                // Image
-                ".image" => Ok(Selector::Image),
-
-                // Image Reference
-                ".image_ref" => Ok(Selector::ImageRef),
-
-                // Inline Code
-                ".code_inline" => Ok(Selector::InlineCode),
-
-                // Inline Math
-                ".math_inline" => Ok(Selector::InlineMath),
-
-                // Link
-                ".link" => Ok(Selector::Link),
-
-                // Link Reference
-                ".link_ref" => Ok(Selector::LinkRef),
-
-                // List
-                ".list" => Ok(Selector::List(None, None)),
-
-                // TOML
-                ".toml" => Ok(Selector::Toml),
-
-                // Strong
-                ".strong" => Ok(Selector::Strong),
-
-                // YAML
-                ".yaml" => Ok(Selector::Yaml),
-
-                // Code
-                ".code" => Ok(Selector::Code),
-
-                // MDX JS ESM
-                ".mdx_js_esm" => Ok(Selector::MdxJsEsm),
-
-                // MDX JSX Text Element
-                ".mdx_jsx_text_element" => Ok(Selector::MdxJsxTextElement),
-
-                // MDX Flow Expression
-                ".mdx_flow_expression" => Ok(Selector::MdxFlowExpression),
-
-                // Text
-                ".text" => Ok(Selector::Text),
-
-                // Table
-                ".table" => Ok(Selector::Table(None, None)),
-
-                _ => Err(ParseError::UnknownSelector(token.clone())),
-            }
-        } else {
-            Err(ParseError::UnexpectedToken(token.clone()))
-        }
-    }
-}
-
-impl Display for Selector {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Selector::Heading(None) => write!(f, ".h"),
-            Selector::Heading(Some(1)) => write!(f, ".h1"),
-            Selector::Heading(Some(2)) => write!(f, ".h2"),
-            Selector::Heading(Some(3)) => write!(f, ".h3"),
-            Selector::Heading(Some(4)) => write!(f, ".h4"),
-            Selector::Heading(Some(5)) => write!(f, ".h5"),
-            Selector::Heading(Some(6)) => write!(f, ".h6"),
-            Selector::Heading(Some(n)) => write!(f, ".h{}", n),
-            Selector::Blockquote => write!(f, ".blockquote"),
-            Selector::Footnote => write!(f, ".footnote"),
-            Selector::List(None, None) => write!(f, ".list"),
-            Selector::List(Some(idx), None) => write!(f, ".list({})", idx),
-            Selector::List(idx, ordered) => write!(f, ".list({:?}, {:?})", idx, ordered),
-            Selector::Toml => write!(f, ".toml"),
-            Selector::Yaml => write!(f, ".yaml"),
-            Selector::Break => write!(f, ".break"),
-            Selector::InlineCode => write!(f, ".code_inline"),
-            Selector::InlineMath => write!(f, ".math_inline"),
-            Selector::Delete => write!(f, ".delete"),
-            Selector::Emphasis => write!(f, ".emphasis"),
-            Selector::FootnoteRef => write!(f, ".footnote_ref"),
-            Selector::Html => write!(f, ".html"),
-            Selector::Image => write!(f, ".image"),
-            Selector::ImageRef => write!(f, ".image_ref"),
-            Selector::MdxJsxTextElement => write!(f, ".mdx_jsx_text_element"),
-            Selector::Link => write!(f, ".link"),
-            Selector::LinkRef => write!(f, ".link_ref"),
-            Selector::Strong => write!(f, ".strong"),
-            Selector::Code => write!(f, ".code"),
-            Selector::Math => write!(f, ".math"),
-            Selector::Table(None, None) => write!(f, ".table"),
-            Selector::Table(Some(row), None) => write!(f, ".[{}]", row),
-            Selector::Table(Some(row), Some(col)) => write!(f, ".[{}][{}]", row, col),
-            Selector::Table(None, Some(col)) => write!(f, ".[][{}]", col),
-            Selector::Text => write!(f, ".text"),
-            Selector::HorizontalRule => write!(f, ".horizontal_rule"),
-            Selector::Definition => write!(f, ".definition"),
-            Selector::MdxFlowExpression => write!(f, ".mdx_flow_expression"),
-            Selector::MdxTextExpression => write!(f, ".mdx_text_expression"),
-            Selector::MdxJsEsm => write!(f, ".mdx_js_esm"),
-            Selector::MdxJsxFlowElement => write!(f, ".mdx_jsx_flow_element"),
-        }
     }
 }
 
@@ -805,7 +612,7 @@ mod tests {
     ) {
         let mut arena = Arena::new(150);
         for (_, range) in &token_ranges {
-            let token = create_token(range.clone());
+            let token = create_token(*range);
             let _ = arena.alloc(token);
         }
         let node = Node {
@@ -813,119 +620,5 @@ mod tests {
             expr: Shared::new(expr),
         };
         assert_eq!(node.range(Shared::new(arena)), expected);
-    }
-
-    #[rstest]
-    // Heading selectors
-    #[case::heading(".h", Selector::Heading(None), ".h")]
-    #[case::heading_h1(".h1", Selector::Heading(Some(1)), ".h1")]
-    #[case::heading_h2(".h2", Selector::Heading(Some(2)), ".h2")]
-    #[case::heading_h3(".h3", Selector::Heading(Some(3)), ".h3")]
-    #[case::heading_h4(".h4", Selector::Heading(Some(4)), ".h4")]
-    #[case::heading_h5(".h5", Selector::Heading(Some(5)), ".h5")]
-    #[case::heading_h6(".h6", Selector::Heading(Some(6)), ".h6")]
-    // Blockquote
-    #[case::blockquote(".blockquote", Selector::Blockquote, ".blockquote")]
-    #[case::blockquote_alias(".>", Selector::Blockquote, ".blockquote")]
-    // Footnote
-    #[case::footnote(".footnote", Selector::Footnote, ".footnote")]
-    #[case::footnote_alias(".^", Selector::Footnote, ".footnote")]
-    // MDX JSX Flow Element
-    #[case::mdx_jsx_flow_element(".mdx_jsx_flow_element", Selector::MdxJsxFlowElement, ".mdx_jsx_flow_element")]
-    #[case::mdx_jsx_flow_element_alias(".<", Selector::MdxJsxFlowElement, ".mdx_jsx_flow_element")]
-    // Emphasis
-    #[case::emphasis(".emphasis", Selector::Emphasis, ".emphasis")]
-    #[case::emphasis_alias(".**", Selector::Emphasis, ".emphasis")]
-    // Math
-    #[case::math(".math", Selector::Math, ".math")]
-    #[case::math_alias(".$$", Selector::Math, ".math")]
-    // Horizontal Rule
-    #[case::horizontal_rule(".horizontal_rule", Selector::HorizontalRule, ".horizontal_rule")]
-    #[case::horizontal_rule_alias_dash(".---", Selector::HorizontalRule, ".horizontal_rule")]
-    #[case::horizontal_rule_alias_star(".***", Selector::HorizontalRule, ".horizontal_rule")]
-    #[case::horizontal_rule_alias_underscore(".___", Selector::HorizontalRule, ".horizontal_rule")]
-    // MDX Text Expression
-    #[case::mdx_text_expression(".mdx_text_expression", Selector::MdxTextExpression, ".mdx_text_expression")]
-    #[case::mdx_text_expression_alias(".{}", Selector::MdxTextExpression, ".mdx_text_expression")]
-    // Footnote Reference
-    #[case::footnote_ref(".footnote_ref", Selector::FootnoteRef, ".footnote_ref")]
-    #[case::footnote_ref_alias(".[^]", Selector::FootnoteRef, ".footnote_ref")]
-    // Definition
-    #[case::definition(".definition", Selector::Definition, ".definition")]
-    // Break
-    #[case::break_selector(".break", Selector::Break, ".break")]
-    // Delete
-    #[case::delete(".delete", Selector::Delete, ".delete")]
-    // HTML
-    #[case::html(".html", Selector::Html, ".html")]
-    #[case::html_alias(".<>", Selector::Html, ".html")]
-    // Image
-    #[case::image(".image", Selector::Image, ".image")]
-    // Image Reference
-    #[case::image_ref(".image_ref", Selector::ImageRef, ".image_ref")]
-    // Inline Code
-    #[case::code_inline(".code_inline", Selector::InlineCode, ".code_inline")]
-    // Inline Math
-    #[case::math_inline(".math_inline", Selector::InlineMath, ".math_inline")]
-    // Link
-    #[case::link(".link", Selector::Link, ".link")]
-    // Link Reference
-    #[case::link_ref(".link_ref", Selector::LinkRef, ".link_ref")]
-    // List
-    #[case::list(".list", Selector::List(None, None), ".list")]
-    // TOML
-    #[case::toml(".toml", Selector::Toml, ".toml")]
-    // Strong
-    #[case::strong(".strong", Selector::Strong, ".strong")]
-    // YAML
-    #[case::yaml(".yaml", Selector::Yaml, ".yaml")]
-    // Code
-    #[case::code(".code", Selector::Code, ".code")]
-    // MDX JS ESM
-    #[case::mdx_js_esm(".mdx_js_esm", Selector::MdxJsEsm, ".mdx_js_esm")]
-    // MDX JSX Text Element
-    #[case::mdx_jsx_text_element(".mdx_jsx_text_element", Selector::MdxJsxTextElement, ".mdx_jsx_text_element")]
-    // MDX Flow Expression
-    #[case::mdx_flow_expression(".mdx_flow_expression", Selector::MdxFlowExpression, ".mdx_flow_expression")]
-    // Text
-    #[case::text(".text", Selector::Text, ".text")]
-    // Table
-    #[case::table(".table", Selector::Table(None, None), ".table")]
-    fn test_selector_try_from_and_display(
-        #[case] input: &str,
-        #[case] expected_selector: Selector,
-        #[case] expected_display: &str,
-    ) {
-        // Test TryFrom
-        let selector = Selector::try_from(&Token {
-            kind: TokenKind::Selector(SmolStr::new(input)),
-            range: Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 0),
-            },
-            module_id: ArenaId::new(0),
-        })
-        .expect("Should parse valid selector");
-        assert_eq!(selector, expected_selector);
-
-        // Test Display
-        assert_eq!(selector.to_string(), expected_display);
-    }
-
-    #[test]
-    fn test_selector_try_from_unknown() {
-        let token = Token {
-            kind: TokenKind::Selector(SmolStr::new(".unknown")),
-            range: Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 0),
-            },
-            module_id: ArenaId::new(0),
-        };
-        let result = Selector::try_from(&token);
-        assert!(result.is_err());
-        if let Err(e) = result {
-            assert_eq!(e, ParseError::UnknownSelector(token));
-        }
     }
 }

--- a/crates/mq-lang/src/cst/error.rs
+++ b/crates/mq-lang/src/cst/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{Shared, Token};
+use crate::{Shared, Token, selector};
 
 #[derive(Error, Debug, PartialEq, Clone, PartialOrd, Eq, Ord)]
 pub enum ParseError {
@@ -12,4 +12,6 @@ pub enum ParseError {
     InsufficientTokens(Shared<Token>),
     #[error("Expected a closing bracket `]` but got `{0}` delimiter")]
     ExpectedClosingBracket(Shared<Token>),
+    #[error(transparent)]
+    UnknownSelector(selector::UnknownSelector),
 }

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -55,9 +55,9 @@ impl Trivia {
 
     pub fn range(&self) -> Range {
         match self {
-            Trivia::Comment(token) => token.range.clone(),
-            Trivia::Whitespace(token) => token.range.clone(),
-            Trivia::Tab(token) => token.range.clone(),
+            Trivia::Comment(token) => token.range,
+            Trivia::Whitespace(token) => token.range,
+            Trivia::Tab(token) => token.range,
             _ => Range::default(),
         }
     }
@@ -160,7 +160,7 @@ impl Node {
     }
 
     pub fn range(&self) -> Range {
-        self.token.as_ref().map(|token| token.range.clone()).unwrap_or_default()
+        self.token.as_ref().map(|token| token.range).unwrap_or_default()
     }
 
     pub fn node_range(&self) -> Range {
@@ -168,11 +168,7 @@ impl Node {
             self.range()
         } else {
             let start = self.range().start;
-            let end = self
-                .children
-                .last()
-                .map(|child| child.range().end)
-                .unwrap_or(start.clone());
+            let end = self.children.last().map(|child| child.range().end).unwrap_or(start);
             Range { start, end }
         }
     }

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -2,8 +2,12 @@ use miette::{Diagnostic, SourceOffset, SourceSpan};
 use std::borrow::Cow;
 
 use crate::{
-    Module, ModuleLoader, ModuleResolver, ast::error::ParseError, eval::error::EvalError, lexer::error::LexerError,
-    module, module::error::ModuleError,
+    Module, ModuleLoader, ModuleResolver,
+    ast::error::ParseError,
+    eval::error::EvalError,
+    lexer::error::LexerError,
+    module::{self, error::ModuleError},
+    selector,
 };
 
 #[allow(clippy::useless_conversion)]
@@ -49,7 +53,7 @@ impl Error {
                 ParseError::ExpectedClosingParen(token) => Some(token),
                 ParseError::ExpectedClosingBrace(token) => Some(token),
                 ParseError::ExpectedClosingBracket(token) => Some(token),
-                ParseError::UnknownSelector(token) => Some(token),
+                ParseError::UnknownSelector(selector::UnknownSelector(token)) => Some(token),
             },
             InnerError::Eval(err) => match err {
                 EvalError::UserDefined { token, .. } => Some(token),
@@ -84,7 +88,7 @@ impl Error {
                     ParseError::ExpectedClosingParen(token) => Some(token),
                     ParseError::ExpectedClosingBrace(token) => Some(token),
                     ParseError::ExpectedClosingBracket(token) => Some(token),
-                    ParseError::UnknownSelector(token) => Some(token),
+                    ParseError::UnknownSelector(selector::UnknownSelector(token)) => Some(token),
                 },
                 ModuleError::InvalidModule => None,
             },

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -10,6 +10,7 @@ use crate::{
     IdentWithToken, LocalFsModuleResolver, ModuleResolver,
     eval::{env::EnvError, runtime_value::ModuleEnv},
     module::{self, error::ModuleError},
+    selector::Selector,
 };
 #[cfg(feature = "debugger")]
 use crate::{Module, eval::debugger::Source};
@@ -558,7 +559,7 @@ impl<T: ModuleResolver> Evaluator<T> {
     }
 
     #[inline(always)]
-    fn eval_selector_expr(runtime_value: &RuntimeValue, ident: &ast::Selector) -> RuntimeValue {
+    fn eval_selector_expr(runtime_value: &RuntimeValue, ident: &Selector) -> RuntimeValue {
         match runtime_value {
             RuntimeValue::Markdown(node_value, _) => {
                 if builtin::eval_selector(node_value, ident) {
@@ -3173,12 +3174,12 @@ mod tests {
         ])]))]
     #[case::text_selector(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test".to_string(), position: None}), None)],
         vec![
-            ast_node(ast::Expr::Selector(ast::Selector::Text)),
+            ast_node(ast::Expr::Selector(Selector::Text)),
         ],
         Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test".to_string(), position: None}), None)]))]
     #[case::text_selector_heading(vec![RuntimeValue::Markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 1, values: vec!["Heading 1".to_string().into()], position: None}), None)],
         vec![
-            ast_node(ast::Expr::Selector(ast::Selector::Text)),
+            ast_node(ast::Expr::Selector(Selector::Text)),
         ],
         Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Fragment(mq_markdown::Fragment { values: vec!["Heading 1".to_string().into()] }), None)]))]
     #[case::to_md_table_row(vec![RuntimeValue::Array(vec![

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2,6 +2,7 @@ use crate::arena::Arena;
 use crate::ast::{constants, node as ast};
 use crate::ident::all_symbols;
 use crate::number::{self, Number};
+use crate::selector::Selector;
 use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input};
 use base64::prelude::*;
 use itertools::Itertools;
@@ -3481,21 +3482,21 @@ pub fn eval_builtin(runtime_value: &RuntimeValue, ident: &Ident, args: Args) -> 
     )
 }
 
-pub fn eval_selector(node: &mq_markdown::Node, selector: &ast::Selector) -> bool {
+pub fn eval_selector(node: &mq_markdown::Node, selector: &Selector) -> bool {
     match selector {
-        ast::Selector::Code => node.is_code(None),
-        ast::Selector::InlineCode => node.is_inline_code(),
-        ast::Selector::InlineMath => node.is_inline_math(),
-        ast::Selector::Strong => node.is_strong(),
-        ast::Selector::Emphasis => node.is_emphasis(),
-        ast::Selector::Delete => node.is_delete(),
-        ast::Selector::Link => node.is_link(),
-        ast::Selector::LinkRef => node.is_link_ref(),
-        ast::Selector::Image => node.is_image(),
-        ast::Selector::Heading(depth) => node.is_heading(*depth),
-        ast::Selector::HorizontalRule => node.is_horizontal_rule(),
-        ast::Selector::Blockquote => node.is_blockquote(),
-        ast::Selector::Table(row, column) => match (row, column, node.clone()) {
+        Selector::Code => node.is_code(None),
+        Selector::InlineCode => node.is_inline_code(),
+        Selector::InlineMath => node.is_inline_math(),
+        Selector::Strong => node.is_strong(),
+        Selector::Emphasis => node.is_emphasis(),
+        Selector::Delete => node.is_delete(),
+        Selector::Link => node.is_link(),
+        Selector::LinkRef => node.is_link_ref(),
+        Selector::Image => node.is_image(),
+        Selector::Heading(depth) => node.is_heading(*depth),
+        Selector::HorizontalRule => node.is_horizontal_rule(),
+        Selector::Blockquote => node.is_blockquote(),
+        Selector::Table(row, column) => match (row, column, node.clone()) {
             (
                 Some(row1),
                 Some(column1),
@@ -3514,10 +3515,10 @@ pub fn eval_selector(node: &mq_markdown::Node, selector: &ast::Selector) -> bool
             (None, None, mq_markdown::Node::TableCell(_)) => true,
             _ => false,
         },
-        ast::Selector::Html => node.is_html(),
-        ast::Selector::Footnote => node.is_footnote(),
-        ast::Selector::MdxJsxFlowElement => node.is_mdx_jsx_flow_element(),
-        ast::Selector::List(index, checked) => match (index, node.clone()) {
+        Selector::Html => node.is_html(),
+        Selector::Footnote => node.is_footnote(),
+        Selector::MdxJsxFlowElement => node.is_mdx_jsx_flow_element(),
+        Selector::List(index, checked) => match (index, node.clone()) {
             (
                 Some(index),
                 mq_markdown::Node::List(mq_markdown::List {
@@ -3529,18 +3530,19 @@ pub fn eval_selector(node: &mq_markdown::Node, selector: &ast::Selector) -> bool
             (_, mq_markdown::Node::List(mq_markdown::List { .. })) => true,
             _ => false,
         },
-        ast::Selector::MdxJsEsm => node.is_mdx_js_esm(),
-        ast::Selector::Text => node.is_text(),
-        ast::Selector::Toml => node.is_toml(),
-        ast::Selector::Yaml => node.is_yaml(),
-        ast::Selector::Break => node.is_break(),
-        ast::Selector::MdxTextExpression => node.is_mdx_text_expression(),
-        ast::Selector::FootnoteRef => node.is_footnote_ref(),
-        ast::Selector::ImageRef => node.is_image_ref(),
-        ast::Selector::MdxJsxTextElement => node.is_mdx_jsx_text_element(),
-        ast::Selector::Math => node.is_math(),
-        ast::Selector::MdxFlowExpression => node.is_mdx_flow_expression(),
-        ast::Selector::Definition => node.is_definition(),
+        Selector::MdxJsEsm => node.is_mdx_js_esm(),
+        Selector::Text => node.is_text(),
+        Selector::Toml => node.is_toml(),
+        Selector::Yaml => node.is_yaml(),
+        Selector::Break => node.is_break(),
+        Selector::MdxTextExpression => node.is_mdx_text_expression(),
+        Selector::FootnoteRef => node.is_footnote_ref(),
+        Selector::ImageRef => node.is_image_ref(),
+        Selector::MdxJsxTextElement => node.is_mdx_jsx_text_element(),
+        Selector::Math => node.is_math(),
+        Selector::MdxFlowExpression => node.is_mdx_flow_expression(),
+        Selector::Definition => node.is_definition(),
+        Selector::Attr(_) => false, // Attribute selectors don't match nodes directly
     }
 }
 
@@ -3879,168 +3881,168 @@ mod tests {
     #[rstest]
     #[case::code(
         Node::Code(mq_markdown::Code { value: "test".into(), lang: Some("rust".into()), fence: true, meta: None, position: None }),
-        ast::Selector::Code,
+        Selector::Code,
         true
     )]
     #[case::inline_code(
         Node::CodeInline(mq_markdown::CodeInline { value: "test".into(), position: None }),
-        ast::Selector::InlineCode,
+        Selector::InlineCode,
         true
     )]
     #[case::inline_math(
         Node::MathInline(mq_markdown::MathInline { value: "test".into(), position: None }),
-        ast::Selector::InlineMath,
+        Selector::InlineMath,
         true
     )]
     #[case::strong(
         Node::Strong(mq_markdown::Strong { values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Strong,
+        Selector::Strong,
         true
     )]
     #[case::emphasis(
         Node::Emphasis(mq_markdown::Emphasis{ values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Emphasis,
+        Selector::Emphasis,
         true
     )]
     #[case::delete(
         Node::Delete(mq_markdown::Delete{ values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Delete,
+        Selector::Delete,
         true
     )]
     #[case::link(
         Node::Link(mq_markdown::Link { url: mq_markdown::Url::new("https://example.com".into()), values: Vec::new(), title: None, position: None }),
-        ast::Selector::Link,
+        Selector::Link,
         true
     )]
     #[case::heading_matching_depth(
         Node::Heading(mq_markdown::Heading { depth: 2, values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Heading(Some(2)),
+        Selector::Heading(Some(2)),
         true
     )]
     #[case::heading_wrong_depth(
         Node::Heading(mq_markdown::Heading { depth: 2, values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Heading(Some(3)),
+        Selector::Heading(Some(3)),
         false
     )]
     #[case::table_cell_with_matching_row_col(
         Node::TableCell(mq_markdown::TableCell { row: 1, column: 2, values: vec!["test".to_string().into()],
                                                last_cell_in_row: false, last_cell_of_in_table: false, position: None }),
-        ast::Selector::Table(Some(1), Some(2)),
+        Selector::Table(Some(1), Some(2)),
         true
     )]
     #[case::table_cell_with_wrong_row(
         Node::TableCell(mq_markdown::TableCell { row: 1, column: 2, values: vec!["test".to_string().into()],
                                                last_cell_in_row: false, last_cell_of_in_table: false, position: None }),
-        ast::Selector::Table(Some(2), Some(2)),
+        Selector::Table(Some(2), Some(2)),
         false
     )]
     #[case::table_cell_with_only_row(
         Node::TableCell(mq_markdown::TableCell { row: 1, column: 2, values: vec!["test".to_string().into()],
                                                last_cell_in_row: false, last_cell_of_in_table: false, position: None }),
-        ast::Selector::Table(Some(1), None),
+        Selector::Table(Some(1), None),
         true
     )]
     #[case::list_with_matching_index_checked(
         Node::List(mq_markdown::List { values: vec!["test".to_string().into()], ordered: false, index: 1, level: 1, checked: Some(true), position: None }),
-        ast::Selector::List(Some(1), Some(true)),
+        Selector::List(Some(1), Some(true)),
         true
     )]
     #[case::list_with_wrong_index(
         Node::List(mq_markdown::List { values: vec!["test".to_string().into()], ordered: false, index: 1, level: 1, checked: Some(true), position: None }),
-        ast::Selector::List(Some(2), Some(true)),
+        Selector::List(Some(2), Some(true)),
         false
     )]
     #[case::list_without_index(
         Node::List(mq_markdown::List { values: vec!["test".to_string().into()], ordered: false, index: 1, level: 1, checked: Some(true), position: None }),
-        ast::Selector::List(None, None),
+        Selector::List(None, None),
         true
     )]
     #[case::text(
         Node::Text(mq_markdown::Text { value: "test".into(), position: None }),
-        ast::Selector::Text,
+        Selector::Text,
         true
     )]
     #[case::html(
         Node::Html(mq_markdown::Html { value: "<div>test</div>".into(), position: None }),
-        ast::Selector::Html,
+        Selector::Html,
         true
     )]
     #[case::yaml(
         Node::Yaml(mq_markdown::Yaml { value: "test".into(), position: None }),
-        ast::Selector::Yaml,
+        Selector::Yaml,
         true
     )]
     #[case::toml(
         Node::Toml(mq_markdown::Toml { value: "test".into(), position: None }),
-        ast::Selector::Toml,
+        Selector::Toml,
         true
     )]
     #[case::break_(
         Node::Break(mq_markdown::Break{position: None}),
-        ast::Selector::Break,
+        Selector::Break,
         true
     )]
     #[case::image(
         Node::Image(mq_markdown::Image { alt: "".to_string(), url: "".to_string(), title: None, position: None }),
-        ast::Selector::Image,
+        Selector::Image,
         true
     )]
     #[case::image_ref(
         Node::ImageRef(mq_markdown::ImageRef{ alt: "".to_string(), ident: "".to_string(), label: None, position: None }),
-        ast::Selector::ImageRef,
+        Selector::ImageRef,
         true
     )]
     #[case::footnote(
         Node::Footnote(mq_markdown::Footnote{ident: "".to_string(), values: vec!["test".to_string().into()], position: None}),
-        ast::Selector::Footnote,
+        Selector::Footnote,
         true
     )]
     #[case::footnote_ref(
         Node::FootnoteRef(mq_markdown::FootnoteRef{ident: "".to_string(), label: None, position: None}),
-        ast::Selector::FootnoteRef,
+        Selector::FootnoteRef,
         true
     )]
     #[case::math(
         Node::Math(mq_markdown::Math { value: "E=mc^2".into(), position: None }),
-        ast::Selector::Math,
+        Selector::Math,
         true
     )]
     #[case::horizontal_rule(
         Node::HorizontalRule(mq_markdown::HorizontalRule{ position: None }),
-        ast::Selector::HorizontalRule,
+        Selector::HorizontalRule,
         true
     )]
     #[case::blockquote(
         Node::Blockquote(mq_markdown::Blockquote{ values: vec!["test".to_string().into()], position: None }),
-        ast::Selector::Blockquote,
+        Selector::Blockquote,
         true
     )]
     #[case::definition(
         Node::Definition(mq_markdown::Definition { ident: "id".to_string(), url: mq_markdown::Url::new("url".into()), label: None, title: None, position: None }),
-        ast::Selector::Definition,
+        Selector::Definition,
         true
     )]
     #[case::mdx_jsx_flow_element(
         Node::MdxJsxFlowElement(mq_markdown::MdxJsxFlowElement { name: Some("div".to_string()), attributes: Vec::new(), children: Vec::new(), position: None }),
-        ast::Selector::MdxJsxFlowElement,
+        Selector::MdxJsxFlowElement,
         true
     )]
     #[case::mdx_flow_expression(
         Node::MdxFlowExpression(mq_markdown::MdxFlowExpression{ value: "value".into(), position: None }),
-        ast::Selector::MdxFlowExpression,
+        Selector::MdxFlowExpression,
         true
     )]
     #[case::mdx_text_expression(
         Node::MdxTextExpression(mq_markdown::MdxTextExpression{ value: "value".into(), position: None }),
-        ast::Selector::MdxTextExpression,
+        Selector::MdxTextExpression,
         true
     )]
     #[case::mdx_js_esm(
         Node::MdxJsEsm(mq_markdown::MdxJsEsm{ value: "value".into(), position: None }),
-        ast::Selector::MdxJsEsm,
+        Selector::MdxJsEsm,
         true
     )]
-    fn test_eval_selector(#[case] node: Node, #[case] selector: ast::Selector, #[case] expected: bool) {
+    fn test_eval_selector(#[case] node: Node, #[case] selector: Selector, #[case] expected: bool) {
         assert_eq!(eval_selector(&node, &selector), expected);
     }
 

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -114,8 +114,14 @@ pub enum TokenKind {
 }
 
 impl Token {
+    #[inline(always)]
     pub fn is_eof(&self) -> bool {
         matches!(self.kind, TokenKind::Eof)
+    }
+
+    #[inline(always)]
+    pub fn is_selector(&self) -> bool {
+        matches!(self.kind, TokenKind::Selector(_))
     }
 }
 

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -52,6 +52,7 @@ mod module;
 mod number;
 mod optimizer;
 mod range;
+mod selector;
 
 use lexer::Lexer;
 #[cfg(not(feature = "sync"))]
@@ -88,6 +89,7 @@ pub use module::{
 };
 pub use optimizer::OptimizationLevel;
 pub use range::{Position, Range};
+pub use selector::{AttrKind, Selector};
 
 pub type DefaultEngine = Engine<LocalFsModuleResolver>;
 pub type DefaultModuleLoader = ModuleLoader<LocalFsModuleResolver>;

--- a/crates/mq-lang/src/range.rs
+++ b/crates/mq-lang/src/range.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub type Span<'a> = LocatedSpan<&'a str, ModuleId>;
 
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash)]
 pub struct Position {
     pub line: u32,
     pub column: usize,
@@ -26,7 +26,7 @@ impl Position {
 }
 
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Default, Hash)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Default, Hash)]
 pub struct Range {
     pub start: Position,
     pub end: Position,

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -1,0 +1,487 @@
+use std::fmt::{self, Display, Formatter};
+
+#[cfg(feature = "ast-json")]
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{Token, TokenKind};
+
+#[derive(Error, Clone, Debug, PartialOrd, Eq, Ord, PartialEq)]
+#[error("Unknown selector `{0}`")]
+pub struct UnknownSelector(pub Token);
+
+impl UnknownSelector {
+    pub fn new(token: Token) -> Self {
+        Self(token)
+    }
+}
+
+#[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
+#[derive(PartialEq, PartialOrd, Debug, Eq, Clone)]
+pub enum Selector {
+    Blockquote,
+    Footnote,
+    List(Option<usize>, Option<bool>),
+    Toml,
+    Yaml,
+    Break,
+    InlineCode,
+    InlineMath,
+    Delete,
+    Emphasis,
+    FootnoteRef,
+    Html,
+    Image,
+    ImageRef,
+    MdxJsxTextElement,
+    Link,
+    LinkRef,
+    Strong,
+    Code,
+    Math,
+    Heading(Option<u8>),
+    Table(Option<usize>, Option<usize>),
+    Text,
+    HorizontalRule,
+    Definition,
+    MdxFlowExpression,
+    MdxTextExpression,
+    MdxJsEsm,
+    MdxJsxFlowElement,
+    Attr(AttrKind),
+}
+
+/// Represents an attribute that can be accessed from Markdown nodes
+#[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
+#[derive(PartialEq, PartialOrd, Debug, Eq, Clone)]
+pub enum AttrKind {
+    // Common text attributes
+    Value,    // "value"
+    Values,   // "values"
+    Children, // "children"
+
+    // Code attributes
+    Lang,  // "lang"
+    Meta,  // "meta"
+    Fence, // "fence"
+
+    // Link/Image attributes
+    Url,   // "url"
+    Alt,   // "alt"
+    Title, // "title"
+
+    // Reference attributes (LinkRef, ImageRef, FootnoteRef, Definition, Footnote)
+    Ident, // "ident"
+    Label, // "label"
+
+    // Heading attributes
+    Depth, // "depth"
+    Level, // "level" (alias for depth)
+
+    // List attributes
+    Index,   // "index"
+    Ordered, // "ordered"
+    Checked, // "checked"
+
+    // TableCell attributes
+    Column,            // "column"
+    Row,               // "row"
+    LastCellInRow,     // "last_cell_in_row"
+    LastCellOfInTable, // "last_cell_of_in_table"
+
+    // TableHeader attributes
+    Align, // "align"
+
+    // MDX attributes
+    Name, // "name" (for MdxJsxFlowElement, MdxJsxTextElement)
+}
+
+impl Display for AttrKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            AttrKind::Value => write!(f, ".value"),
+            AttrKind::Values => write!(f, ".values"),
+            AttrKind::Children => write!(f, ".children"),
+            AttrKind::Lang => write!(f, ".lang"),
+            AttrKind::Meta => write!(f, ".meta"),
+            AttrKind::Fence => write!(f, ".fence"),
+            AttrKind::Url => write!(f, ".url"),
+            AttrKind::Alt => write!(f, ".alt"),
+            AttrKind::Title => write!(f, ".title"),
+            AttrKind::Ident => write!(f, ".ident"),
+            AttrKind::Label => write!(f, ".label"),
+            AttrKind::Depth => write!(f, ".depth"),
+            AttrKind::Level => write!(f, ".level"),
+            AttrKind::Index => write!(f, ".index"),
+            AttrKind::Ordered => write!(f, ".ordered"),
+            AttrKind::Checked => write!(f, ".checked"),
+            AttrKind::Column => write!(f, ".column"),
+            AttrKind::Row => write!(f, ".row"),
+            AttrKind::LastCellInRow => write!(f, ".last_cell_in_row"),
+            AttrKind::LastCellOfInTable => write!(f, ".last_cell_of_in_table"),
+            AttrKind::Align => write!(f, ".align"),
+            AttrKind::Name => write!(f, ".name"),
+        }
+    }
+}
+
+impl TryFrom<&Token> for Selector {
+    type Error = UnknownSelector;
+
+    fn try_from(token: &Token) -> Result<Self, Self::Error> {
+        if let TokenKind::Selector(s) = &token.kind {
+            match s.as_str() {
+                // Heading selectors
+                ".h" => Ok(Selector::Heading(None)),
+                ".h1" => Ok(Selector::Heading(Some(1))),
+                ".h2" => Ok(Selector::Heading(Some(2))),
+                ".h3" => Ok(Selector::Heading(Some(3))),
+                ".h4" => Ok(Selector::Heading(Some(4))),
+                ".h5" => Ok(Selector::Heading(Some(5))),
+                ".h6" => Ok(Selector::Heading(Some(6))),
+
+                // Blockquote
+                ".>" | ".blockquote" => Ok(Selector::Blockquote),
+
+                // Footnote
+                ".^" | ".footnote" => Ok(Selector::Footnote),
+
+                // MDX JSX Flow Element
+                ".<" | ".mdx_jsx_flow_element" => Ok(Selector::MdxJsxFlowElement),
+
+                // Emphasis
+                ".**" | ".emphasis" => Ok(Selector::Emphasis),
+
+                // Math
+                ".$$" | ".math" => Ok(Selector::Math),
+
+                // Horizontal Rule
+                ".horizontal_rule" | ".---" | ".***" | ".___" => Ok(Selector::HorizontalRule),
+
+                // MDX Text Expression
+                ".{}" | ".mdx_text_expression" => Ok(Selector::MdxTextExpression),
+
+                // Footnote Reference
+                ".[^]" | ".footnote_ref" => Ok(Selector::FootnoteRef),
+
+                // Definition
+                ".definition" => Ok(Selector::Definition),
+
+                // Break
+                ".break" => Ok(Selector::Break),
+
+                // Delete
+                ".delete" => Ok(Selector::Delete),
+
+                // HTML
+                ".<>" | ".html" => Ok(Selector::Html),
+
+                // Image
+                ".image" => Ok(Selector::Image),
+
+                // Image Reference
+                ".image_ref" => Ok(Selector::ImageRef),
+
+                // Inline Code
+                ".code_inline" => Ok(Selector::InlineCode),
+
+                // Inline Math
+                ".math_inline" => Ok(Selector::InlineMath),
+
+                // Link
+                ".link" => Ok(Selector::Link),
+
+                // Link Reference
+                ".link_ref" => Ok(Selector::LinkRef),
+
+                // List
+                ".list" => Ok(Selector::List(None, None)),
+
+                // TOML
+                ".toml" => Ok(Selector::Toml),
+
+                // Strong
+                ".strong" => Ok(Selector::Strong),
+
+                // YAML
+                ".yaml" => Ok(Selector::Yaml),
+
+                // Code
+                ".code" => Ok(Selector::Code),
+
+                // MDX JS ESM
+                ".mdx_js_esm" => Ok(Selector::MdxJsEsm),
+
+                // MDX JSX Text Element
+                ".mdx_jsx_text_element" => Ok(Selector::MdxJsxTextElement),
+
+                // MDX Flow Expression
+                ".mdx_flow_expression" => Ok(Selector::MdxFlowExpression),
+
+                // Text
+                ".text" => Ok(Selector::Text),
+
+                // Table
+                ".table" => Ok(Selector::Table(None, None)),
+
+                // Attribute selectors - Common
+                ".value" => Ok(Selector::Attr(AttrKind::Value)),
+                ".values" => Ok(Selector::Attr(AttrKind::Values)),
+                ".children" | ".cn" => Ok(Selector::Attr(AttrKind::Children)),
+
+                // Attribute selectors - Code
+                ".lang" => Ok(Selector::Attr(AttrKind::Lang)),
+                ".meta" => Ok(Selector::Attr(AttrKind::Meta)),
+                ".fence" => Ok(Selector::Attr(AttrKind::Fence)),
+
+                // Attribute selectors - Link/Image
+                ".url" => Ok(Selector::Attr(AttrKind::Url)),
+                ".alt" => Ok(Selector::Attr(AttrKind::Alt)),
+                ".title" => Ok(Selector::Attr(AttrKind::Title)),
+
+                // Attribute selectors - Reference
+                ".ident" => Ok(Selector::Attr(AttrKind::Ident)),
+                ".label" => Ok(Selector::Attr(AttrKind::Label)),
+
+                // Attribute selectors - Heading
+                ".depth" => Ok(Selector::Attr(AttrKind::Depth)),
+                ".level" => Ok(Selector::Attr(AttrKind::Level)),
+
+                // Attribute selectors - List
+                ".index" => Ok(Selector::Attr(AttrKind::Index)),
+                ".ordered" => Ok(Selector::Attr(AttrKind::Ordered)),
+                ".checked" => Ok(Selector::Attr(AttrKind::Checked)),
+
+                // Attribute selectors - TableCell
+                ".column" => Ok(Selector::Attr(AttrKind::Column)),
+                ".row" => Ok(Selector::Attr(AttrKind::Row)),
+                ".last_cell_in_row" => Ok(Selector::Attr(AttrKind::LastCellInRow)),
+                ".last_cell_of_in_table" => Ok(Selector::Attr(AttrKind::LastCellOfInTable)),
+
+                // Attribute selectors - TableHeader
+                ".align" => Ok(Selector::Attr(AttrKind::Align)),
+
+                // Attribute selectors - MDX
+                ".name" => Ok(Selector::Attr(AttrKind::Name)),
+
+                _ => Err(UnknownSelector(token.clone())),
+            }
+        } else {
+            Err(UnknownSelector(token.clone()))
+        }
+    }
+}
+
+impl Display for Selector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Selector::Heading(None) => write!(f, ".h"),
+            Selector::Heading(Some(1)) => write!(f, ".h1"),
+            Selector::Heading(Some(2)) => write!(f, ".h2"),
+            Selector::Heading(Some(3)) => write!(f, ".h3"),
+            Selector::Heading(Some(4)) => write!(f, ".h4"),
+            Selector::Heading(Some(5)) => write!(f, ".h5"),
+            Selector::Heading(Some(6)) => write!(f, ".h6"),
+            Selector::Heading(Some(n)) => write!(f, ".h{}", n),
+            Selector::Blockquote => write!(f, ".blockquote"),
+            Selector::Footnote => write!(f, ".footnote"),
+            Selector::List(None, None) => write!(f, ".list"),
+            Selector::List(Some(idx), None) => write!(f, ".list({})", idx),
+            Selector::List(idx, ordered) => write!(f, ".list({:?}, {:?})", idx, ordered),
+            Selector::Toml => write!(f, ".toml"),
+            Selector::Yaml => write!(f, ".yaml"),
+            Selector::Break => write!(f, ".break"),
+            Selector::InlineCode => write!(f, ".code_inline"),
+            Selector::InlineMath => write!(f, ".math_inline"),
+            Selector::Delete => write!(f, ".delete"),
+            Selector::Emphasis => write!(f, ".emphasis"),
+            Selector::FootnoteRef => write!(f, ".footnote_ref"),
+            Selector::Html => write!(f, ".html"),
+            Selector::Image => write!(f, ".image"),
+            Selector::ImageRef => write!(f, ".image_ref"),
+            Selector::MdxJsxTextElement => write!(f, ".mdx_jsx_text_element"),
+            Selector::Link => write!(f, ".link"),
+            Selector::LinkRef => write!(f, ".link_ref"),
+            Selector::Strong => write!(f, ".strong"),
+            Selector::Code => write!(f, ".code"),
+            Selector::Math => write!(f, ".math"),
+            Selector::Table(None, None) => write!(f, ".table"),
+            Selector::Table(Some(row), None) => write!(f, ".[{}]", row),
+            Selector::Table(Some(row), Some(col)) => write!(f, ".[{}][{}]", row, col),
+            Selector::Table(None, Some(col)) => write!(f, ".[][{}]", col),
+            Selector::Text => write!(f, ".text"),
+            Selector::HorizontalRule => write!(f, ".horizontal_rule"),
+            Selector::Definition => write!(f, ".definition"),
+            Selector::MdxFlowExpression => write!(f, ".mdx_flow_expression"),
+            Selector::MdxTextExpression => write!(f, ".mdx_text_expression"),
+            Selector::MdxJsEsm => write!(f, ".mdx_js_esm"),
+            Selector::MdxJsxFlowElement => write!(f, ".mdx_jsx_flow_element"),
+            Selector::Attr(attr) => write!(f, "{}", attr),
+        }
+    }
+}
+
+impl Selector {
+    pub fn is_attribute_selector(&self) -> bool {
+        matches!(self, Selector::Attr(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ArenaId, Position, Range, Token, TokenKind,
+        selector::{AttrKind, Selector, UnknownSelector},
+    };
+    use rstest::rstest;
+    use smol_str::SmolStr;
+
+    #[rstest]
+    // Heading selectors
+    #[case::heading(".h", Selector::Heading(None), ".h")]
+    #[case::heading_h1(".h1", Selector::Heading(Some(1)), ".h1")]
+    #[case::heading_h2(".h2", Selector::Heading(Some(2)), ".h2")]
+    #[case::heading_h3(".h3", Selector::Heading(Some(3)), ".h3")]
+    #[case::heading_h4(".h4", Selector::Heading(Some(4)), ".h4")]
+    #[case::heading_h5(".h5", Selector::Heading(Some(5)), ".h5")]
+    #[case::heading_h6(".h6", Selector::Heading(Some(6)), ".h6")]
+    // Blockquote
+    #[case::blockquote(".blockquote", Selector::Blockquote, ".blockquote")]
+    #[case::blockquote_alias(".>", Selector::Blockquote, ".blockquote")]
+    // Footnote
+    #[case::footnote(".footnote", Selector::Footnote, ".footnote")]
+    #[case::footnote_alias(".^", Selector::Footnote, ".footnote")]
+    // MDX JSX Flow Element
+    #[case::mdx_jsx_flow_element(".mdx_jsx_flow_element", Selector::MdxJsxFlowElement, ".mdx_jsx_flow_element")]
+    #[case::mdx_jsx_flow_element_alias(".<", Selector::MdxJsxFlowElement, ".mdx_jsx_flow_element")]
+    // Emphasis
+    #[case::emphasis(".emphasis", Selector::Emphasis, ".emphasis")]
+    #[case::emphasis_alias(".**", Selector::Emphasis, ".emphasis")]
+    // Math
+    #[case::math(".math", Selector::Math, ".math")]
+    #[case::math_alias(".$$", Selector::Math, ".math")]
+    // Horizontal Rule
+    #[case::horizontal_rule(".horizontal_rule", Selector::HorizontalRule, ".horizontal_rule")]
+    #[case::horizontal_rule_alias_dash(".---", Selector::HorizontalRule, ".horizontal_rule")]
+    #[case::horizontal_rule_alias_star(".***", Selector::HorizontalRule, ".horizontal_rule")]
+    #[case::horizontal_rule_alias_underscore(".___", Selector::HorizontalRule, ".horizontal_rule")]
+    // MDX Text Expression
+    #[case::mdx_text_expression(".mdx_text_expression", Selector::MdxTextExpression, ".mdx_text_expression")]
+    #[case::mdx_text_expression_alias(".{}", Selector::MdxTextExpression, ".mdx_text_expression")]
+    // Footnote Reference
+    #[case::footnote_ref(".footnote_ref", Selector::FootnoteRef, ".footnote_ref")]
+    #[case::footnote_ref_alias(".[^]", Selector::FootnoteRef, ".footnote_ref")]
+    // Definition
+    #[case::definition(".definition", Selector::Definition, ".definition")]
+    // Break
+    #[case::break_selector(".break", Selector::Break, ".break")]
+    // Delete
+    #[case::delete(".delete", Selector::Delete, ".delete")]
+    // HTML
+    #[case::html(".html", Selector::Html, ".html")]
+    #[case::html_alias(".<>", Selector::Html, ".html")]
+    // Image
+    #[case::image(".image", Selector::Image, ".image")]
+    // Image Reference
+    #[case::image_ref(".image_ref", Selector::ImageRef, ".image_ref")]
+    // Inline Code
+    #[case::code_inline(".code_inline", Selector::InlineCode, ".code_inline")]
+    // Inline Math
+    #[case::math_inline(".math_inline", Selector::InlineMath, ".math_inline")]
+    // Link
+    #[case::link(".link", Selector::Link, ".link")]
+    // Link Reference
+    #[case::link_ref(".link_ref", Selector::LinkRef, ".link_ref")]
+    // List
+    #[case::list(".list", Selector::List(None, None), ".list")]
+    // TOML
+    #[case::toml(".toml", Selector::Toml, ".toml")]
+    // Strong
+    #[case::strong(".strong", Selector::Strong, ".strong")]
+    // YAML
+    #[case::yaml(".yaml", Selector::Yaml, ".yaml")]
+    // Code
+    #[case::code(".code", Selector::Code, ".code")]
+    // MDX JS ESM
+    #[case::mdx_js_esm(".mdx_js_esm", Selector::MdxJsEsm, ".mdx_js_esm")]
+    // MDX JSX Text Element
+    #[case::mdx_jsx_text_element(".mdx_jsx_text_element", Selector::MdxJsxTextElement, ".mdx_jsx_text_element")]
+    // MDX Flow Expression
+    #[case::mdx_flow_expression(".mdx_flow_expression", Selector::MdxFlowExpression, ".mdx_flow_expression")]
+    // Text
+    #[case::text(".text", Selector::Text, ".text")]
+    // Table
+    #[case::table(".table", Selector::Table(None, None), ".table")]
+    // Attribute selectors - Common
+    #[case::attr_value(".value", Selector::Attr(AttrKind::Value), ".value")]
+    #[case::attr_values(".values", Selector::Attr(AttrKind::Values), ".values")]
+    #[case::attr_children(".children", Selector::Attr(AttrKind::Children), ".children")]
+    // Attribute selectors - Code
+    #[case::attr_lang(".lang", Selector::Attr(AttrKind::Lang), ".lang")]
+    #[case::attr_meta(".meta", Selector::Attr(AttrKind::Meta), ".meta")]
+    #[case::attr_fence(".fence", Selector::Attr(AttrKind::Fence), ".fence")]
+    // Attribute selectors - Link/Image
+    #[case::attr_url(".url", Selector::Attr(AttrKind::Url), ".url")]
+    #[case::attr_alt(".alt", Selector::Attr(AttrKind::Alt), ".alt")]
+    #[case::attr_title(".title", Selector::Attr(AttrKind::Title), ".title")]
+    // Attribute selectors - Reference
+    #[case::attr_ident(".ident", Selector::Attr(AttrKind::Ident), ".ident")]
+    #[case::attr_label(".label", Selector::Attr(AttrKind::Label), ".label")]
+    // Attribute selectors - Heading
+    #[case::attr_depth(".depth", Selector::Attr(AttrKind::Depth), ".depth")]
+    #[case::attr_level(".level", Selector::Attr(AttrKind::Level), ".level")]
+    // Attribute selectors - List
+    #[case::attr_index(".index", Selector::Attr(AttrKind::Index), ".index")]
+    #[case::attr_ordered(".ordered", Selector::Attr(AttrKind::Ordered), ".ordered")]
+    #[case::attr_checked(".checked", Selector::Attr(AttrKind::Checked), ".checked")]
+    // Attribute selectors - TableCell
+    #[case::attr_column(".column", Selector::Attr(AttrKind::Column), ".column")]
+    #[case::attr_row(".row", Selector::Attr(AttrKind::Row), ".row")]
+    #[case::attr_last_cell_in_row(".last_cell_in_row", Selector::Attr(AttrKind::LastCellInRow), ".last_cell_in_row")]
+    #[case::attr_last_cell_of_in_table(
+        ".last_cell_of_in_table",
+        Selector::Attr(AttrKind::LastCellOfInTable),
+        ".last_cell_of_in_table"
+    )]
+    // Attribute selectors - TableHeader
+    #[case::attr_align(".align", Selector::Attr(AttrKind::Align), ".align")]
+    // Attribute selectors - MDX
+    #[case::attr_name(".name", Selector::Attr(AttrKind::Name), ".name")]
+    fn test_selector_try_from_and_display(
+        #[case] input: &str,
+        #[case] expected_selector: Selector,
+        #[case] expected_display: &str,
+    ) {
+        // Test TryFrom
+        let selector = Selector::try_from(&Token {
+            kind: TokenKind::Selector(SmolStr::new(input)),
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            module_id: ArenaId::new(0),
+        })
+        .expect("Should parse valid selector");
+        assert_eq!(selector, expected_selector);
+
+        // Test Display
+        assert_eq!(selector.to_string(), expected_display);
+    }
+
+    #[test]
+    fn test_selector_try_from_unknown() {
+        let token = Token {
+            kind: TokenKind::Selector(SmolStr::new(".unknown")),
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            module_id: ArenaId::new(0),
+        };
+        let result = Selector::try_from(&token);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e, UnknownSelector(token));
+        }
+    }
+}

--- a/crates/mq-lsp/src/document_symbol.rs
+++ b/crates/mq-lsp/src/document_symbol.rs
@@ -17,7 +17,7 @@ pub fn response(
             .find_symbols_in_source(*source_id)
             .iter()
             .filter_map(|symbol| {
-                symbol.source.text_range.clone().and_then(|text_range| {
+                symbol.source.text_range.and_then(|text_range| {
                     let kind = match &symbol.kind {
                         mq_hir::SymbolKind::Function(_) => SymbolKind::FUNCTION,
                         mq_hir::SymbolKind::Variable => SymbolKind::FIELD,

--- a/crates/mq-lsp/src/references.rs
+++ b/crates/mq-lsp/src/references.rs
@@ -25,7 +25,7 @@ pub fn response(
                 .references(symbol_id)
                 .iter()
                 .filter_map(|(_, symbol)| {
-                    symbol.source.text_range.clone().and_then(|text_range| {
+                    symbol.source.text_range.and_then(|text_range| {
                         symbol.source.source_id.and_then(|id| {
                             source_map.get_by_right(&id).map(|url| Location {
                                 uri: lsp_types::Uri::from_str(url).unwrap(),

--- a/crates/mq-lsp/src/semantic_tokens.rs
+++ b/crates/mq-lsp/src/semantic_tokens.rs
@@ -17,7 +17,7 @@ pub fn response(hir: Arc<RwLock<mq_hir::Hir>>, url: Url) -> Vec<SemanticToken> {
 
     for symbol in symbols
         .into_iter()
-        .sorted_by_key(|symbol| symbol.source.text_range.clone())
+        .sorted_by_key(|symbol| symbol.source.text_range)
         .collect::<Vec<_>>()
     {
         for (range, _) in &symbol.doc {

--- a/crates/mq-lsp/src/server.rs
+++ b/crates/mq-lsp/src/server.rs
@@ -256,7 +256,7 @@ impl Backend {
                     if symbol.source.source_id == Some(*source_id)
                         && let Some(ref text_range) = symbol.source.text_range
                     {
-                        range_map.insert(text_range.clone(), true);
+                        range_map.insert(text_range, true);
                     }
                 }
 

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -1755,16 +1755,16 @@ impl Node {
         match self {
             Node::Footnote(Footnote { ident, values, .. }) => match attr {
                 "ident" => Some(AttrValue::String(ident.clone())),
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
             Node::Html(Html { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 _ => None,
             },
             Node::Text(Text { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 _ => None,
             },
             Node::Code(Code {
@@ -1774,30 +1774,30 @@ impl Node {
                 fence,
                 ..
             }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 "lang" => lang.clone().map(AttrValue::String),
                 "meta" => meta.clone().map(AttrValue::String),
                 "fence" => Some(AttrValue::Boolean(*fence)),
                 _ => None,
             },
             Node::CodeInline(CodeInline { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.to_string())),
+                "value" => Some(AttrValue::String(value.to_string())),
                 _ => None,
             },
             Node::MathInline(MathInline { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.to_string())),
+                "value" => Some(AttrValue::String(value.to_string())),
                 _ => None,
             },
             Node::Math(Math { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 _ => None,
             },
             Node::Yaml(Yaml { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 _ => None,
             },
             Node::Toml(Toml { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.clone())),
+                "value" => Some(AttrValue::String(value.clone())),
                 _ => None,
             },
             Node::Image(Image { alt, url, title, .. }) => match attr {
@@ -1815,7 +1815,7 @@ impl Node {
             Node::Link(Link { url, title, values, .. }) => match attr {
                 "url" => Some(AttrValue::String(url.as_str().to_string())),
                 "title" => title.as_ref().map(|t| AttrValue::String(t.to_value())),
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
@@ -1844,7 +1844,7 @@ impl Node {
             },
             Node::Heading(Heading { depth, values, .. }) => match attr {
                 "depth" | "level" => Some(AttrValue::Integer(*depth as i64)),
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
@@ -1860,7 +1860,7 @@ impl Node {
                 "level" => Some(AttrValue::Integer(*level as i64)),
                 "ordered" => Some(AttrValue::Boolean(*ordered)),
                 "checked" => checked.map(AttrValue::Boolean),
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
@@ -1876,7 +1876,7 @@ impl Node {
                 "row" => Some(AttrValue::Integer(*row as i64)),
                 "last_cell_in_row" => Some(AttrValue::Boolean(*last_cell_in_row)),
                 "last_cell_of_in_table" => Some(AttrValue::Boolean(*last_cell_of_in_table)),
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
@@ -1887,15 +1887,15 @@ impl Node {
                 _ => None,
             },
             Node::MdxFlowExpression(MdxFlowExpression { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.to_string())),
+                "value" => Some(AttrValue::String(value.to_string())),
                 _ => None,
             },
             Node::MdxTextExpression(MdxTextExpression { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.to_string())),
+                "value" => Some(AttrValue::String(value.to_string())),
                 _ => None,
             },
             Node::MdxJsEsm(MdxJsEsm { value, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(value.to_string())),
+                "value" => Some(AttrValue::String(value.to_string())),
                 _ => None,
             },
             Node::MdxJsxFlowElement(MdxJsxFlowElement { name, .. }) => match attr {
@@ -1907,7 +1907,7 @@ impl Node {
                 _ => None,
             },
             Node::Strong(Strong { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(
+                "value" => Some(AttrValue::String(values_to_string(
                     values.as_ref(),
                     &RenderOptions::default(),
                 ))),
@@ -1915,27 +1915,27 @@ impl Node {
                 _ => None,
             },
             Node::Blockquote(Blockquote { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
             Node::Delete(Delete { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
             Node::Emphasis(Emphasis { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
             Node::TableRow(TableRow { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
             Node::Fragment(Fragment { values, .. }) => match attr {
-                "value" | "text" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                "value" => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
                 "values" | "children" | "cn" => Some(AttrValue::Array(values.clone())),
                 _ => None,
             },
@@ -1954,18 +1954,16 @@ impl Node {
                     f.ident = value_str;
                 }
             }
-            Node::Html(h) => match attr {
-                "value" | "text" => {
+            Node::Html(h) => {
+                if attr == "value" {
                     h.value = value_str;
                 }
-                _ => (),
-            },
-            Node::Text(t) => match attr {
-                "value" | "text" => {
+            }
+            Node::Text(t) => {
+                if attr == "value" {
                     t.value = value_str;
                 }
-                _ => (),
-            },
+            }
             Node::Code(c) => match attr {
                 "value" => {
                     c.value = value_str;
@@ -1984,36 +1982,31 @@ impl Node {
                 }
                 _ => (),
             },
-            Node::CodeInline(ci) => match attr {
-                "value" | "text" => {
+            Node::CodeInline(ci) => {
+                if attr == "value" {
                     ci.value = value_str.into();
                 }
-                _ => (),
-            },
-            Node::MathInline(mi) => match attr {
-                "value" | "text" => {
+            }
+            Node::MathInline(mi) => {
+                if attr == "value" {
                     mi.value = value_str.into();
                 }
-                _ => (),
-            },
-            Node::Math(m) => match attr {
-                "value" | "text" => {
+            }
+            Node::Math(m) => {
+                if attr == "value" {
                     m.value = value_str;
                 }
-                _ => (),
-            },
-            Node::Yaml(y) => match attr {
-                "value" | "text" => {
+            }
+            Node::Yaml(y) => {
+                if attr == "value" {
                     y.value = value_str;
                 }
-                _ => (),
-            },
-            Node::Toml(t) => match attr {
-                "value" | "text" => {
+            }
+            Node::Toml(t) => {
+                if attr == "value" {
                     t.value = value_str;
                 }
-                _ => (),
-            },
+            }
             Node::Image(i) => match attr {
                 "alt" => {
                     i.alt = value_str;
@@ -2169,24 +2162,21 @@ impl Node {
                         .collect();
                 }
             }
-            Node::MdxFlowExpression(m) => match attr {
-                "value" | "text" => {
+            Node::MdxFlowExpression(m) => {
+                if attr == "value" {
                     m.value = value_str.into();
                 }
-                _ => (),
-            },
-            Node::MdxTextExpression(m) => match attr {
-                "value" | "text" => {
+            }
+            Node::MdxTextExpression(m) => {
+                if attr == "value" {
                     m.value = value_str.into();
                 }
-                _ => (),
-            },
-            Node::MdxJsEsm(m) => match attr {
-                "value" | "text" => {
+            }
+            Node::MdxJsEsm(m) => {
+                if attr == "value" {
                     m.value = value_str.into();
                 }
-                _ => (),
-            },
+            }
             Node::MdxJsxFlowElement(m) => {
                 if attr == "name" {
                     m.name = if value_str.is_empty() { None } else { Some(value_str) };

--- a/docs/books/src/reference/selectors.md
+++ b/docs/books/src/reference/selectors.md
@@ -18,12 +18,11 @@ Once you've selected a node, you can access its attributes using dot notation. T
 
 ### Common Attributes
 
-#### `text` or `value`
+#### `value`
 
-Most nodes support `text` or `value` to get the text content:
+Most nodes support `value` to get the text content:
 
 ```mq
-.h.text        # Gets the text of headings
 .code.value    # Gets the code content
 ```
 
@@ -31,18 +30,18 @@ Most nodes support `text` or `value` to get the text content:
 
 Heading nodes support the following attributes:
 
-| Attribute        | Type    | Description                     | Example    |
-| ---------------- | ------- | ------------------------------- | ---------- |
-| `depth`, `level` | Integer | The heading level (1-6)         | `.h.level` |
-| `text`, `value`  | String  | The text content of the heading | `.h.text`  |
+| Attribute        | Type    | Description              | Example    |
+| ---------------- | ------- | ------------------------ | ---------- |
+| `depth`, `level` | Integer | The heading level (1-6)  | `.h.level` |
+| `value`          | String  | The value of the heading | `.h.value` |
 
 Example:
 
 ```mq
 # Input: # Hello World
 
-.h.level        # Returns: 1
-.h.text         # Returns: "Hello World"
+.h.level # Returns: 1
+.h.value # Returns: "Hello World"
 ```
 
 ### Code Block Attributes
@@ -52,7 +51,7 @@ Code block nodes support the following attributes:
 | Attribute          | Type    | Description                             | Example       |
 | ------------------ | ------- | --------------------------------------- | ------------- |
 | `lang`, `language` | String  | The language of the code block          | `.code.lang`  |
-| `value`, `text`    | String  | The code content                        | `.code.value` |
+| `value`            | String  | The code content                        | `.code.value` |
 | `meta`             | String  | Metadata associated with the code block | `.code.meta`  |
 | `fence`            | Boolean | Whether the code block is fenced        | `.code.fence` |
 
@@ -71,11 +70,11 @@ Example:
 
 Link nodes support the following attributes:
 
-| Attribute       | Type   | Description           | Example       |
-| --------------- | ------ | --------------------- | ------------- |
-| `url`           | String | The URL of the link   | `.link.url`   |
-| `title`         | String | The title of the link | `.link.title` |
-| `text`, `value` | String | The link text         | `.link.text`  |
+| Attribute | Type   | Description           | Example       |
+| --------- | ------ | --------------------- | ------------- |
+| `url`     | String | The URL of the link   | `.link.url`   |
+| `title`   | String | The title of the link | `.link.title` |
+| `value`   | String | The link value        | `.link.value` |
 
 Example:
 
@@ -84,7 +83,7 @@ Example:
 
 .link.url       # Returns: "https://example.com"
 .link.title     # Returns: "Example Site"
-.link.text      # Returns: "Example"
+.link.value     # Returns: "Example"
 ```
 
 ### Image Attributes
@@ -111,13 +110,13 @@ Example:
 
 List nodes support the following attributes:
 
-| Attribute       | Type    | Description                        | Example         |
-| --------------- | ------- | ---------------------------------- | --------------- |
-| `index`         | Integer | The index of the list item         | `.list.index`   |
-| `level`         | Integer | The nesting level of the list item | `.list.level`   |
-| `ordered`       | Boolean | Whether the list is ordered        | `.list.ordered` |
-| `checked`       | Boolean | The checked state (for task lists) | `.list.checked` |
-| `text`, `value` | String  | The text content of the list item  | `.list.text`    |
+| Attribute | Type    | Description                        | Example         |
+| --------- | ------- | ---------------------------------- | --------------- |
+| `index`   | Integer | The index of the list item         | `.list.index`   |
+| `level`   | Integer | The nesting level of the list item | `.list.level`   |
+| `ordered` | Boolean | Whether the list is ordered        | `.list.ordered` |
+| `checked` | Boolean | The checked state (for task lists) | `.list.checked` |
+| `value`   | String  | The text content of the list item  | `.list.value`   |
 
 ### Table Cell Attributes
 
@@ -129,7 +128,7 @@ Table cell nodes support the following attributes:
 | `column`                | Integer | The column number of the cell              | `.[0][0].column`                |
 | `last_cell_in_row`      | Boolean | Whether this is the last cell in the row   | `.[0][0].last_cell_in_row`      |
 | `last_cell_of_in_table` | Boolean | Whether this is the last cell in the table | `.[0][0].last_cell_of_in_table` |
-| `text`, `value`         | String  | The text content of the cell               | `.[0][0].text`                  |
+| `value`                 | String  | The text content of the cell               | `.[0][0].value`                 |
 
 ### Reference Nodes Attributes
 
@@ -147,18 +146,18 @@ Reference nodes (link references, image references, footnotes) support:
 
 MDX nodes support the following attributes:
 
-| Attribute       | Type   | Description                 | Example                      |
-| --------------- | ------ | --------------------------- | ---------------------------- |
-| `name`          | String | The name of the MDX element | `.mdx_jsx_flow_element.name` |
-| `text`, `value` | String | The content of the MDX node | `.mdx_flow_expression.value` |
+| Attribute | Type   | Description                 | Example                      |
+| --------- | ------ | --------------------------- | ---------------------------- |
+| `name`    | String | The name of the MDX element | `.mdx_jsx_flow_element.name` |
+| `value`   | String | The content of the MDX node | `.mdx_flow_expression.value` |
 
 ### Text Nodes Attributes
 
 Text, HTML, YAML, TOML, Math nodes support:
 
-| Attribute       | Type   | Description      | Example       |
-| --------------- | ------ | ---------------- | ------------- |
-| `text`, `value` | String | The text content | `.text.value` |
+| Attribute | Type   | Description      | Example       |
+| --------- | ------ | ---------------- | ------------- |
+| `value`   | String | The text content | `.text.value` |
 
 ## Combining Selectors with Functions
 


### PR DESCRIPTION
This commit refactors the selector-related code and improves overall code quality:

**Selector Module Extraction:**
- Extract Selector enum and related types from ast/node.rs to new selector.rs module
- Add AttrKind enum to represent attribute selectors (value, lang, title, etc.)
- Introduce UnknownSelector error type for better error handling
- Add validation to distinguish between node selectors and attribute selectors

**Code Quality Improvements:**
- Simplify pattern matching in CST parser by matching on TokenKind directly
- Remove redundant match arms in markdown node attribute setters
- Add is_selector() helper method to Token for cleaner checks
- Update error handling to use transparent attribute for UnknownSelector
- Remove .text attribute in favor of .value for consistency

This refactoring improves code organization, reduces unnecessary allocations, and provides better error messages for invalid selectors.