### PR TITLE
♻️ refactor(cargo): remove workspace.package and workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,3 @@
-[workspace.package]
-authors = ["Takahiro Sato <harehare1110@gmail.com>"]
-description = "mq is a Markdown processing tool that can filter markdown nodes by using jq-like syntax."
-documentation = "https://mqlang.org/book/"
-edition = "2024"
-homepage = "https://mqlang.org/"
-keywords = ["markdown", "jq", "query"]
-license = "MIT"
-readme = "README.md"
-repository = "https://github.com/harehare/mq"
-version = "0.5.1"
-categories = ["command-line-utilities", "text-processing"]
-
 [workspace]
 members = [
   "crates/mq-c-api",
@@ -30,31 +17,6 @@ members = [
   "crates/mq-crawler",
 ]
 resolver = "3"
-
-[workspace.dependencies]
-arboard = {version = "3.6.1", default-features = false}
-clap = {version = "4.5.53", features = ["derive"]}
-colored = "3.0.0"
-dirs = "6.0.0"
-itertools = "0.14.0"
-miette = {version = "7.6.0"}
-mq-dap = {path = "./crates/mq-dap"}
-mq-formatter = {path = "./crates/mq-formatter"}
-mq-hir = {path = "./crates/mq-hir"}
-mq-lang = {path = "./crates/mq-lang"}
-mq-lsp = {path = "./crates/mq-lsp"}
-mq-markdown = {path = "./crates/mq-markdown"}
-mq-repl = {path = "./crates/mq-repl"}
-mq-test = {path = "./crates/mq-test"}
-proptest = "1.9"
-regex-lite = "0.1.8"
-rstest = "0.26.1"
-rustc-hash = "2.1.1"
-serde = "1.0"
-serde_json = "1.0"
-smol_str = "0.3.4"
-thiserror = "2.0.17"
-url = "2.5.7"
 
 [profile.release]
 codegen-units = 1

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -9,9 +9,9 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = {version = "1.4.2", features = ["derive"]}
-itertools.workspace = true
+itertools = "0.14.0"
 libfuzzer-sys = "0.4"
-mq-lang.workspace = true
+mq-lang = {path = "../mq-lang", version = "0.5.1"}
 
 [[bin]]
 bench = false

--- a/crates/mq-c-api/Cargo.toml
+++ b/crates/mq-c-api/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "C API for integrating mq into C applications"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-c-api"
-repository.workspace = true
-version.workspace = true
+readme = "README.md"
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 libc = "0.2"
-mq-lang.workspace = true
-mq-markdown.workspace = true
+mq-lang = {path = "../mq-lang", version = "0.5.1"}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/crates/mq-cli/Cargo.toml
+++ b/crates/mq-cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Command-line interface for mq Markdown processing tool"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-cli"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [features]
 debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex-lite", "mq-dap"]
@@ -16,30 +16,30 @@ std = []
 use_mimalloc = ["mimalloc"]
 
 [dependencies]
-clap.workspace = true
-colored.workspace = true
-dirs.workspace = true
-itertools.workspace = true
-miette = {workspace = true, features = ["fancy"]}
+clap = {version = "4.5.53", features = ["derive"]}
+colored = "3.0.0"
+dirs = "6.0.0"
+itertools = "0.14.0"
+miette = {version = "7.6.0", features = ["fancy"]}
 mimalloc = {version = "0.1.48", features = ["v3"], optional = true}
-mq-dap = {workspace = true, optional = true}
-mq-formatter.workspace = true
-mq-hir.workspace = true
-mq-lang = {workspace = true, features = ["file-io"]}
-mq-lsp.workspace = true
-mq-markdown = {workspace = true, features = ["json", "html-to-markdown"]}
-mq-repl.workspace = true
+mq-dap = {path = "../mq-dap", optional = true, version = "0.5.1"}
+mq-formatter = {path = "../mq-formatter", version = "0.5.1"}
+mq-hir = {path = "../mq-hir", version = "0.5.1"}
+mq-lang = {path = "../mq-lang", features = ["file-io"], version = "0.5.1"}
+mq-lsp = {path = "../mq-lsp", version = "0.5.1"}
+mq-markdown = {path = "../mq-markdown", features = ["json", "html-to-markdown"], version = "0.5.1"}
+mq-repl = {path = "../mq-repl", version = "0.5.1"}
 rayon = "1.11.0"
-regex-lite = {workspace = true, optional = true}
+regex-lite = {version = "0.1.8", optional = true}
 rustyline = {version = "17.0.2", optional = true, default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {version = "0.27.2", features = ["derive"], optional = true}
 tokio = {version = "1.48.0", features = ["io-util", "io-std", "rt"]}
-url.workspace = true
+url = "2.5.7"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"
-mq-test.workspace = true
-rstest.workspace = true
+mq-test = {path = "../mq-test", version = "0.5.1"}
+rstest = "0.26.1"
 
 [[bin]]
 doc = false

--- a/crates/mq-crawler/Cargo.toml
+++ b/crates/mq-crawler/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Directory crawler for batch Markdown file processing"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-crawler"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 clap = {version = "4.5", features = ["derive"]}
@@ -15,9 +15,9 @@ crossbeam = "0.8.4"
 dashmap = "6.1.0"
 fantoccini = "0.22.0"
 futures = "0.3"
-miette.workspace = true
-mq-lang.workspace = true
-mq-markdown.workspace = true
+miette = {version = "7.6.0", features = ["fancy"]}
+mq-lang = {path = "../mq-lang", version = "0.5.1"}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
 reqwest = {version = "0.12", features = ["json", "rustls-tls"]}
 robots_txt = "0.7"
 scraper = "0.24"
@@ -26,7 +26,7 @@ serde_json = "1.0"
 tokio = {version = "1", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
-url.workspace = true
+url = "2.5.7"
 
 [[bin]]
 doc = false
@@ -35,4 +35,4 @@ path = "src/main.rs"
 
 [dev-dependencies]
 httpmock = "0.8.2"
-rstest.workspace = true
+rstest = "0.26.1"

--- a/crates/mq-dap/Cargo.toml
+++ b/crates/mq-dap/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Debug Adapter Protocol implementation for mq"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-dap"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 crossbeam-channel = "0.5.15"
 dap = "0.4.1-alpha1"
-miette = {workspace = true, features = ["fancy"]}
-mq-lang = {workspace = true, features = ["debugger"]}
-serde.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
+miette = {version = "7.6.0", features = ["fancy"]}
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["debugger"]}
+serde = "1.0"
+serde_json = "1.0"
+thiserror = "2.0.17"
 tokio = {version = "1.48", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}

--- a/crates/mq-formatter/Cargo.toml
+++ b/crates/mq-formatter/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Code formatter for mq query language"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-formatter"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
-mq-lang = {workspace = true, features = ["cst"]}
-rustc-hash.workspace = true
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["cst"]}
+rustc-hash = "2.1.1"
 
 [dev-dependencies]
-rstest.workspace = true
+rstest = "0.26.1"

--- a/crates/mq-hir/Cargo.toml
+++ b/crates/mq-hir/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "High-level Internal Representation (HIR) for mq query language"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-hir"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
-itertools.workspace = true
-mq-lang = {workspace = true, features = ["cst"]}
-rustc-hash.workspace = true
+itertools = "0.14.0"
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["cst"]}
+rustc-hash = "2.1.1"
 slotmap = "1.0.7"
-smol_str.workspace = true
+smol_str = "0.3.4"
 strsim = "0.11.1"
-thiserror.workspace = true
-url.workspace = true
+thiserror = "2.0.17"
+url = "2.5.7"
 
 [dev-dependencies]
-rstest.workspace = true
+rstest = "0.26.1"

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Core language implementation for mq query language"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-lang"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 base64 = "0.22.1"
 chrono = "0.4.42"
-dirs.workspace = true
-itertools.workspace = true
-miette.workspace = true
-mq-markdown = {workspace = true, features = ["html-to-markdown"]}
+dirs = "6.0.0"
+itertools = "0.14.0"
+miette = {version = "7.6.0"}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1", features = ["html-to-markdown"]}
 nom = {version = "8.0.0"}
 nom_locate = "5.0.0"
 percent-encoding = "2.3.2"
 regex-lite = "0.1.8"
-rustc-hash.workspace = true
-serde = {workspace = true, features = ["derive", "rc"], optional = true}
-serde_json = {workspace = true, optional = true}
+rustc-hash = "2.1.1"
+serde = {version = "1.0", features = ["derive", "rc"], optional = true}
+serde_json = {version = "1.0", optional = true}
 smallvec = "1.15.1"
-smol_str.workspace = true
+smol_str = "0.3.4"
 string-interner = "0.19"
-thiserror.workspace = true
+thiserror = "2.0.17"
 
 [features]
 ast-json = ["dep:serde", "dep:serde_json", "smallvec/serde", "smol_str/serde"]
@@ -39,9 +39,9 @@ sync = []
 
 [dev-dependencies]
 divan = {version = "3.0.5", package = "codspeed-divan-compat"}
-mq-test.workspace = true
-proptest.workspace = true
-rstest.workspace = true
+mq-test = {path = "../mq-test", version = "0.5.1"}
+proptest = "1.9"
+rstest = "0.26.1"
 
 [[bench]]
 harness = false

--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Language Server Protocol implementation for mq query language"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-lsp"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 bimap = "0.6.3"
 dashmap = "6.1.0"
 itertools = "0.14.0"
 miette = {version = "7.6.0", features = ["fancy"]}
-mq-formatter.workspace = true
-mq-hir.workspace = true
-mq-lang = {workspace = true, features = ["ast-json", "sync"]}
-mq-markdown.workspace = true
+mq-formatter = {path = "../mq-formatter", version = "0.5.1"}
+mq-hir = {path = "../mq-hir", version = "0.5.1"}
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["ast-json", "sync"]}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
 serde_json = "1.0.145"
 tokio = {version = "1.48", features = ["macros", "io-std", "rt-multi-thread"]}
 tokio-macros = "2.5.0"
 tower-lsp-server = "0.22.1"
-url.workspace = true
+url = "2.5.7"
 
 [[bin]]
 name = "mq-lsp"

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Markdown parsing and manipulation utilities for mq"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-markdown"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 ego-tree = {version = "0.10.0", optional = true}
-itertools.workspace = true
+itertools = "0.14.0"
 markdown = "1.0.0"
-miette.workspace = true
-rustc-hash.workspace = true
+miette = {version = "7.6.0"}
+rustc-hash = "2.1.1"
 scraper = {version = "0.24.0", optional = true}
-serde = {workspace = true, features = ["derive"], optional = true}
-serde_json = {workspace = true, optional = true}
+serde = {version = "1.0", features = ["derive"], optional = true}
+serde_json = {version = "1.0", optional = true}
 serde_yaml = {version = "0.9", optional = true}
-smol_str.workspace = true
+smol_str = "0.3.4"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/crates/mq-python/Cargo.toml
+++ b/crates/mq-python/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Python bindings for mq Markdown processing"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-python"
-repository.workspace = true
-version.workspace = true
+publish = false
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [lib]
 crate-type = ["cdylib"]
 name = "mq"
 
 [dependencies]
-mq-lang.workspace = true
-mq-markdown.workspace = true
+mq-lang = {path = "../mq-lang", version = "0.5.1"}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
 pyo3 = {version = "0.27.1", features = ["extension-module", "abi3-py39"]}

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Read-Eval-Print Loop (REPL) for mq query language"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-repl"
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
-arboard.workspace = true
-colored.workspace = true
-dirs.workspace = true
-itertools.workspace = true
-miette.workspace = true
-mq-hir.workspace = true
-mq-lang.workspace = true
-mq-markdown.workspace = true
-regex-lite.workspace = true
+arboard = {version = "3.6.1", default-features = false}
+colored = "3.0.0"
+dirs = "6.0.0"
+itertools = "0.14.0"
+miette = {version = "7.6.0"}
+mq-hir = {path = "../mq-hir", version = "0.5.1"}
+mq-lang = {path = "../mq-lang", version = "0.5.1"}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
+regex-lite = "0.1.8"
 rustyline = {version = "17.0.2", default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {version = "0.27.2", features = ["derive"]}
 
 [dev-dependencies]
-mq-test.workspace = true
-rstest.workspace = true
+mq-test = {path = "../mq-test", version = "0.5.1"}
+rstest = "0.26.1"

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Test utilities and helpers for mq"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-test"
 publish = false
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [lib]
 bench = false
 doctest = false
 
 [dependencies]
-proptest.workspace = true
+proptest = "1.9"
 scopeguard = "1.2.0"

--- a/crates/mq-wasm/Cargo.toml
+++ b/crates/mq-wasm/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "WebAssembly bindings for mq Markdown processing"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-wasm"
 publish = false
-repository.workspace = true
-version.workspace = true
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -16,16 +16,16 @@ path = "src/lib.rs"
 
 [dependencies]
 futures = "0.3"
-itertools.workspace = true
+itertools = "0.14.0"
 js-sys = "0.3.77"
-mq-formatter.workspace = true
-mq-hir.workspace = true
-mq-lang = {workspace = true, features = ["ast-json"]}
-mq-markdown.workspace = true
+mq-formatter = {path = "../mq-formatter", version = "0.5.1"}
+mq-hir = {path = "../mq-hir", version = "0.5.1"}
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["ast-json"]}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
 opfs = "0.1.4"
-serde = {workspace = true, features = ["derive"]}
+serde = {version = "1.0", features = ["derive"]}
 serde-wasm-bindgen = "0.6.5"
-serde_json.workspace = true
+serde_json = "1.0"
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.55"
 

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -1,31 +1,32 @@
 [package]
-categories.workspace = true
+categories = ["command-line-utilities", "text-processing"]
 description = "Web API bindings for mq"
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query"]
+license = "MIT"
 name = "mq-web-api"
-repository.workspace = true
-version.workspace = true
+publish = false
+repository = "https://github.com/harehare/mq"
+version = "0.5.1"
 
 [dependencies]
 async-trait = "0.1.83"
 axum = "0.8.7"
 deadpool-libsql = "0.1.0"
 libsql = "0.9.29"
-miette = {workspace = true}
-mq-lang = {workspace = true, features = ["cst"]}
-mq-markdown = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_json.workspace = true
+miette = {version = "7.6.0"}
+mq-lang = {path = "../mq-lang", version = "0.5.1", features = ["cst"]}
+mq-markdown = {path = "../mq-markdown", version = "0.5.1"}
+serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0"
 thiserror = "2.0.17"
 tokio = {version = "1.48.0", features = ["full"]}
 tower = "0.5.2"
 tower-http = {version = "0.6.6", features = ["cors", "trace"]}
 tracing = "0.1.41"
 tracing-subscriber = {version = "0.3.20", features = ["env-filter", "json"]}
-url = {workspace = true}
+url = "2.5.7"
 utoipa = {version = "5.4", features = ["preserve_order"]}
 
 [[bin]]

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -5,8 +5,12 @@ export README="../README.md"
 export INSTALL_DOC="../docs/books/src/start/install.md"
 
 # Update Cargo.toml files
-tmpfile=$(mktemp)
-mq -I text 'include "update_version" | update_crate_version()' "../Cargo.toml" > "$tmpfile" && mv "$tmpfile" "../Cargo.toml"
+for crate in ../crates/*; do
+    if [ -f "$crate/Cargo.toml" ]; then
+        tmpfile=$(mktemp)
+        mq -I text 'include "update_version" | update_crate_version()' "$crate/Cargo.toml" > "$tmpfile" && mv "$tmpfile" "$crate/Cargo.toml"
+    fi
+done
 
 # Update package.json files
 for dir in ../packages ../editors; do


### PR DESCRIPTION
Replace workspace inheritance with explicit values in all crate Cargo.toml files. This change improves clarity and makes each crate's configuration self-contained.

Changes:
- Removed [workspace.package] section from root Cargo.toml
- Removed [workspace.dependencies] section from root Cargo.toml
- Updated all 15 crates to use explicit package metadata instead of workspace = true
- Added explicit versions to all dependencies previously using workspace = true
- Ensured workspace crate references include both path and version

All crates validated with cargo check.

https://github.com/harehare/mq/issues/860