### PR TITLE
✨ feat(mq-run): add check command for syntax validation

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -504,7 +504,7 @@ impl Cli {
 
                     if !errors.is_empty() || !warnings.is_empty() {
                         has_error = true;
-                        writeln!(handle, "{}", format!("Checking: {}", file.display()).bold()).ok();
+                        writeln!(handle, "Checking: {}", file.display()).into_diagnostic()?;
 
                         for (message, range) in errors {
                             writeln!(


### PR DESCRIPTION
Add a new 'check' command that validates mq files for syntax errors and warnings. The command accepts multiple file paths and reports errors/warnings with their locations (line and column numbers). Returns a non-zero exit code if any errors or warnings are found.

Features:
- Validates one or more mq files for syntax errors
- Displays errors and warnings with line/column information
- Color-coded output (red for errors, yellow for warnings)
- Includes comprehensive test coverage for valid files, invalid syntax, and missing files