### PR TITLE
📝 docs(install): improve cargo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ The installer will:
 ### Cargo
 
 ```sh
+# Install from crates.io
+cargo install mq-run
+# Install from Github
 cargo install --git https://github.com/harehare/mq.git mq-run --tag v0.5.2
 # Latest Development Version
 cargo install --git https://github.com/harehare/mq.git mq-run --bin mq
 # Install the debugger
 cargo install --git https://github.com/harehare/mq.git mq-run --bin mq-dbg --features="debugger"
+# Install using binstall
+cargo binstall mq-run
 ```
 
 ### Binaries

--- a/docs/books/src/start/install.md
+++ b/docs/books/src/start/install.md
@@ -16,11 +16,16 @@ The installer will:
 ## Cargo
 
 ```sh
+# Install from crates.io
+cargo install mq-run
+# Install from Github
 cargo install --git https://github.com/harehare/mq.git mq-run --tag v0.5.2
 # Latest Development Version
-$ cargo install --git https://github.com/harehare/mq.git mq-run --bin mq
+cargo install --git https://github.com/harehare/mq.git mq-run --bin mq
 # Install the debugger
-$ cargo install --git https://github.com/harehare/mq.git mq-run --bin mq-dbg --features="debugger"
+cargo install --git https://github.com/harehare/mq.git mq-run --bin mq-dbg --features="debugger"
+# Install using binstall
+cargo binstall mq-run
 ```
 
 ## Binaries


### PR DESCRIPTION
Add crates.io as the primary installation method, document cargo-binstall support, and improve formatting consistency by removing shell prompts from code examples.