### PR TITLE
📝 docs(builtin): remove incorrect parameter documentation from selectors

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2372,7 +2372,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<SmolStr, BuiltinSelectorDoc>
         SmolStr::new(".h"),
         BuiltinSelectorDoc {
             description: "Selects a heading node with the specified depth.",
-            params: &["depth"],
+            params: &[],
         },
     );
 
@@ -2436,7 +2436,7 @@ pub static BUILTIN_SELECTOR_DOC: LazyLock<FxHashMap<SmolStr, BuiltinSelectorDoc>
         SmolStr::new(".code"),
         BuiltinSelectorDoc {
             description: "Selects a code block node with the specified language.",
-            params: &["lang"],
+            params: &[],
         },
     );
 


### PR DESCRIPTION
Remove params field from .h and .code selector documentation as these selectors do not require parameters. This fixes incorrect documentation that suggested these selectors accept parameters.