### PR TITLE
✨ feat(lang): support full expressions in interpolated strings

### DIFF
--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -555,9 +555,9 @@ impl Hir {
                         parent,
                     });
                 }
-                mq_lang::StringSegment::Ident(ident, range) => {
+                mq_lang::StringSegment::Expr(expr, range) => {
                     self.symbols.insert(Symbol {
-                        value: Some(ident.clone()),
+                        value: Some(expr.clone()),
                         kind: SymbolKind::Variable,
                         source: SourceInfo::new(Some(source_id), Some(*range)),
                         scope: scope_id,

--- a/crates/mq-lang/src/ast/constants.rs
+++ b/crates/mq-lang/src/ast/constants.rs
@@ -1,3 +1,5 @@
+pub const SELF: &str = "self";
+
 pub const ARRAY: &str = "array";
 pub const DICT: &str = "dict";
 

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -1,7 +1,7 @@
 use super::{Program, TokenId};
 #[cfg(feature = "ast-json")]
 use crate::arena::ArenaId;
-use crate::{Ident, Shared, Token, arena::Arena, lexer, number::Number, range::Range, selector::Selector};
+use crate::{Ident, Shared, Token, arena::Arena, number::Number, range::Range, selector::Selector};
 #[cfg(feature = "ast-json")]
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -175,10 +175,10 @@ impl Display for IdentWithToken {
 }
 
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub enum StringSegment {
     Text(String),
-    Ident(Ident),
+    Expr(Shared<Node>),
     Env(SmolStr),
     Self_,
 }
@@ -201,19 +201,6 @@ pub struct MatchArm {
     pub pattern: Pattern,
     pub guard: Option<Shared<Node>>,
     pub body: Shared<Node>,
-}
-
-impl From<&lexer::token::StringSegment> for StringSegment {
-    fn from(segment: &lexer::token::StringSegment) -> Self {
-        match segment {
-            lexer::token::StringSegment::Text(text, _) => StringSegment::Text(text.to_owned()),
-            lexer::token::StringSegment::Ident(ident, _) if ident == "self" => StringSegment::Self_,
-            lexer::token::StringSegment::Ident(ident, _) if ident.starts_with("$") => {
-                StringSegment::Env(SmolStr::from(&ident[1..]))
-            }
-            lexer::token::StringSegment::Ident(ident, _) => StringSegment::Ident(Ident::new(ident)),
-        }
-    }
 }
 
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -3331,13 +3331,13 @@ mod tests {
     )]
     #[case::interpolated_string(
         vec![
-            Shared::new(token(TokenKind::InterpolatedString(vec![StringSegment::Ident("val".into(), Range::default()), StringSegment::Text("hello".into(), Range::default())]))),
+            Shared::new(token(TokenKind::InterpolatedString(vec![StringSegment::Expr("val".into(), Range::default()), StringSegment::Text("hello".into(), Range::default())]))),
         ],
         (
             vec![
                 Shared::new(Node {
                     kind: NodeKind::InterpolatedString,
-                    token: Some(Shared::new(token(TokenKind::InterpolatedString(vec![StringSegment::Ident("val".into(), Range::default()), StringSegment::Text("hello".into(), Range::default())])))),
+                    token: Some(Shared::new(token(TokenKind::InterpolatedString(vec![StringSegment::Expr("val".into(), Range::default()), StringSegment::Text("hello".into(), Range::default())])))),
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: Vec::new(),

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -13,14 +13,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub enum StringSegment {
     Text(String, Range),
-    Ident(SmolStr, Range),
+    Expr(SmolStr, Range),
 }
 
 impl Display for StringSegment {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             StringSegment::Text(text, _) => write!(f, "{}", text),
-            StringSegment::Ident(ident, _) => write!(f, "${{{}}}", ident),
+            StringSegment::Expr(expr, _) => write!(f, "${{{}}}", expr),
         }
     }
 }
@@ -212,12 +212,12 @@ mod tests {
         StringSegment::Text("hello".to_string(), Range::default()),
         "hello"
     )]
-    #[case(StringSegment::Ident(SmolStr::new("world"), Range::default()), "${world}")]
+    #[case(StringSegment::Expr(SmolStr::new("world"), Range::default()), "${world}")]
     #[case(
         StringSegment::Text("".to_string(), Range::default()),
         ""
     )]
-    #[case(StringSegment::Ident(SmolStr::new(""), Range::default()), "${}")]
+    #[case(StringSegment::Expr(SmolStr::new(""), Range::default()), "${}")]
     fn string_segment_display_works(#[case] segment: StringSegment, #[case] expected: &str) {
         assert_eq!(segment.to_string(), expected);
     }


### PR DESCRIPTION
Changed string interpolation to support arbitrary expressions instead of just identifiers. This allows constructs like "Value: \${add(1, 2)}" and "Result: \${some_func()}" in addition to the existing "Name: \${var}" syntax.

Key changes:
- Renamed StringSegment::Ident to StringSegment::Expr in AST
- Updated lexer to tokenize interpolations as expressions
- Enhanced parser to parse full expressions in \${} blocks
- Modified evaluator to evaluate expression nodes in strings
- Updated optimizer to handle expression-based segments
- Added comprehensive tests for expression interpolation
- Added SELF constant to constants.rs