### PR TITLE
📝 docs(install): update binstall command to specify version 0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cargo install --git https://github.com/harehare/mq.git mq-run --bin mq
 # Install the debugger
 cargo install --git https://github.com/harehare/mq.git mq-run --bin mq-dbg --features="debugger"
 # Install using binstall
-cargo binstall mq-run
+cargo binstall mq-run@0.5.3
 ```
 
 ### Binaries
@@ -163,8 +163,8 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 
 Arguments:
-  [QUERY OR FILE]  
-  [FILES]...       
+  [QUERY OR FILE]
+  [FILES]...
 
 Options:
   -A, --aggregate
@@ -184,7 +184,7 @@ Options:
       --stream
           Enable streaming mode for processing large files line by line
       --json
-          
+
       --csv
           Include the built-in CSV module
       --fuzzy

--- a/docs/books/src/start/install.md
+++ b/docs/books/src/start/install.md
@@ -25,7 +25,7 @@ cargo install --git https://github.com/harehare/mq.git mq-run --bin mq
 # Install the debugger
 cargo install --git https://github.com/harehare/mq.git mq-run --bin mq-dbg --features="debugger"
 # Install using binstall
-cargo binstall mq-run
+cargo binstall mq-run@0.5.3
 ```
 
 ## Binaries


### PR DESCRIPTION
Updated installation instructions to use cargo binstall mq-run@0.5.3 instead of unversioned install. Also cleaned up trailing whitespace in CLI help output formatting.