### PR TITLE
👷 ci(dependabot): add GitHub Actions to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
       interval: "daily"
       time: "20:00"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "20:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Add GitHub Actions package ecosystem to Dependabot configuration to automatically monitor and update workflow dependencies.