### PR TITLE
✨ feat(web-api): Add RFC 9457 Problem Details error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2941,6 +2947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3046,6 +3053,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -5241,9 +5254,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5254,9 +5267,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "futures-core",
@@ -5268,9 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5278,9 +5291,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5291,21 +5304,29 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -5313,9 +5334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5324,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use tracing::{debug, error, info};
 use utoipa::OpenApi;
 
-use crate::api::{ApiRequest, DiagnosticsApiResponse, InputFormat, QueryApiResponse};
+use crate::{
+    api::{ApiRequest, DiagnosticsApiResponse, InputFormat, QueryApiResponse},
+    problem::ProblemDetails,
+};
 
 #[derive(Clone)]
 pub struct AppState {}
@@ -55,7 +58,7 @@ pub struct ApiDoc;
 pub async fn get_query_api(
     Query(params): Query<QueryParams>,
     State(_state): State<AppState>,
-) -> Result<Json<QueryApiResponse>, StatusCode> {
+) -> Result<Json<QueryApiResponse>, ProblemDetails> {
     debug!("GET /query called with query: {}", params.query);
 
     let input_format = params
@@ -81,7 +84,9 @@ pub async fn get_query_api(
         }
         Err(e) => {
             error!("Failed to process query '{}': {}", params.query, e);
-            Err(StatusCode::BAD_REQUEST)
+            Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid query")
+                .with_detail("error", &e.to_string()))
         }
     }
 }
@@ -98,7 +103,7 @@ pub async fn get_query_api(
 pub async fn post_query_api(
     State(_state): State<AppState>,
     Json(request): Json<ApiRequest>,
-) -> Result<Json<QueryApiResponse>, StatusCode> {
+) -> Result<Json<QueryApiResponse>, ProblemDetails> {
     debug!("POST /query called with query: {}", request.query);
     debug!("Processing request with input_format: {:?}", request.input_format);
 
@@ -113,7 +118,9 @@ pub async fn post_query_api(
         }
         Err(e) => {
             error!("Failed to process query '{}': {}", request.query, e);
-            Err(StatusCode::BAD_REQUEST)
+            Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid query")
+                .with_detail("error", &e.to_string()))
         }
     }
 }

--- a/crates/mq-web-api/src/lib.rs
+++ b/crates/mq-web-api/src/lib.rs
@@ -60,6 +60,7 @@ pub mod cleanup;
 pub mod config;
 pub mod handlers;
 pub mod middleware;
+pub mod problem;
 pub mod rate_limiter;
 pub mod routes;
 pub mod server;

--- a/crates/mq-web-api/src/problem.rs
+++ b/crates/mq-web-api/src/problem.rs
@@ -1,0 +1,58 @@
+use axum::http::StatusCode;
+use axum::{
+    Json,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use serde::ser::SerializeMap;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+pub struct ProblemDetails {
+    status: StatusCode,
+    details: HashMap<Cow<'static, str>, String>,
+}
+
+impl Serialize for ProblemDetails {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.details.len() + 1))?;
+        map.serialize_entry("status", &self.status.as_u16())?;
+        for (k, v) in &self.details {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl ProblemDetails {
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            status,
+            details: HashMap::new(),
+        }
+    }
+
+    pub fn with_type(mut self, value: &str) -> Self {
+        self.details.insert(Cow::Borrowed("type"), value.to_string());
+        self
+    }
+
+    pub fn with_detail(mut self, key: &str, value: &str) -> Self {
+        self.details.insert(Cow::Owned(key.to_string()), value.to_string());
+        self
+    }
+
+    pub fn with_title(mut self, value: &str) -> Self {
+        self.details.insert(Cow::Borrowed("title"), value.to_string());
+        self
+    }
+}
+
+impl IntoResponse for ProblemDetails {
+    fn into_response(self) -> Response {
+        (self.status, Json(self)).into_response()
+    }
+}


### PR DESCRIPTION
Implement Problem Details (RFC 9457) format for API error responses:

- Add new `problem.rs` module with `ProblemDetails` struct
- Replace generic StatusCode returns with structured error responses
- Include error details, titles, and HTTP status in JSON responses
- Update GET and POST query handlers to use ProblemDetails
- Maintain backward compatibility with existing error status codes

This improves API error clarity by providing structured error information following RFC 9457 standards, making it easier for clients to handle and display errors appropriately.