### PR TITLE
🔧 chore(ci): update dependabot configuration for package structure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
       time: "20:00"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
-    directory: "/playground"
+    directory: "/packages/mq-playground"
+    schedule:
+      interval: "daily"
+      time: "20:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/packages/mq-web"
     schedule:
       interval: "daily"
       time: "20:00"


### PR DESCRIPTION
Update dependabot.yml to reflect the new package directory structure:
- Changed `/playground` to `/packages/mq-playground`
- Added `/packages/mq-web` for npm dependency management

This ensures dependabot correctly monitors npm dependencies in both packages.