### PR TITLE
👷 ci: improve wasm-pack installation and update Node.js version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,9 @@ name: Publish npm package
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 permissions:
   id-token: write
@@ -15,7 +18,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: extractions/setup-just@v3
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 just 1.42.4
-nodejs 22.14.0
+nodejs 24.11.1


### PR DESCRIPTION
- Replace cargo install with taiki-e/install-action for wasm-pack installation
- Update Node.js version from 22.14.0 to 24.11.1 in .tool-versions

The new installation method is more efficient and provides better caching support.