### PR TITLE
🐛 fix(repl): ensure Android clipboard error is shown correctly

### DIFF
--- a/crates/mq-repl/src/command_context.rs
+++ b/crates/mq-repl/src/command_context.rs
@@ -130,7 +130,7 @@ impl CommandContext {
                     clipboard.set_text(text).into_diagnostic()?;
                     Ok(CommandOutput::None)
                 }
-                #[cfg(not(feature = "clipboard"))]
+                #[cfg(any(not(feature = "clipboard"), target_os = "android"))]
                 {
                     Err(miette!("Clipboard functionality is not available on this platform"))
                 }


### PR DESCRIPTION
Update the cfg attribute to properly handle Android builds where clipboard functionality is not available. Even when the clipboard feature is enabled, Android targets should receive the appropriate error message since arboard clipboard is excluded on Android.