### PR TITLE
✨ feat(lang): modernize syntax and add MDX support

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -48,7 +48,7 @@ end
 
 # Checks if string, array or dict is empty
 def is_empty(s):
-  if (or(is_string(s), is_array(s), is_dict(s))):
+  if (is_string(s) || is_array(s) || is_dict(s)):
     len(s) == 0
   elif (is_none(s)):
     true
@@ -57,7 +57,7 @@ def is_empty(s):
 end
 
 # Tests if string matches a pattern
-def test(s, pattern): regex_match(s, pattern) | is_empty() | not();
+def test(s, pattern): regex_match(s, pattern) | !is_empty();
 
 # Returns value if condition is true, None otherwise
 def select(v, f): if (f): v;
@@ -79,49 +79,54 @@ def to_date_iso8601(d): to_date(d, "%Y-%m-%dT%H:%M:%SZ");
 
 # Applies a given function to each element of the provided array and returns a new array with the results.
 def map(v, f):
-  let map_dict = fn(v, f):
-      let mapped = foreach (x, entries(v)): f(x); | dict(mapped);
-
-  | if (is_dict(v)):
-      map_dict(v, f)
-    else:
-      foreach (x, v): f(x);
+  if (is_dict(v)):
+    do
+      let map_dict = fn(v, f): let mapped = foreach (x, entries(v)): f(x); | dict(mapped);
+      | map_dict(v, f)
+    end
+  elif (is_none(v)):
+    None
+  else:
+    foreach (x, v): f(x);
 end
 
 # Applies a function to each element and flattens the result into a single array
 def flat_map(v, f):
-  let flat_map_dict = fn(v, f):
-      let mapped = do foreach (x, entries(v)): f(x); | flatten(mapped) | dict(mapped);
+  if (is_dict(v)):
+    do
+      let flat_map_dict = fn(v, f): let mapped = do foreach (x, entries(v)): f(x); | flatten(mapped) | dict(mapped);;
+      | flat_map_dict(v, f)
     end
-
-  | if (is_dict(v)):
-      flat_map_dict(v, f)
-    else:
-      foreach (x, v): f(x); | flatten()
+  elif (is_none(v)):
+    None
+  else:
+    foreach (x, v): f(x); | flatten()
 end
 
 # Filters the elements of an array based on a provided callback function.
 def filter(v, f):
-  let filter_dict = fn(v, f):
-      let fileted = foreach (x, entries(v)): select(x, f(x)); | dict(compact(fileted));
-
-  | let _filter = fn(v, f):
-      foreach (x, v): select(x, f(x)); | compact();
-
-  | if (is_dict(v)):
-      filter_dict(v, f)
-    else:
-      _filter(v, f)
+  if (is_dict(v)):
+    do
+      let filter_dict = fn(v, f): let fileted = foreach (x, entries(v)): select(x, f(x)); | dict(compact(fileted));
+      | filter_dict(v, f)
+    end
+  elif (is_none(v)):
+    None
+  else:
+    do
+      let _filter = fn(v, f): foreach (x, v): select(x, f(x)); | compact();
+      | _filter(v, f)
+    end
 end
 
 # Returns the first element of an array
-def first(arr): get(arr, 0);
+def first(arr): arr[0];
 
 # Returns the last element of an array
-def last(arr): get(arr, len(arr) - 1);
+def last(arr): arr[len(arr) - 1];
 
 # Returns the second element of an array
-def second(arr): if (len(arr) > 1): get(arr, 1);
+def second(arr): if (len(arr) > 1): arr[1];
 
 # Checks if markdown is h1 heading
 def is_h1(md): to_md_name(md) == "h1";
@@ -205,12 +210,12 @@ def is_mdx_text_expression(mdx): to_md_name(mdx) == "mdx_text_expression";
 def is_mdx_js_esm(mdx): to_md_name(mdx) == "mdx_js_esm";
 
 # Checks if markdown is MDX
-def is_mdx(mdx): or(
-  is_mdx_flow_expression(mdx),
-  is_mdx_jsx_flow_element(mdx),
-  is_mdx_jsx_text_element(mdx),
-  is_mdx_text_expression(mdx),
-  is_mdx_js_esm(mdx))
+def is_mdx(mdx):
+  is_mdx_flow_expression(mdx) ||
+  is_mdx_jsx_flow_element(mdx) ||
+  is_mdx_jsx_text_element(mdx) ||
+  is_mdx_text_expression(mdx) ||
+  is_mdx_js_esm(mdx)
 end
 
 # Returns an array of length n filled with the given value.
@@ -224,8 +229,7 @@ def fill(value, n):
 end
 
 # Prints the debug information of the given value.
-def debug(msg):
-  let s = to_string(msg) | stderr(s"DEBUG: ${s}");
+def debug(msg): stderr(s"DEBUG: ${to_string(msg)}");
 
 # Sorts an array using a key function that extracts a comparable value for each element.
 def sort_by(arr, f):

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -67,6 +67,17 @@ include "test"
     | assert_eq(result3, false)
   end
 
+| def test_is_mdx():
+    let result1 = do "import Component from './Component'\n\n# Hello\n\n<Component />" | to_mdx() | get(2) | is_mdx();
+    | assert_eq(result1, true)
+
+    | let result2 = do "# Hello\n\nThis is markdown." | to_mdx() | first() | is_mdx();
+    | assert_eq(result2, false)
+
+    | let result3 = is_mdx("plain string")
+    | assert_eq(result3, false)
+  end
+
 # String manipulation tests
 | def test_contains():
     let result1 = contains("hello world", "world")
@@ -165,6 +176,9 @@ include "test"
 
     | let result2 = map({"a": 1, "b": 2}, fn(x): [x[0], x[1] * 2];)
     | assert_eq(result2, {"a": 2, "b": 4})
+
+    | let result3 = map(None, fn(x): [x[0], x[1] * 2];)
+    | assert_eq(result3, None)
   end
 
 | def test_flat_map():
@@ -173,6 +187,9 @@ include "test"
 
     | let result2 = flat_map([[1, 2], [3, 4]], fn(x): x;)
     | assert_eq(result2, [1, 2, 3, 4])
+
+    | let result3 = flat_map(None, fn(x): [x[0], x[1] * 2];)
+    | assert_eq(result3, None)
   end
 
 | def test_filter():
@@ -181,6 +198,9 @@ include "test"
 
     | let result2 = filter({"a": 1, "b": 2, "c": 3}, fn(x): x[1] > 1;)
     | assert_eq(result2, {"b": 2, "c": 3})
+
+    | let result3 = filter(None, fn(x): [x[0], x[1] * 2];)
+    | assert_eq(result3, None)
   end
 
 | def test_first():
@@ -392,6 +412,22 @@ include "test"
     | assert_eq(result3, [[1, 3, 5], [2, 4, 6]])
   end
 
+| def test_regex_test():
+  let result1 = test("aaa", "[a-z]+")
+  | assert_eq(result1, true)
+
+  | let result2 = test("aaa", "[0-9]+")
+  | assert_eq(result2, false)
+end
+
+| def test_regex_match():
+  let result1 = regex_match("aaa", "[a-z]+")
+  | assert_eq(result1, ["aaa"])
+
+  | let result2 = regex_match("aaa", "[0-9]+")
+  | assert_eq(result2, [])
+end
+
 run_tests([
   # Type checking
   test_case("is_array", test_is_array),
@@ -400,6 +436,7 @@ run_tests([
   test_case("is_string", test_is_string),
   test_case("is_none", test_is_none),
   test_case("is_dict", test_is_dict),
+  test_case("is_mdx", test_is_mdx),
 
   # String manipulation
   test_case("contains", test_contains),
@@ -438,5 +475,8 @@ run_tests([
   test_case("fold", test_fold),
   test_case("unique_by", test_unique_by),
   test_case("identity", test_identity),
-  test_case("transpose", test_transpose)
+  test_case("transpose", test_transpose),
+
+  test_case("regex_test", test_regex_test),
+  test_case("regex_match", test_regex_match)
 ])

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -677,6 +677,7 @@ impl<'a> Parser<'a> {
             | TokenKind::While
             | TokenKind::If
             | TokenKind::LParen
+            | TokenKind::Do
             | TokenKind::Colon
             | TokenKind::LBrace => self.parse_expr(leading_trivia, false, false),
             _ => Err(ParseError::UnexpectedToken(Shared::clone(&token))),
@@ -6748,6 +6749,65 @@ mod tests {
                 ],
                 100
             )
+        )
+    )]
+    #[case::call_with_do_block_argument(
+        vec![
+            Shared::new(token(TokenKind::Ident("foo".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::Do)),
+            Shared::new(token(TokenKind::Ident("bar".into()))),
+            Shared::new(token(TokenKind::End)),
+            Shared::new(token(TokenKind::RParen)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Call,
+                    token: Some(Shared::new(token(TokenKind::Ident("foo".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Block,
+                            token: Some(Shared::new(token(TokenKind::Do))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: vec![
+                                Shared::new(Node {
+                                    kind: NodeKind::Ident,
+                                    token: Some(Shared::new(token(TokenKind::Ident("bar".into())))),
+                                    leading_trivia: Vec::new(),
+                                    trailing_trivia: Vec::new(),
+                                    children: Vec::new(),
+                                }),
+                                Shared::new(Node {
+                                    kind: NodeKind::End,
+                                    token: Some(Shared::new(token(TokenKind::End))),
+                                    leading_trivia: Vec::new(),
+                                    trailing_trivia: Vec::new(),
+                                    children: Vec::new(),
+                                }),
+                            ],
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+            ],
+            ErrorReporter::default()
         )
     )]
     fn test_parse(#[case] input: Vec<Shared<Token>>, #[case] expected: (Vec<Shared<Node>>, ErrorReporter)) {

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4,7 +4,7 @@ use crate::eval::env::{self, Env};
 use crate::ident::all_symbols;
 use crate::number::{self, Number};
 use crate::selector::Selector;
-use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input};
+use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input, parse_mdx_input};
 use base64::prelude::*;
 use itertools::Itertools;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
@@ -2102,6 +2102,19 @@ define_builtin!(
 );
 
 define_builtin!(
+    TO_MDX,
+    ParamNum::Fixed(1),
+    |ident, _, mut args, _| match args.as_mut_slice() {
+        [RuntimeValue::String(s)] =>
+            Ok(RuntimeValue::Array(parse_mdx_input(s).map_err(|e| {
+                Error::Runtime(format!("Failed to parse mdx: {}", e))
+            })?)),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)],)),
+        _ => unreachable!(),
+    }
+);
+
+define_builtin!(
     _GET_MARKDOWN_POSITION,
     ParamNum::Fixed(1),
     |ident, _, mut args, _| match args.as_mut_slice() {
@@ -2315,6 +2328,7 @@ const HASH_TO_IMAGE: u64 = fnv1a_hash_64("to_image");
 const HASH_TO_LINK: u64 = fnv1a_hash_64("to_link");
 const HASH_TO_MARKDOWN_STRING: u64 = fnv1a_hash_64("to_markdown_string");
 const HASH_TO_MARKDOWN: u64 = fnv1a_hash_64("to_markdown");
+const HASH_TO_MDX: u64 = fnv1a_hash_64("to_mdx");
 const HASH_TO_MATH: u64 = fnv1a_hash_64("to_math");
 const HASH_TO_MATH_INLINE: u64 = fnv1a_hash_64("to_math_inline");
 const HASH_TO_MD_LIST: u64 = fnv1a_hash_64("to_md_list");
@@ -2434,6 +2448,7 @@ pub fn get_builtin_functions_by_str(name_str: &str) -> Option<&'static BuiltinFu
         HASH_TO_LINK => Some(&TO_LINK),
         HASH_TO_MARKDOWN_STRING => Some(&TO_MARKDOWN_STRING),
         HASH_TO_MARKDOWN => Some(&TO_MARKDOWN),
+        HASH_TO_MDX => Some(&TO_MDX),
         HASH_TO_MATH => Some(&TO_MATH),
         HASH_TO_MATH_INLINE => Some(&TO_MATH_INLINE),
         HASH_TO_MD_LIST => Some(&TO_MD_LIST),
@@ -3577,6 +3592,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Parses a markdown string and returns an array of markdown nodes.",
             params: &["markdown_string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("to_mdx"),
+        BuiltinFunctionDoc {
+            description: "Parses an MDX string and returns an array of MDX nodes.",
+            params: &["mdx_string"],
         },
     );
     map.insert(

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -1603,6 +1603,11 @@ fn engine_with_opt() -> Engine {
           ",
           vec![RuntimeValue::Number(0.into())],
           Ok(vec![RuntimeValue::String("foobar".to_string())].into()))]
+#[case::to_mdx_single_text(
+            r#""<Component />" | to_mdx() | first() | to_string()"#,
+            vec![RuntimeValue::None],
+            Ok(vec![RuntimeValue::String("<Component />".to_string())].into())
+          )]
 fn test_eval(
     mut engine_no_opt: Engine,
     #[case] program: &str,


### PR DESCRIPTION
- Replace verbose or() calls with || operator for cleaner syntax
- Replace not() with ! operator for negation
- Simplify array access by using direct indexing (arr[0]) instead of get()
- Add to_mdx() builtin function for parsing MDX content
- Support do blocks as function call arguments in parser
- Improve map(), flat_map(), and filter() with better None handling
- Simplify function implementations by removing unnecessary let bindings
- Add comprehensive tests for new features and edge cases