### PR TITLE
📝 docs(sitemap): Remove tools page URL and refactor sitemap generation

### DIFF
--- a/docs/books/src/sitemap.xml
+++ b/docs/books/src/sitemap.xml
@@ -6,9 +6,6 @@
     <loc>https://mqlang.org/playground</loc><priority>1.0</priority>
   </url>
   <url>
-    <loc>https://mqlang.org/tools</loc><priority>1.0</priority>
-  </url>
-  <url>
     <loc>https://mqlang.org/book/</loc>
     <priority>1.0</priority>
   </url>

--- a/scripts/sitemap.mq
+++ b/scripts/sitemap.mq
@@ -1,6 +1,6 @@
 # Generate sitemap.xml from mdbook SUMMARY.md
 def sitemap_item(item, base_url):
-  let path = replace(replace(to_text(item), ".md", ""), "index", "")
+  let path = do to_text(item) | replace(".md", "") | replace("index", "");
   | let loc = add(base_url, path)
   | s"  <url>
     <loc>${loc}</loc>
@@ -13,7 +13,6 @@ def sitemap(items, base_url):
     "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">",
     "  <url>\n    <loc>https://mqlang.org</loc><priority>1.0</priority>  </url>",
     "  <url>\n    <loc>https://mqlang.org/playground</loc><priority>1.0</priority>\n  </url>",
-    "  <url>\n    <loc>https://mqlang.org/tools</loc><priority>1.0</priority>\n  </url>"
   ]
   | let footer = "</urlset>"
   | [headers, map(items, fn(item): sitemap_item(item, base_url);), footer]


### PR DESCRIPTION
- Remove /tools URL entry from sitemap.xml as page no longer exists
- Refactor sitemap.mq to use do block syntax for better readability
- Update sitemap_item function to chain replace operations more cleanly