### PR TITLE
📝 docs(readme): `mq` is in Homebrew now

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.5/m
 
 ```sh
 # Using Homebrew (macOS and Linux)
-brew install harehare/tap/mq
+brew install mq
 ```
 
 ### Docker


### PR DESCRIPTION
I just saw this in my `brew update` run earlier today: <https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/mq.rb>

```
> brew install mq
==> Fetching downloads for: mq
✔︎ Bottle Manifest mq (0.5.5)                                                [Downloaded    7.4KB/  7.4KB]
✔︎ Bottle mq (0.5.5)                                                         [Downloaded    4.2MB/  4.2MB]
==> Pouring mq--0.5.5.arm64_sequoia.bottle.tar.gz
🍺  /opt/homebrew/Cellar/mq/0.5.5: 9 files, 9.7MB
```