### PR TITLE
📝 docs(mq-lang): Add comprehensive API documentation

### DIFF
--- a/crates/mq-lang/src/arena.rs
+++ b/crates/mq-lang/src/arena.rs
@@ -2,6 +2,10 @@
 use serde::{Deserialize, Serialize};
 use std::{marker::PhantomData, ops::Index};
 
+/// A type-safe identifier for elements stored in an [`Arena`].
+///
+/// Uses phantom data to ensure type safety - an `ArenaId<A>` cannot be used
+/// to access elements from an `Arena<B>`.
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArenaId<T> {
@@ -37,6 +41,7 @@ impl<T> From<i32> for ArenaId<T> {
 }
 
 impl<T> ArenaId<T> {
+    /// Creates a new arena identifier from a raw `u32` index.
     pub const fn new(id: u32) -> ArenaId<T> {
         Self {
             id,
@@ -45,32 +50,42 @@ impl<T> ArenaId<T> {
     }
 }
 
+/// An arena allocator for efficiently storing and accessing elements.
+///
+/// The arena allocates elements sequentially and returns type-safe [`ArenaId`]s
+/// that can be used to retrieve elements later. This pattern provides fast allocation
+/// and cache-friendly access.
 #[derive(Debug, Clone, Default)]
 pub struct Arena<T> {
     items: Vec<T>,
 }
 
 impl<T: Clone + PartialEq> Arena<T> {
+    /// Creates a new arena with the specified initial capacity.
     pub fn new(size: usize) -> Self {
         Arena {
             items: Vec::with_capacity(size),
         }
     }
 
+    /// Allocates a value in the arena and returns its identifier.
     pub fn alloc(&mut self, value: T) -> ArenaId<T> {
         let arena_id = self.items.len() as u32;
         self.items.push(value);
         ArenaId::new(arena_id)
     }
 
+    /// Returns the number of elements in the arena.
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
+    /// Returns `true` if the arena contains no elements.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Returns `true` if the arena contains the specified value.
     pub fn contains(&self, value: T) -> bool {
         self.items.contains(&value)
     }

--- a/crates/mq-lang/src/error/syntax.rs
+++ b/crates/mq-lang/src/error/syntax.rs
@@ -3,29 +3,40 @@ use thiserror::Error;
 
 use crate::{Token, module::ModuleId, selector};
 
+/// Errors that occur during parsing of mq source code.
 #[derive(Error, Debug, PartialEq)]
 pub enum SyntaxError {
+    /// An environment variable was not found.
     #[error("Not found env `{1}`")]
     EnvNotFound(Token, SmolStr),
+    /// An unexpected token was encountered during parsing.
     #[error("Unexpected token `{}`", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     UnexpectedToken(Token),
+    /// Unexpected end-of-file was encountered.
     #[error("Unexpected EOF detected")]
     UnexpectedEOFDetected(ModuleId),
+    /// Insufficient tokens available to complete parsing.
     #[error("Insufficient tokens `{}`", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     InsufficientTokens(Token),
+    /// Expected a closing parenthesis `)` but found a different delimiter.
     #[error("Expected a closing parenthesis `)` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     ExpectedClosingParen(Token),
+    /// Expected a closing brace `}` but found a different delimiter.
     #[error("Expected a closing brace `}}` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     ExpectedClosingBrace(Token),
+    /// Expected a closing bracket `]` but found a different delimiter.
     #[error("Expected a closing bracket `]` but got `{}` delimiter", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     ExpectedClosingBracket(Token),
+    /// An invalid assignment target was encountered (expected an identifier).
     #[error("Invalid assignment target: expected an identifier but got `{}`", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     InvalidAssignmentTarget(Token),
+    /// An unknown selector was encountered.
     #[error(transparent)]
     UnknownSelector(selector::UnknownSelector),
 }
 
 impl SyntaxError {
+    /// Returns the token associated with this error, if available.
     #[cold]
     pub fn token(&self) -> Option<&Token> {
         match self {

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -39,8 +39,10 @@ pub mod runtime_value;
 use env::Env;
 use runtime_value::RuntimeValue;
 
+/// Configuration options for the evaluator.
 #[derive(Debug, Clone)]
 pub struct Options {
+    /// Maximum depth of the call stack to prevent infinite recursion.
     pub max_call_stack_depth: u32,
 }
 
@@ -62,6 +64,10 @@ impl Default for Options {
     }
 }
 
+/// The AST evaluator for executing mq programs.
+///
+/// Evaluates abstract syntax trees and manages the runtime environment,
+/// including variable bindings, function calls, and module loading.
 #[derive(Debug)]
 pub struct Evaluator<T: ModuleResolver = LocalFsModuleResolver> {
     env: Shared<SharedCell<Env>>,

--- a/crates/mq-lang/src/ident.rs
+++ b/crates/mq-lang/src/ident.rs
@@ -5,18 +5,32 @@ use string_interner::{DefaultBackend, DefaultSymbol, StringInterner};
 static STRING_INTERNER: LazyLock<Mutex<StringInterner<DefaultBackend>>> =
     LazyLock::new(|| Mutex::new(StringInterner::default()));
 
+/// An interned string identifier for efficient storage and comparison.
+///
+/// Identifiers are stored in a global string interner, allowing fast equality
+/// checks and reduced memory usage for frequently used strings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ident(DefaultSymbol);
 
 impl Ident {
+    /// Creates a new interned identifier from a string slice.
+    ///
+    /// If the string already exists in the interner, returns the existing identifier.
     pub fn new(s: &str) -> Self {
         Self(STRING_INTERNER.lock().unwrap().get_or_intern(s))
     }
 
+    /// Resolves the identifier to its string representation.
+    ///
+    /// Returns a new `String` with the identifier's content.
     pub fn as_str(&self) -> String {
         STRING_INTERNER.lock().unwrap().resolve(self.0).unwrap().to_string()
     }
 
+    /// Resolves the identifier and passes it to a callback function.
+    ///
+    /// This is more efficient than `as_str()` when you don't need to own the string,
+    /// as it avoids allocating a new `String`.
     pub fn resolve_with<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&str) -> R,
@@ -72,6 +86,7 @@ impl<'de> serde::Deserialize<'de> for Ident {
     }
 }
 
+/// Returns all interned strings currently in the global string interner.
 pub fn all_symbols() -> Vec<String> {
     STRING_INTERNER
         .lock()

--- a/crates/mq-lang/src/number.rs
+++ b/crates/mq-lang/src/number.rs
@@ -4,34 +4,48 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
+
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub struct Number(f64);
 
+/// Represents a Not-a-Number (NaN) value.
 pub const NAN: Number = Number(f64::NAN);
+
+/// Represents positive infinity.
 pub const INFINITE: Number = Number(f64::INFINITY);
 
 impl Number {
+    /// Creates a new `Number` from an `f64` value.
     pub fn new(value: f64) -> Self {
         Number(value)
     }
 
+    /// Returns the underlying `f64` value.
     pub fn value(&self) -> f64 {
         self.0
     }
 
+    /// Returns `true` if the number represents an integer value.
+    ///
+    /// Uses epsilon comparison to account for floating-point precision.
     pub fn is_int(&self) -> bool {
         (self.0 - self.0.trunc()).abs() < f64::EPSILON
     }
 
+    /// Returns the absolute value of this number.
     pub fn abs(&self) -> Self {
         Number(self.0.abs())
     }
 
+    /// Returns `true` if the number is zero or very close to zero.
+    ///
+    /// Uses epsilon comparison to account for floating-point precision.
     pub fn is_zero(&self) -> bool {
         self.0.abs() < f64::EPSILON
     }
 
+    /// Returns `true` if the number is NaN (Not-a-Number).
     pub fn is_nan(&self) -> bool {
         self.0.is_nan()
     }

--- a/crates/mq-lang/src/range.rs
+++ b/crates/mq-lang/src/range.rs
@@ -4,8 +4,13 @@ use crate::module::ModuleId;
 #[cfg(feature = "ast-json")]
 use serde::{Deserialize, Serialize};
 
+/// A span representing a location in source code with module context.
+///
+/// This type combines nom's `LocatedSpan` with a module identifier,
+/// enabling accurate source location tracking across multiple modules.
 pub type Span<'a> = LocatedSpan<&'a str, ModuleId>;
 
+/// A position in source code, representing a line and column.
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash)]
 pub struct Position {
@@ -20,11 +25,13 @@ impl Default for Position {
 }
 
 impl Position {
+    /// Creates a new position with the specified line and column.
     pub fn new(line: u32, column: usize) -> Self {
         Position { line, column }
     }
 }
 
+/// A range in source code, spanning from a start position to an end position.
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Default, Hash)]
 pub struct Range {
@@ -33,6 +40,7 @@ pub struct Range {
 }
 
 impl Range {
+    /// Returns `true` if the specified position falls within this range (inclusive).
     pub fn contains(&self, position: &Position) -> bool {
         (self.start.line < position.line || (self.start.line == position.line && self.start.column <= position.column))
             && (self.end.line > position.line || (self.end.line == position.line && self.end.column >= position.column))


### PR DESCRIPTION
Add documentation comments to core mq-lang modules including arena allocator, error types, evaluator, runtime values, identifiers, numbers, ranges, and selectors. This improves API discoverability and understanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)