### PR TITLE
📝 docs: Update code selector syntax in examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 
 Arguments:
-  [QUERY OR FILE]  
-  [FILES]...       
+  [QUERY OR FILE]
+  [FILES]...
 
 Options:
   -A, --aggregate
@@ -188,7 +188,7 @@ Options:
       --stream
           Enable streaming mode for processing large files line by line
       --json
-          
+
       --csv
           Include the built-in CSV module
       --fuzzy
@@ -257,7 +257,7 @@ mq '.[][] | select(contains("name"))'
 # list or header
 mq 'select(.[] || .h) | select(contains("name"))'
 # Exclude js code
-mq 'select(!.code("js"))'
+mq '.code | select(.code.lang != "js")'
 # CSV to markdown table
 mq 'include "csv" | csv_parse(true) | csv_to_markdown_table()' example.csv
 ```

--- a/crates/mq-lang/examples/extract_js_code.rs
+++ b/crates/mq-lang/examples/extract_js_code.rs
@@ -17,7 +17,7 @@ console.log('Hello, World!')
     let mut engine = mq_lang::DefaultEngine::default();
     engine.load_builtin_module();
 
-    let code = r#".code("js") | to_text()?"#;
+    let code = r#"select(.code.lang == "js") | to_text()?"#;
     println!(
         "{:?}",
         engine

--- a/docs/books/src/start/example.md
+++ b/docs/books/src/start/example.md
@@ -31,7 +31,7 @@ select(!.code)
 ### Extract js code
 
 ```js
-.code("js")
+select(.code.lang == "js")
 ```
 
 ### Extracts the language name from code blocks

--- a/docs/books/src/start/mcp.md
+++ b/docs/books/src/start/mcp.md
@@ -103,7 +103,7 @@ Returns JSON with selector names, descriptions, and parameters.
 Common mq queries you can use with the MCP tools:
 
 - `.h1` - Select all h1 headings
-- `.code("js")` - Select JavaScript code blocks
+- `select(.code.lang == "js")` - Select JavaScript code blocks
 - `.text` - Extract all text content
 - `select(.h1, .h2)` - Select h1 and h2 headings
 - `select(not(.code))` - Select everything except code blocks

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -58,7 +58,7 @@ $ mq '.[][] | select(contains("name"))'
 # list or header
 $ mq 'or(.[], .h) | select(contains("name"))'
 # Exclude js code
-$ mq 'select(not(.code("js")))'
+$ mq '.code | select(.code.lang != "js")'
 # CSV to markdown table
 $ mq 'include "csv" | nodes | csv_parse(true) | csv_to_markdown_table()' example.csv
 ```

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -10,7 +10,7 @@ const COMMANDS = ["mq/run"] as const;
 
 const EXAMPLES = `# To hide these examples, set mq.showExamplesInNewFile to false in settings
 # Extract js code
-.code("js")
+select(.code.lang == "js")
 
 # Extract list
 .[]

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -129,7 +129,7 @@ Some text here.
     examples: [
       {
         name: "Extract js code",
-        code: `.code("js")`,
+        code: `select(.code.lang == "js")`,
         markdown: `# Sample codes
 \`\`\`js
 console.log("Hello, World!");


### PR DESCRIPTION
Replace deprecated `.code("js")` syntax with more explicit `select(.code.lang == "js")` syntax across all documentation, examples, and editor integrations.

Changes include:
- README.md: Updated query examples and removed trailing whitespace
- Rust examples: Updated extract_js_code.rs example
- Documentation: Updated example.md and mcp.md
- VS Code extension: Updated README and default examples
- Playground: Updated example queries