### PR TITLE
♻️ refactor(mq-lang): Use var for mutable variables in module files

### DIFF
--- a/crates/mq-lang/modules/csv.mq
+++ b/crates/mq-lang/modules/csv.mq
@@ -2,22 +2,22 @@
 # Based on RFC 4180 for CSV format
 
 def _parse_csv_line(line, delimiter):
-  let fields = []
-  | let pos = 0
+  var fields = []
+  | var pos = 0
   | let line_count = len(line)
   | let result = while (pos < line_count):
       let field_result =
         if (starts_with(line[pos], "\"")):
           do
-            let pos = pos + 1
-            | let field_content = ""
-            | let escaped = false
-            | let end_pos = pos
+            pos = pos + 1
+            | var field_content = ""
+            | var escaped = false
+            | var end_pos = pos
             | let result = while (end_pos < line_count && (escaped || line[end_pos] != "\"")):
                           let char = line[end_pos]
-                          | let field_content = field_content + char
-                          | let escaped = char == "\"" && !escaped
-                          | let end_pos = end_pos + 1
+                          | field_content = field_content + char
+                          | escaped = char == "\"" && !escaped
+                          | end_pos = end_pos + 1
                           | [field_content, end_pos]
                         end
             | let field_content = if (is_none(result)): "" else: result[0]
@@ -29,11 +29,11 @@ def _parse_csv_line(line, delimiter):
           end
         else:
           do
-            let end_pos = pos
-            | let current_input = line[end_pos]
+            var end_pos = pos
+            | var current_input = line[end_pos]
             | let result = while (end_pos < line_count && current_input != delimiter && current_input != "\n" && current_input != "\r"):
-                          let end_pos = end_pos + 1
-                          | let current_input = line[end_pos]
+                          end_pos = end_pos + 1
+                          | var current_input = line[end_pos]
                           | end_pos
                         end
             | let result = if (is_none(result)): end_pos else: result
@@ -41,23 +41,23 @@ def _parse_csv_line(line, delimiter):
             | [field_content, result]
           end
       | let new_pos = field_result[1]
-      | let fields = fields + field_result[0]
-      | let pos = if (new_pos < line_count && line[new_pos] == delimiter):
-              new_pos + 1
-            else:
-              new_pos
+      | fields = fields + field_result[0]
+      | pos = if (new_pos < line_count && line[new_pos] == delimiter):
+        new_pos + 1
+      else:
+        new_pos
       | [fields, pos]
     end
   | result[0]
 end
 
 def _split_csv_lines(input):
-  let lines = []
-  | let current_line = ""
-  | let in_quotes = false
-  | let i = 0
+  var lines = []
+  | var current_line = ""
+  | var in_quotes = false
+  | var i = 0
   | let result = foreach (char, input):
-      let i = i + 1
+      i = i + 1
       | let result = if (char == "\"" && !in_quotes):
               [lines, current_line + char, true]
             elif (char == "\"" && in_quotes):
@@ -68,9 +68,9 @@ def _split_csv_lines(input):
               [if (is_empty(trim(current_line))): lines else: lines + current_line, "", false]
             else:
               [lines, current_line + char, in_quotes]
-      | let lines = result[0]
-      | let current_line = result[1]
-      | let in_quotes = result[2]
+      | lines = result[0]
+      | current_line = result[1]
+      | in_quotes = result[2]
       | if (i < len(input)): continue else: result
     end
 
@@ -88,13 +88,13 @@ def _parse_csv_content(input, delimiter, has_header):
   | let headers = if (has_header && len(parsed_lines) > 0): first(parsed_lines) else: None
   | let data_lines = if (has_header && len(parsed_lines) > 0): parsed_lines[1:len(parsed_lines)] else: parsed_lines
   | let csv_to_dict = fn(row):
-      let obj = {}
-      | let i = 0
+      var obj = {}
+      | var i = 0
       | while (i < len(headers) && i < len(row)):
           let key = if (i < len(headers)): headers[i] else: "column_" + to_string(i)
           | let value = if (i < len(row)): row[i] else: ""
-          | let obj = set(obj, key, value)
-          | let i = i + 1
+          | obj = set(obj, key, value)
+          | i = i + 1
           | obj
         end
     end

--- a/crates/mq-lang/modules/fuzzy.mq
+++ b/crates/mq-lang/modules/fuzzy.mq
@@ -3,8 +3,8 @@
 def _levenshtein_distance(s1, s2):
   let len1 = len(s1)
   | let len2 = len(s2)
-  | let matrix = []
-  | let i = 0
+  | var matrix = []
+  | var i = 0
   | let matrix = while (i <= len1):
       let j = 0
       | let row = []
@@ -19,11 +19,11 @@ def _levenshtein_distance(s1, s2):
               | let j = j + 1
               | row
             end
-      | let matrix = matrix + [row]
-      | let i = i + 1
+      | matrix = matrix + [row]
+      | i = i + 1
       | matrix
     end
-  | let i = 1
+  | var i = 1
   | let matrix = while (i <= len1):
       let j = 1
       | let matrix = while (j <= len2):
@@ -43,7 +43,7 @@ def _levenshtein_distance(s1, s2):
               | let j = j + 1
               | matrix
             end
-      | let i = i + 1
+      | i = i + 1
       | matrix
     end
   | if (len1 == 0): len2 elif (len2 == 0): len1 elif (is_none(matrix)): 0 else: matrix[len1][len2]
@@ -52,10 +52,10 @@ end
 def _calculate_jaro_distance(s1, s2, len1, len2):
   let match_window = floor(if (len1 > len2): (len1 / 2) - 1 else: (len2 / 2) - 1)
   | let match_window = if (match_window < 0): 0 else: match_window
-  | let s1_matches = []
-  | let s2_matches = []
-  | let matches = 0
-  | let i = 0
+  | var s1_matches = []
+  | var s2_matches = []
+  | var matches = 0
+  | var i = 0
   | let result = while (i < len1):
       let start = max(i - match_window, 0)
       | let end_ = min(len2, i + match_window + 1)
@@ -77,15 +77,15 @@ def _calculate_jaro_distance(s1, s2, len1, len2):
               | let matches = result[2]
               | result
             end
-      | let s1_matches = result[0]
-      | let s2_matches = result[1]
-      | let matches = result[2]
-      | let i = i + 1
+      | s1_matches = result[0]
+      | s2_matches = result[1]
+      | matches = result[2]
+      | i = i + 1
       | [s1_matches, s2_matches, matches]
     end
-  | let s1_matches = result[0]
-  | let s2_matches = result[1]
-  | let matches = result[2]
+  | s1_matches = result[0]
+  | s2_matches = result[1]
+  | matches = result[2]
   | if (is_none(matches) || matches == 0):
       0
     else:
@@ -93,18 +93,18 @@ def _calculate_jaro_distance(s1, s2, len1, len2):
 end
 
 def _calculate_jaro_with_transpositions(s1, s2, s1_matches, s2_matches, matches, len1, len2):
-  let transpositions = 0
-  | let i = 0
+  var transpositions = 0
+  | var i = 0
   | let s1_matches_len = len(s1_matches)
   | let transpositions = while (i < s1_matches_len):
-      let transpositions = if (s1_matches[i] != s2_matches[i]):
-        transpositions + 1
-      else:
-        transpositions
-      | let i = i + 1
+      transpositions = if (s1_matches[i] != s2_matches[i]):
+  transpositions + 1
+else:
+  transpositions
+      | i = i + 1
       | transpositions
     end
-  | let transpositions = transpositions / 2
+  | transpositions = transpositions / 2
   | ((matches / len1) + (matches / len2) + ((matches - transpositions) / matches)) / 3
 end
 
@@ -121,10 +121,9 @@ end
 
 def _common_prefix_length(s1, s2):
   let min_len = if (len(s1) < len(s2)): len(s1) else: len(s2)
-  | let i = 0
+  | var i = 0
   | let i = while (i < min_len && s1[i] == s2[i]):
-      let i = i + 1
-      | i
+      i = i + 1 | i
     end
   | i
 end

--- a/crates/mq-lang/modules/json.mq
+++ b/crates/mq-lang/modules/json.mq
@@ -13,18 +13,18 @@ def _parse_json_value(input):
     end
 
   def _parse_string(input):
-    let escaped = false
-    | let pos = 1
-    | let end_pos = None
-    | let input_len = len(input)
+    var escaped = false
+    | var pos = 1
+    | var end_pos = None
+    | var input_len = len(input)
     | let pos = while (is_none(end_pos) && pos < input_len):
           let char = input[pos]
           | let tokens = handle_string_char(char, escaped, pos)
           | let should_end = tokens[0]
           | let new_escaped = tokens[1]
-          | let end_pos = if (should_end): pos else: None
-          | let escaped = if (!should_end): new_escaped else: false
-          | let pos = pos + 1
+          | end_pos = if (should_end): pos else: None
+          | escaped = if (!should_end): new_escaped else: false
+          | pos = pos + 1
           | pos
         end
     | let str_content = input[1:pos - 1]
@@ -115,31 +115,31 @@ def _parse_json_value(input):
   end
 
   def _parse_object(input):
-    let input = input[1:len(input)]
-    | let input = trim(input)
-    | let obj = {}
+    var input = input[1:len(input)]
+    | input = trim(input)
+    | var obj = {}
     | let result = if (starts_with(input, "}")):
           [obj, input[1:len(input)]]
         else:
           while (!starts_with(input, "}") && !is_empty(input)):
             let tokens = _parse_string(input)
             | let key = tokens[0]
-            | let input = trim(tokens[1])
+            | input = trim(tokens[1])
             | if (is_none(key)): error("Invalid JSON object key")
             | if (!starts_with(input, ":")): error("Expected ':' after object key")
             | let result = _parse_object_value(obj, key, input)
-            | let obj = result[0]
-            | let input = trim(result[1])
+            | obj = result[0]
+            | input = trim(result[1])
             | let result = if (starts_with(input, ",")):
                           [obj, input[1:len(input)]]
                         else:
                           [obj, input]
-            | let obj = result[0]
-            | let input = trim(result[1])
+            | obj = result[0]
+            | input = trim(result[1])
             | [obj, input]
           end
-    | let obj = result[0]
-    | let input = result[1]
+    | obj = result[0]
+    | input = result[1]
     | if (starts_with(input, "}")):
         [obj, trim(input[1:len(input)])]
       else:

--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -8,14 +8,14 @@ def split(md_nodes, level):
     do
       let indices = do foreach (i, range(len(md_nodes) - 1)): if (is_h_level(md_nodes[i], level)): i; | compact();
       | let indices_with_end = indices + len(md_nodes)
-      | let result = []
-      | let i = 0
+      | var result = []
+      | var i = 0
       | while (i < len(indices)):
           let start_node = indices[i]
           | let end_node = indices_with_end[i + 1]
           | let children = md_nodes[start_node + 1:end_node]
-          | let result = result + [{type: :section, header: md_nodes[start_node], children: children}]
-          | let i = i + 1
+          | result = result + [{type: :section, header: md_nodes[start_node], children: children}]
+          | i = i + 1
           | result
         end
     end

--- a/crates/mq-lang/modules/toml.mq
+++ b/crates/mq-lang/modules/toml.mq
@@ -37,10 +37,9 @@ let INFINITY = 9223372036854775807
 | def _skip_comment(input):
     if (len(input) > 0 && input[0] == "#"):
       do
-        let i = 1
+        var i = 1
         | let result = while (i < len(input) && !_is_newline(input[i])):
-                  let i = i + 1
-                  | i
+                  i = i + 1 | i
                 end
         | let skip_count = if (is_none(result)): 1 else: result
         | trim(input[skip_count:len(input)])
@@ -53,9 +52,9 @@ let INFINITY = 9223372036854775807
     if (len(input) > 0 && (input[0] == "\"" || input[0] == "'")):
       do
         let quote_char = input[0]
-        | let i = 1
+        | var i = 1
         | let key_chars = ""
-        | let escaped = false
+        | var escaped = false
         | let result = while (i < len(input) && (escaped || input[i] != quote_char)):
                   let result = if (escaped):
                     [key_chars + input[i], false, i + 1]
@@ -64,8 +63,8 @@ let INFINITY = 9223372036854775807
                   else:
                     [key_chars + input[i], escaped, i + 1]
                   | let key_chars = result[0]
-                  | let escaped = result[1]
-                  | let i = result[2]
+                  | escaped = result[1]
+                  | i = result[2]
                   | result
                 end
         # Add 1 to skip the closing quote character
@@ -149,9 +148,9 @@ let INFINITY = 9223372036854775807
 
     def _parse_string(input):
       let quote_char = input[0]
-      | let i = 1
+      | var i = 1
       | let value_chars = ""
-      | let escaped = false
+      | var escaped = false
       | let result = while (i < len(input) && (escaped || input[i] != quote_char)):
               let result = if (escaped):
                 [value_chars + input[i], false, i + 1]
@@ -160,8 +159,8 @@ let INFINITY = 9223372036854775807
               else:
                 [value_chars + input[i], escaped, i + 1]
               | let value_chars = result[0]
-              | let escaped = result[1]
-              | let i = result[2]
+              | escaped = result[1]
+              | i = result[2]
               | result
             end
       | let value = if (is_none(result[0])): "" else: result[0]
@@ -170,12 +169,11 @@ let INFINITY = 9223372036854775807
     end
 
     def _parse_integer(input):
-      let i = 0
+      var i = 0
       | let has_sign = len(input) > 0 && (input[0] == "+" || input[0] == "-")
-      | let i = if (has_sign): 1 else: 0
+      | i = if (has_sign): 1 else: 0
       | let result = while (i < len(input) && (_is_digit(input[i]) || input[i] == "_")):
-              let i = i + 1
-              | i
+              i = i + 1 | i
             end
       | let consumed = if (is_none(result)): i else: result
       | let value_str = do input[0:consumed] | replace("_", "");
@@ -184,12 +182,11 @@ let INFINITY = 9223372036854775807
     end
 
     def _parse_float(input):
-      let i = 0
+      var i = 0
       | let has_sign = len(input) > 0 && (input[0] == "+" || input[0] == "-")
-      | let i = if (has_sign): 1 else: 0
+      | i = if (has_sign): 1 else: 0
       | let result = while (i < len(input) && (_is_digit(input[i]) || input[i] == "." || input[i] == "_")):
-              let i = i + 1
-              | i
+              i = i + 1 | i
             end
       | let consumed = if (is_none(result)): i else: result
       | let value_str = do input[0:consumed] | replace("_", "");
@@ -209,18 +206,18 @@ let INFINITY = 9223372036854775807
     end
 
     def _parse_array(input):
-      let remaining = input[1:len(input)]
+      var remaining = input[1:len(input)]
       | let _values = []
-      | let remaining = trim(remaining)
+      | remaining = trim(remaining)
       | let result = while (len(remaining) > 0 && remaining[0] != "]"):
               let value_result = _parse_value(remaining)
               | let value = value_result[0]
-              | let remaining = trim(value_result[1])
+              | remaining = trim(value_result[1])
               | let _values = if (is_none(value)): _values else: _values + value
-              | let remaining = if (len(remaining) > 0 && remaining[0] == ","):
-                              trim(remaining[1:len(remaining)])
-                            else:
-                              remaining
+              | remaining = if (len(remaining) > 0 && remaining[0] == ","):
+                trim(remaining[1:len(remaining)])
+              else:
+                remaining
               | [_values, remaining]
             end
       | let _values = if (is_none(result)): _values else: result[0]
@@ -230,31 +227,31 @@ let INFINITY = 9223372036854775807
     end
 
     def _parse_inline_table(input):
-      let remaining = input[1:len(input)]
-      | let table = {}
-      | let remaining = trim(remaining)
+      var remaining = input[1:len(input)]
+      | var table = {}
+      | remaining = trim(remaining)
       | let result = while (len(remaining) > 0 && remaining[0] != "}"):
               let key_result = _parse_key(remaining)
               | let key = key_result[0]
-              | let remaining = trim(key_result[1])
-              | let remaining = if (len(remaining) > 0 && remaining[0] == "="): remaining[1:len(remaining)] else: remaining
-              | let remaining = trim(remaining)
+              | remaining = trim(key_result[1])
+              | remaining = if (len(remaining) > 0 && remaining[0] == "="): remaining[1:len(remaining)] else: remaining
+              | remaining = trim(remaining)
               | let value_result = _parse_value(remaining)
               | let value = value_result[0]
-              | let remaining = value_result[1]
-              | let table = set(table, key, value)
-              | let remaining = trim(remaining)
+              | remaining = value_result[1]
+              | table = set(table, key, value)
+              | remaining = trim(remaining)
               | let result = if (len(remaining) > 0 && remaining[0] == ","):
                               [table, trim(remaining[1:len(remaining)])]
                             else:
                               [table, remaining]
-              | let table = result[0]
-              | let remaining = result[1]
+              | table = result[0]
+              | remaining = result[1]
               | result
             end
       | let table = result[0]
-      | let remaining = result[1]
-      | let remaining = if (len(remaining) > 0 && remaining[0] == "}"): remaining[1:len(remaining)] else: remaining
+      | remaining = result[1]
+      | remaining = if (len(remaining) > 0 && remaining[0] == "}"): remaining[1:len(remaining)] else: remaining
       | [table, remaining]
     end
 
@@ -319,13 +316,13 @@ let INFINITY = 9223372036854775807
       | [keys[0:-1] + last_key, is_array_section, temp_remaining]
     end
 
-    | let table = {}
-    | let current_section = []
-    | let is_array_section = false
-    | let remaining = input
+    | var table = {}
+    | var current_section = []
+    | var is_array_section = false
+    | var remaining = input
     | let result = while (len(remaining) > 0):
-          let remaining = trim(remaining)
-          | let remaining = _skip_comment(remaining)
+          remaining = trim(remaining)
+          | remaining = _skip_comment(remaining)
           | let result = if (len(remaining) == 0 || _is_newline(remaining[0])):
                       [table, current_section, is_array_section, if (len(remaining) > 0): remaining[1:len(remaining)] else: ""]
                     elif (remaining[0] == "["): do
@@ -361,10 +358,10 @@ let INFINITY = 9223372036854775807
                         | let temp_remaining = trim(temp_remaining)
                         | [updated_table, current_section, false, temp_remaining]
                       end
-          | let table = result[0]
-          | let current_section = result[1]
-          | let is_array_section = result[2]
-          | let remaining = result[3]
+          | table = result[0]
+          | current_section = result[1]
+          | is_array_section = result[2]
+          | remaining = result[3]
           | result
         end
     | result[0]
@@ -411,14 +408,14 @@ end
 
 # Converts a data structure to a TOML string representation.
 def toml_stringify(data):
-  let lines = []
+  var lines = []
   | let result = keys(data)
-  | let i = 0
+  | var i = 0
   | let final_lines = while (i < len(result)):
       let key = result[i]
       | let value = data[key]
       | let lines = _add_toml_lines(lines, key, value)
-      | let i = i + 1
+      | i = i + 1
       | lines
     end
   | join(final_lines, "\n")

--- a/crates/mq-lang/modules/xml.mq
+++ b/crates/mq-lang/modules/xml.mq
@@ -1,26 +1,26 @@
 # XML Implementation in mq
 
 def _parse_attributes(input):
-  let input = trim(input)
-  | let attributes = {}
+  var input = trim(input)
+  | var attributes = {}
   | let result = while (!is_empty(input) && !starts_with(input, ">") && !starts_with(input, "/>")):
       let name_match = regex_match(input, "([a-zA-Z_][a-zA-Z0-9_-]*)")
       | if (is_empty(name_match)):
           error("Invalid attribute name")
       | let attr_name = first(name_match)
-      | let input = input[len(attr_name):len(input)]
-      | let input = trim(input)
+      | input = input[len(attr_name):len(input)]
+      | input = trim(input)
       | if (!starts_with(input, "=")):
           error("Expected '=' after attribute name")
-      | let input = input[1:len(input)]
-      | let input = trim(input)
+      | input = input[1:len(input)]
+      | input = trim(input)
       | let quote_char = if (starts_with(input, "\"")):
               "\""
             elif (starts_with(input, "'")):
               "'"
             else:
               error("Attribute value must be quoted")
-      | let input = input[1:len(input)]
+      | input = input[1:len(input)]
       | let value_result = do
               let pos = 0
               | let start_pos = pos
@@ -33,9 +33,9 @@ def _parse_attributes(input):
               | [value, input[pos + 1:len(input)]]
             end
       | let attr_value = value_result[0]
-      | let input = value_result[1]
-      | let attributes = set(attributes, attr_name, attr_value)
-      | let input = trim(input)
+      | input = value_result[1]
+      | attributes = set(attributes, attr_name, attr_value)
+      | input = trim(input)
       | [attributes, input]
     end
   | if (is_none(result)): [{}, input] else: result
@@ -43,13 +43,13 @@ end
 
 def _find_closing_tag(input, tag_name):
   let closing_tag = "</" + tag_name + ">"
-  | let pos = 0
-  | let depth = 0
+  | var pos = 0
+  | var depth = 0
   | let open_tag_start = "<" + tag_name
   | let closing_tag_len = len(closing_tag)
   | let open_tag_start_len = len(open_tag_start)
   | let input_len = len(input)
-  | let has_close_tag = false
+  | var has_close_tag = false
   | let result = while (pos < input_len && !has_close_tag):
       let next_char_pos = pos + open_tag_start_len
       | let result = if (pos + open_tag_start_len <= input_len && input[pos:pos + open_tag_start_len] == open_tag_start):
@@ -63,9 +63,9 @@ def _find_closing_tag(input, tag_name):
               [depth - 1, pos + closing_tag_len, true]
             else:
               [depth, pos + 1, false]
-      | let depth = result[0]
-      | let pos = result[1]
-      | let has_close_tag = result[2]
+      | depth = result[0]
+      | pos = result[1]
+      | has_close_tag = result[2]
       | result
     end
   | result[1]
@@ -135,9 +135,9 @@ def _create_self_closing_element(tag_name, attributes, remaining):
 end
 
 def _parse_xml_content(input):
-  let input = trim(input)
-  | let children = []
-  | let text_parts = []
+  var input = trim(input)
+  | var children = []
+  | var text_parts = []
   | let result = while (!is_empty(input)):
       let result = if (starts_with(input, "<")):
         _parse_child_element(input, children)
@@ -145,11 +145,11 @@ def _parse_xml_content(input):
         _parse_text_content(input, text_parts)
       | let children = children + if (is_empty(result[0])): [] else: result[0]
       | let text_parts = result[1]
-      | let input = result[2]
+      | input = result[2]
       | [children, text_parts, input]
     end
-  | let children = if (is_none(result)): [] else: result[0]
-  | let text_parts = if (is_none(result)): [] else: result[1]
+  | children = if (is_none(result)): [] else: result[0]
+  | text_parts = if (is_none(result)): [] else: result[1]
   | let text = if (is_empty(text_parts)):
       None
     else:
@@ -185,11 +185,10 @@ def _parse_cdata_content(input, text_parts):
 end
 
 def _parse_text_content(input, text_parts):
-  let pos = 0
-  | let start_pos = pos
+  var pos = 0
+  | var start_pos = pos
   | let pos = while (pos < len(input) && input[pos] != "<"):
-      let pos = pos + 1
-      | pos
+      pos = pos + 1 | pos
     end
   | if (is_none(pos)): error("Unexpected end of input while parsing text content")
   | let text = input[start_pos:pos]

--- a/crates/mq-lang/modules/yaml.mq
+++ b/crates/mq-lang/modules/yaml.mq
@@ -73,10 +73,9 @@ def _parse_yaml_key_value(line):
 end
 
 def _get_indent_level(line):
-  let i = 0
+  var i = 0
   | let count = while (i < len(line) && line[i] == " "):
-      let i = i + 1
-      | i
+      i = i + 1 | i
     end
   | let count = if (is_none(count)): i else: count
   | count / 2
@@ -133,8 +132,8 @@ def parse_yaml_content(input):
   end
 
   def _parse_yaml_object(lines, start_index, target_indent):
-    let obj = {}
-    | let current_index = start_index
+    var obj = {}
+    | var current_index = start_index
     | while (current_index < len(lines)):
         let line = lines[current_index]
         | let trimmed_line = trim(line)
@@ -155,15 +154,15 @@ def parse_yaml_content(input):
                 else:
                   _handle_object_indent_break(obj, current_index)
 
-        | let obj = result[0]
-        | let current_index = result[1]
+        | obj = result[0]
+        | current_index = result[1]
         | if (result[2]): break else: result
       end
   end
 
   def _parse_yaml_array(lines, start_index, target_indent):
-    let arr = []
-    | let current_index = start_index
+    var arr = []
+    | var current_index = start_index
     | while (current_index < len(lines)):
         let line = lines[current_index]
         | let trimmed_line = trim(line)
@@ -185,15 +184,15 @@ def parse_yaml_content(input):
                 else:
                   _handle_array_indent_break(arr, current_index)
 
-        | let arr = result[0]
-        | let current_index = result[1]
+        | arr = result[0]
+        | current_index = result[1]
         | if (result[2]): break else: result
       end
   end
 
   def _parse_yaml_multi_lines(lines, start_index, target_indent):
-    let multi_line = ""
-    | let current_index = start_index
+    var multi_line = ""
+    | var current_index = start_index
     | while (current_index < len(lines)):
         let line = lines[current_index]
         | let trimmed_line = trim(line)
@@ -204,8 +203,8 @@ def parse_yaml_content(input):
                 else:
                   [if (is_empty(multi_line)): trimmed_line else: s"${multi_line}
 ${trimmed_line}", current_index + 1]
-        | let multi_line = result[0]
-        | let current_index = result[1]
+        | multi_line = result[0]
+        | current_index = result[1]
         | result
       end
   end


### PR DESCRIPTION
Replace let bindings with var for mutable variables across all module files (csv, fuzzy, json, section, toml, xml, yaml) to improve code clarity and explicitly mark variables that are reassigned during execution.