### PR TITLE
🐛 fix(formatter): Fix indentation for multiline assignment expressions

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -317,7 +317,13 @@ impl Formatter {
                     _ => unreachable!(),
                 }
 
-                self.format_node(right, block_indent_level);
+                let indent_level = if right.has_new_line() {
+                    block_indent_level + 1
+                } else {
+                    block_indent_level
+                };
+
+                self.format_node(right, indent_level);
             }
             _ => unreachable!(),
         }
@@ -1894,6 +1900,36 @@ end
         "let result = match (x):\n  | 1: do\n      foo() |\n      bar()\n    end\n  | 2: \"two\"\nend\n"
     )]
     #[case::assign("var i=0 | i=i + 1", "var i = 0 | i = i + 1")]
+    #[case::assign_right_multiline(
+        r#"let x =
+"test""#,
+        r#"let x =
+  "test"
+"#
+    )]
+    #[case::assign_right_multiline_pipe(
+        r#"let x =
+"test"
+| upcase()"#,
+        r#"let x =
+  "test"
+| upcase()
+"#
+    )]
+    #[case::assign_right_multiline_if(
+        r#"let x =
+if(test):
+test
+else:
+test2"#,
+        r#"let x =
+  if (test):
+    test
+  else:
+    test2
+"#
+    )]
+
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);
         assert_eq!(result.unwrap(), expected);


### PR DESCRIPTION
Improves the formatter to correctly indent the right-hand side of assignment statements when they span multiple lines. Previously, multiline expressions in assignments were not properly indented relative to the assignment operator.

This change adds logic to detect when the right-hand side expression contains newlines and applies an additional indentation level accordingly.

Added test cases cover:
- Simple multiline string assignment
- Multiline assignment with pipe operators
- Multiline assignment with if-else blocks