### PR TITLE
✅ test(mq-lang): add comprehensive macro expansion test coverage

### DIFF
--- a/docs/books/src/reference/macros.md
+++ b/docs/books/src/reference/macros.md
@@ -5,7 +5,7 @@ Macros enable compile-time code generation and transformation in mq. They allow 
 ## Syntax
 
 ```
-macro name(parameters): body;
+macro name(parameters): body
 ```
 
 Macros are invoked like functions:


### PR DESCRIPTION
Add extensive test cases covering all expand_node branches, substitute_node edge cases, quote/unquote scenarios, and macro expansion edge cases. These tests improve code coverage and ensure robustness of the macro expansion system.

Test additions include:
- expand_node branches for while, foreach, match, module, and, or, try/catch
- substitute_node cases for parameter shadowing and dynamic calls
- quote/unquote with complex nesting scenarios
- edge cases for single/multi-node bodies, nested macros, and zero parameters
- verification tests for macro output structure

Also fix macro syntax documentation to remove unnecessary semicolon.