### PR TITLE
🐛 fix(parser): add quote/unquote token support in statement position

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -431,7 +431,7 @@ end
 
 # Sets a breakpoint for debugging; execution will pause at this point if a debugger is attached.
 macro breakpoint() do
-    quote do
-      if (is_debug_mode()): _breakpoint()
-    end
+  quote do
+    if (is_debug_mode()): _breakpoint()
   end
+end

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -740,6 +740,8 @@ impl<'a> Parser<'a> {
             | TokenKind::LParen
             | TokenKind::Do
             | TokenKind::Colon
+            | TokenKind::Unquote
+            | TokenKind::Quote
             | TokenKind::LBrace => self.parse_expr(leading_trivia, false, false),
             _ => Err(ParseError::UnexpectedToken(Shared::clone(&token))),
         }


### PR DESCRIPTION
- Add TokenKind::Quote and TokenKind::Unquote to statement parsing
- Fix indentation in breakpoint() macro in builtin.mq
- Enables quote/unquote expressions to be parsed as statements