### PR TITLE
✨ feat(macro): add implicit self parameter support for macro expansion

### DIFF
--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -401,17 +401,14 @@ impl Macro {
         let (params, body) = {
             let macro_def = self.macros.get(&name).ok_or(RuntimeError::UndefinedMacro(name))?;
 
-            if macro_def.params.len() == args.len() + 1 {
-                // Case 2: One argument missing -> first parameter will be mapped to Expr::Self_
+            if macro_def.params.len() == args.len() || macro_def.params.len() == args.len() + 1 {
                 (macro_def.params.clone(), Shared::clone(&macro_def.body))
-            } else if macro_def.params.len() != args.len() {
+            } else {
                 return Err(RuntimeError::ArityMismatch {
                     macro_name: name,
                     expected: macro_def.params.len(),
                     got: args.len(),
                 });
-            } else {
-                (macro_def.params.clone(), Shared::clone(&macro_def.body))
             }
         };
 


### PR DESCRIPTION
Add support for calling macros with one fewer argument than defined parameters. When a macro is called with N-1 arguments (where N is the number of parameters), the first parameter is automatically mapped to Expr::Self_, allowing for more ergonomic macro usage with implicit self.

Changes:
- Modified arity checking to allow N-1 arguments
- Added substitution logic to map first parameter to Expr::Self_ when one argument is missing
- Maintained existing arity mismatch errors for 2+ missing arguments
- Added comprehensive test coverage with 11 new test cases

Test coverage includes:
- Simple self substitution scenarios
- Multiple parameter counts (2-4 params)
- Block macros with self
- Nested expressions and arithmetic operations
- String operations and function applications
- Chained macros with self
- Error cases for 2+ missing arguments