### PR TITLE
✨ feat(repl): add Esc+C keybinding to clear all input

### DIFF
--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -227,6 +227,11 @@ impl Repl {
             KeyEvent(KeyCode::Right, Modifiers::CTRL),
             Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Big)),
         );
+        // Bind Esc+C (Alt+C) to clear all input lines
+        editor.bind_sequence(
+            KeyEvent(KeyCode::Char('c'), Modifiers::ALT),
+            Cmd::Kill(Movement::WholeBuffer),
+        );
 
         let config_dir = config_dir();
 


### PR DESCRIPTION
Add Alt+C (Esc+C) keybinding to clear the entire input buffer in the REPL. This provides a convenient way to discard all entered lines and start fresh.