### PR TITLE
🐛 fix(mq-lang): fix is_mutable check for scoped variables

### DIFF
--- a/crates/mq-lang/src/eval/env.rs
+++ b/crates/mq-lang/src/eval/env.rs
@@ -528,52 +528,52 @@ mod tests {
         let var = Ident::new(var_name);
 
         // Define in grandparent if specified
-        if let Some(is_mutable) = define_in_grandparent {
-            if let Some(ref gp) = grandparent_env {
-                #[cfg(not(feature = "sync"))]
-                {
-                    if is_mutable {
-                        gp.borrow_mut().define_mutable(var, RuntimeValue::Number(1.0.into()));
-                    } else {
-                        gp.borrow_mut().define(var, RuntimeValue::Number(1.0.into()));
-                    }
+        if let Some(is_mutable) = define_in_grandparent
+            && let Some(ref gp) = grandparent_env
+        {
+            #[cfg(not(feature = "sync"))]
+            {
+                if is_mutable {
+                    gp.borrow_mut().define_mutable(var, RuntimeValue::Number(1.0.into()));
+                } else {
+                    gp.borrow_mut().define(var, RuntimeValue::Number(1.0.into()));
                 }
-                #[cfg(feature = "sync")]
-                {
-                    if is_mutable {
-                        gp.write()
-                            .unwrap()
-                            .define_mutable(var, RuntimeValue::Number(1.0.into()));
-                    } else {
-                        gp.write().unwrap().define(var, RuntimeValue::Number(1.0.into()));
-                    }
+            }
+            #[cfg(feature = "sync")]
+            {
+                if is_mutable {
+                    gp.write()
+                        .unwrap()
+                        .define_mutable(var, RuntimeValue::Number(1.0.into()));
+                } else {
+                    gp.write().unwrap().define(var, RuntimeValue::Number(1.0.into()));
                 }
             }
         }
 
         // Define in parent if specified
-        if let Some(is_mutable) = define_in_parent {
-            if let Some(ref parent) = parent_env {
-                #[cfg(not(feature = "sync"))]
-                {
-                    if is_mutable {
-                        parent
-                            .borrow_mut()
-                            .define_mutable(var, RuntimeValue::Number(100.0.into()));
-                    } else {
-                        parent.borrow_mut().define(var, RuntimeValue::Number(100.0.into()));
-                    }
+        if let Some(is_mutable) = define_in_parent
+            && let Some(ref parent) = parent_env
+        {
+            #[cfg(not(feature = "sync"))]
+            {
+                if is_mutable {
+                    parent
+                        .borrow_mut()
+                        .define_mutable(var, RuntimeValue::Number(100.0.into()));
+                } else {
+                    parent.borrow_mut().define(var, RuntimeValue::Number(100.0.into()));
                 }
-                #[cfg(feature = "sync")]
-                {
-                    if is_mutable {
-                        parent
-                            .write()
-                            .unwrap()
-                            .define_mutable(var, RuntimeValue::Number(100.0.into()));
-                    } else {
-                        parent.write().unwrap().define(var, RuntimeValue::Number(100.0.into()));
-                    }
+            }
+            #[cfg(feature = "sync")]
+            {
+                if is_mutable {
+                    parent
+                        .write()
+                        .unwrap()
+                        .define_mutable(var, RuntimeValue::Number(100.0.into()));
+                } else {
+                    parent.write().unwrap().define(var, RuntimeValue::Number(100.0.into()));
                 }
             }
         }
@@ -622,28 +622,28 @@ mod tests {
         let var = Ident::new(var_name);
 
         // Define in parent if specified
-        if let Some(is_mutable) = define_in_parent {
-            if let Some(ref parent) = parent_env {
-                #[cfg(not(feature = "sync"))]
-                {
-                    if is_mutable {
-                        parent
-                            .borrow_mut()
-                            .define_mutable(var, RuntimeValue::Number(100.0.into()));
-                    } else {
-                        parent.borrow_mut().define(var, RuntimeValue::Number(100.0.into()));
-                    }
+        if let Some(is_mutable) = define_in_parent
+            && let Some(ref parent) = parent_env
+        {
+            #[cfg(not(feature = "sync"))]
+            {
+                if is_mutable {
+                    parent
+                        .borrow_mut()
+                        .define_mutable(var, RuntimeValue::Number(100.0.into()));
+                } else {
+                    parent.borrow_mut().define(var, RuntimeValue::Number(100.0.into()));
                 }
-                #[cfg(feature = "sync")]
-                {
-                    if is_mutable {
-                        parent
-                            .write()
-                            .unwrap()
-                            .define_mutable(var, RuntimeValue::Number(100.0.into()));
-                    } else {
-                        parent.write().unwrap().define(var, RuntimeValue::Number(100.0.into()));
-                    }
+            }
+            #[cfg(feature = "sync")]
+            {
+                if is_mutable {
+                    parent
+                        .write()
+                        .unwrap()
+                        .define_mutable(var, RuntimeValue::Number(100.0.into()));
+                } else {
+                    parent.write().unwrap().define(var, RuntimeValue::Number(100.0.into()));
                 }
             }
         }


### PR DESCRIPTION
Fix the is_mutable method to properly check if a variable exists in the current scope before checking its mutability status. The previous implementation would return true for any variable in mutable_vars set without verifying it exists in the current context, potentially causing incorrect behavior for shadowed variables.

Additionally, add comprehensive rstest-based parameterized tests for is_mutable and assign methods covering:
- Current scope mutable/immutable variables
- Parent scope variable resolution
- Variable shadowing scenarios
- Grandparent scope resolution
- Assignment to mutable/immutable variables
- Error handling for undefined and immutable assignments