### PR TITLE
📝 docs: move mq-lsp installation instructions to documentation



### DIFF
--- a/README.md
+++ b/README.md
@@ -149,44 +149,6 @@ Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.11/
 $ docker run --rm ghcr.io/harehare/mq:0.5.11
 ```
 
-### mq-lsp (Language Server)
-
-The mq Language Server provides IDE features like completion, hover, and diagnostics for mq query files.
-
-#### Quick Install
-
-```bash
-curl -sSL https://mqlang.org/install_lsp.sh | bash
-```
-
-#### Cargo
-
-```sh
-# Install from crates.io
-cargo install mq-lsp
-# Install from Github
-cargo install --git https://github.com/harehare/mq.git mq-lsp --tag v0.5.11
-# Latest Development Version
-cargo install --git https://github.com/harehare/mq.git mq-lsp
-# Install using binstall
-cargo binstall mq-lsp@0.5.11
-```
-
-#### Binaries
-
-You can download pre-built binaries from the [GitHub releases page](https://github.com/harehare/mq/releases):
-
-```sh
-# macOS (Apple Silicon)
-curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-aarch64-apple-darwin -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
-# Linux x86_64
-curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-x86_64-unknown-linux-gnu -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
-# Linux arm64
-curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-aarch64-unknown-linux-gnu -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
-# Windows (PowerShell)
-Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-x86_64-pc-windows-msvc.exe -OutFile "$env:USERPROFILE\bin\mq-lsp.exe"
-```
-
 ### Visual Studio Code Extension
 
 You can install the VSCode extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=harehare.vscode-mq).

--- a/docs/books/src/start/install.md
+++ b/docs/books/src/start/install.md
@@ -50,6 +50,44 @@ Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.11/
 $ brew install harehare/tap/mq
 ```
 
+### mq-lsp (Language Server)
+
+The mq Language Server provides IDE features like completion, hover, and diagnostics for mq query files.
+
+#### Quick Install
+
+```bash
+curl -sSL https://mqlang.org/install_lsp.sh | bash
+```
+
+#### Cargo
+
+```sh
+# Install from crates.io
+cargo install mq-lsp
+# Install from Github
+cargo install --git https://github.com/harehare/mq.git mq-lsp --tag v0.5.11
+# Latest Development Version
+cargo install --git https://github.com/harehare/mq.git mq-lsp
+# Install using binstall
+cargo binstall mq-lsp@0.5.11
+```
+
+#### Binaries
+
+You can download pre-built binaries from the [GitHub releases page](https://github.com/harehare/mq/releases):
+
+```sh
+# macOS (Apple Silicon)
+curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-aarch64-apple-darwin -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
+# Linux x86_64
+curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-x86_64-unknown-linux-gnu -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
+# Linux arm64
+curl -L https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-aarch64-unknown-linux-gnu -o /usr/local/bin/mq-lsp && chmod +x /usr/local/bin/mq-lsp
+# Windows (PowerShell)
+Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.11/mq-lsp-x86_64-pc-windows-msvc.exe -OutFile "$env:USERPROFILE\bin\mq-lsp.exe"
+```
+
 ## Docker
 
 ```sh


### PR DESCRIPTION
Move the mq-lsp installation section from README.md to docs/books/src/start/install.md for better organization. This keeps the README concise while providing detailed installation instructions in the proper documentation location.