### PR TITLE
♻️ refactor(eval): separate control flow from error handling

### DIFF
--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -248,8 +248,12 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::ModuleLoadError(_)) => {
                 Some(Cow::Borrowed("Failed to load module. Check module paths and names."))
             }
-            InnerError::Runtime(RuntimeError::Break) => None,
-            InnerError::Runtime(RuntimeError::Continue) => None,
+            InnerError::Runtime(RuntimeError::UnexpectedBreak(_)) => {
+                Some(Cow::Borrowed("'break' can only be used inside a loop."))
+            }
+            InnerError::Runtime(RuntimeError::UnexpectedContinue(_)) => {
+                Some(Cow::Borrowed("'continue' can only be used inside a loop."))
+            }
             InnerError::Runtime(RuntimeError::EnvNotFound(..)) => {
                 Some(Cow::Borrowed("Environment variable not found during evaluation."))
             }
@@ -712,8 +716,16 @@ mod test {
             module_id: ArenaId::new(0),
         }))
     )]
-    #[case::eval_break(InnerError::Runtime(RuntimeError::Break))]
-    #[case::eval_continue(InnerError::Runtime(RuntimeError::Continue))]
+    #[case::eval_unexpected_break(InnerError::Runtime(RuntimeError::UnexpectedBreak(Token {
+        range: Range::default(),
+        kind: TokenKind::Eof,
+        module_id: ArenaId::new(0),
+    })))]
+    #[case::eval_unexpected_continue(InnerError::Runtime(RuntimeError::UnexpectedContinue(Token {
+        range: Range::default(),
+        kind: TokenKind::Eof,
+        module_id: ArenaId::new(0),
+    })))]
     #[case::eval_env_not_found(
         InnerError::Runtime(RuntimeError::EnvNotFound(Token {
             range: Range::default(),

--- a/crates/mq-lang/src/error/runtime.rs
+++ b/crates/mq-lang/src/error/runtime.rs
@@ -48,10 +48,10 @@ pub enum RuntimeError {
     Runtime(ErrorToken, String),
     #[error("Divided by 0")]
     ZeroDivision(ErrorToken),
-    #[error("Unexpected token break")]
-    Break,
-    #[error("Unexpected token continue")]
-    Continue,
+    #[error("Unexpected break outside of loop")]
+    UnexpectedBreak(ErrorToken),
+    #[error("Unexpected continue outside of loop")]
+    UnexpectedContinue(ErrorToken),
     #[error("Not found env `{1}`")]
     EnvNotFound(Token, SmolStr),
     #[error("Cannot assign to immutable variable \"{1}\"")]
@@ -96,8 +96,8 @@ impl RuntimeError {
             RuntimeError::ModuleLoadError(err) => err.token(),
             RuntimeError::Runtime(token, _) => Some(token),
             RuntimeError::ZeroDivision(token) => Some(token),
-            RuntimeError::Break => None,
-            RuntimeError::Continue => None,
+            RuntimeError::UnexpectedBreak(token) => Some(token),
+            RuntimeError::UnexpectedContinue(token) => Some(token),
             RuntimeError::EnvNotFound(token, _) => Some(token),
             RuntimeError::AssignToImmutable(token, _) => Some(token),
             RuntimeError::UndefinedVariable(token, _) => Some(token),


### PR DESCRIPTION
Introduce `ControlFlow` enum to handle `break` and `continue` as control flow signals rather than errors. This makes the code semantically correct: break/continue are not errors, they are control flow mechanisms.

- Add `ControlFlow` enum with `Break(Token)` and `Continue(Token)` variants
- Add `EvalError` enum combining `Flow(ControlFlow)` and `Runtime(RuntimeError)`
- Add `EvalResult` type alias for internal evaluation functions
- Rename `RuntimeError::Break`/`Continue` to `UnexpectedBreak`/`UnexpectedContinue` for cases when they occur outside of loops
- Update loop handlers to match on control flow signals
- Convert control flow to runtime error at external API boundaries