### PR TITLE
✨ feat(mq-lang): add lpad and rpad string padding functions

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -510,3 +510,31 @@ def inspect(value) do
   | value
 end
 
+# Left-pads a string to a specified length using a given padding string.
+def lpad(s, length, pad_str = " "):
+  let pad_needed = length - len(s)
+  | if (pad_needed <= 0):
+      s
+    else: do
+        let full_repeats = floor(pad_needed / len(pad_str))
+        | let remainder = pad_needed % len(pad_str)
+        | let full_pad = do foreach (_, range(0, full_repeats - 1)): pad_str; | join("");
+        | let final_pad = full_pad + slice(pad_str, 0, remainder)
+        | final_pad + s
+      end
+end
+
+# Right-pads a string to a specified length using a given padding string.
+def rpad(s, length, pad_str = " "):
+  let pad_needed = length - len(s)
+  | if (pad_needed <= 0):
+      s
+    else: do
+        let full_repeats = floor(pad_needed / len(pad_str))
+        | let remainder = pad_needed % len(pad_str)
+        | let full_pad = do foreach (_, range(0, full_repeats - 1)): pad_str; | join("");
+        | let final_pad = full_pad + slice(pad_str, 0, remainder)
+        | s + final_pad
+      end
+end
+

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -558,11 +558,33 @@ def test_inspect():
   | assert_eq(result1, 1)
 end
 
-| def test_each():
-    var i = 0
-    | each([1, 2, 3], fn(x): i += x;)
-    | assert_eq(i, 6)
-  end
+def test_each():
+  var i = 0
+  | each([1, 2, 3], fn(x): i += x;)
+  | assert_eq(i, 6)
+end
+
+def test_lpad():
+  let result1 = lpad("test", 6, "0")
+  | assert_eq(result1, "00test")
+
+  | let result2 = lpad("hello", 3, "x")
+  | assert_eq(result2, "hello")
+
+  | let result3 = lpad("abc", 5)
+  | assert_eq(result3, "  abc")
+end
+
+def test_rpad():
+  let result1 = rpad("test", 6, "0")
+  | assert_eq(result1, "test00")
+
+  | let result2 = rpad("hello", 3, "x")
+  | assert_eq(result2, "hello")
+
+  | let result3 = rpad("abc", 5)
+  | assert_eq(result3, "abc  ")
+end
 
 | run_tests([
   # Type checking
@@ -578,6 +600,8 @@ end
   test_case("contains", test_contains),
   test_case("ltrimstr", test_ltrimstr),
   test_case("rtrimstr", test_rtrimstr),
+  test_case("lpad", test_lpad),
+  test_case("rpad", test_rpad),
 
   # Collection operations
   test_case("is_empty", test_is_empty),


### PR DESCRIPTION
- Add lpad() function for left-padding strings with custom padding characters
- Add rpad() function for right-padding strings with custom padding characters

https://github.com/harehare/mq/issues/1144
https://github.com/harehare/mq/issues/1143