### PR TITLE
✨ feat(playground): add include keyword to syntax highlighting

### DIFF
--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -1119,7 +1119,7 @@ export const Playground = () => {
         root: [
           [/#[^\n]*/, "comment"],
           [
-            /\b(let|def|do|match|while|foreach|if|elif|else|end|self|None|nodes|break|continue|import|module|var|macro|quote|unquote|loop)\b/,
+            /\b(let|def|do|match|while|foreach|if|elif|else|end|self|None|nodes|break|continue|include|import|module|var|macro|quote|unquote|loop)\b/,
             "keyword",
           ],
           [/;/, "delimiter"],


### PR DESCRIPTION
Add `include` to the list of keywords in the Monaco editor's tokenizer for proper syntax highlighting in the mq playground.