### PR TITLE
📝 docs: add mq syntax highlighting to mdbook documentation

### DIFF
--- a/docs/books/book.toml
+++ b/docs/books/book.toml
@@ -7,6 +7,7 @@ title = "mq - jq like tool for markdown processing"
 
 [output.html]
 additional-css = ["theme/custom.css"]
+additional-js = ["theme/highlight-mq.js"]
 default-theme = "navy"
 git-repository-url = "https://github.com/harehare/mq"
 no-section-label = true

--- a/docs/books/src/reference/assignment_operators.md
+++ b/docs/books/src/reference/assignment_operators.md
@@ -8,7 +8,7 @@ The basic assignment operator (`=`) assigns a value to a variable.
 
 ### Usage
 
-```js
+```mq
 let x = 10 |
 let name = "mq" |
 let items = [1, 2, 3]
@@ -20,7 +20,7 @@ The update operator (`|=`) applies an expression to a selected value and updates
 
 ### Usage
 
-```js
+```mq
 <selector.value> |= expr
 ```
 
@@ -28,7 +28,7 @@ The left side specifies what to update using a selector, and the right side is t
 
 ### Examples
 
-```js
+```mq
 # Update a code block
 .code.value |= "test" | to_text()
 # => test
@@ -46,7 +46,7 @@ Compound assignment operators combine an arithmetic or logical operation with as
 
 Adds a value to a variable and assigns the result back to the variable.
 
-```js
+```mq
 var x = 10 |
 x += 5
 # => x is now 15
@@ -60,7 +60,7 @@ count += 1
 
 Subtracts a value from a variable and assigns the result back to the variable.
 
-```js
+```mq
 var x = 10 |
 x -= 3
 # => x is now 7
@@ -74,7 +74,7 @@ balance -= 25
 
 Multiplies a variable by a value and assigns the result back to the variable.
 
-```js
+```mq
 var x = 5 |
 x *= 3
 # => x is now 15
@@ -88,7 +88,7 @@ price *= 1.1
 
 Divides a variable by a value and assigns the result back to the variable.
 
-```js
+```mq
 var x = 20 |
 x /= 4
 # => x is now 5
@@ -102,7 +102,7 @@ total /= 2
 
 Computes the remainder of dividing a variable by a value and assigns the result back to the variable.
 
-```js
+```mq
 var x = 17 |
 x %= 5
 # => x is now 2
@@ -116,7 +116,7 @@ count %= 10
 
 Divides a variable by a value, floors the result (rounds down to the nearest integer), and assigns it back to the variable.
 
-```ruby
+```mq
 var x = 17 |
 x //= 5
 # => x is now 3

--- a/docs/books/src/reference/comments.md
+++ b/docs/books/src/reference/comments.md
@@ -2,7 +2,7 @@
 
 Similar to jq, comments starting with `#` are doc-comments.
 
-```python
+```mq
 # doc-comment
 let value = add(2, 3);
 ```

--- a/docs/books/src/reference/comparisons.md
+++ b/docs/books/src/reference/comparisons.md
@@ -15,7 +15,7 @@ Standard comparison operators are supported:
 
 ### Examples
 
-```python
+```mq
 # Basic comparisons
 1 == 1
 # => true

--- a/docs/books/src/reference/conditionals.md
+++ b/docs/books/src/reference/conditionals.md
@@ -8,7 +8,7 @@ mq supports standard conditional operations through the following functions:
 
 ### Examples
 
-```python
+```mq
 # Basic comparisons
 and(true, true, true)
 true && true && true

--- a/docs/books/src/reference/control_flow.md
+++ b/docs/books/src/reference/control_flow.md
@@ -4,7 +4,7 @@
 
 The if expression evaluates a condition and executes code based on the result:
 
-```js
+```mq
  if (eq(x, 1)):
    "one"
  elif (eq(x, 2)):
@@ -13,7 +13,7 @@ The if expression evaluates a condition and executes code based on the result:
    "other"
 ```
 
-```js
+```mq
  if (eq(x, 1)):
    do "one" | upcase();
  elif (eq(x, 2)):
@@ -24,7 +24,7 @@ The if expression evaluates a condition and executes code based on the result:
    end
 ```
 
-```js
+```mq
  if (eq(x, 1)):
    "one"
 ```
@@ -36,7 +36,7 @@ The conditions must evaluate to boolean values.
 
 The while loop repeatedly executes code while a condition is true:
 
-```ruby
+```mq
 let x = 5 |
 while (x > 0):
   let x = x - 1 | x
@@ -46,7 +46,7 @@ end
 
 You can use `break: <expr>` to return a value from a while loop:
 
-```ruby
+```mq
 var x = 10 |
 while (x > 0):
   x = x - 1 |
@@ -62,7 +62,7 @@ end
 
 The foreach loop iterates over elements in an array:
 
-```ruby
+```mq
 let items = array(1, 2, 3) |
 foreach (x, items):
    sub(x, 1)
@@ -72,7 +72,7 @@ end
 
 You can use `break: <expr>` to exit early and return a specific value instead of an array:
 
-```ruby
+```mq
 let items = array(1, 2, 3, 4, 5) |
 foreach (x, items):
   if(x > 3):
@@ -93,7 +93,7 @@ Foreach loops are useful for:
 
 The loop expression creates an infinite loop that continues until explicitly terminated with `break`:
 
-```ruby
+```mq
 var x = 0 |
 loop:
   x = x + 1 |
@@ -107,7 +107,7 @@ end
 
 The loop can be controlled using `break` to exit the loop and `continue` to skip to the next iteration:
 
-```ruby
+```mq
 var x = 0 |
 loop:
   x = x + 1 |
@@ -123,7 +123,7 @@ end
 
 The `break` statement can return a value from a loop using the `break: <expr>` syntax. This allows loops to be used as expressions that produce a specific value when exited:
 
-```ruby
+```mq
 var x = 0 |
 loop:
   x = x + 1 |

--- a/docs/books/src/reference/def.md
+++ b/docs/books/src/reference/def.md
@@ -11,7 +11,7 @@ def function_name(parameters):
 
 ## Examples
 
-```python
+```mq
 # Function that doubles input
 def double(x):
   mul(x, 2);
@@ -31,14 +31,14 @@ You can define default values for function parameters. Parameters with default v
 
 ### Syntax
 
-```python
+```mq
 def function_name(param1, param2=default_value):
   program;
 ```
 
 ### Examples
 
-```python
+```mq
 # Function with default parameter
 def greet(name, greeting="Hello"):
   greeting + " " + name;

--- a/docs/books/src/reference/fn.md
+++ b/docs/books/src/reference/fn.md
@@ -11,7 +11,7 @@ fn(parameters): program;
 
 ## Examples
 
-```python
+```mq
 # Basic Anonymous Function
 nodes | map(fn(x): add(x, "1");)
 
@@ -25,13 +25,13 @@ Anonymous functions also support default parameter values, just like named funct
 
 ### Syntax
 
-```python
+```mq
 fn(param1, param2=default_value): program;
 ```
 
 ### Examples
 
-```python
+```mq
 # Anonymous function with default parameter
 let multiply = fn(x, factor=2): x * factor;
 

--- a/docs/books/src/reference/macros.md
+++ b/docs/books/src/reference/macros.md
@@ -24,7 +24,7 @@ Macros differ from functions:
 
 ## Basic Examples
 
-```elixir
+```mq
 # Simple value transformation
 macro double(x) do
   x + x
@@ -49,7 +49,7 @@ end
 
 ## Advanced Examples
 
-```python
+```mq
 # Nested macro calls
 macro double(x): x + x
 macro quadruple(x): double(double(x))
@@ -74,7 +74,7 @@ def inc(n): n + 1;
 
 ### Practical Examples
 
-```python
+```mq
 # Basic injection
 macro make_expr(x) do
   quote: unquote(x) + 1

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -6,7 +6,7 @@ mq provides several ways to organize and reuse code: `module`, `import`, and `in
 
 Defines a module to group related functions and prevent naming conflicts using the syntax `module name: ... end`.
 
-```js
+```mq
 module module_name:
   def function1(): ...
   def function2(): ...
@@ -15,13 +15,13 @@ end
 
 Functions within a module can be accessed using qualified access syntax:
 
-```js
+```mq
 module_name::function1()
 ```
 
 ### Examples
 
-```python
+```mq
 # Define a math module
 module math:
   def add(a, b): a + b;
@@ -46,20 +46,20 @@ The import directive searches for .mq files in the following locations:
 - `$ORIGIN/../lib` - Parent lib directory relative to the source file
 - `$ORIGIN` - Current directory relative to the source file
 
-```js
+```mq
 import "module_name"
 ```
 
 ### Examples
 
 **math.mq:**
-```python
+```mq
 def add(a, b): a + b;
 def sub(a, b): a - b;
 ```
 
 **main.mq:**
-```python
+```mq
 # Import the math module
 import "math"
 
@@ -75,20 +75,20 @@ Unlike `import`, functions are available without a namespace prefix.
 
 The include directive searches for .mq files in the same locations as `import`.
 
-```js
+```mq
 include "module_name"
 ```
 
 ### Examples
 
 **math.mq:**
-```python
+```mq
 def add(a, b): a + b;
 def sub(a, b): a - b;
 ```
 
 **main.mq:**
-```python
+```mq
 # Include math functions
 include "math"
 

--- a/docs/books/src/reference/operators.md
+++ b/docs/books/src/reference/operators.md
@@ -10,7 +10,7 @@ The pipe operator (`|`) enables sequential processing of filters, where the outp
 
 ### Examples
 
-```js
+```mq
 # Basic pipe usage
 42 | add(1) | mul(2)
 # => 86
@@ -38,7 +38,7 @@ The range operator generates arrays of values from a starting point to an ending
 
 ### Examples
 
-```js
+```mq
 # Numeric ranges
 1..5
 # => [1, 2, 3, 4, 5]

--- a/docs/books/src/reference/pattern_matching.md
+++ b/docs/books/src/reference/pattern_matching.md
@@ -4,7 +4,7 @@ The match expression enables pattern matching on values, providing a powerful wa
 
 ## Basic Syntax
 
-```ruby
+```mq
 match (value):
   | pattern: body
 end
@@ -16,7 +16,7 @@ The match expression evaluates the value and compares it against a series of pat
 
 Match against specific values:
 
-```ruby
+```mq
 match (x):
   | 1: "one"
   | 2: "two"
@@ -34,7 +34,7 @@ Literal patterns support:
 
 Match based on value type using the `:type_name` syntax:
 
-```ruby
+```mq
 match (value):
   | :string: "is string"
   | :number: "is number"
@@ -59,7 +59,7 @@ Available type patterns:
 
 Destructure arrays and bind elements to variables:
 
-```ruby
+```mq
 match (arr):
   | []: "empty array"
   | [x]: x
@@ -77,7 +77,7 @@ Array patter features:
 
 ### Rest Pattern Example
 
-```ruby
+```mq
 match (arr):
   | [head, ..tail]: tail
 end
@@ -88,7 +88,7 @@ end
 
 Destructure dictionaries and extract values:
 
-```ruby
+```mq
 match (obj):
   | {name, age}: name
   | {x, y}: add(x, y)
@@ -104,7 +104,7 @@ Dict pattern features:
 
 ### Example with Object
 
-```ruby
+```mq
 let person = {"name": "Alice", "age": 30, "city": "Tokyo"} |
 match (person):
   | {name, age}: s"${name} is ${age} years old"
@@ -118,7 +118,7 @@ end
 
 Bind the matched value to a variable:
 
-```ruby
+```mq
 match (value):
   | x: x + 1
 end
@@ -130,7 +130,7 @@ Variable binding captures the entire value and makes it available in the body ex
 
 The underscore `_` matches any value:
 
-```ruby
+```mq
 match (x):
   | 1: "one"
   | 2: "two"
@@ -144,7 +144,7 @@ Use the wildcard pattern as the last arm to handle all remaining cases.
 
 Add conditions to patterns using `if`:
 
-```ruby
+```mq
 match (n):
   | x if (x > 0): "positive"
   | x if (x < 0): "negative"
@@ -159,7 +159,7 @@ Guards allow you to:
 
 ### Guard Examples
 
-```ruby
+```mq
 # Match even numbers
 match (n):
   | x if (x % 2 == 0): "even"
@@ -177,7 +177,7 @@ end
 
 Combine multiple patterns for comprehensive matching:
 
-```ruby
+```mq
 match (value):
   | 0: "zero"
   | x if (x > 0): "positive"
@@ -196,7 +196,7 @@ Pattern matching provides several advantages over if expressions:
 
 ### Using If Expressions
 
-```ruby
+```mq
 if (type_of(x) == "number"):
   if (x == 0):
     "positive number"
@@ -215,7 +215,7 @@ else:
 
 ### Using Pattern Matching
 
-```ruby
+```mq
 match (x):
   | n if (n > 0): "positive number"
   | n if (n < 0): "negative number"
@@ -230,7 +230,7 @@ end
 
 ### Processing Different Data Types
 
-```ruby
+```mq
 def describe(value):
   match (value):
     | :none: "nothing"
@@ -249,7 +249,7 @@ def describe(value):
 
 ### Extracting Data from Structures
 
-```ruby
+```mq
 def get_first_name(user):
   match (user):
     | {name}: name
@@ -259,7 +259,7 @@ def get_first_name(user):
 
 ### Handling API Responses
 
-```ruby
+```mq
 def handle_response(response):
   match (response):
     | {status, data} if (eq(status, 200)): data

--- a/docs/books/src/reference/self.md
+++ b/docs/books/src/reference/self.md
@@ -4,7 +4,7 @@ The current value being processed can be referenced as `self` or `.` (dot). Both
 
 ### Examples
 
-```python
+```mq
 # These expressions are equivalent
 "hello" | upcase()
 "hello" | upcase(self)

--- a/docs/books/src/reference/string_interpolation.md
+++ b/docs/books/src/reference/string_interpolation.md
@@ -13,7 +13,7 @@ s"text ${ident} more text"
 You can escape the `$` character in a string interpolation by using `$$`.
 This allows you to include literal `$` symbols in your interpolated strings.
 
-```python
+```mq
 let price = 25
 | s"The price is $$${price}"
 # => Output: "The price is $25"
@@ -21,7 +21,7 @@ let price = 25
 
 ## Examples
 
-```python
+```mq
 let name = "Alice"
 | let age = 30
 | s"Hello, my name is ${name} and I am ${age} years old."

--- a/docs/books/src/reference/try_catch.md
+++ b/docs/books/src/reference/try_catch.md
@@ -18,7 +18,7 @@ try <expr> catch <expr>
 
 ### Basic Error Handling
 
-```python
+```mq
 # When the expression succeeds
 try: "value" catch: "unknown"
 
@@ -28,7 +28,7 @@ try: get("missing") catch: "default"
 
 ### Chaining with Pipe
 
-```python
+```mq
 # Try to parse as JSON, fallback to raw string
 try: from_json() catch: self
 
@@ -38,7 +38,7 @@ try: do get("data") | from_json(); catch: []
 
 ### Nested Try-Catch
 
-```python
+```mq
 # Multiple fallback levels
 try: get("primary") catch: try: get("secondary") catch: "default"
 ```
@@ -49,7 +49,7 @@ The error suppression operator `?` provides a concise way to handle errors by re
 
 ### Examples
 
-```python
+```mq
 # Equivalent to a regular try-catch with a default value
 get("missing")?
 ```

--- a/docs/books/src/reference/variables.md
+++ b/docs/books/src/reference/variables.md
@@ -4,7 +4,7 @@
 
 The `let` binds an immutable value to an identifier for later use:
 
-```js
+```mq
 # Binds 42 to x
 let x = 42
 # Uses x in an expression
@@ -19,7 +19,7 @@ Once a variable is declared with `let`, its value cannot be changed.
 
 The `var` declares a mutable variable that can be reassigned:
 
-```js
+```mq
 # Declares a mutable variable
 var counter = 0
 # Reassigns the value
@@ -29,7 +29,7 @@ counter = counter + 1
 
 Variables declared with `var` can be modified using the assignment operator (`=`):
 
-```js
+```mq
 var total = 100
 | total = total - 25
 # total is now 75

--- a/docs/books/src/start/debugger.md
+++ b/docs/books/src/start/debugger.md
@@ -109,7 +109,7 @@ Breakpoints:
 
 You can also set breakpoints directly in your mq code using the `breakpoint()` function:
 
-```python
+```mq
 def process_data(items) {
    breakpoint()  # Execution will pause here when debugger is attached
    | items | filter(fn(item): item == "test")

--- a/docs/books/src/start/example.md
+++ b/docs/books/src/start/example.md
@@ -8,7 +8,7 @@ This page demonstrates practical examples of mq queries for common Markdown proc
 
 Extract all headings from a markdown document:
 
-```js
+```mq
 .h
 ```
 
@@ -27,7 +27,7 @@ Extract all headings from a markdown document:
 
 Extract the second row from a markdown table:
 
-```js
+```mq
 .[1][]
 ```
 **Input example**:
@@ -45,7 +45,7 @@ Extract the second row from a markdown table:
 
 Extract the second list from the document:
 
-```js
+```mq
 .[1]
 ```
 
@@ -55,7 +55,7 @@ Extract the second list from the document:
 
 Filter out all code blocks from a document, keeping only prose content:
 
-```js
+```mq
 select(!.code)
 ```
 
@@ -77,7 +77,7 @@ Another paragraph.
 
 Select only code blocks with a specific language:
 
-```js
+```mq
 select(.code.lang == "js")
 ```
 
@@ -103,7 +103,7 @@ const y = 2;
 
 Get a list of all programming languages used in code blocks:
 
-```js
+```mq
 .code.lang
 ```
 
@@ -115,7 +115,7 @@ Get a list of all programming languages used in code blocks:
 
 Select all MDX components (JSX-like elements in Markdown):
 
-```python
+```mq
 select(is_mdx())
 ```
 
@@ -138,7 +138,7 @@ Another paragraph.
 
 Get all URLs from markdown links:
 
-```js
+```mq
 .link.url
 ```
 
@@ -155,7 +155,7 @@ Check out [mq](https://mqlang.org) and [GitHub](https://github.com).
 
 Create a hierarchical table of contents from headings:
 
-```js
+```mq
 .h
 | let link = to_link("#" + to_text(self), to_text(self), "")
 | let level = .h.depth
@@ -184,7 +184,7 @@ Create a hierarchical table of contents from headings:
 
 Create an XML sitemap from markdown files:
 
-```scala
+```mq
 def sitemap(item, base_url):
     let path = replace(to_text(item), ".md", ".html")
     | let loc = base_url + path
@@ -215,7 +215,7 @@ $ mq 'sitemap(__FILE__, "https://example.com")' docs/**/*.md
 
 Create reusable functions for complex transformations:
 
-```ruby
+```mq
 def snake_to_camel(x):
   let words = split(x, "_")
   | foreach (word, words):
@@ -234,7 +234,7 @@ end
 
 Transform each element in an array:
 
-```js
+```mq
 map([1, 2, 3, 4, 5], fn(x): x + 1;)
 ```
 
@@ -244,7 +244,7 @@ map([1, 2, 3, 4, 5], fn(x): x + 1;)
 
 Select elements that meet a condition:
 
-```js
+```mq
 filter([5, 15, 8, 20, 3], fn(x): x > 10;)
 ```
 
@@ -254,7 +254,7 @@ filter([5, 15, 8, 20, 3], fn(x): x > 10;)
 
 Combine array elements into a single value:
 
-```js
+```mq
 fold([1, 2, 3, 4], 0, fn(acc, x): acc + x;)
 ```
 
@@ -326,7 +326,7 @@ $ mq -P 5 '.h1' docs/**/*.md
 
 Extract specific sections to create focused context for LLM inputs:
 
-```js
+```mq
 select(.h || .code) | self[:10]
 ```
 
@@ -343,7 +343,7 @@ $ mq -A 'let headers = count_by(fn(x): x | select(.h);)
 ```
 ### Generate Documentation Index
 
-```js
+```mq
 .h
 | let level = .h.level
 | let text = to_text(self)

--- a/docs/books/theme/highlight-mq.js
+++ b/docs/books/theme/highlight-mq.js
@@ -1,0 +1,129 @@
+/*
+ * highlight.js syntax definition for mq language
+ * mq is a jq-like tool for markdown processing
+ */
+(function () {
+  function hljsDefineMq(hljs) {
+    const KEYWORDS = {
+      keyword:
+        "def do let if elif else end while foreach self nodes match fn break continue include import module var macro quote unquote loop try catch",
+      literal: "true false None",
+    };
+
+    const COMMENT = hljs.COMMENT("#", "$");
+
+    const NUMBER = {
+      className: "number",
+      begin: "\\b[0-9]+(?:\\.[0-9]+)?\\b",
+      relevance: 0,
+    };
+
+    const STRING = {
+      className: "string",
+      begin: '"',
+      end: '"',
+      contains: [
+        {
+          className: "char.escape",
+          begin: "\\\\.",
+        },
+      ],
+    };
+
+    const INTERPOLATED_STRING = {
+      className: "string",
+      begin: 's"',
+      end: '"',
+      contains: [
+        {
+          className: "char.escape",
+          begin: "\\\\.",
+        },
+        {
+          className: "subst",
+          begin: "\\$\\{",
+          end: "\\}",
+          contains: [
+            {
+              className: "variable",
+              begin: "[a-zA-Z_][a-zA-Z0-9_]*",
+            },
+          ],
+        },
+      ],
+    };
+
+    const SYMBOL = {
+      className: "symbol",
+      begin: ":[a-zA-Z_][a-zA-Z0-9_]*",
+    };
+
+    const SELECTOR = {
+      className: "title.function",
+      begin: "\\.[a-zA-Z_\\[][a-zA-Z0-9_\\[\\]]*",
+    };
+
+    const FUNCTION_DEF = {
+      className: "function",
+      beginKeywords: "def fn",
+      end: "\\(",
+      excludeEnd: true,
+      contains: [
+        {
+          className: "title.function",
+          begin: "[a-zA-Z_][a-zA-Z0-9_]*",
+        },
+      ],
+    };
+
+    const FUNCTION_CALL = {
+      className: "title.function.invoke",
+      begin: "\\b[a-zA-Z_][a-zA-Z0-9_]*\\s*\\(",
+      returnBegin: true,
+      contains: [
+        {
+          className: "title.function",
+          begin: "[a-zA-Z_][a-zA-Z0-9_]*",
+        },
+      ],
+    };
+
+    const VARIABLE = {
+      className: "variable",
+      begin: "\\$[a-zA-Z_][a-zA-Z0-9_]*",
+    };
+
+    return {
+      name: "mq",
+      aliases: ["mq"],
+      keywords: KEYWORDS,
+      contains: [
+        COMMENT,
+        INTERPOLATED_STRING,
+        STRING,
+        NUMBER,
+        SYMBOL,
+        SELECTOR,
+        FUNCTION_DEF,
+        FUNCTION_CALL,
+        VARIABLE,
+      ],
+    };
+  }
+
+  // Register the language with highlight.js
+  if (typeof hljs !== "undefined") {
+    hljs.registerLanguage("mq", hljsDefineMq);
+
+    // Re-highlight all mq code blocks after registration
+    // Need to reset the content since book.js already processed them
+    document.querySelectorAll("pre code.language-mq").forEach((block) => {
+      // Remove hljs class to allow re-highlighting
+      block.classList.remove("hljs");
+      // Reset content to plain text (remove any existing highlighting spans)
+      block.textContent = block.textContent;
+      // Re-apply highlighting with mq language
+      hljs.highlightBlock(block);
+    });
+  }
+})();


### PR DESCRIPTION
Add custom highlight.js language definition for mq and update all code blocks in the documentation to use the new mq language tag instead of borrowing syntax highlighting from js, python, ruby, etc.