### PR TITLE
📝 docs: add playground links to mq code blocks in documentation

### DIFF
--- a/docs/books/book.toml
+++ b/docs/books/book.toml
@@ -7,7 +7,7 @@ title = "mq - jq like tool for markdown processing"
 
 [output.html]
 additional-css = ["theme/custom.css"]
-additional-js = ["theme/highlight-mq.js"]
+additional-js = ["theme/highlight-mq.js", "theme/playground-link.js"]
 default-theme = "navy"
 git-repository-url = "https://github.com/harehare/mq"
 no-section-label = true

--- a/docs/books/theme/custom.css
+++ b/docs/books/theme/custom.css
@@ -596,3 +596,63 @@ table tbody tr:hover {
     background-color: transparent;
     color: inherit;
 }
+
+/* ===========================================
+   Playground Link Styles
+   =========================================== */
+
+.playground-link-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: -0.5rem;
+    margin-bottom: 1rem;
+}
+
+.playground-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--mq-accent-primary);
+    background-color: transparent;
+    border: 1px solid var(--mq-border-default);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Noto Sans", Helvetica, Arial, sans-serif;
+}
+
+.playground-link::before {
+    content: "▶";
+    font-size: 0.7rem;
+}
+
+.playground-link:hover {
+    background-color: var(--mq-accent-primary);
+    color: var(--mq-code-bg);
+    border-color: var(--mq-accent-primary);
+    text-decoration: none;
+    box-shadow: 0 2px 8px rgba(103, 184, 227, 0.3);
+    transform: translateY(-1px);
+}
+
+.playground-link:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 4px rgba(103, 184, 227, 0.2);
+}
+
+/* Light theme adjustments */
+:root .playground-link {
+    color: #2563eb;
+    border-color: #cbd5e1;
+}
+
+:root .playground-link:hover {
+    background-color: #2563eb;
+    color: #ffffff;
+    border-color: #2563eb;
+}

--- a/docs/books/theme/playground-link.js
+++ b/docs/books/theme/playground-link.js
@@ -1,0 +1,124 @@
+/*
+ * Add "Open in Playground" links to mq code blocks
+ * Uses lz-string for URL compression (same as mq-playground)
+ */
+(function () {
+  const PLAYGROUND_URL = "https://mqlang.org/playground";
+
+  const DEFAULT_MARKDOWN = `# Sample Document
+
+## Introduction
+
+This is a sample markdown document for testing mq queries.
+
+## Features
+
+- Easy to use
+- Powerful filtering
+- Markdown transformation
+
+## Code Example
+
+\`\`\`js
+console.log("Hello, mq!");
+\`\`\`
+
+## Links
+
+[mq Documentation](https://mqlang.org/book)
+`;
+
+  // Load lz-string from CDN
+  function loadLZString() {
+    return new Promise((resolve, reject) => {
+      if (typeof LZString !== "undefined") {
+        resolve(LZString);
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src =
+        "https://cdn.jsdelivr.net/npm/lz-string@1.5.0/libs/lz-string.min.js";
+      script.onload = () => resolve(LZString);
+      script.onerror = () => reject(new Error("Failed to load lz-string"));
+      document.head.appendChild(script);
+    });
+  }
+
+  // Generate playground share URL
+  function generatePlaygroundUrl(code) {
+    const shareData = {
+      code,
+      markdown: DEFAULT_MARKDOWN,
+      options: {
+        isUpdate: false,
+        inputFormat: "markdown",
+        listStyle: null,
+        linkUrlStyle: null,
+        linkTitleStyle: null,
+      },
+    };
+
+    const compressed = LZString.compressToEncodedURIComponent(
+      JSON.stringify(shareData),
+    );
+    return `${PLAYGROUND_URL}#${compressed}`;
+  }
+
+  // Create playground link element
+  function createPlaygroundLink(code) {
+    const link = document.createElement("a");
+    link.className = "playground-link";
+    link.textContent = "Open in Playground";
+    link.title = "Open this code in mq Playground";
+    link.href = "#";
+    link.onclick = async (e) => {
+      e.preventDefault();
+      try {
+        await loadLZString();
+        const url = generatePlaygroundUrl(code);
+        window.open(url, "_blank");
+      } catch (error) {
+        console.error("Failed to open playground:", error);
+        alert("Failed to open playground. Please try again.");
+      }
+    };
+    return link;
+  }
+
+  // Add playground links to all mq code blocks
+  function addPlaygroundLinks() {
+    const mqCodeBlocks = document.querySelectorAll("pre code.language-mq");
+
+    mqCodeBlocks.forEach((codeBlock) => {
+      const pre = codeBlock.parentElement;
+      if (!pre || pre.querySelector(".playground-link")) {
+        return; // Skip if already has a link
+      }
+
+      const code = codeBlock.textContent || "";
+      // Skip empty code blocks or comment-only blocks
+      if (!code.trim() || code.trim().startsWith("#") && !code.includes("\n")) {
+        return;
+      }
+
+      // Create wrapper for the link
+      const linkWrapper = document.createElement("div");
+      linkWrapper.className = "playground-link-wrapper";
+      linkWrapper.appendChild(createPlaygroundLink(code));
+
+      // Insert after the pre element
+      pre.parentElement.insertBefore(linkWrapper, pre.nextSibling);
+    });
+  }
+
+  // Run after DOM is ready and highlight.js has processed
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      // Delay slightly to ensure highlight.js has processed
+      setTimeout(addPlaygroundLinks, 100);
+    });
+  } else {
+    setTimeout(addPlaygroundLinks, 100);
+  }
+})();


### PR DESCRIPTION
Add "Open in Playground" buttons to mq code blocks in the mdbook documentation, allowing users to quickly test code examples in the mq playground.

- Add playground-link.js with lz-string compression for URL sharing
- Add CSS styles for playground link buttons with theme support
- Register the script in book.toml

https://github.com/harehare/mq/issues/1194