### PR TITLE
✨ feat(table): add map_rows, filter_rows, and sort_rows functions

### DIFF
--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -293,6 +293,28 @@ def test_table_to_markdown():
   | assert(len(md_result) > 0)
 end
 
+def test_table_map_rows():
+  let t = first(table::tables(table_nodes))
+  | let md_result = table::map_rows(t, fn(row): map(row, upcase);)
+  | assert_eq(to_string(md_result[:rows][0][0]), "ALICE")
+  | assert_eq(to_string(md_result[:rows][1][0]), "BOB")
+end
+
+def test_table_filter_rows():
+  let t = first(table::tables(table_nodes))
+  | let md_result = table::filter_rows(t, fn(row): to_string(row[0]) == "Alice";)
+  | assert_eq(len(md_result[:rows]), 1)
+end
+
+def test_table_sort_rows():
+  let t = first(table::tables(table_nodes))
+  | let md_result = table::sort_rows(t, 1)
+  | assert_eq(to_string(md_result[:rows][0][0]), "Bob")
+
+  | let md_result = table::sort_rows(t)
+  | assert_eq(to_string(md_result[:rows][0][0]), "Alice")
+end
+
 | run_tests([
   # csv
   test_case("CSV Parse for Dict", test_csv_parse_for_dict),
@@ -340,4 +362,8 @@ end
   test_case("Table Remove Row", test_table_remove_row),
   test_case("Table Remove Column", test_table_remove_column),
   test_case("Table To Markdown", test_table_to_markdown),
+  test_case("Table Map Rows", test_table_map_rows),
+  test_case("Table Filter Rows", test_table_filter_rows),
+  test_case("Table Sort Rows", test_table_sort_rows),
 ])
+

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -90,6 +90,25 @@ def remove_column(table, col_index):
   | set(table, :rows, rows)
 end
 
+# Map a function over each row in the table.
+def map_rows(table, f):
+  set(table, :rows, map(table[:rows], f))
+end
+
+# Filter rows in the table based on a predicate function.
+def filter_rows(table, f):
+  set(table, :rows, filter(table[:rows], f))
+end
+
+# Sort rows in the table by a specified column index or default sorting.
+def sort_rows(table, column_index = None):
+  let new_rows = if (column_index == None):
+    sort(table[:rows])
+  else:
+    sort_by(table[:rows], fn(row): row[column_index];)
+  | set(table, :rows, new_rows)
+end
+
 # Convert a table structure back into a list of markdown nodes.
 def to_markdown(table)
   table[:header] + table[:align] + flatten(table[:rows])

--- a/crates/mq-lang/src/module/resolver.rs
+++ b/crates/mq-lang/src/module/resolver.rs
@@ -22,6 +22,7 @@ pub fn module_name(name: &str) -> Cow<'static, str> {
         "test" => Cow::Borrowed("test.mq"),
         "section" => Cow::Borrowed("section.mq"),
         "fuzzy" => Cow::Borrowed("fuzzy.mq"),
+        "table" => Cow::Borrowed("table.mq"),
         _ => Cow::Owned(format!("{}.mq", name)),
     }
 }


### PR DESCRIPTION
Add row transformation operations to the table module:
- map_rows: applies a function to each row
- filter_rows: filters rows based on a predicate
- sort_rows: sorts rows by column index or default ordering

Also registers the table module in the resolver for static lookup.