### PR TITLE
👷 ci: add cargo publish workflow

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,0 +1,21 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish-crates-io:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Verify packages can be published
+        run: cargo publish --dry-run --workspace
+      - name: Publish to crates.io
+        run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ example.html
 .serena
 
 tsconfig.tsbuildinfo
+
+mutants.out


### PR DESCRIPTION
- Add .github/workflows/cargo-publish.yml for crates.io publishing

Closes #1133