### PR TITLE
feat(typechecker): support row polymorphism for dicts via Record type

### DIFF
--- a/crates/mq-typechecker/tests/type_errors_test.rs
+++ b/crates/mq-typechecker/tests/type_errors_test.rs
@@ -52,11 +52,14 @@ fn test_heterogeneous_array_allowed() {
 
 #[test]
 fn test_dict_heterogeneous_values_allowed() {
-    // mq dicts are like JSON objects - values can have different types
-    // So this should succeed (heterogeneous values are allowed)
+    // With row polymorphism, each field has its own type in a Record
+    // {"a": 1, "b": "string"} → Record({a: int, b: string}, RowEmpty)
     let result = check_types(r#"{"a": 1, "b": "string"}"#);
-    println!("Dict value type mismatch: {:?}", result);
-    assert!(result.is_empty(), "Dict with mixed value types should be allowed");
+    println!("Dict with heterogeneous values: {:?}", result);
+    assert!(
+        result.is_empty(),
+        "Dict with mixed value types should be allowed via row polymorphism"
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Dict literals with string keys are now inferred as Record types with per-field value types
- Implements row polymorphism: Record unification, Dict↔Record compatibility, field access resolution
- Updates constraint generation, unification, and type display logic
- Adds/updates tests for Record type inference, unification, and bracket access