### PR TITLE
👷 ci: remove paths-filter and simplify workflow dependencies

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,9 +19,8 @@ env:
 
 jobs:
   benchmarks:
-    needs: changes
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && contains(github.event.commits.*.message, '[skip ci]') == false
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   build_and_deploy:
-    needs: changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Refactor CI workflows to remove dorny/paths-filter and direct job dependencies. Benchmarks and docs deploy jobs now run based on file path triggers and actor checks, improving reliability and maintainability.