### PR TITLE
🐛  fix(markdown): filter empty values in Fragment render, join with newline

### DIFF
--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -1220,7 +1220,6 @@ impl Node {
                 .iter()
                 .map(|value| value.render_with_theme(options, theme))
                 .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
                 .join("\n"),
             Self::Empty => String::new(),
         }


### PR DESCRIPTION
Ensure Fragment node rendering skips empty values and joins non-empty with newline. Add tests for fragment rendering edge cases.