### PR TITLE
📝 docs: add installation section to landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -930,7 +930,7 @@
 
           <div id="windows" class="tab-content">
             <div class="code-block">
-              <code>Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.5.19/mq-x86_64-pc-windows-msvc.exe -OutFile "$env:USERPROFILE\bin\mq.exe"</code>
+              <code>Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/latest/download/mq-x86_64-pc-windows-msvc.exe -OutFile "$env:USERPROFILE\bin\mq.exe"</code>
               <button class="copy-button" onclick="copyCode(this)">Copy</button>
             </div>
           </div>


### PR DESCRIPTION
Add tabbed installation instructions with Linux, macOS, and Windows options. Includes OS auto-detection to show the relevant tab by default, and copy-to-clipboard buttons for each install command.