### PR TITLE
✨ feat(mq-lang): replace toon parser with native toon-format builtin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,6 +2756,7 @@ dependencies = [
  "smol_str",
  "string-interner",
  "thiserror 2.0.18",
+ "toon-format",
  "url",
 ]
 
@@ -4151,6 +4152,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -4853,6 +4855,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "toon-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d25e33e50b37f95f3b55b6e664218cac7e1a50f056a75bb4c7a6cccfbc8a8c4"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -32,6 +32,7 @@ smol_str = {workspace = true}
 string-interner = {workspace = true}
 thiserror = {workspace = true}
 url = {workspace = true}
+toon-format = { version = "0.4", default-features = false }
 
 [features]
 ast-json = ["smallvec/serde", "smol_str/serde"]

--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -66,13 +66,13 @@ end
 
 def test_json_stringify():
   let result = json::json_stringify(json::json_parse(json_input))
-  | assert_eq(result, "{\"meta\": {\"count\": 3, \"generated_at\": \"2024-06-01T12:00:00Z\"}, \"users\": [{\"name\": \"Alice\", \"email\": \"alice@example.com\", \"id\": 1, \"roles\": [\"admin\", \"user\"]}, {\"name\": \"Bob\", \"email\": \"bob@example.com\", \"id\": 2, \"roles\": [\"user\"]}, {\"name\": \"Charlie\", \"email\": \"charlie@example.com\", \"id\": 3, \"roles\": [\"editor\", \"user\"]}]}")
+  | assert_eq(result, "{\"users\": [{\"name\": \"Alice\", \"id\": 1, \"email\": \"alice@example.com\", \"roles\": [\"admin\", \"user\"]}, {\"name\": \"Bob\", \"id\": 2, \"email\": \"bob@example.com\", \"roles\": [\"user\"]}, {\"name\": \"Charlie\", \"id\": 3, \"email\": \"charlie@example.com\", \"roles\": [\"editor\", \"user\"]}], \"meta\": {\"count\": 3, \"generated_at\": \"2024-06-01T12:00:00Z\"}}")
 end
 
 def test_json_to_markdown_table():
   let result = json::json_parse(json_input)
   | let result = json::json_to_markdown_table(result["users"])
-  | assert_eq(result, "| name | email | id | roles |\n| --- | --- | --- | --- |\n| Alice | alice@example.com | 1 | [\"admin\", \"user\"] |\n| Bob | bob@example.com | 2 | [\"user\"] |\n| Charlie | charlie@example.com | 3 | [\"editor\", \"user\"] |")
+  | assert_eq(result, "| name | id | email | roles |\n| --- | --- | --- | --- |\n| Alice | 1 | alice@example.com | [\"admin\", \"user\"] |\n| Bob | 2 | bob@example.com | [\"user\"] |\n| Charlie | 3 | charlie@example.com | [\"editor\", \"user\"] |")
 end
 
 # -- TOML Tests --

--- a/crates/mq-lang/modules/toon.mq
+++ b/crates/mq-lang/modules/toon.mq
@@ -9,15 +9,6 @@ def _toon_escape_string(s):
   replace(s, "\\", "\\\\") | replace("\"", "\\\"") | replace("\n", "\\n") | replace("\r", "\\r") | replace("\t", "\\t")
 end
 
-def _toon_unescape_string(s):
-  # Reverse of _toon_escape_string: unescape common sequences in quoted strings.
-  replace(s, "\\n", "\n")
-  | replace("\\r", "\r")
-  | replace("\\t", "\t")
-  | replace("\\\"", "\"")
-  | replace("\\\\", "\\")
-end
-
 def _toon_needs_quote(v, delim):
   let s = to_string(v)
   | if (s == ""): true
@@ -50,21 +41,7 @@ def _toon_is_primitive(v):
   is_string(v) || is_number(v) || is_bool(v) || is_none(v)
 end
 
-def _toon_merge_dicts(d1, d2):
-  if (is_none(d1)): d2
-  elif (is_none(d2)): d1
-  else: fold(entries(d2), d1, fn(acc, e): set(acc, e[0], e[1]);)
-end
-
 def _toon_indent(n): repeat("  ", n);
-
-def _toon_get_indent(line):
-  var idx = 0 | let l = len(line)
-  | let res = while (idx < l && line[idx] == " "):
-      idx += 1 | idx
-    end
-  | if (is_none(res)): 0 else: floor(res / 2)
-end
 
 # --- Stringify ---
 
@@ -152,165 +129,7 @@ end
 # To convert a data structure into a TOON string
 def toon_stringify(data): _toon_stringify_recursive(data, 0, ",");
 
-# --- Parse ---
-
-def _toon_parse_primitive(s):
-  let ss = trim(s)
-  | if (starts_with(ss, "\"") && ends_with(ss, "\"")):
-      _toon_escape_string(slice(ss, 1, -1))
-    elif (ss == "true"): true
-    elif (ss == "false"): false
-    elif (ss == "null"): None
-    elif (_toon_is_numeric_like(ss)): to_number(ss)
-    else: ss
-end
-
-def _toon_parse_header(line):
-  let t = trim(line)
-  | if (!ends_with(t, ":")): None
-    else:
-      do
-        let l = slice(t, 0, -1) | let s = index(l, "[") | let e = index(l, "]")
-        | if (s == -1 || e == -1 || s > e): None
-          else:
-            do
-              let key = trim(slice(l, 0, s)) | let bc = slice(l, s + 1, e)
-              | let colon = index(line, ":")
-              | var ls = "" | var dc = ","
-              | if (ends_with(bc, "|")): do ls = slice(bc, 0, -1) | dc = "|" end
-                elif (ends_with(bc, "\t")): do ls = slice(bc, 0, -1) | dc = "\t" end
-                else: ls = bc
-              | let length = to_number(ls)
-              | let ab = trim(slice(l, e + 1, len(l)))
-              | if (starts_with(ab, "{") && ends_with(ab, "}")):
-                  {"key": key, "len": length, "delim": dc, "fields": map(split(slice(ab, 1, -1), dc), trim), "has_f": true}
-                else: {"key": key, "len": length, "delim": dc, "fields": [], "has_f": false}
-            end
-      end
-end
-
-def _toon_parse_tabular(lines, start_i, count, target_indent, fields, delim):
-  var i = start_i | var val = [] | let total = len(lines)
-  | let loop_res = while (len(val) < count && i < total):
-      let line = lines[i]
-      | if (is_empty(trim(line))): i += 1
-        else:
-          do
-            if (_toon_get_indent(line) <= target_indent): break
-            else:
-              do
-                let row = map(split(line, delim), _toon_parse_primitive)
-                | var obj = {} | var f_idx = 0
-                | while (f_idx < len(fields) && f_idx < len(row)):
-                    obj = set(obj, fields[f_idx], row[f_idx]) | f_idx += 1
-                  end
-                | val += [obj] | i += 1
-              end
-          end
-      | [val, i]
-    end
-  | if (is_none(loop_res)): [val, i] else: loop_res
-end
-
-def _toon_parse_inline_array(line, start_b, end_b):
-  let cp = index(line, ":") | let key = trim(slice(line, 0, start_b)) | let bc = slice(line, start_b + 1, end_b)
-  | let delim =
-    if (contains(bc, "|")): "|"
-    elif (contains(bc, "\t")): "\t"
-    else: ","
-  | let values = split(trim(slice(line, cp + 1, len(line))), delim)
-  | [{key: key, length: bc, values: take(map(values, _toon_parse_primitive), to_number(bc))}]
-end
-
-def _toon_parse_expanded(lines, start_i, count, target_indent, delim):
-  var i = start_i | var val = [] | let total = len(lines)
-  | let loop_res = while (len(val) < count && i < total):
-      let line = lines[i]
-      | if (is_empty(trim(line))): i += 1
-        else:
-          do
-            let ind = _toon_get_indent(line)
-            | if (ind <= target_indent): break
-              else:
-                do
-                  let t = trim(line)
-                  | if (starts_with(t, "- ")):
-                      do
-                        let c = slice(t, 2, len(t))
-                        | if (contains(c, ":")):
-                            do
-                              let r1 = _toon_parse_recursive([c], 0, 0, delim)
-                              | let r2 = _toon_parse_recursive(lines, i + 1, ind + 1, delim)
-                              | val += [_toon_merge_dicts(r1[0], r2[0])] | i = r2[1]
-                            end
-                          else: do val += [_toon_parse_primitive(c)] | i += 1 end
-                      end
-                    else: i += 1
-                end
-          end
-      | [val, i]
-    end
-  | if (is_none(loop_res)): [val, i] else: loop_res
-end
-
-def _toon_parse_recursive(lines, start_i, target_indent, active_delim):
-  var i = start_i | var result = None | let total = len(lines)
-  | let loop_res = while (i < total):
-      let line = lines[i] | let ind = _toon_get_indent(line)
-      | if (ind < target_indent): break
-      | if (is_empty(trim(line))): do i += 1 | [result, i] end
-        else:
-          do
-            let h = _toon_parse_header(line)
-            | let step = if (!is_none(h)):
-                          do
-                            let k = h["key"] | let lv = h["len"] | let d = h["delim"]
-                            | let vi = if (h["has_f"]): _toon_parse_tabular(lines, i + 1, lv, target_indent, h["fields"], d)
-                                                        else:
-                                                          do
-                                                            let ci = index(line, ":") | let af = trim(slice(line, ci + 1, len(line)))
-                                                            | if (!is_empty(af)): [map(split(af, d), _toon_parse_primitive), i + 1]
-                                                              else: _toon_parse_expanded(lines, i + 1, lv, target_indent, d)
-                                                          end
-                            | let rt = if (is_none(result)): {} else: result
-                            | [if (k == ""): vi[0] else: set(rt, k, vi[0]), vi[1]]
-                          end
-                        elif (contains(line, ":")):
-                          do
-                            let sb = index(line, "[")
-                            | let eb = index(line, "]")
-                            | if (sb != -1 && eb != -1 && sb < eb):
-                                do
-                                  let arr = _toon_parse_inline_array(line, sb, eb)
-                                  | let rt = if (is_none(result)): {} else: result
-                                  | [set(rt, arr[0]["key"], arr[0]["values"]), i + 1]
-                                end
-                              else:
-                                do
-                                  let cp = index(line, ":") | let raw_key = trim(slice(line, 0, cp)) | let vs = trim(slice(line, cp + 1, len(line)))
-                                  | let key = if (starts_with(raw_key, "\"") && ends_with(raw_key, "\"")):
-                                                _toon_unescape_string(slice(raw_key, 1, len(raw_key) - 1))
-                                              else:
-                                                raw_key
-                                  | let rt = if (is_none(result)): {} else: result
-                                  | if (!is_empty(vs)): [set(rt, key, _toon_parse_primitive(vs)), i + 1]
-                                    else:
-                                      do
-                                        let nest = _toon_parse_recursive(lines, i + 1, ind + 1, active_delim)
-                                        | [set(rt, key, nest[0]), nest[1]]
-                                      end
-                                end
-                          end
-                        else: [if (target_indent == 0 && total == 1): _toon_parse_primitive(line) else: result, i + 1]
-            | result = step[0] | i = step[1] | [result, i]
-          end
-    end
-  | if (is_none(loop_res)): [result, i] else: loop_res
-end
-
 # To parse a TOON string into a data structure
 def toon_parse(input):
-  let lines = split(to_string(input), "\n")
-  | let res = _toon_parse_recursive(lines, 0, 0, ",")
-  | res[0]
+  _toon_parse(to_string(input))
 end

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2286,6 +2286,19 @@ define_builtin!(_JSON_PARSE, ParamNum::Fixed(1), |ident, _, mut args, _| {
     }
 });
 
+define_builtin!(_TOON_PARSE, ParamNum::Fixed(1), |ident, _, mut args, _| {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => Ok(toon_format::decode::<serde_json::Value>(
+            s,
+            &toon_format::DecodeOptions::default(),
+        )
+        .map_err(|e| Error::Runtime(format!("Failed to parse TOON: {}", e)))?
+        .into()),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!(),
+    }
+});
+
 define_builtin!(
     SET_VARIABLE,
     ParamNum::Fixed(2),
@@ -2631,6 +2644,7 @@ const HASH_INTERN: u64 = fnv1a_hash_64("intern");
 const HASH_GET_MARKDOWN_POSITION: u64 = fnv1a_hash_64("_get_markdown_position");
 const HASH_CSV_PARSE: u64 = fnv1a_hash_64("_csv_parse");
 const HASH_JSON_PARSE: u64 = fnv1a_hash_64("_json_parse");
+const HASH_TOON_PARSE: u64 = fnv1a_hash_64("_toon_parse");
 #[cfg(feature = "file-io")]
 const HASH_READ_FILE: u64 = fnv1a_hash_64("read_file");
 
@@ -2764,6 +2778,7 @@ pub fn get_builtin_functions_by_str(name_str: &str) -> Option<&'static BuiltinFu
         HASH_GET_MARKDOWN_POSITION => Some(&_GET_MARKDOWN_POSITION),
         HASH_CSV_PARSE => Some(&_CSV_PARSE),
         HASH_JSON_PARSE => Some(&_JSON_PARSE),
+        HASH_TOON_PARSE => Some(&_TOON_PARSE),
         #[cfg(feature = "file-io")]
         HASH_READ_FILE => Some(&READ_FILE),
         _ => None,
@@ -3165,6 +3180,13 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc
         BuiltinFunctionDoc {
             description: "Parses a JSON string into a data structure.",
             params: &["json_string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("_toon_parse"),
+        BuiltinFunctionDoc {
+            description: "Parses a TOON string into a data structure.",
+            params: &["toon_string"],
         },
     );
 
@@ -5602,5 +5624,84 @@ mod tests {
             &Shared::new(SharedCell::new(Env::default())),
         );
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case::simple_kv(
+        "a: 1\nb: 2",
+        {
+            let mut map = BTreeMap::new();
+            map.insert(Ident::new("a"), RuntimeValue::Number(1.into()));
+            map.insert(Ident::new("b"), RuntimeValue::Number(2.into()));
+            Ok(RuntimeValue::Dict(map))
+        }
+    )]
+    #[case::nested_indent(
+        "parent:\n  child: value",
+        {
+            let mut child_map = BTreeMap::new();
+            child_map.insert(Ident::new("child"), RuntimeValue::String("value".to_string()));
+            let mut parent_map = BTreeMap::new();
+            parent_map.insert(Ident::new("parent"), RuntimeValue::Dict(child_map));
+            Ok(RuntimeValue::Dict(parent_map))
+        }
+    )]
+    #[case::tabular_data(
+        "hikes[2]{id,name}:\n  1,Blue Lake\n  2,Ridge Trail",
+        {
+            let mut row1 = BTreeMap::new();
+            row1.insert(Ident::new("id"), RuntimeValue::Number(1.into()));
+            row1.insert(Ident::new("name"), RuntimeValue::String("Blue Lake".to_string()));
+            let mut row2 = BTreeMap::new();
+            row2.insert(Ident::new("id"), RuntimeValue::Number(2.into()));
+            row2.insert(Ident::new("name"), RuntimeValue::String("Ridge Trail".to_string()));
+            let mut map = BTreeMap::new();
+            map.insert(Ident::new("hikes"), RuntimeValue::Array(vec![RuntimeValue::Dict(row1), RuntimeValue::Dict(row2)]));
+            Ok(RuntimeValue::Dict(map))
+        }
+    )]
+    #[case::inline_array(
+        "items[3]: 1, 2, 3",
+        {
+            let mut map = BTreeMap::new();
+            map.insert(Ident::new("items"), RuntimeValue::Array(vec![
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::Number(2.into()),
+                RuntimeValue::Number(3.into()),
+            ]));
+            Ok(RuntimeValue::Dict(map))
+        }
+    )]
+    #[case::expanded_array(
+        "items[2]:\n  - 1\n  - 2",
+        {
+            let mut map = BTreeMap::new();
+            map.insert(Ident::new("items"), RuntimeValue::Array(vec![
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::Number(2.into()),
+            ]));
+            Ok(RuntimeValue::Dict(map))
+        }
+    )]
+    #[case::primitives(
+        "s: \"string\"\nb: true\nn: null\nf: false",
+        {
+            let mut map = BTreeMap::new();
+            map.insert(Ident::new("s"), RuntimeValue::String("string".to_string()));
+            map.insert(Ident::new("b"), RuntimeValue::TRUE);
+            map.insert(Ident::new("n"), RuntimeValue::NONE);
+            map.insert(Ident::new("f"), RuntimeValue::FALSE);
+            Ok(RuntimeValue::Dict(map))
+        }
+    )]
+    fn test_toon_parse(#[case] toon: &str, #[case] expected: Result<RuntimeValue, Error>) {
+        let ident = Ident::new("_toon_parse");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![RuntimeValue::String(toon.to_string())],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
Replace the pure-mq TOON parser implementation with a native builtin using the toon-format crate. The new _toon_parse builtin delegates parsing to toon_format::decode, simplifying toon.mq and improving reliability. Also update test expectations for JSON key ordering changes.