### PR TITLE
🐛  fix(playground): add collect() to section extraction example

### DIFF
--- a/packages/mq-playground/src/examples.ts
+++ b/packages/mq-playground/src/examples.ts
@@ -282,7 +282,7 @@ This is a sample document with frontmatter.
     examples: [
       {
         name: "Extract section by title",
-        code: `include "section" | nodes | section("Installation")`,
+        code: `include "section" | nodes | section("Installation") | collect()`,
         markdown: `# Introduction
 
 Welcome to the project.


### PR DESCRIPTION
The example for extracting a section by title now ends with collect() for correct output aggregation. This improves clarity for users copying the example.