### PR TITLE
⚡ perf(web-api): add mimalloc, gzip compression, and cache OpenAPI spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +907,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -3044,6 +3073,7 @@ dependencies = [
  "deadpool-libsql",
  "libsql",
  "miette",
+ "mimalloc",
  "mq-check",
  "mq-formatter",
  "mq-hir",
@@ -5168,13 +5198,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -12,12 +12,17 @@ readme = "README.md"
 repository = "https://github.com/harehare/mq"
 version = "0.5.23"
 
+[features]
+default = ["use_mimalloc"]
+use_mimalloc = ["mimalloc"]
+
 [dependencies]
 async-trait = {workspace = true}
 axum = {workspace = true}
 deadpool-libsql = {workspace = true}
 libsql = {workspace = true}
 miette = {workspace = true}
+mimalloc = {workspace = true, features = ["v3"], optional = true}
 mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}
@@ -28,7 +33,7 @@ serde_json = {workspace = true}
 thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tower = {workspace = true}
-tower-http = {workspace = true, features = ["cors", "trace"]}
+tower-http = {workspace = true, features = ["cors", "trace", "compression-gzip"]}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter", "json"]}
 utoipa = {workspace = true, features = ["preserve_order"]}

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -4,6 +4,7 @@ use axum::{
     response::Json,
 };
 use serde::Deserialize;
+use std::sync::OnceLock;
 use tracing::{debug, error, info};
 use utoipa::OpenApi;
 
@@ -219,6 +220,8 @@ pub async fn post_format_api(
     }
 }
 
+static OPENAPI_SPEC: OnceLock<utoipa::openapi::OpenApi> = OnceLock::new();
+
 #[utoipa::path(
     get,
     path = "/openapi.json",
@@ -228,5 +231,5 @@ pub async fn post_format_api(
 )]
 pub async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
     debug!("GET /openapi.json called");
-    Json(ApiDoc::openapi())
+    Json(OPENAPI_SPEC.get_or_init(ApiDoc::openapi).clone())
 }

--- a/crates/mq-web-api/src/main.rs
+++ b/crates/mq-web-api/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "use_mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use mq_web_api::{
     Config,
     server::{init_tracing, start_server},

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -7,6 +7,7 @@ use axum::{
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use tower_http::{
+    compression::CompressionLayer,
     cors::{Any, CorsLayer},
     trace::TraceLayer,
 };
@@ -49,7 +50,12 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
         .route("/api/check", post(post_check_api))
         .route("/api/format", post(post_format_api))
         .route("/openapi.json", get(openapi_json))
-        .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()).layer(cors))
+        .layer(
+            ServiceBuilder::new()
+                .layer(CompressionLayer::new())
+                .layer(TraceLayer::new_for_http())
+                .layer(cors),
+        )
         .layer(middleware::from_fn_with_state(rate_limiter, rate_limit_middleware))
         .with_state(state)
 }


### PR DESCRIPTION
- Use mimalloc as global allocator (feature-gated via use_mimalloc)
- Add CompressionLayer for gzip response compression
- Cache OpenAPI spec using OnceLock to avoid recomputing on each request