### PR TITLE
✨ feat(playground): add settings dialog with vim mode and theme support

### DIFF
--- a/packages/mq-playground/package.json
+++ b/packages/mq-playground/package.json
@@ -13,6 +13,7 @@
     "@monaco-editor/react": "^4.7.0",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",
+    "monaco-vim": "^0.4.4",
     "mq-web": "^0.5.24",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/mq-playground/pnpm-lock.yaml
+++ b/packages/mq-playground/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      monaco-vim:
+        specifier: ^0.4.4
+        version: 0.4.4(monaco-editor@0.55.1)
       mq-web:
         specifier: ^0.5.24
         version: 0.5.24
@@ -444,6 +447,11 @@ packages:
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
+  monaco-vim@0.4.4:
+    resolution: {integrity: sha512-LNChAb//WEm/W+eyeHG/0+pdVEHotk2hLTN+M3sQZx5E8cAlSWSgqcxpcRuQnxDybSln7pfHF9i63HmbIQvrWw==}
+    peerDependencies:
+      monaco-editor: '*'
+
   mq-web@0.5.24:
     resolution: {integrity: sha512-w4HRj4F/zqsvSehYeNPQVwA7Dc8DkRedt5yKfm39FCb6mp5G0R7ixabeJXlFgMhLFFcaklkTcx9DbHAsJRTMmg==}
 
@@ -798,6 +806,10 @@ snapshots:
     dependencies:
       dompurify: 3.2.7
       marked: 14.0.0
+
+  monaco-vim@0.4.4(monaco-editor@0.55.1):
+    dependencies:
+      monaco-editor: 0.55.1
 
   mq-web@0.5.24: {}
 

--- a/packages/mq-playground/pnpm-workspace.yaml
+++ b/packages/mq-playground/pnpm-workspace.yaml
@@ -1,1 +1,2 @@
-minimumReleaseAge: 10080
+minimumReleaseAge: 4320
+

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import Editor, { Monaco } from "@monaco-editor/react";
 import "./index.css";
+import "./vim.css";
 import * as mq from "mq-web";
 import { languages, editor, IPosition } from "monaco-editor";
 import LZString from "lz-string";
 import { FileTree } from "./components/FileTree";
 import { ConfirmDialog } from "./components/ConfirmDialog";
+import { SettingsDialog } from "./components/SettingsDialog";
 import { TabBar, Tab } from "./components/TabBar";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { fileSystem, FileNode, OPFSFileSystem } from "./utils/fileSystem";
@@ -18,7 +20,9 @@ import {
   VscLoading,
   VscWordWrap,
   VscMap,
+  VscSettingsGear,
 } from "react-icons/vsc";
+import { initVimMode } from "monaco-vim";
 import { EXAMPLE_CATEGORIES, EXAMPLES } from "./examples";
 
 type SharedData = {
@@ -40,8 +44,52 @@ const ACTIVE_TAB_ID_KEY = "mq-playground.active_tab_id";
 const SIDEBAR_WIDTH_KEY = "mq-playground.sidebar-width";
 const LEFT_RIGHT_SPLIT_KEY = "mq-playground.left-right-split";
 const TOP_BOTTOM_SPLIT_KEY = "mq-playground.top-bottom-split";
-const MINIMAP_ENABLED_KEY = "mq-playground.minimap-enabled";
-const WORD_WRAP_KEY = "mq-playground.word-wrap";
+const EDITOR_SETTINGS_KEY = "mq-playground.editor-settings";
+
+type EditorSettings = {
+  version: number;
+  minimapEnabled: boolean;
+  wordWrap: "on" | "off";
+  vimModeEnabled: boolean;
+  fontSize: number;
+  theme: "light" | "dark" | "system";
+  lineNumbers: "on" | "off";
+  tabSize: number;
+};
+
+const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
+  version: 1,
+  minimapEnabled: false,
+  wordWrap: "off",
+  vimModeEnabled: false,
+  fontSize: 12,
+  theme: "system",
+  lineNumbers: "on",
+  tabSize: 2,
+};
+
+function loadEditorSettings(): EditorSettings {
+  try {
+    const raw = localStorage.getItem(EDITOR_SETTINGS_KEY);
+    return raw
+      ? { ...DEFAULT_EDITOR_SETTINGS, ...JSON.parse(raw) }
+      : DEFAULT_EDITOR_SETTINGS;
+  } catch {
+    return DEFAULT_EDITOR_SETTINGS;
+  }
+}
+
+function saveEditorSettings(settings: Partial<EditorSettings>) {
+  try {
+    const current = loadEditorSettings();
+    localStorage.setItem(
+      EDITOR_SETTINGS_KEY,
+      JSON.stringify({ ...current, ...settings }),
+    );
+  } catch {
+    // ignore
+  }
+}
 
 export const Playground = () => {
   const [code, setCode] = useState<string | undefined>(
@@ -125,12 +173,25 @@ export const Playground = () => {
     const stored = Number(localStorage.getItem(TOP_BOTTOM_SPLIT_KEY));
     return stored > 0 ? stored : 50;
   });
+  const _initialSettings = loadEditorSettings();
   const [minimapEnabled, setMinimapEnabled] = useState(
-    localStorage.getItem(MINIMAP_ENABLED_KEY) === "true",
+    _initialSettings.minimapEnabled,
   );
   const [wordWrap, setWordWrap] = useState<"on" | "off">(
-    localStorage.getItem(WORD_WRAP_KEY) === "on" ? "on" : "off",
+    _initialSettings.wordWrap,
   );
+  const [lineNumbers, setLineNumbers] = useState<"on" | "off">(
+    _initialSettings.lineNumbers,
+  );
+  const [tabSize, setTabSize] = useState(_initialSettings.tabSize);
+  const [vimModeEnabled, setVimModeEnabled] = useState(
+    _initialSettings.vimModeEnabled,
+  );
+  const [fontSize, setFontSize] = useState(_initialSettings.fontSize);
+  const [theme, setTheme] = useState<"light" | "dark" | "system">(
+    _initialSettings.theme,
+  );
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [cursorPosition, setCursorPosition] = useState({
     line: 1,
     column: 1,
@@ -152,6 +213,10 @@ export const Playground = () => {
   });
   const hasInitialized = useRef(false);
   const enableTypeCheckRef = useRef(enableTypeCheck);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const vimModeRef = useRef<any>(null);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const vimStatusBarRef = useRef<HTMLDivElement>(null);
 
   // Keep enableTypeCheckRef in sync with state
   useEffect(() => {
@@ -922,6 +987,24 @@ export const Playground = () => {
     );
   }, [isSidebarVisible]);
 
+  useEffect(() => {
+    saveEditorSettings({
+      vimModeEnabled,
+      fontSize,
+      theme,
+      lineNumbers,
+      tabSize,
+      minimapEnabled,
+      wordWrap,
+    });
+
+    if (theme === "system") {
+      document.documentElement.style.colorScheme = "";
+    } else {
+      document.documentElement.style.colorScheme = theme;
+    }
+  }, [vimModeEnabled, fontSize, theme, lineNumbers, tabSize, minimapEnabled, wordWrap]);
+
   // Add keyboard shortcut for save (Ctrl+S / Cmd+S)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -940,6 +1023,27 @@ export const Playground = () => {
   const toggleSidebar = useCallback(() => {
     setIsSidebarVisible((prev) => !prev);
   }, []);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      if (vimModeEnabled) {
+        if (!vimModeRef.current) {
+          vimModeRef.current = initVimMode(
+            editorRef.current,
+            vimStatusBarRef.current,
+          );
+        }
+      } else {
+        if (vimModeRef.current) {
+          vimModeRef.current.dispose();
+          vimModeRef.current = null;
+          if (vimStatusBarRef.current) {
+            vimStatusBarRef.current.innerHTML = "";
+          }
+        }
+      }
+    }
+  }, [vimModeEnabled]);
 
   const handleSidebarResize = useCallback((delta: number) => {
     setSidebarWidth((prev) => {
@@ -980,28 +1084,14 @@ export const Playground = () => {
   }, []);
 
   const toggleMinimap = useCallback(() => {
-    setMinimapEnabled((prev) => {
-      const next = !prev;
-      localStorage.setItem(MINIMAP_ENABLED_KEY, String(next));
-      return next;
-    });
+    setMinimapEnabled((prev) => !prev);
   }, []);
 
   const toggleWordWrap = useCallback(() => {
-    setWordWrap((prev) => {
-      const next = prev === "on" ? "off" : "on";
-      localStorage.setItem(WORD_WRAP_KEY, next);
-      return next;
-    });
+    setWordWrap((prev) => (prev === "on" ? "off" : "on"));
   }, []);
 
   const beforeMount = (monaco: Monaco) => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const themeParam = urlParams.get("theme");
-    const isDarkMode = !themeParam
-      ? window.matchMedia("(prefers-color-scheme: dark)").matches
-      : themeParam === "dark";
-
     monaco.editor.addEditorAction({
       id: "run-script",
       label: "Run Script",
@@ -1313,50 +1403,64 @@ export const Playground = () => {
       includeLF: true,
     });
 
-    monaco.editor.defineTheme("mq-base", {
-      base: isDarkMode ? "vs-dark" : "vs",
+    const rules = (dark: boolean) => [
+      {
+        token: "comment",
+        foreground: dark ? "#6A9955" : "#008000",
+        fontStyle: "italic",
+      },
+      {
+        token: "keyword",
+        foreground: dark ? "#569CD6" : "#0000FF",
+        fontStyle: "bold",
+      },
+      { token: "function", foreground: dark ? "#DCDCAA" : "#795E26" },
+      { token: "variable", foreground: dark ? "#9CDCFE" : "#001080" },
+      { token: "property", foreground: dark ? "#9CDCFE" : "#001080" },
+      { token: "string", foreground: dark ? "#CE9178" : "#A31515" },
+      { token: "number", foreground: dark ? "#B5CEA8" : "#098658" },
+      {
+        token: "operator",
+        foreground: dark ? "#D4D4D4" : "#000000",
+        fontStyle: "bold",
+      },
+      { token: "delimiter", foreground: dark ? "#D4D4D4" : "#000000" },
+      { token: "identifier", foreground: dark ? "#D4D4D4" : "#000000" },
+    ];
+
+    monaco.editor.defineTheme("mq-dark", {
+      base: "vs-dark",
       inherit: true,
-      rules: [
-        {
-          token: "comment",
-          foreground: isDarkMode ? "#6A9955" : "#008000",
-          fontStyle: "italic",
-        },
-        {
-          token: "keyword",
-          foreground: isDarkMode ? "#569CD6" : "#0000FF",
-          fontStyle: "bold",
-        },
-        { token: "function", foreground: isDarkMode ? "#DCDCAA" : "#795E26" },
-        { token: "variable", foreground: isDarkMode ? "#9CDCFE" : "#001080" },
-        { token: "property", foreground: isDarkMode ? "#9CDCFE" : "#001080" },
-        { token: "string", foreground: isDarkMode ? "#CE9178" : "#A31515" },
-        { token: "number", foreground: isDarkMode ? "#B5CEA8" : "#098658" },
-        {
-          token: "operator",
-          foreground: isDarkMode ? "#D4D4D4" : "#000000",
-          fontStyle: "bold",
-        },
-        { token: "delimiter", foreground: isDarkMode ? "#D4D4D4" : "#000000" },
-        { token: "identifier", foreground: isDarkMode ? "#D4D4D4" : "#000000" },
-      ],
-      colors: isDarkMode
-        ? {
-            "editor.background": "#1E1E1E",
-            "editor.foreground": "#D4D4D4",
-            "editorLineNumber.foreground": "#858585",
-            "editor.lineHighlightBackground": "#2D2D30",
-            "editorCursor.foreground": "#A7A7A7",
-          }
-        : {
-            "editor.background": "#FFFFFF",
-            "editor.foreground": "#000000",
-            "editorLineNumber.foreground": "#237893",
-            "editor.lineHighlightBackground": "#F3F3F3",
-            "editorCursor.foreground": "#000000",
-          },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      rules: rules(true) as any,
+      colors: {
+        "editor.background": "#1E1E1E",
+        "editor.foreground": "#D4D4D4",
+        "editorLineNumber.foreground": "#858585",
+        "editor.lineHighlightBackground": "#2D2D30",
+        "editorCursor.foreground": "#A7A7A7",
+      },
+    });
+
+    monaco.editor.defineTheme("mq-light", {
+      base: "vs",
+      inherit: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      rules: rules(false) as any,
+      colors: {
+        "editor.background": "#FFFFFF",
+        "editor.foreground": "#000000",
+        "editorLineNumber.foreground": "#237893",
+        "editor.lineHighlightBackground": "#F3F3F3",
+        "editorCursor.foreground": "#000000",
+      },
     });
   };
+
+  const isDarkMode =
+    theme === "system"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : theme === "dark";
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -1410,6 +1514,13 @@ export const Playground = () => {
               marginRight: "8px",
             }}
           >
+            <button
+              className="header-icon-button"
+              onClick={() => setIsSettingsOpen(true)}
+              title="Settings"
+            >
+              <VscSettingsGear size={16} />
+            </button>
             <a
               href="https://github.com/harehare/mq"
               target="_blank"
@@ -1545,25 +1656,43 @@ export const Playground = () => {
                 onChange={setCode}
                 beforeMount={beforeMount}
                 onMount={(editor) => {
+                  editorRef.current = editor as editor.IStandaloneCodeEditor;
                   const disposable = editor.onDidChangeCursorPosition((e) => {
                     setCursorPosition({
                       line: e.position.lineNumber,
                       column: e.position.column,
                     });
                   });
-                  editor.onDidDispose(() => disposable.dispose());
+
+                  if (vimModeEnabled && !vimModeRef.current) {
+                    vimModeRef.current = initVimMode(
+                      editor,
+                      vimStatusBarRef.current,
+                    );
+                  }
+
+                  editor.onDidDispose(() => {
+                    disposable.dispose();
+                    if (vimModeRef.current) {
+                      vimModeRef.current.dispose();
+                      vimModeRef.current = null;
+                    }
+                    editorRef.current = null;
+                  });
                 }}
                 options={{
                   minimap: { enabled: minimapEnabled },
                   scrollBeyondLastLine: false,
-                  fontSize: 12,
+                  fontSize,
                   automaticLayout: true,
                   fontFamily:
                     "'JetBrains Mono', 'Source Code Pro', Menlo, monospace",
                   fontLigatures: true,
                   wordWrap,
+                  lineNumbers,
+                  tabSize,
                 }}
-                theme="mq-base"
+                theme={isDarkMode ? "mq-dark" : "mq-light"}
               />
             </div>
           </div>
@@ -1600,13 +1729,15 @@ export const Playground = () => {
                 options={{
                   minimap: { enabled: false },
                   scrollBeyondLastLine: false,
-                  fontSize: 12,
+                  fontSize,
                   automaticLayout: true,
                   fontFamily:
                     "'JetBrains Mono', 'Source Code Pro', Menlo, monospace",
                   fontLigatures: true,
+                  lineNumbers,
+                  tabSize,
                 }}
-                theme="mq-base"
+                theme={isDarkMode ? "mq-dark" : "mq-light"}
               />
             </div>
           </div>
@@ -1745,10 +1876,10 @@ export const Playground = () => {
                   domReadOnly: true,
                   minimap: { enabled: false },
                   scrollBeyondLastLine: false,
-                  fontSize: 12,
+                  fontSize,
                   automaticLayout: true,
                 }}
-                theme="mq-base"
+                theme={isDarkMode ? "mq-dark" : "mq-light"}
               />
             )}
             {activeTab === "ast" && (
@@ -1762,10 +1893,10 @@ export const Playground = () => {
                   domReadOnly: true,
                   minimap: { enabled: false },
                   scrollBeyondLastLine: false,
-                  fontSize: 12,
+                  fontSize,
                   automaticLayout: true,
                 }}
-                theme="mq-base"
+                theme={isDarkMode ? "mq-dark" : "mq-light"}
               />
             )}
           </div>
@@ -1775,6 +1906,16 @@ export const Playground = () => {
       {!isEmbed && (
         <footer className="playground-footer">
           <div className="footer-left">
+            <div
+              ref={vimStatusBarRef}
+              className="vim-status-bar"
+              style={{
+                display: vimModeEnabled ? "block" : "none",
+                minWidth: "100px",
+                fontFamily: "monospace",
+                fontSize: "11px",
+              }}
+            />
             {currentFilePath && (
               <>
                 <div className="footer-item">
@@ -1848,6 +1989,25 @@ export const Playground = () => {
           onCancel={() => setDeleteConfirmDialog(null)}
         />
       )}
+
+      <SettingsDialog
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        vimModeEnabled={vimModeEnabled}
+        onVimModeToggle={setVimModeEnabled}
+        fontSize={fontSize}
+        onFontSizeChange={setFontSize}
+        theme={theme}
+        onThemeChange={setTheme}
+        minimapEnabled={minimapEnabled}
+        onMinimapToggle={setMinimapEnabled}
+        wordWrap={wordWrap}
+        onWordWrapToggle={setWordWrap}
+        lineNumbers={lineNumbers}
+        onLineNumbersToggle={setLineNumbers}
+        tabSize={tabSize}
+        onTabSizeChange={setTabSize}
+      />
     </div>
   );
 };

--- a/packages/mq-playground/src/components/SettingsDialog.css
+++ b/packages/mq-playground/src/components/SettingsDialog.css
@@ -1,0 +1,106 @@
+.settings-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.settings-dialog {
+    background-color: light-dark(#ffffff, #1e1e1e);
+    color: light-dark(#2d3748, #e2e8f0);
+    border-radius: 8px;
+    width: 400px;
+    max-width: 90%;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-header {
+    padding: 16px;
+    border-bottom: 1px solid light-dark(#e2e8f0, #333);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.settings-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.settings-close-btn {
+    background: none;
+    border: none;
+    color: light-dark(#718096, #a0aec0);
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.settings-close-btn:hover {
+    background-color: light-dark(#edf2f7, #2d2d2d);
+    color: light-dark(#2d3748, #ffffff);
+}
+
+.settings-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.settings-section h4 {
+    margin: 0 0 12px 0;
+    font-size: 0.9rem;
+    color: var(--accent-blue);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.settings-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.settings-item label {
+    font-size: 0.95rem;
+}
+
+.settings-select {
+    padding: 6px 10px;
+    border-radius: 4px;
+    background-color: light-dark(#f7fafc, #2d2d30);
+    border: 1px solid light-dark(#cbd5e0, #3e3e42);
+    color: light-dark(#2d3748, #d4d4d4);
+}
+
+.font-size-control {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.font-size-control span {
+    font-size: 0.9rem;
+    width: 40px;
+    text-align: right;
+}
+
+input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}

--- a/packages/mq-playground/src/components/SettingsDialog.tsx
+++ b/packages/mq-playground/src/components/SettingsDialog.tsx
@@ -1,0 +1,145 @@
+import { VscClose } from "react-icons/vsc";
+import "./SettingsDialog.css";
+
+type SettingsDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  vimModeEnabled: boolean;
+  onVimModeToggle: (enabled: boolean) => void;
+  fontSize: number;
+  onFontSizeChange: (size: number) => void;
+  theme: "light" | "dark" | "system";
+  onThemeChange: (theme: "light" | "dark" | "system") => void;
+  minimapEnabled: boolean;
+  onMinimapToggle: (enabled: boolean) => void;
+  wordWrap: "on" | "off";
+  onWordWrapToggle: (wordWrap: "on" | "off") => void;
+  lineNumbers: "on" | "off";
+  onLineNumbersToggle: (lineNumbers: "on" | "off") => void;
+  tabSize: number;
+  onTabSizeChange: (size: number) => void;
+};
+
+export const SettingsDialog = ({
+  isOpen,
+  onClose,
+  vimModeEnabled,
+  onVimModeToggle,
+  fontSize,
+  onFontSizeChange,
+  theme,
+  onThemeChange,
+  minimapEnabled,
+  onMinimapToggle,
+  wordWrap,
+  onWordWrapToggle,
+  lineNumbers,
+  onLineNumbersToggle,
+  tabSize,
+  onTabSizeChange,
+}: SettingsDialogProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="settings-overlay" onClick={onClose}>
+      <div className="settings-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="settings-header">
+          <h3>Settings</h3>
+          <button className="settings-close-btn" onClick={onClose}>
+            <VscClose size={20} />
+          </button>
+        </div>
+        <div className="settings-content">
+          <div className="settings-section">
+            <h4>Editor</h4>
+            <div className="settings-item">
+              <label htmlFor="vim-mode">Vim Mode</label>
+              <input
+                id="vim-mode"
+                type="checkbox"
+                checked={vimModeEnabled}
+                onChange={(e) => onVimModeToggle(e.target.checked)}
+              />
+            </div>
+            <div className="settings-item">
+              <label htmlFor="minimap">Minimap</label>
+              <input
+                id="minimap"
+                type="checkbox"
+                checked={minimapEnabled}
+                onChange={(e) => onMinimapToggle(e.target.checked)}
+              />
+            </div>
+            <div className="settings-item">
+              <label htmlFor="word-wrap">Word Wrap</label>
+              <input
+                id="word-wrap"
+                type="checkbox"
+                checked={wordWrap === "on"}
+                onChange={(e) =>
+                  onWordWrapToggle(e.target.checked ? "on" : "off")
+                }
+              />
+            </div>
+            <div className="settings-item">
+              <label htmlFor="line-numbers">Line Numbers</label>
+              <input
+                id="line-numbers"
+                type="checkbox"
+                checked={lineNumbers === "on"}
+                onChange={(e) =>
+                  onLineNumbersToggle(e.target.checked ? "on" : "off")
+                }
+              />
+            </div>
+            <div className="settings-item">
+              <label htmlFor="font-size">Font Size</label>
+              <div className="font-size-control">
+                <input
+                  id="font-size"
+                  type="range"
+                  min="10"
+                  max="24"
+                  value={fontSize}
+                  onChange={(e) => onFontSizeChange(parseInt(e.target.value))}
+                />
+                <span>{fontSize}px</span>
+              </div>
+            </div>
+            <div className="settings-item">
+              <label htmlFor="tab-size">Tab Size</label>
+              <select
+                id="tab-size"
+                className="settings-select"
+                value={tabSize}
+                onChange={(e) => onTabSizeChange(parseInt(e.target.value))}
+              >
+                <option value="2">2</option>
+                <option value="4">4</option>
+                <option value="8">8</option>
+              </select>
+            </div>
+          </div>
+          <div className="settings-section">
+            <h4>Appearance</h4>
+            <div className="settings-item">
+              <label htmlFor="theme-select">Theme</label>
+              <select
+                id="theme-select"
+                className="settings-select"
+                value={theme}
+                onChange={(e) =>
+                  onThemeChange(e.target.value as "light" | "dark" | "system")
+                }
+              >
+                <option value="system">System</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/mq-playground/src/index.css
+++ b/packages/mq-playground/src/index.css
@@ -45,7 +45,9 @@ body {
   border: none;
   color: var(--header-icon-color);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: 0;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -418,10 +420,6 @@ body {
 
 /* Mobile breakpoint - stacks vertically */
 @media (max-width: 768px) {
-
-  .header-icon-button {
-    padding: 4px;
-  }
 
   .footer-left {
     gap: 8px;

--- a/packages/mq-playground/src/vim.css
+++ b/packages/mq-playground/src/vim.css
@@ -1,0 +1,8 @@
+.vim-status-bar {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.vim-status-bar .vim-notification {
+    padding-left: 10px;
+}


### PR DESCRIPTION
- Add SettingsDialog component with controls for vim mode, minimap, word wrap, line numbers, font size, tab size, and theme
- Integrate monaco-vim for vim keybinding support in the editor
- Replace separate localStorage keys with unified EDITOR_SETTINGS_KEY
- Add separate mq-dark/mq-light Monaco themes with system/light/dark toggle
- Add vim status bar display in footer