### PR TITLE
refactor: migrate installation to XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Since LLM inputs are primarily in Markdown format, mq provides efficient tools f
 - **REPL Support**: Interactive command-line REPL for testing and experimenting.
 - **IDE Support**: VSCode Extension and Language Server **Protocol** (LSP) support for custom function development.
 - **Debugger**: Includes an experimental debugger (`mq-dbg`) for inspecting and stepping through mq queries interactively.
-- **External Subcommands**: Extend mq with custom subcommands by placing executable files starting with `mq-` in `~/.mq/bin/`.
+- **External Subcommands**: Extend mq with custom subcommands by placing executable files starting with `mq-` in `~/.local/bin/`.
 
 ## Installation
 
@@ -61,7 +61,7 @@ curl -sSL https://mqlang.org/install.sh | bash
 The installer will:
 
 - Download the latest mq binary for your platform
-- Install it to `~/.mq/bin/`
+- Install it to `~/.local/bin/`
 - Update your shell profile to add mq to your PATH
 
 ### Cargo

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -235,10 +235,10 @@ enum Commands {
 }
 
 impl Cli {
-    /// Get the path to the external commands directory (~/.mq/bin)
+    /// Get the path to the external commands directory (~/.local/bin)
     fn get_external_commands_dir() -> Option<PathBuf> {
         let home_dir = dirs::home_dir()?;
-        let mq_bin_dir = home_dir.join(".mq").join("bin");
+        let mq_bin_dir = home_dir.join(".local").join("bin");
         if mq_bin_dir.exists() && mq_bin_dir.is_dir() {
             Some(mq_bin_dir)
         } else {
@@ -246,11 +246,11 @@ impl Cli {
         }
     }
 
-    /// Find all external commands (mq-* files in ~/.mq/bin and PATH)
+    /// Find all external commands (mq-* files in ~/.local/bin and PATH)
     fn find_external_commands() -> Vec<String> {
         let mut seen = std::collections::HashSet::new();
 
-        // Search ~/.mq/bin first
+        // Search ~/.local/bin first
         if let Some(bin_dir) = Self::get_external_commands_dir() {
             Self::collect_mq_commands_from_dir(&bin_dir, &mut seen);
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,8 +5,7 @@ set -e
 # mq installation script
 
 readonly MQ_REPO="harehare/mq"
-readonly MQ_INSTALL_DIR="$HOME/.mq"
-readonly MQ_BIN_DIR="$MQ_INSTALL_DIR/bin"
+readonly MQ_BIN_DIR="${MQ_HOME:-${XDG_DATA_HOME:-$HOME/.local}/bin}"
 
 # Installation options
 INSTALL_DEBUG=false


### PR DESCRIPTION
## Problem

The current mq installer uses `~/.mq/bin/` for binary installation, which doesn't follow the standard `~/.local/bin/` path used by most tools.

## Solution

Migrate to `~/.local/bin/` following FHS (Filesystem Hierarchy Standard):

- **Binary installation**: `~/.mq/bin/` → `~/.local/bin/`
- Supports environment variable overrides: `MQ_HOME`, `XDG_DATA_HOME`

## Changes

1. **scripts/install.sh** — Updated `MQ_BIN_DIR` to use `~/.local/bin/`
2. **crates/mq-run/src/cli.rs** — Changed path from `~/.mq/bin` to `~/.local/bin`
3. **README.md** — Updated installation path documentation

## Benefits

- ✅ Standards compliant (FHS)
- ✅ Aligns with industry tools (pipx, jq, gh, cargo)
- ✅ Cleaner PATH management
- ✅ Minimal code changes