### PR TITLE
✨ feat(mq-test): add standalone test runner binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           mv target/${{ matrix.target }}/release/mq-lsp${{ matrix.ext }} target/${{ matrix.target }}/release/mq-lsp-${{ matrix.asset_name}}${{ matrix.ext }}
           mv target/${{ matrix.target }}/release/mq-check${{ matrix.ext }} target/${{ matrix.target }}/release/mq-check-${{ matrix.asset_name}}${{ matrix.ext }}
           mv target/${{ matrix.target }}/release/mq-crawl${{ matrix.ext }} target/${{ matrix.target }}/release/mq-crawl-${{ matrix.asset_name}}${{ matrix.ext }}
+          mv target/${{ matrix.target }}/release/mq-test${{ matrix.ext }} target/${{ matrix.target }}/release/mq-test-${{ matrix.asset_name}}${{ matrix.ext }}
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -64,6 +65,7 @@ jobs:
             target/${{ matrix.target }}/release/mq-lsp-${{ matrix.asset_name }}${{ matrix.ext }}
             target/${{ matrix.target }}/release/mq-check-${{ matrix.asset_name }}${{ matrix.ext }}
             target/${{ matrix.target }}/release/mq-crawl-${{ matrix.asset_name }}${{ matrix.ext }}
+            target/${{ matrix.target }}/release/mq-test-${{ matrix.asset_name }}${{ matrix.ext }}
           if-no-files-found: error
           retention-days: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mq-test"
+version = "0.5.25"
+dependencies = [
+ "clap",
+ "glob",
+ "miette",
+ "mq-lang",
+]
+
+[[package]]
 name = "mq-wasm"
 version = "0.5.25"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ members = [
   "crates/mq-crawler",
   "editors/zed",
   "crates/mq-check",
+  "crates/mq-test",
 ]
 resolver = "3"
 
 [workspace.dependencies]
 # Internal crates
 mq-check = {path = "crates/mq-check", version = "0.5.25"}
+mq-test = {path = "crates/mq-test", version = "0.5.25"}
 mq-dap = {path = "crates/mq-dap", version = "0.5.25"}
 mq-formatter = {path = "crates/mq-formatter", version = "0.5.25"}
 mq-hir = {path = "crates/mq-hir", version = "0.5.25"}
@@ -52,6 +54,7 @@ divan = {version = "3.0.5", package = "codspeed-divan-compat"}
 ego-tree = "0.11.0"
 fantoccini = {version = "0.22.1", default-features = false, features = ["rustls-tls"]}
 futures = "0.3"
+glob = "0.3.3"
 httpmock = "0.8.2"
 itertools = "0.14.0"
 js-sys = "0.3.77"

--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -237,7 +237,7 @@ def test_section_filter_sections():
 end
 
 def test_section_map_sections():
-  let level_list = do test_sections | section::map_sections(fn(head, children): section::level(head););
+  let level_list = do test_sections | section::map_sections(fn(head, children): head.level;);
   | assert_eq(level_list, [1, 2, 1])
 end
 
@@ -474,6 +474,7 @@ end
   test_case("Section By Level H2", test_section_by_level_h2),
   test_case("Section By Level Range", test_section_by_level_range),
   test_case("Section By Level Empty", test_section_by_level_empty),
+  test_case("Section Map Sections", test_section_map_sections),
   # table
   test_case("Table Tables", test_table_tables),
   test_case("Table Tables Empty", test_table_tables_empty),

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -21,7 +21,7 @@ use_mimalloc = ["mimalloc"]
 clap = {workspace = true, features = ["derive"]}
 colored = {workspace = true}
 dirs = {workspace = true}
-glob = "0.3.3"
+glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mimalloc = {workspace = true, features = ["v3"], optional = true}
 mq-dap = {workspace = true, optional = true}

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = ["Takahiro Sato <harehare1110@gmail.com>"]
+categories = ["command-line-utilities", "text-processing"]
+description = "Test runner for mq"
+edition = "2024"
+homepage = "https://mqlang.org/"
+keywords = ["markdown", "jq", "query", "test"]
+license = "MIT"
+name = "mq-test"
+repository = "https://github.com/harehare/mq"
+version = "0.5.25"
+
+[dependencies]
+clap = {workspace = true, features = ["derive"]}
+glob = {workspace = true}
+miette = {workspace = true, features = ["fancy"]}
+mq-lang = {workspace = true, features = ["cst", "file-io"]}
+
+[[bin]]
+name = "mq-test"
+path = "src/main.rs"

--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -1,0 +1,121 @@
+<h1 align="center">mq-test</h1>
+
+Standalone test runner for mq — auto-discovers and executes test functions in `.mq` files.
+
+## Overview
+
+`mq-test` discovers test functions in `.mq` files and runs them using the mq engine. A function is treated as a test if:
+
+- Its name starts with `test_`, **OR**
+- It is immediately preceded by a `# @test` annotation comment.
+
+Test discovery uses the CST so both conventions are resolved accurately without any line-scanning heuristics.
+
+## Installation
+
+```bash
+cargo install mq-test
+```
+
+## Usage
+
+```bash
+# Run all *.mq files in the current directory (recursive)
+mq-test
+
+# Run a specific test file
+mq-test tests.mq
+
+# Run multiple test files
+mq-test tests.mq other_tests.mq
+```
+
+## Writing Tests
+
+### Naming Convention
+
+Any function whose name begins with `test_` is automatically treated as a test:
+
+```mq
+include "test"
+|
+
+def test_is_array():
+  assert_eq(is_array([1, 2, 3]), true)
+end
+```
+
+### Annotation Convention
+
+Use the `# @test` comment immediately before a function to mark it as a test regardless of its name:
+
+```mq
+include "test"
+|
+
+# @test
+def check_string_len():
+  assert_eq(len("hello"), 5)
+end
+```
+
+### Test Helpers
+
+Tests use the built-in `assert_eq` and related helpers from the `test` module:
+
+| Function                   | Description                             |
+| -------------------------- | --------------------------------------- |
+| `assert_eq(actual, expect)` | Fails if `actual != expect`            |
+| `assert(cond)`              | Fails if `cond` is not `true`          |
+| `test_case(name, fn)`       | Registers a named test case            |
+| `run_tests(cases)`          | Runs all registered test cases         |
+
+The runner automatically generates a `run_tests([...])` call from all discovered test functions — test files do not need to maintain a manual list.
+
+## Example
+
+```mq
+include "test"
+|
+
+def test_add():
+  assert_eq(1 + 1, 2)
+end
+
+def test_string_upcase():
+  assert_eq(upcase("hello"), "HELLO")
+end
+
+# @test
+def verify_array_length():
+  assert_eq(length([1, 2, 3]), 3)
+end
+```
+
+```bash
+$ mq-test example.mq
+✓ add
+✓ string_upcase
+✓ verify_array_length
+
+3 passed, 0 failed
+```
+
+## Development
+
+### Running Tests
+
+```bash
+just test
+```
+
+### Building
+
+```bash
+cargo build -p mq-test
+```
+
+## License
+
+MIT
+

--- a/crates/mq-test/src/lib.rs
+++ b/crates/mq-test/src/lib.rs
@@ -1,0 +1,2 @@
+mod runner;
+pub use runner::TestRunner;

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -1,7 +1,7 @@
 mod runner;
 
 use clap::Parser;
-use std::path::PathBuf;
+use std::{path::PathBuf, process::ExitCode};
 
 #[derive(Parser, Debug)]
 #[command(name = "mq-test")]
@@ -20,11 +20,13 @@ struct Cli {
     files: Vec<PathBuf>,
 }
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
     if let Err(e) = runner::TestRunner::new(cli.files).run() {
         eprintln!("{e:?}");
-        std::process::exit(1);
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
     }
 }

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -1,0 +1,30 @@
+mod runner;
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "mq-test")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(about = "Test runner for mq — auto-discovers test_ functions and runs them")]
+#[command(after_help = "# Examples:\n\n\
+    ## Run all tests in a specific file:\n\
+    mq-test tests.mq\n\n\
+    ## Run tests across multiple files:\n\
+    mq-test tests.mq other_tests.mq\n\n\
+    ## Discover and run all *.mq files in the current directory:\n\
+    mq-test")]
+struct Cli {
+    /// Path(s) to mq test files.
+    /// Defaults to **/*.mq in the current directory when omitted.
+    files: Vec<PathBuf>,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    if let Err(e) = runner::TestRunner::new(cli.files).run() {
+        eprintln!("{e:?}");
+        std::process::exit(1);
+    }
+}

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -1,0 +1,175 @@
+use glob::glob;
+use miette::IntoDiagnostic;
+use mq_lang::{CstNodeKind, CstTrivia};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Discovers and runs mq test functions from `.mq` files.
+///
+/// A function is treated as a test if:
+/// - Its name starts with `test_`, OR
+/// - It is immediately preceded by a `# @test` annotation comment.
+///
+/// Test discovery uses the CST so that both conditions are resolved accurately
+/// without any line-scanning heuristics.
+///
+/// The runner auto-generates the `run_tests([...])` call so test files do not
+/// need to maintain a manual list of test cases.
+pub struct TestRunner {
+    files: Vec<PathBuf>,
+}
+
+impl TestRunner {
+    /// Create a new `TestRunner` for the given files.
+    ///
+    /// If `files` is empty the runner will glob `**/*.mq` in the current
+    /// working directory.
+    pub fn new(files: Vec<PathBuf>) -> Self {
+        Self { files }
+    }
+
+    /// Discover and execute all test functions.
+    ///
+    /// Files that contain no test functions are skipped silently.
+    /// Returns an error (and stops) if any test fails or if a file cannot be
+    /// read / executed.
+    pub fn run(self) -> miette::Result<()> {
+        let test_files: Vec<PathBuf> = if self.files.is_empty() {
+            glob("./**/*.mq")
+                .into_diagnostic()?
+                .collect::<Result<Vec<_>, _>>()
+                .into_diagnostic()?
+        } else {
+            self.files
+        };
+
+        for file in &test_files {
+            let content = fs::read_to_string(file).into_diagnostic()?;
+            let test_names = Self::discover_test_functions(&content);
+            if test_names.is_empty() {
+                continue;
+            }
+
+            let query = Self::build_test_query(&content, &test_names);
+            let mut engine = mq_lang::DefaultEngine::default();
+            engine.load_builtin_module();
+
+            // Add the file's directory to the search path so relative `include`
+            // statements in the test file resolve correctly.
+            if let Some(parent) = file.parent()
+                && parent != Path::new("")
+            {
+                engine.set_search_paths(vec![parent.to_path_buf()]);
+            }
+
+            let input = mq_lang::null_input();
+            engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
+        }
+
+        Ok(())
+    }
+
+    /// Parse `content` via the CST and return the names of all test functions.
+    ///
+    /// A top-level `def` node is included when:
+    /// - Its name starts with `test_`, OR
+    /// - Its `leading_trivia` contains a comment whose text (trimmed) is `@test`.
+    fn discover_test_functions(content: &str) -> Vec<String> {
+        let (nodes, _) = mq_lang::parse_recovery(content);
+        let mut names = Vec::new();
+
+        for node in &nodes {
+            if node.kind != CstNodeKind::Def {
+                continue;
+            }
+
+            // The function name is children[0] — same convention as the formatter.
+            let func_name = match node.children.first() {
+                Some(child) => child.to_string(),
+                None => continue,
+            };
+
+            if func_name.is_empty() {
+                continue;
+            }
+
+            if func_name.starts_with("test_") || Self::has_test_annotation(&node.leading_trivia) {
+                names.push(func_name);
+            }
+        }
+
+        names
+    }
+
+    /// Returns `true` if `trivia` contains a `# @test` annotation comment.
+    fn has_test_annotation(trivia: &[CstTrivia]) -> bool {
+        trivia
+            .iter()
+            .any(|t| t.comment().is_some_and(|c| c.trim() == "@test"))
+    }
+
+    /// Append an auto-generated `run_tests([…])` call to the file content.
+    ///
+    /// Display names strip the `test_` prefix to match the existing manual
+    /// convention (e.g. `test_is_array` → `"is_array"`).
+    fn build_test_query(content: &str, test_names: &[String]) -> String {
+        let cases = test_names
+            .iter()
+            .map(|name| {
+                let display = name.strip_prefix("test_").unwrap_or(name);
+                format!("  test_case(\"{display}\", {name})")
+            })
+            .collect::<Vec<_>>()
+            .join(",\n");
+
+        format!("{content}\n| run_tests([\n{cases}\n])")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discover_test_prefix() {
+        let content = r#"
+def test_foo():
+  None
+end
+
+def helper():
+  None
+end
+
+def test_bar():
+  None
+end
+"#;
+        let names = TestRunner::discover_test_functions(content);
+        assert_eq!(names, vec!["test_foo", "test_bar"]);
+    }
+
+    #[test]
+    fn test_discover_annotation() {
+        let content = "# @test\ndef my_check():\n  None\nend\n\ndef not_a_test():\n  None\nend\n";
+        let names = TestRunner::discover_test_functions(content);
+        assert_eq!(names, vec!["my_check"]);
+    }
+
+    #[test]
+    fn test_build_test_query_strips_prefix() {
+        let content = "include \"test\"\n|";
+        let names = vec!["test_foo".to_string(), "test_bar".to_string()];
+        let query = TestRunner::build_test_query(content, &names);
+        assert!(query.contains("test_case(\"foo\", test_foo)"));
+        assert!(query.contains("test_case(\"bar\", test_bar)"));
+    }
+
+    #[test]
+    fn test_build_test_query_annotation_no_strip() {
+        let content = "include \"test\"\n|";
+        let names = vec!["my_check".to_string()];
+        let query = TestRunner::build_test_query(content, &names);
+        assert!(query.contains("test_case(\"my_check\", my_check)"));
+    }
+}

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -103,9 +103,7 @@ impl TestRunner {
 
     /// Returns `true` if `trivia` contains a `# @test` annotation comment.
     fn has_test_annotation(trivia: &[CstTrivia]) -> bool {
-        trivia
-            .iter()
-            .any(|t| t.comment().is_some_and(|c| c.trim() == "@test"))
+        trivia.iter().any(|t| t.comment().is_some_and(|c| c.trim() == "@test"))
     }
 
     /// Append an auto-generated `run_tests([…])` call to the file content.

--- a/justfile
+++ b/justfile
@@ -25,14 +25,14 @@ bench-local:
 build:
     cargo build --release -p mq-run --bin mq
     cargo build --release -p mq-run --bin mq-dbg --features="debugger"
-    cargo build --release -p mq-lsp -p mq-crawler
+    cargo build --release -p mq-lsp -p mq-crawler -p mq-test
     cargo build --release -p mq-check --features="cli"
 
 # Build for a specific target architecture
 build-target target:
     cargo build --release --target {{target}} -p mq-run --bin mq
     cargo build --release --target {{target}} -p mq-run --bin mq-dbg --features="debugger"
-    cargo build --release --target {{target}} -p mq-lsp -p mq-crawler
+    cargo build --release --target {{target}} -p mq-lsp -p mq-crawler -p mq-test
     cargo build --release --target {{target}} -p mq-check --features="cli"
 
 # Build benchmarks with codspeed


### PR DESCRIPTION
Add `mq-test` as a new standalone crate with its own binary. Test functions are auto-discovered from `.mq` files via the CST (`mq_lang::parse_recovery`) — no manual `run_tests([...])` list needed.

Discovery rules:
- `def test_*` functions are included automatically
- `def` preceded by `# @test` annotation is included regardless of name

Function name is extracted from `children[0]` of the Def CST node, consistent with how mq-formatter resolves identifiers. Comment annotations are read from `node.leading_trivia`.

Usage:
```
  mq-test file.mq          # run tests in specific file
  mq-test                  # glob **/*.mq in current directory
```