### PR TITLE
Format code using cargo fmt

### DIFF
--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -103,9 +103,7 @@ impl TestRunner {
 
     /// Returns `true` if `trivia` contains a `# @test` annotation comment.
     fn has_test_annotation(trivia: &[CstTrivia]) -> bool {
-        trivia
-            .iter()
-            .any(|t| t.comment().is_some_and(|c| c.trim() == "@test"))
+        trivia.iter().any(|t| t.comment().is_some_and(|c| c.trim() == "@test"))
     }
 
     /// Append an auto-generated `run_tests([…])` call to the file content.


### PR DESCRIPTION
Applied `cargo fmt --all` to the workspace. This ensures all Rust code adheres to the project's formatting standards defined in `rustfmt.toml`. Only `crates/mq-test/src/runner.rs` was affected in this run.

---
*PR created automatically by Jules for task [14298677602096132075](https://jules.google.com/task/14298677602096132075) started by @harehare*