### PR TITLE
🐛 fix(mq-run): use binary placeholder in binstall pkg-url template

### DIFF
--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -55,7 +55,7 @@ required-features = ["debugger"]
 
 [package.metadata.binstall]
 pkg-fmt = "bin"
-pkg-url = "{ repo }/releases/download/v{ version }/mq-{ target }{ binary-ext }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ binary }-{ target }{ binary-ext }"
 
 [package.metadata.binstall.overrides.mq-dbg]
 pkg-url = "{ disabled }"


### PR DESCRIPTION
Replace hardcoded `mq-` prefix with `{ binary }` placeholder so the binstall URL template correctly resolves for all binary names.