### PR TITLE
✨ feat(mq-web-api): add OpenTelemetry tracing support via otel feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1733,6 +1733,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,7 +2368,7 @@ dependencies = [
  "miette",
  "mq-lang",
  "mq-markdown",
- "reqwest",
+ "reqwest 0.13.2",
  "robots_txt",
  "rstest",
  "scraper",
@@ -2595,6 +2608,9 @@ dependencies = [
  "mq-hir",
  "mq-lang",
  "mq-markdown",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2602,6 +2618,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
@@ -2798,6 +2815,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "opfs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +3017,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3150,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3290,6 +3426,40 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reqwest"
@@ -4309,6 +4479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4578,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "toon-format"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,9 +4640,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4527,6 +4748,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,11 @@ toml = "1.1"
 tower = "0.5.3"
 tower-http = "0.6.8"
 tower-lsp-server = "0.23.0"
+opentelemetry = "0.31"
+opentelemetry-otlp = {version = "0.31", features = ["grpc-tonic"]}
+opentelemetry_sdk = {version = "0.31", features = ["rt-tokio"]}
 tracing = "0.1.44"
+tracing-opentelemetry = "0.32"
 tracing-subscriber = "0.3.23"
 url = "2.5.8"
 utoipa = "5.4"

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -15,12 +15,17 @@ version = "0.5.26"
 [features]
 default = ["use_mimalloc"]
 use_mimalloc = ["mimalloc"]
+otel = ["opentelemetry", "opentelemetry-otlp", "opentelemetry_sdk", "tracing-opentelemetry"]
 
 [dependencies]
 async-trait = {workspace = true}
 axum = {workspace = true}
 miette = {workspace = true}
 mimalloc = {workspace = true, features = ["v3"], optional = true}
+opentelemetry = {workspace = true, optional = true}
+opentelemetry-otlp = {workspace = true, optional = true}
+opentelemetry_sdk = {workspace = true, optional = true}
+tracing-opentelemetry = {workspace = true, optional = true}
 mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}

--- a/crates/mq-web-api/src/config.rs
+++ b/crates/mq-web-api/src/config.rs
@@ -9,6 +9,10 @@ pub struct Config {
     pub log_format: LogFormat,
     pub cors_origins: Vec<String>,
     pub rate_limit: RateLimitConfig,
+    /// OTLP exporter endpoint (e.g. `http://localhost:4317`). Requires the `otel` feature.
+    pub otel_endpoint: Option<String>,
+    /// Service name reported to the OpenTelemetry collector.
+    pub otel_service_name: String,
 }
 
 #[derive(Debug, Clone)]
@@ -26,6 +30,8 @@ impl Default for Config {
             log_format: LogFormat::Json,
             cors_origins: vec!["*".to_string()],
             rate_limit: RateLimitConfig::default(),
+            otel_endpoint: None,
+            otel_service_name: "mq-web-api".to_string(),
         }
     }
 }
@@ -106,6 +112,18 @@ impl Config {
                     "Warning: Invalid RATE_LIMIT_CLEANUP_INTERVAL_SECONDS value '{}', using default {}",
                     cleanup_str, config.rate_limit.cleanup_interval_seconds
                 );
+            }
+        }
+
+        if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+            if !endpoint.is_empty() {
+                config.otel_endpoint = Some(endpoint);
+            }
+        }
+
+        if let Ok(service_name) = env::var("OTEL_SERVICE_NAME") {
+            if !service_name.is_empty() {
+                config.otel_service_name = service_name;
             }
         }
 

--- a/crates/mq-web-api/src/config.rs
+++ b/crates/mq-web-api/src/config.rs
@@ -115,16 +115,16 @@ impl Config {
             }
         }
 
-        if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
-            if !endpoint.is_empty() {
-                config.otel_endpoint = Some(endpoint);
-            }
+        if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+            && !endpoint.is_empty()
+        {
+            config.otel_endpoint = Some(endpoint);
         }
 
-        if let Ok(service_name) = env::var("OTEL_SERVICE_NAME") {
-            if !service_name.is_empty() {
-                config.otel_service_name = service_name;
-            }
+        if let Ok(service_name) = env::var("OTEL_SERVICE_NAME")
+            && !service_name.is_empty()
+        {
+            config.otel_service_name = service_name;
         }
 
         config

--- a/crates/mq-web-api/src/server.rs
+++ b/crates/mq-web-api/src/server.rs
@@ -5,8 +5,7 @@ use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[cfg(feature = "otel")]
-static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
-    std::sync::OnceLock::new();
+static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> = std::sync::OnceLock::new();
 
 use crate::{
     cleanup::CleanupService,

--- a/crates/mq-web-api/src/server.rs
+++ b/crates/mq-web-api/src/server.rs
@@ -4,6 +4,10 @@ use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
+#[cfg(feature = "otel")]
+static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
+
 use crate::{
     cleanup::CleanupService,
     config::{Config, LogFormat},
@@ -11,8 +15,61 @@ use crate::{
     routes::create_router,
 };
 
+/// Builds and installs a global tracing subscriber.
+///
+/// When the `otel` feature is enabled and `config.otel_endpoint` is set,
+/// an OTLP span exporter is attached so traces are forwarded to the
+/// configured OpenTelemetry collector.
 pub fn init_tracing(config: &Config) {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.log_level.clone().into());
+
+    #[cfg(feature = "otel")]
+    if let Some(ref endpoint) = config.otel_endpoint {
+        use opentelemetry::KeyValue;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_otlp::WithExportConfig;
+        use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint)
+            .build()
+            .expect("Failed to build OTLP span exporter");
+
+        let resource = Resource::builder()
+            .with_attribute(KeyValue::new("service.name", config.otel_service_name.clone()))
+            .build();
+
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(resource)
+            .build();
+
+        opentelemetry::global::set_tracer_provider(provider.clone());
+
+        // Store for graceful shutdown on server exit.
+        let _ = TRACER_PROVIDER.set(provider.clone());
+
+        // Create an otel layer per format branch to avoid type-inference conflicts
+        // between JsonFields and DefaultFields formatter types.
+        match config.log_format {
+            LogFormat::Json => {
+                tracing_subscriber::registry()
+                    .with(env_filter)
+                    .with(fmt::layer().json())
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("mq-web-api")))
+                    .init();
+            }
+            LogFormat::Text => {
+                tracing_subscriber::registry()
+                    .with(env_filter)
+                    .with(fmt::layer())
+                    .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("mq-web-api")))
+                    .init();
+            }
+        }
+        return;
+    }
 
     match config.log_format {
         LogFormat::Json => {
@@ -99,6 +156,11 @@ pub async fn start_server(config: Config) -> Result<(), Box<dyn std::error::Erro
         .expect("Failed to start server");
 
     info!("Shutting down mq-web-api server");
+
+    #[cfg(feature = "otel")]
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        provider.shutdown().ok();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Add an optional `otel` feature flag to mq-web-api that enables OTLP trace export using opentelemetry_sdk 0.31, opentelemetry-otlp 0.31, and tracing-opentelemetry 0.32.
