### PR TITLE
✨ feat(mq-run): add grep output format with line numbers and context

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -14,6 +14,8 @@ use std::str::FromStr;
 use std::{fs, path::PathBuf};
 use which::which;
 
+use crate::grep;
+
 #[derive(Parser, Debug, Default)]
 #[command(name = "mq")]
 #[command(author = env!("CARGO_PKG_AUTHORS"))]
@@ -96,6 +98,7 @@ enum OutputFormat {
     Text,
     Json,
     Table,
+    Grep,
     None,
 }
 
@@ -204,6 +207,29 @@ struct OutputArgs {
     /// Colorize markdown output
     #[arg(short = 'C', long = "color-output", default_value_t = false)]
     color_output: bool,
+
+    /// Show NUM nodes before each match. Only effective with -F grep.
+    #[clap(short = 'B', long, value_name = "NUM")]
+    before_context: Option<usize>,
+
+    /// Show NUM nodes after each match. Only effective with -F grep.
+    #[clap(long, value_name = "NUM")]
+    after_context: Option<usize>,
+
+    /// Show NUM nodes before and after each match. Only effective with -F grep.
+    #[clap(long, value_name = "NUM")]
+    context: Option<usize>,
+}
+
+impl OutputArgs {
+    /// Returns `(before, after)` node counts for grep context expansion.
+    /// `--context N` sets both sides; `--before-context` / `--after-context` override each side.
+    fn context_counts(&self) -> (usize, usize) {
+        let base = self.context.unwrap_or(0);
+        let before = self.before_context.unwrap_or(base);
+        let after = self.after_context.unwrap_or(base);
+        (before, after)
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -410,6 +436,16 @@ impl Cli {
             return self.list_commands();
         }
 
+        if (self.output.before_context.is_some()
+            || self.output.after_context.is_some()
+            || self.output.context.is_some())
+            && !matches!(self.output.output_format, OutputFormat::Grep)
+        {
+            return Err(miette!(
+                "--before-context, --after-context, and --context are only valid with -F grep"
+            ));
+        }
+
         // Check if query is actually an external subcommand
         // This handles the case where clap parses "mq test arg1" as query="test", files=["arg1"]
         if !self.input.from_file
@@ -608,6 +644,9 @@ impl Cli {
             InputFormat::Raw => mq_lang::raw_input(content),
         };
 
+        let is_grep = matches!(self.output.output_format, OutputFormat::Grep);
+        let original_input: Option<Vec<mq_lang::RuntimeValue>> = is_grep.then(|| input.clone());
+
         let runtime_values = if self.output.update {
             let results = engine.eval(query, input.clone().into_iter()).map_err(|e| *e)?;
             let current_values: mq_lang::RuntimeValues = input.clone().into();
@@ -631,7 +670,20 @@ impl Cli {
             self.print(separator)?;
         }
 
-        self.print(runtime_values)
+        if let Some(orig) = original_input {
+            let (before, after) = self.output.context_counts();
+            grep::print_grep(
+                runtime_values,
+                &orig,
+                file,
+                &self.output.output_file,
+                self.output.unbuffered,
+                before,
+                after,
+            )
+        } else {
+            self.print(runtime_values)
+        }
     }
 
     fn process_batch(&self) -> Result<(), miette::Error> {
@@ -878,6 +930,9 @@ impl Cli {
                 let table = crate::table::runtime_values_to_table(runtime_values, theme.as_ref());
                 Self::write_ignore_pipe(&mut handle, format!("{}\n", table).as_bytes())?;
             }
+            OutputFormat::Grep => {
+                Self::write_ignore_pipe(&mut handle, markdown.to_string().as_bytes())?;
+            }
             OutputFormat::None => {}
         }
 
@@ -891,6 +946,7 @@ impl Cli {
         Ok(())
     }
 }
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -969,6 +1025,7 @@ mod tests {
             OutputFormat::Html,
             OutputFormat::Text,
             OutputFormat::Table,
+            OutputFormat::Grep,
         ] {
             let cli = Cli {
                 input: InputArgs::default(),

--- a/crates/mq-run/src/grep.rs
+++ b/crates/mq-run/src/grep.rs
@@ -1,0 +1,200 @@
+//! Grep-like output format for the `-F grep` CLI option.
+//!
+//! Prints query results as `[file:]line:content`, with optional context nodes
+//! before and after each match (controlled by `--before-context`, `--after-context`,
+//! `--context`). Groups of context nodes are separated by `--`, matching the
+//! behaviour of `grep -A/-B/-C`.
+
+use miette::IntoDiagnostic;
+use miette::miette;
+use std::collections::HashSet;
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+
+/// Prints query results in grep-like format.
+///
+/// - `runtime_values`: the matched nodes returned by the query engine.
+/// - `original_input`: all top-level nodes from the input document (used for context expansion).
+/// - `file`: source file path, included as a prefix when present.
+/// - `output_file`: redirect output to a file instead of stdout.
+/// - `unbuffered`: skip buffering (flush after every write).
+/// - `before` / `after`: number of sibling nodes to include before / after each match.
+pub(crate) fn print_grep(
+    runtime_values: mq_lang::RuntimeValues,
+    original_input: &[mq_lang::RuntimeValue],
+    file: &Option<PathBuf>,
+    output_file: &Option<PathBuf>,
+    unbuffered: bool,
+    before: usize,
+    after: usize,
+) -> miette::Result<()> {
+    let stdout = io::stdout();
+    let mut handle: Box<dyn Write> = if let Some(path) = output_file {
+        let f = std::fs::File::create(path).into_diagnostic()?;
+        Box::new(BufWriter::new(f))
+    } else if unbuffered {
+        Box::new(stdout.lock())
+    } else {
+        Box::new(BufWriter::new(stdout.lock()))
+    };
+
+    let filename = file.as_ref().map(|p| p.to_string_lossy().into_owned());
+
+    // Collect start lines of matched nodes for quick lookup.
+    let match_lines: HashSet<usize> = runtime_values
+        .values()
+        .iter()
+        .filter_map(|v| {
+            if let mq_lang::RuntimeValue::Markdown(node, _) = v {
+                node.position().map(|p| p.start.line)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if before == 0 && after == 0 {
+        for value in runtime_values.values() {
+            for node in to_nodes(value) {
+                let line_num = node.position().map(|p| p.start.line);
+                let content = mq_markdown::Markdown::new(vec![node]).to_string();
+                let content = content.trim_end_matches('\n');
+                if content.is_empty() {
+                    continue;
+                }
+                let line = format_line(&filename, line_num, content, ":");
+                write_ignore_pipe(&mut handle, line.as_bytes())?;
+            }
+        }
+    } else {
+        let orig: Vec<&mq_lang::RuntimeValue> = original_input.iter().collect();
+
+        // Build [start, end] index ranges (inclusive) for each matched node.
+        let mut ranges: Vec<(usize, usize)> = match_lines
+            .iter()
+            .filter_map(|&line| {
+                orig.iter().position(|v| {
+                    if let mq_lang::RuntimeValue::Markdown(node, _) = v {
+                        node.position().map(|p| p.start.line) == Some(line)
+                    } else {
+                        false
+                    }
+                })
+            })
+            .map(|idx| {
+                let end = (idx + after).min(orig.len().saturating_sub(1));
+                (idx.saturating_sub(before), end)
+            })
+            .collect();
+
+        ranges.sort_unstable_by_key(|r| r.0);
+
+        // Merge overlapping or adjacent ranges.
+        let merged = ranges
+            .into_iter()
+            .fold(Vec::<(usize, usize)>::new(), |mut acc, (s, e)| {
+                if let Some(last) = acc.last_mut()
+                    && s <= last.1
+                {
+                    last.1 = last.1.max(e);
+                    return acc;
+                }
+                acc.push((s, e));
+                acc
+            });
+
+        let mut first_group = true;
+        for (start, end) in merged {
+            if !first_group {
+                write_ignore_pipe(&mut handle, b"--\n")?;
+            }
+            first_group = false;
+
+            for idx in start..=end {
+                if let Some(value) = orig.get(idx) {
+                    for node in to_nodes(value) {
+                        let line_num = node.position().map(|p| p.start.line);
+                        let is_match = line_num.map(|l| match_lines.contains(&l)).unwrap_or(false);
+                        let sep = if is_match { ":" } else { "-" };
+                        let content = mq_markdown::Markdown::new(vec![node]).to_string();
+                        let content = content.trim_end_matches('\n');
+                        if content.is_empty() {
+                            continue;
+                        }
+                        let line = format_line(&filename, line_num, content, sep);
+                        write_ignore_pipe(&mut handle, line.as_bytes())?;
+                    }
+                }
+            }
+        }
+    }
+
+    if !unbuffered
+        && let Err(e) = handle.flush()
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(miette!(e));
+    }
+
+    Ok(())
+}
+
+fn format_line(filename: &Option<String>, line_num: Option<usize>, content: &str, sep: &str) -> String {
+    match (filename, line_num) {
+        (Some(f), Some(l)) => format!("{}{}{}{}{}\n", f, sep, l, sep, content),
+        (Some(f), None) => format!("{}{}{}\n", f, sep, content),
+        (None, Some(l)) => format!("{}{}{}\n", l, sep, content),
+        (None, None) => format!("{}\n", content),
+    }
+}
+
+fn write_ignore_pipe<W: Write>(handle: &mut W, data: &[u8]) -> miette::Result<()> {
+    match handle.write_all(data) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(miette!(e)),
+    }
+}
+
+fn to_nodes(value: &mq_lang::RuntimeValue) -> Vec<mq_markdown::Node> {
+    match value {
+        mq_lang::RuntimeValue::Markdown(node, _) => vec![node.clone()],
+        mq_lang::RuntimeValue::Array(items) => items.iter().flat_map(to_nodes).collect(),
+        _ => vec![value.to_string().into()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_line_with_filename_and_line() {
+        let result = format_line(&Some("file.md".to_string()), Some(5), "## Heading", ":");
+        assert_eq!(result, "file.md:5:## Heading\n");
+    }
+
+    #[test]
+    fn test_format_line_context_separator() {
+        let result = format_line(&Some("file.md".to_string()), Some(4), "Some text.", "-");
+        assert_eq!(result, "file.md-4-Some text.\n");
+    }
+
+    #[test]
+    fn test_format_line_without_filename() {
+        let result = format_line(&None, Some(3), "Paragraph.", ":");
+        assert_eq!(result, "3:Paragraph.\n");
+    }
+
+    #[test]
+    fn test_format_line_without_line_number() {
+        let result = format_line(&Some("file.md".to_string()), None, "text", ":");
+        assert_eq!(result, "file.md:text\n");
+    }
+
+    #[test]
+    fn test_format_line_no_filename_no_line() {
+        let result = format_line(&None, None, "plain", ":");
+        assert_eq!(result, "plain\n");
+    }
+}

--- a/crates/mq-run/src/grep.rs
+++ b/crates/mq-run/src/grep.rs
@@ -90,18 +90,7 @@ pub(crate) fn print_grep(
         ranges.sort_unstable_by_key(|r| r.0);
 
         // Merge overlapping or adjacent ranges.
-        let merged = ranges
-            .into_iter()
-            .fold(Vec::<(usize, usize)>::new(), |mut acc, (s, e)| {
-                if let Some(last) = acc.last_mut()
-                    && s <= last.1
-                {
-                    last.1 = last.1.max(e);
-                    return acc;
-                }
-                acc.push((s, e));
-                acc
-            });
+        let merged = merge_ranges(ranges);
 
         let mut first_group = true;
         for (start, end) in merged {
@@ -156,6 +145,23 @@ fn write_ignore_pipe<W: Write>(handle: &mut W, data: &[u8]) -> miette::Result<()
     }
 }
 
+/// Merges a sorted list of `(start, end)` index ranges, combining ranges that
+/// overlap or are directly adjacent (end + 1 == next start), matching `grep` behaviour.
+fn merge_ranges(ranges: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    ranges
+        .into_iter()
+        .fold(Vec::<(usize, usize)>::new(), |mut acc, (s, e)| {
+            if let Some(last) = acc.last_mut()
+                && s <= last.1 + 1
+            {
+                last.1 = last.1.max(e);
+                return acc;
+            }
+            acc.push((s, e));
+            acc
+        })
+}
+
 fn to_nodes(value: &mq_lang::RuntimeValue) -> Vec<mq_markdown::Node> {
     match value {
         mq_lang::RuntimeValue::Markdown(node, _) => vec![node.clone()],
@@ -196,5 +202,53 @@ mod tests {
     fn test_format_line_no_filename_no_line() {
         let result = format_line(&None, None, "plain", ":");
         assert_eq!(result, "plain\n");
+    }
+
+    // --- merge_ranges tests ---
+
+    #[test]
+    fn test_merge_ranges_empty() {
+        assert_eq!(merge_ranges(vec![]), vec![]);
+    }
+
+    #[test]
+    fn test_merge_ranges_single() {
+        assert_eq!(merge_ranges(vec![(2, 5)]), vec![(2, 5)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_overlapping() {
+        // (0,3) and (2,5) overlap — should become (0,5)
+        assert_eq!(merge_ranges(vec![(0, 3), (2, 5)]), vec![(0, 5)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_adjacent() {
+        // (0,1) and (2,3) are adjacent (end+1 == next start) — should merge into (0,3)
+        assert_eq!(merge_ranges(vec![(0, 1), (2, 3)]), vec![(0, 3)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_non_adjacent() {
+        // (0,1) and (3,4) have a gap — should remain two separate groups
+        assert_eq!(merge_ranges(vec![(0, 1), (3, 4)]), vec![(0, 1), (3, 4)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_multiple_adjacent_chain() {
+        // Three adjacent ranges should collapse into one
+        assert_eq!(merge_ranges(vec![(0, 1), (2, 3), (4, 5)]), vec![(0, 5)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_mixed() {
+        // First two merge (adjacent), third is separate
+        assert_eq!(merge_ranges(vec![(0, 1), (2, 3), (5, 6)]), vec![(0, 3), (5, 6)]);
+    }
+
+    #[test]
+    fn test_merge_ranges_already_merged() {
+        // No-op when ranges are already fully merged
+        assert_eq!(merge_ranges(vec![(0, 10)]), vec![(0, 10)]);
     }
 }

--- a/crates/mq-run/src/lib.rs
+++ b/crates/mq-run/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 
 pub mod cli;
+pub(crate) mod grep;
 pub(crate) mod table;
 
 #[cfg(feature = "debugger")]

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -201,10 +201,15 @@ In {year}, the snowfall was above average.
     "Intro.\n\n# title\n\nBody text.\n",
     Some("1-Intro.\n3:# title\n5-Body text.\n")
 )]
-#[case::grep_multiple_matches_separator(
+#[case::grep_multiple_matches_no_separator_when_adjacent(
     vec!["--unbuffered", "-F", "grep", "--after-context", "1", ".h"],
     "# h1\n\nParagraph.\n\n# h2\n\nEnd.\n",
-    Some("1:# h1\n3-Paragraph.\n--\n5:# h2\n7-End.\n")
+    Some("1:# h1\n3-Paragraph.\n5:# h2\n7-End.\n")
+)]
+#[case::grep_multiple_matches_separator(
+    vec!["--unbuffered", "-F", "grep", "--after-context", "1", ".h"],
+    "# h1\n\nP1.\n\nP2.\n\n# h2\n\nEnd.\n",
+    Some("1:# h1\n3-P1.\n--\n7:# h2\n9-End.\n")
 )]
 fn test_cli_commands(
     #[case] args: Vec<&str>,

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -176,6 +176,36 @@ In {year}, the snowfall was above average.
     "# title 42\n",
     Some("{\"level\": \"title\", \"num\": \"42\"}\n")
 )]
+#[case::grep_basic(
+    vec!["--unbuffered", "-F", "grep", ".h"],
+    "# title\n\nBody text.\n",
+    Some("1:# title\n")
+)]
+#[case::grep_no_empty_lines(
+    vec!["--unbuffered", "-F", "grep", "self"],
+    "# title\n\nBody text.\n",
+    Some("1:# title\n3:Body text.\n")
+)]
+#[case::grep_after_context(
+    vec!["--unbuffered", "-F", "grep", "--after-context", "1", ".h"],
+    "# title\n\nBody text.\n",
+    Some("1:# title\n3-Body text.\n")
+)]
+#[case::grep_before_context(
+    vec!["--unbuffered", "-F", "grep", "-B", "1", ".h"],
+    "Intro.\n\n# title\n\nBody text.\n",
+    Some("1-Intro.\n3:# title\n")
+)]
+#[case::grep_context_both(
+    vec!["--unbuffered", "-F", "grep", "--context", "1", ".h"],
+    "Intro.\n\n# title\n\nBody text.\n",
+    Some("1-Intro.\n3:# title\n5-Body text.\n")
+)]
+#[case::grep_multiple_matches_separator(
+    vec!["--unbuffered", "-F", "grep", "--after-context", "1", ".h"],
+    "# h1\n\nParagraph.\n\n# h2\n\nEnd.\n",
+    Some("1:# h1\n3-Paragraph.\n--\n5:# h2\n7-End.\n")
+)]
 fn test_cli_commands(
     #[case] args: Vec<&str>,
     #[case] input: &str,


### PR DESCRIPTION
Add -F grep output format that prints results as [file:]line:content, addressing #1623 (line numbers) and #1624 (context nodes).

https://github.com/harehare/mq/issues/1624
https://github.com/harehare/mq/issues/1623