### PR TITLE
✨ feat(mq-lang): support selector expressions on Dict values

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 #[cfg(feature = "debugger")]
 use crate::DebuggerHandler;
@@ -733,11 +734,34 @@ impl<T: ModuleResolver> Evaluator<T> {
                             RuntimeValue::Array(arr) => arr,
                             other => vec![other],
                         },
+                        RuntimeValue::Dict(_) => {
+                            vec![Self::eval_selector_expr(value, ident)]
+                        }
                         _ => vec![RuntimeValue::NONE],
                     })
                     .collect::<Vec<_>>();
 
                 RuntimeValue::Array(values)
+            }
+            RuntimeValue::Dict(map) => {
+                let type_key = Ident::new("type");
+                let new_map: BTreeMap<_, _> = map
+                    .iter()
+                    .map(|(k, v)| {
+                        let new_v = if *k == type_key {
+                            v.clone()
+                        } else {
+                            Self::eval_selector_expr(v, ident)
+                        };
+                        (*k, new_v)
+                    })
+                    .collect();
+
+                if new_map.is_empty() {
+                    RuntimeValue::NONE
+                } else {
+                    RuntimeValue::Dict(new_map)
+                }
             }
             _ => RuntimeValue::NONE,
         }

--- a/crates/mq-lang/src/eval/runtime_value.rs
+++ b/crates/mq-lang/src/eval/runtime_value.rs
@@ -385,6 +385,12 @@ impl RuntimeValue {
         matches!(self, RuntimeValue::Array(_))
     }
 
+    /// Returns `true` if this value is a dict.
+    #[inline(always)]
+    pub fn is_dict(&self) -> bool {
+        matches!(self, RuntimeValue::Dict(_))
+    }
+
     /// Returns `true` if this value is considered empty.
     ///
     /// Empty values include empty arrays, empty strings, empty markdown nodes,

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2457,6 +2457,10 @@ fn engine() -> DefaultEngine {
 #[case::selector_mdx_flow_expr(r##"to_mdx("{1 + 1}") | .mdx_flow_expression | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::selector_footnote(r##"to_markdown("[^1]: note\n\n# title") | .footnote | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::selector_definition(r##"to_markdown("[id]: url") | .definition | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+#[case::selector_dict_empty_returns_none("{} | .h | is_none()", vec![RuntimeValue::None], Ok(vec![RuntimeValue::TRUE].into()))]
+#[case::selector_dict_with_markdown_values(r##"{"docs": to_markdown("# Title\n\ntext")} | .h | is_dict()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::TRUE].into()))]
+#[case::selector_dict_preserves_type_key(r##"{"type": "mytype"} | .h | entries() | first() | last()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("mytype".to_string())].into()))]
+#[case::selector_array_of_dicts_preserves_dict(r##"array({"docs": to_markdown("# Title")}) | .h | first() | is_dict()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::TRUE].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }


### PR DESCRIPTION
- Apply selector to each value in Dict while preserving the "type" key
- Handle Dict within Array selector to delegate to eval_selector_expr
- Add is_dict() helper method to RuntimeValue
- Add integration tests for dict selector behavior