### PR TITLE
✨ feat(section): add depth parameter to section() function

### DIFF
--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -308,6 +308,27 @@ def test_section_section_no_match():
   | assert_eq(secs, [])
 end
 
+def test_section_section_depth_h1():
+  let secs = do test_sections | section::section(., "Introduction", true);
+  | assert_eq(len(secs), 1)
+  | let s = first(secs)
+  | assert_eq(section::level(s), 1)
+  | assert(len(section::body(s)) > 1)
+end
+
+def test_section_section_depth_h2():
+  let secs = do test_sections | section::section(., "Advanced Topics", true);
+  | assert_eq(len(secs), 1)
+  | let s = first(secs)
+  | assert_eq(section::level(s), 2)
+end
+
+def test_section_section_depth_false_unchanged():
+  let secs_default = do test_sections | section::section("Introduction");
+  | let secs_depth = do test_sections | section::section(., "Introduction", false);
+  | assert_eq(len(secs_default), len(secs_depth))
+end
+
 def test_section_bodies_pipe():
   let body_list = do test_sections | section::section("Introduction") | section::bodies();
   | assert_eq(len(body_list), 1)

--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -1,8 +1,40 @@
 def _is_section(section): is_dict(section) && section[:type] == :section;
 
+def _h_level_num(md):
+  if (is_h1(md)): 1
+  elif (is_h2(md)): 2
+  elif (is_h3(md)): 3
+  elif (is_h4(md)): 4
+  elif (is_h5(md)): 5
+  elif (is_h6(md)): 6
+  else: 0
+end
+
 # Returns sections whose title contains the specified pattern.
-def section(md_nodes, pattern):
-  sections(md_nodes) | title_contains(pattern)
+# If depth is true, each section spans until the next header at the same or higher level.
+def section(md_nodes, pattern, depth = false):
+  if (depth):
+    if (is_empty(md_nodes)):
+      []
+    else:
+      do
+        let n = len(md_nodes)
+        | let match_indices = do foreach (i, range(n - 1)): if (is_h(md_nodes[i]) && contains(to_text(md_nodes[i]), pattern)): i; | compact();
+        | var result = []
+        | var i = 0
+        | while (i < len(match_indices)):
+            let start = match_indices[i]
+            | let lvl = _h_level_num(md_nodes[start])
+            | let boundaries = do foreach (j, range(n - 1)): if (is_h(md_nodes[j]) && _h_level_num(md_nodes[j]) <= lvl): j; | compact();
+            | let boundaries_with_end = boundaries + n
+            | let end_node = first(filter(boundaries_with_end, fn(b): b > start;))
+            | result += [{type: :section, header: md_nodes[start], children: md_nodes[start + 1:end_node]}]
+            | i += 1
+            | result
+          end
+      end
+  else:
+    sections(md_nodes) | title_contains(pattern)
 end
 
 # Splits markdown nodes into sections based on headers.


### PR DESCRIPTION
Add optional `depth` parameter to `section(md_nodes, pattern, depth = false)`. When depth is true, each matched section spans until the next header at the same or higher level, rather than stopping at the next header of any level.