### PR TITLE
✨ feat(lang): add selector call syntax for filtered matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ Here's a basic example of how to use `mq`:
 # Extract all headings from a document
 mq '.h' README.md
 
+# Extract only h1 headings
+mq '.h(1)' README.md
+
+# Extract h1 and h2 headings
+mq '.h(1, 2)' README.md
+
+# Extract headings from level 1 to 3 using a range
+mq '.h(1..3)' README.md
+
+# Extract only Rust code blocks
+mq '.code("rust")' example.md
+
 # Extract code blocks containing "name"
 mq '.code | select(contains("name"))' example.md
 

--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -288,7 +288,7 @@ impl Formatter {
             | mq_lang::CstNodeKind::Do
             | mq_lang::CstNodeKind::Continue => self.format_keyword(&node, indent_level_consider_new_line),
             mq_lang::CstNodeKind::Break => self.format_break(&node, indent_level_consider_new_line),
-            mq_lang::CstNodeKind::Selector | mq_lang::CstNodeKind::SelfAttr => {
+            mq_lang::CstNodeKind::Selector | mq_lang::CstNodeKind::SelectorCall | mq_lang::CstNodeKind::SelfAttr => {
                 self.format_selector(&node, indent_level_consider_new_line)
             }
             mq_lang::CstNodeKind::Try => self.format_try(&node, indent_level_consider_new_line),
@@ -1393,7 +1393,7 @@ impl Formatter {
 
     fn format_selector(&mut self, node: &mq_lang::Shared<mq_lang::CstNode>, indent_level: usize) {
         if let mq_lang::CstNode {
-            kind: mq_lang::CstNodeKind::Selector | mq_lang::CstNodeKind::SelfAttr,
+            kind: mq_lang::CstNodeKind::Selector | mq_lang::CstNodeKind::SelfAttr | mq_lang::CstNodeKind::SelectorCall,
             token: Some(token),
             children,
             ..
@@ -2785,6 +2785,10 @@ end
     #[case::index_assign("arr[0]=10", "arr[0] = 10")]
     #[case::index_assign_string_key("dict[\"key\"]=\"value\"", "dict[\"key\"] = \"value\"")]
     #[case::index_compound_assign("arr[0]+=1", "arr[0] += 1")]
+    #[case::selector_call_heading_single_arg(".h(1)", ".h(1)")]
+    #[case::selector_call_heading_multi_arg(".h(1,2)", ".h(1, 2)")]
+    #[case::selector_call_code_lang(".code(\"rust\")", ".code(\"rust\")")]
+    #[case::selector_call_pipe(".h(1)|.text()", ".h(1) | .text()")]
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);
         assert_eq!(result.unwrap(), expected);

--- a/crates/mq-lang/src/ast/code.rs
+++ b/crates/mq-lang/src/ast/code.rs
@@ -28,6 +28,12 @@ impl Node {
             Expr::Selector(selector) => {
                 write!(buf, "{}", selector).unwrap();
             }
+            Expr::SelectorCall(selector, args) => {
+                write!(buf, "{}", selector).unwrap();
+                buf.push('(');
+                format_args(args, buf, indent);
+                buf.push(')');
+            }
             Expr::Break(None) => {
                 buf.push_str("break");
             }

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -180,6 +180,14 @@ impl Node {
                 let end = value_node.range(Shared::clone(&arena)).end;
                 Range { start, end }
             }
+            Expr::SelectorCall(_, args) => {
+                let start = arena[self.token_id].range.start;
+                let end = args
+                    .last()
+                    .map(|node| node.range(Shared::clone(&arena)).end)
+                    .unwrap_or_else(|| arena[self.token_id].range.end);
+                Range { start, end }
+            }
             Expr::Literal(_)
             | Expr::Ident(_)
             | Expr::Selector(_)
@@ -328,6 +336,10 @@ pub enum Expr {
     Ident(IdentWithToken),
     InterpolatedString(Vec<StringSegment>),
     Selector(Selector),
+    /// A selector with runtime-evaluated arguments for filtered matching.
+    ///
+    /// Supports `.h(1..2)`, `.h(1, 2)`, `.code("rust")`, etc.
+    SelectorCall(Selector, Args),
     While(Shared<Node>, Program),
     Foreach(IdentWithToken, Shared<Node>, Program),
     If(Branches),

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -2367,7 +2367,6 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         attr_token: Shared<Token>,
     ) -> Result<Shared<Node>, SyntaxError> {
         if let TokenKind::Selector(attr_selector) = &attr_token.kind {
-            let attribute = &attr_selector[1..]; // Skip the dot
             // Parse the base selector recursively
             let base_node = self.parse_selector_direct(token)?;
 
@@ -2378,6 +2377,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                 return Err(SyntaxError::UnexpectedToken((*attr_token).clone()));
             }
 
+            let attribute = &attr_selector[1..]; // Skip the dot
             // Create the attribute string literal
             let attr_literal = Shared::new(Node {
                 token_id: self.token_arena.alloc(Shared::clone(token)),
@@ -2424,13 +2424,9 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                             token_id,
                             expr: Shared::new(Expr::Self_),
                         });
-                        let TokenKind::Selector(selector_str) = &token.kind else {
-                            unreachable!()
-                        };
-                        let attribute_name = selector_str[1..].to_string();
                         let attr_literal = Shared::new(Node {
                             token_id,
-                            expr: Shared::new(Expr::Literal(Literal::String(attribute_name))),
+                            expr: Shared::new(Expr::Literal(Literal::String(selector.name()))),
                         });
                         if self.is_next_token(|kind| matches!(kind, TokenKind::PipeEqual)) {
                             self.tokens.next();

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -2466,6 +2466,21 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
             return self.parse_selector_with_attribute(token, Shared::clone(attr_token));
         }
 
+        // Check for selector call: `.h(...)`, `.code(...)`
+        if self.is_next_token(|kind| matches!(kind, TokenKind::LParen))
+            && let TokenKind::Selector(s) = &token.kind
+            && s != "."
+        {
+            let selector = Selector::try_from(&**token).map_err(SyntaxError::UnknownSelector)?;
+            if !selector.is_attribute_selector() {
+                let args = self.parse_args()?;
+                return Ok(Shared::new(Node {
+                    token_id: self.token_arena.alloc(Shared::clone(token)),
+                    expr: Shared::new(Expr::SelectorCall(selector, args)),
+                }));
+            }
+        }
+
         self.parse_selector_direct(token)
     }
 
@@ -3830,6 +3845,71 @@ mod tests {
         Ok(vec![Shared::new(Node {
             token_id: 2.into(),
             expr: Shared::new(Expr::Selector(Selector::Code)),
+        })]))]
+    #[case::selector_call_heading_single_arg(
+        vec![
+            token(TokenKind::Selector(SmolStr::new(".h"))),
+            token(TokenKind::LParen),
+            token(TokenKind::NumberLiteral(1.into())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 1.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Heading(None),
+                // arg literal is allocated first (id=0), then the selector token (id=1)
+                smallvec![Shared::new(Node {
+                    token_id: 0.into(),
+                    expr: Shared::new(Expr::Literal(Literal::Number(1.into()))),
+                })],
+            )),
+        })]))]
+    #[case::selector_call_heading_multi_arg(
+        vec![
+            token(TokenKind::Selector(SmolStr::new(".h"))),
+            token(TokenKind::LParen),
+            token(TokenKind::NumberLiteral(1.into())),
+            token(TokenKind::Comma),
+            token(TokenKind::NumberLiteral(2.into())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 2.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Heading(None),
+                // args are allocated first (id=0, id=1), then the selector token (id=2)
+                smallvec![
+                    Shared::new(Node {
+                        token_id: 0.into(),
+                        expr: Shared::new(Expr::Literal(Literal::Number(1.into()))),
+                    }),
+                    Shared::new(Node {
+                        token_id: 1.into(),
+                        expr: Shared::new(Expr::Literal(Literal::Number(2.into()))),
+                    }),
+                ],
+            )),
+        })]))]
+    #[case::selector_call_code_lang(
+        vec![
+            token(TokenKind::Selector(SmolStr::new(".code"))),
+            token(TokenKind::LParen),
+            token(TokenKind::StringLiteral("rust".to_owned())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 1.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Code,
+                // arg literal is allocated first (id=0), then the selector token (id=1)
+                smallvec![Shared::new(Node {
+                    token_id: 0.into(),
+                    expr: Shared::new(Expr::Literal(Literal::String("rust".to_owned()))),
+                })],
+            )),
         })]))]
     #[case::table_selector(
         vec![

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -115,6 +115,7 @@ pub enum NodeKind {
     QualifiedAccess,
     Quote,
     Selector,
+    SelectorCall,
     Self_,
     SelfAttr,
     Token,

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -959,6 +959,13 @@ impl<'a> Parser<'a> {
                     return Ok(Shared::new(node));
                 }
 
+                // Check for selector call args: `.h(...)`, `.code(...)`
+                if self.try_next_token(|kind| matches!(kind, TokenKind::LParen)) {
+                    node.kind = NodeKind::SelectorCall;
+                    node.children = self.parse_args()?;
+                    return Ok(Shared::new(node));
+                }
+
                 if let Some(attr_token) = self.peek()
                     && attr_token.is_selector()
                     && Selector::try_from(&**attr_token)
@@ -2278,6 +2285,7 @@ mod tests {
     use crate::{lexer::token::StringSegment, range::Range};
 
     use super::*;
+    use crate::cst::node::BinaryOp;
     use rstest::rstest;
 
     fn token(token_kind: TokenKind) -> Token {
@@ -9480,6 +9488,290 @@ mod tests {
                         Shared::new(Node {
                             kind: NodeKind::Token,
                             token: Some(Shared::new(token(TokenKind::SemiColon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_call_heading_single_arg(
+        vec![
+            Shared::new(token(TokenKind::Selector(".h".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::NumberLiteral(1.into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::SelectorCall,
+                    token: Some(Shared::new(token(TokenKind::Selector(".h".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::NumberLiteral(1.into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_call_heading_multi_arg(
+        vec![
+            Shared::new(token(TokenKind::Selector(".h".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::NumberLiteral(1.into()))),
+            Shared::new(token(TokenKind::Comma)),
+            Shared::new(token(TokenKind::NumberLiteral(2.into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::SelectorCall,
+                    token: Some(Shared::new(token(TokenKind::Selector(".h".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::NumberLiteral(1.into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Comma))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::NumberLiteral(2.into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_call_code_lang(
+        vec![
+            Shared::new(token(TokenKind::Selector(".code".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::StringLiteral("rust".into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::SelectorCall,
+                    token: Some(Shared::new(token(TokenKind::Selector(".code".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::StringLiteral("rust".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_call_heading_range(
+        vec![
+            Shared::new(token(TokenKind::Selector(".h".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::NumberLiteral(1.into()))),
+            Shared::new(token(TokenKind::DoubleDot)),
+            Shared::new(token(TokenKind::NumberLiteral(3.into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::SelectorCall,
+                    token: Some(Shared::new(token(TokenKind::Selector(".h".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        // 1..3 is parsed as a BinaryOp(RangeOp) expression by parse_expr
+                        Shared::new(Node {
+                            kind: NodeKind::BinaryOp(BinaryOp::RangeOp),
+                            token: Some(Shared::new(token(TokenKind::DoubleDot))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: vec![
+                                Shared::new(Node {
+                                    kind: NodeKind::Literal,
+                                    token: Some(Shared::new(token(TokenKind::NumberLiteral(1.into())))),
+                                    leading_trivia: Vec::new(),
+                                    trailing_trivia: Vec::new(),
+                                    children: Vec::new(),
+                                }),
+                                Shared::new(Node {
+                                    kind: NodeKind::Literal,
+                                    token: Some(Shared::new(token(TokenKind::NumberLiteral(3.into())))),
+                                    leading_trivia: Vec::new(),
+                                    trailing_trivia: Vec::new(),
+                                    children: Vec::new(),
+                                }),
+                            ],
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Eof,
+                    token: Some(Shared::new(token(TokenKind::Eof))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_call_ident_arg(
+        vec![
+            Shared::new(token(TokenKind::Selector(".h".into()))),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::Ident("n".into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::SelectorCall,
+                    token: Some(Shared::new(token(TokenKind::Selector(".h".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("n".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -723,6 +723,55 @@ impl<T: ModuleResolver> Evaluator<T> {
     }
 
     #[inline(always)]
+    fn eval_selector_expr_with_args(
+        runtime_value: &RuntimeValue,
+        selector: &Selector,
+        args: &[RuntimeValue],
+    ) -> RuntimeValue {
+        match runtime_value {
+            RuntimeValue::Markdown(node_value, _) => builtin::eval_selector_with_args(node_value, selector, args),
+            RuntimeValue::Array(values) => {
+                let values = values
+                    .iter()
+                    .flat_map(|value| match value {
+                        RuntimeValue::Markdown(node_value, _) => {
+                            match builtin::eval_selector_with_args(node_value, selector, args) {
+                                RuntimeValue::Array(arr) => arr,
+                                other => vec![other],
+                            }
+                        }
+                        RuntimeValue::Dict(_) => {
+                            vec![Self::eval_selector_expr_with_args(value, selector, args)]
+                        }
+                        _ => vec![RuntimeValue::NONE],
+                    })
+                    .collect::<Vec<_>>();
+                RuntimeValue::Array(values)
+            }
+            RuntimeValue::Dict(map) => {
+                let type_key = Ident::new("type");
+                let new_map: BTreeMap<_, _> = map
+                    .iter()
+                    .map(|(k, v)| {
+                        let new_v = if *k == type_key {
+                            v.clone()
+                        } else {
+                            Self::eval_selector_expr_with_args(v, selector, args)
+                        };
+                        (*k, new_v)
+                    })
+                    .collect();
+                if new_map.is_empty() {
+                    RuntimeValue::NONE
+                } else {
+                    RuntimeValue::Dict(new_map)
+                }
+            }
+            _ => RuntimeValue::NONE,
+        }
+    }
+
+    #[inline(always)]
     fn eval_selector_expr(runtime_value: &RuntimeValue, ident: &Selector) -> RuntimeValue {
         match runtime_value {
             RuntimeValue::Markdown(node_value, _) => builtin::eval_selector(node_value, ident),
@@ -862,6 +911,17 @@ impl<T: ModuleResolver> Evaluator<T> {
 
         match &*node.expr {
             ast::Expr::Selector(ident) => Ok(Self::eval_selector_expr(runtime_value, ident)),
+            ast::Expr::SelectorCall(selector, args) => {
+                let evaluated_args = args
+                    .iter()
+                    .map(|arg| self.eval_expr(runtime_value, arg, env))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::eval_selector_expr_with_args(
+                    runtime_value,
+                    selector,
+                    &evaluated_args,
+                ))
+            }
             ast::Expr::Call(ident, args) => {
                 #[cfg(feature = "debugger")]
                 if ident.name == constants::builtins::BREAKPOINT.into() {
@@ -3654,6 +3714,42 @@ mod tests {
             ast_node(ast::Expr::Selector(Selector::Text)),
         ],
         Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Fragment(mq_markdown::Fragment { values: vec!["Heading 1".to_string().into()] }), None)]))]
+    // SelectorCall: .h(1) matches h1
+    #[case::selector_call_heading_exact_match(
+        vec![RuntimeValue::Markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 1, values: vec!["H1".to_string().into()], position: None}), None)],
+        vec![ast_node(ast::Expr::SelectorCall(Selector::Heading(None), smallvec![
+            ast_node(ast::Expr::Literal(ast::Literal::Number(crate::number::Number::new(1.0)))),
+        ]))],
+        Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 1, values: vec!["H1".to_string().into()], position: None}), None)]))]
+    // SelectorCall: .h(2) does not match a non-markdown value
+    #[case::selector_call_heading_no_match(
+        vec![RuntimeValue::NONE],
+        vec![ast_node(ast::Expr::SelectorCall(Selector::Heading(None), smallvec![
+            ast_node(ast::Expr::Literal(ast::Literal::Number(crate::number::Number::new(2.0)))),
+        ]))],
+        Ok(vec![RuntimeValue::NONE]))]
+    // SelectorCall: .h(1, 2) matches h2
+    #[case::selector_call_heading_multi_arg(
+        vec![RuntimeValue::Markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 2, values: vec!["H2".to_string().into()], position: None}), None)],
+        vec![ast_node(ast::Expr::SelectorCall(Selector::Heading(None), smallvec![
+            ast_node(ast::Expr::Literal(ast::Literal::Number(crate::number::Number::new(1.0)))),
+            ast_node(ast::Expr::Literal(ast::Literal::Number(crate::number::Number::new(2.0)))),
+        ]))],
+        Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 2, values: vec!["H2".to_string().into()], position: None}), None)]))]
+    // SelectorCall: .code("rust") matches rust code block
+    #[case::selector_call_code_lang_match(
+        vec![RuntimeValue::Markdown(mq_markdown::Node::Code(mq_markdown::Code{lang: Some("rust".to_string()), meta: None, value: "fn main() {}".to_string(), fence: true, position: None}), None)],
+        vec![ast_node(ast::Expr::SelectorCall(Selector::Code, smallvec![
+            ast_node(ast::Expr::Literal(ast::Literal::String("rust".to_string()))),
+        ]))],
+        Ok(vec![RuntimeValue::Markdown(mq_markdown::Node::Code(mq_markdown::Code{lang: Some("rust".to_string()), meta: None, value: "fn main() {}".to_string(), fence: true, position: None}), None)]))]
+    // SelectorCall: .code("python") does not match a non-markdown value
+    #[case::selector_call_code_lang_no_match(
+        vec![RuntimeValue::NONE],
+        vec![ast_node(ast::Expr::SelectorCall(Selector::Code, smallvec![
+            ast_node(ast::Expr::Literal(ast::Literal::String("python".to_string()))),
+        ]))],
+        Ok(vec![RuntimeValue::NONE]))]
     #[case::to_md_table_row(vec![RuntimeValue::Array(vec![
             RuntimeValue::String("Cell 1".to_string()),
             RuntimeValue::String("Cell 2".to_string()),

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4714,6 +4714,95 @@ pub fn eval_builtin(
     )
 }
 
+/// Collect numeric (u8) depth values from evaluated selector arguments.
+///
+/// Accepts `Number` values directly and flattens `Array` values recursively.
+fn collect_depth_values(args: &[RuntimeValue]) -> Vec<u8> {
+    args.iter()
+        .flat_map(|arg| match arg {
+            RuntimeValue::Number(n) => vec![n.value() as u8],
+            RuntimeValue::Array(arr) => arr
+                .iter()
+                .filter_map(|v| {
+                    if let RuntimeValue::Number(n) = v {
+                        Some(n.value() as u8)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => vec![],
+        })
+        .collect()
+}
+
+/// Collect string values from evaluated selector arguments.
+///
+/// Accepts `String` values directly and flattens `Array` values.
+fn collect_string_values(args: &[RuntimeValue]) -> Vec<String> {
+    args.iter()
+        .flat_map(|arg| match arg {
+            RuntimeValue::String(s) => vec![s.clone()],
+            RuntimeValue::Array(arr) => arr
+                .iter()
+                .filter_map(|v| {
+                    if let RuntimeValue::String(s) = v {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => vec![],
+        })
+        .collect()
+}
+
+/// Evaluates a selector with runtime arguments against a markdown node.
+///
+/// Supports filtered matching for selectors that accept arguments:
+/// - `Heading`: filters by depth using numeric or range args (e.g. `.h(1..2)`, `.h(1, 2)`)
+/// - `Code`: filters by language using string args (e.g. `.code("rust")`)
+/// - All other selectors fall back to [`eval_selector`].
+pub fn eval_selector_with_args(node: &mq_markdown::Node, selector: &Selector, args: &[RuntimeValue]) -> RuntimeValue {
+    if args.is_empty() {
+        return eval_selector(node, selector);
+    }
+
+    let is_match = match selector {
+        Selector::Heading(_) => {
+            let depths = collect_depth_values(args);
+            if depths.is_empty() {
+                return eval_selector(node, selector);
+            }
+            if let mq_markdown::Node::Heading(mq_markdown::Heading { depth, .. }) = node {
+                depths.contains(depth)
+            } else {
+                false
+            }
+        }
+        Selector::Code => {
+            let langs = collect_string_values(args);
+            if langs.is_empty() {
+                return eval_selector(node, selector);
+            }
+            if let mq_markdown::Node::Code(mq_markdown::Code { lang, .. }) = node {
+                let node_lang = lang.as_deref().unwrap_or("");
+                langs.iter().any(|l| l == node_lang)
+            } else {
+                false
+            }
+        }
+        _ => return eval_selector(node, selector),
+    };
+
+    if is_match {
+        RuntimeValue::Markdown(node.clone(), None)
+    } else {
+        RuntimeValue::NONE
+    }
+}
+
 pub fn eval_selector(node: &mq_markdown::Node, selector: &Selector) -> RuntimeValue {
     let is_match = match selector {
         Selector::Code => node.is_code(None),
@@ -6412,5 +6501,84 @@ mod tests {
         } else {
             panic!("Expected Array result");
         }
+    }
+
+    #[rstest]
+    #[case::single_number(vec![RuntimeValue::Number(1.into())], vec![1u8])]
+    #[case::multiple_numbers(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())], vec![1u8, 2u8])]
+    #[case::number_array(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])], vec![1u8, 2u8])]
+    #[case::empty(vec![], vec![])]
+    #[case::ignores_strings(vec![RuntimeValue::String("x".into())], vec![])]
+    fn test_collect_depth_values(#[case] args: Vec<RuntimeValue>, #[case] expected: Vec<u8>) {
+        assert_eq!(collect_depth_values(&args), expected);
+    }
+
+    #[rstest]
+    #[case::single_string(vec![RuntimeValue::String("rust".into())], vec!["rust".to_string()])]
+    #[case::multiple_strings(vec![RuntimeValue::String("rust".into()), RuntimeValue::String("go".into())], vec!["rust".to_string(), "go".to_string()])]
+    #[case::string_array(vec![RuntimeValue::Array(vec![RuntimeValue::String("rust".into()), RuntimeValue::String("go".into())])], vec!["rust".to_string(), "go".to_string()])]
+    #[case::empty(vec![], vec![])]
+    #[case::ignores_numbers(vec![RuntimeValue::Number(1.into())], vec![])]
+    fn test_collect_string_values(#[case] args: Vec<RuntimeValue>, #[case] expected: Vec<String>) {
+        assert_eq!(collect_string_values(&args), expected);
+    }
+
+    #[rstest]
+    #[case::heading_depth_match(
+        Node::Heading(mq_markdown::Heading { depth: 1, values: vec![], position: None }),
+        Selector::Heading(None),
+        vec![RuntimeValue::Number(1.into())],
+        true
+    )]
+    #[case::heading_depth_no_match(
+        Node::Heading(mq_markdown::Heading { depth: 2, values: vec![], position: None }),
+        Selector::Heading(None),
+        vec![RuntimeValue::Number(1.into())],
+        false
+    )]
+    #[case::heading_multi_depth_match(
+        Node::Heading(mq_markdown::Heading { depth: 2, values: vec![], position: None }),
+        Selector::Heading(None),
+        vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())],
+        true
+    )]
+    #[case::heading_no_args_fallback(
+        Node::Heading(mq_markdown::Heading { depth: 1, values: vec![], position: None }),
+        Selector::Heading(None),
+        vec![],
+        true
+    )]
+    #[case::code_lang_match(
+        Node::Code(mq_markdown::Code { lang: Some("rust".to_string()), meta: None, value: "fn main() {}".to_string(), fence: true, position: None }),
+        Selector::Code,
+        vec![RuntimeValue::String("rust".into())],
+        true
+    )]
+    #[case::code_lang_no_match(
+        Node::Code(mq_markdown::Code { lang: Some("python".to_string()), meta: None, value: "pass".to_string(), fence: true, position: None }),
+        Selector::Code,
+        vec![RuntimeValue::String("rust".into())],
+        false
+    )]
+    #[case::code_no_args_fallback(
+        Node::Code(mq_markdown::Code { lang: None, meta: None, value: "".to_string(), fence: true, position: None }),
+        Selector::Code,
+        vec![],
+        true
+    )]
+    #[case::non_heading_node(
+        Node::HorizontalRule(mq_markdown::HorizontalRule { position: None }),
+        Selector::Heading(None),
+        vec![RuntimeValue::Number(1.into())],
+        false
+    )]
+    fn test_eval_selector_with_args(
+        #[case] node: Node,
+        #[case] selector: Selector,
+        #[case] args: Vec<RuntimeValue>,
+        #[case] expected_match: bool,
+    ) {
+        let result = eval_selector_with_args(&node, &selector, &args);
+        assert_eq!(!result.is_none(), expected_match);
     }
 }

--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -2,7 +2,7 @@ use crate::{
     Ident, Shared,
     ast::{
         Program, TokenId,
-        node::{AccessTarget, Expr, MatchArm, Node, StringSegment},
+        node::{AccessTarget, Args, Expr, MatchArm, Node, StringSegment},
     },
     error::runtime::RuntimeError,
     eval::runtime_value::RuntimeValue,
@@ -381,6 +381,16 @@ impl Macro {
             Expr::Macro(_, _, _) => {
                 // This should not happen in normal flow as we filter them out
                 Ok(Shared::clone(node))
+            }
+            Expr::SelectorCall(selector, args) => {
+                let expanded_args = args
+                    .iter()
+                    .map(|arg| self.expand_node(arg, evaluator))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::SelectorCall(selector.clone(), expanded_args.into())),
+                }))
             }
             // Leaf nodes and other expressions - no expansion needed, avoid cloning
             Expr::Literal(_)
@@ -773,6 +783,16 @@ impl Macro {
             // Unquote: Unwrap and return the substituted inner expression
             // Unquote should not appear in the final expanded code
             Expr::Unquote(inner) => self.substitute_node(inner, substitutions),
+            Expr::SelectorCall(selector, args) => {
+                let substituted_args: Args = args
+                    .iter()
+                    .map(|arg| self.substitute_node(arg, substitutions))
+                    .collect();
+                Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::SelectorCall(selector.clone(), substituted_args)),
+                })
+            }
             // Leaf nodes and other expressions - no substitution needed
             Expr::Literal(_)
             | Expr::Selector(_)
@@ -1061,6 +1081,16 @@ impl Macro {
                 Shared::new(Node {
                     token_id: node.token_id,
                     expr: Shared::new(Expr::QualifiedAccess(path.clone(), substituted_target)),
+                })
+            }
+            Expr::SelectorCall(selector, args) => {
+                let substituted_args: Vec<_> = args
+                    .iter()
+                    .map(|arg| self.substitute_in_quote(arg, substitutions))
+                    .collect();
+                Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::SelectorCall(selector.clone(), substituted_args.into())),
                 })
             }
             // All other nodes (identifiers, literals, etc.) are not substituted in quote context
@@ -2732,5 +2762,43 @@ mod tests {
         } else {
             panic!("Expected Call expression, got {:?}", expanded[0].expr);
         }
+    }
+
+    #[test]
+    fn test_selector_call_in_macro_body_expands_without_error() {
+        let input = "macro h1(doc): doc | .h(1) | h1(.h)";
+        let program = parse_program(input).expect("Failed to parse program");
+        let mut macro_expander = Macro::new();
+        let expanded = macro_expander
+            .expand(&program, &mut MockMacroEvaluator)
+            .expect("Failed to expand program");
+
+        assert!(!expanded.is_empty(), "Expected non-empty expansion");
+        let has_selector_call = expanded
+            .iter()
+            .any(|node| matches!(&*node.expr, Expr::SelectorCall(_, _)));
+        assert!(has_selector_call, "Expected SelectorCall in expanded program");
+    }
+
+    #[test]
+    fn test_selector_call_substitute_arg_in_macro() {
+        let input = "macro filter_lang(sel, lang): sel(lang) | filter_lang(.code, \"rust\")";
+        let program = parse_program(input).expect("Failed to parse program");
+        let mut macro_expander = Macro::new();
+        let result = macro_expander.expand(&program, &mut MockMacroEvaluator);
+        // Expansion should succeed; selector-call substitution must not panic
+        assert!(result.is_ok(), "Expected successful expansion, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_selector_call_in_quote_context() {
+        let input = "macro wrap_selector(s): quote: s(1) | wrap_selector(.h)";
+        let program = parse_program(input).expect("Failed to parse program");
+        let mut macro_expander = Macro::new();
+        let expanded = macro_expander
+            .expand(&program, &mut MockMacroEvaluator)
+            .expect("Failed to expand program");
+
+        assert!(!expanded.is_empty(), "Expected non-empty expansion from quote context");
     }
 }

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -445,6 +445,11 @@ impl Selector {
     pub fn is_attribute_selector(&self) -> bool {
         matches!(self, Selector::Attr(_))
     }
+
+    /// Returns the selector as a string without a leading dot.
+    pub fn name(&self) -> String {
+        self.to_string().trim_start_matches('.').to_string()
+    }
 }
 
 #[cfg(test)]

--- a/docs/books/src/reference/selectors.md
+++ b/docs/books/src/reference/selectors.md
@@ -12,6 +12,59 @@ Selectors use the `.` prefix to select markdown nodes. For example:
 .link    # Selects all link nodes
 ```
 
+## Selector Calls (Filtered Matching)
+
+Selectors can accept arguments to filter nodes by specific properties, using a function-call syntax:
+
+```mq
+.h(1)           # Selects only h1 headings
+.h(2, 3)        # Selects h2 and h3 headings
+.h(1..3)        # Selects h1, h2, and h3 headings (range)
+.code("rust")   # Selects only Rust code blocks
+```
+
+### Heading Depth Filtering
+
+Pass one or more numeric arguments to match headings at specific depths:
+
+```mq
+# Select only top-level headings
+.h(1)
+
+# Select h2 and h3 headings
+.h(2, 3)
+
+# Select h1 through h3 using a range
+.h(1..3)
+```
+
+### Code Language Filtering
+
+Pass a string argument to match code blocks with a specific language:
+
+```mq
+# Select only Rust code blocks
+.code("rust")
+
+# Select Python or JavaScript code blocks
+.code("python") | to_array | concat(.code("javascript"))
+```
+
+### Combining with Other Operations
+
+Selector calls can be combined with pipes and functions just like plain selectors:
+
+```mq
+# Extract content of all h2 headings
+.h(2) | .value
+
+# Count Rust code blocks
+.code("rust") | len()
+
+# Replace language of all TypeScript blocks
+.code("typescript") | set_attr("lang", "ts")
+```
+
 ## Attribute Access
 
 Once you've selected a node, you can access its attributes using dot notation. The available attributes depend on the node type.
@@ -199,6 +252,13 @@ Filter nodes based on attribute values:
 .code | filter(fn(c): c.lang == "rust";)
 ```
 
+The selector call syntax provides a more concise alternative for common cases:
+
+```mq
+.h(2)           # equivalent to: .h | filter(fn(h): h.level == 2;)
+.code("rust")   # equivalent to: .code | filter(fn(c): c.lang == "rust";)
+```
+
 ### Extract Code Languages
 
 ```mq
@@ -214,7 +274,11 @@ Filter nodes based on attribute values:
 ### Filter High-Level Headings
 
 ```mq
+# Using attribute comparison
 select(.h.level <= 2)
+
+# Using selector call for exact levels
+.h(1, 2)
 ```
 
 ## Setting Attributes


### PR DESCRIPTION
Introduce `SelectorCall` — a new expression form that lets selectors accept runtime arguments for inline filtered matching, e.g. `.h(1)`, `.h(1, 2)`, `.h(1..3)`, `.code("rust")`.

- Add `Expr::SelectorCall(Selector, Args)` AST node and range/code-gen support
- Add `NodeKind::SelectorCall` CST node; reuse `parse_args()` for argument parsing so invalid tokens produce `UnexpectedToken` errors at the CST level
- Implement `eval_selector_with_args` / `collect_depth_values` / `collect_string_values` in `eval/builtin.rs`
- Wire evaluation in `eval.rs` and macro expansion in `macro_expand.rs`
- Fix `format_selector` and `append_literal` in `mq-formatter` to handle `SelectorCall` nodes correctly
- Add tests across CST parser, AST parser, evaluator, builtin, formatter, and macro expander
- Update `selectors.md` and `README.md` with usage examples