### PR TITLE
✨ feat(repl): add rich completions and improved UX

### DIFF
--- a/crates/mq-repl/src/command_context.rs
+++ b/crates/mq-repl/src/command_context.rs
@@ -5,21 +5,34 @@ use arboard::Clipboard;
 use miette::{IntoDiagnostic, miette};
 use strum::IntoEnumIterator;
 
+/// A completion candidate with a display label and the name to insert.
+#[derive(Debug, Clone)]
+pub struct CompletionItem {
+    /// The actual text to insert.
+    pub name: String,
+    /// The label shown in the completion list (may include signature or description).
+    pub display: String,
+}
+
 #[derive(Debug, Clone)]
 pub enum CommandOutput {
     Value(Vec<mq_lang::RuntimeValue>),
     String(Vec<String>),
+    History,
     None,
 }
 
 #[derive(Debug, Clone, strum::EnumIter)]
 pub enum Command {
+    Clear,
     Copy,
     Edit,
     Env(String, String),
     Help,
+    History,
     Quit,
     LoadFile(String),
+    Reset,
     Vars,
     Eval(String),
     Version,
@@ -40,14 +53,15 @@ const KEYWORDS: &[&str] = &[
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Command::Clear => write!(f, "/clear"),
             Command::Copy => write!(f, "/copy"),
             Command::Edit => write!(f, "/edit"),
-            Command::Env(_, _) => {
-                write!(f, "/env")
-            }
+            Command::Env(_, _) => write!(f, "/env"),
             Command::Help => write!(f, "/help"),
+            Command::History => write!(f, "/history"),
             Command::Quit => write!(f, "/quit"),
             Command::LoadFile(_) => write!(f, "/load"),
+            Command::Reset => write!(f, "/reset"),
             Command::Vars => write!(f, "/vars"),
             Command::Eval(_) => write!(f, "/eval"),
             Command::Version => write!(f, "/version"),
@@ -59,14 +73,15 @@ impl fmt::Display for Command {
 impl Command {
     pub fn help(&self) -> String {
         match self {
+            Command::Clear => format!("{:<12}{}", "/clear", "Clear the terminal screen"),
             Command::Copy => format!("{:<12}{}", "/copy", "Copy the execution results to the clipboard"),
             Command::Edit => format!("{:<12}{}", "/edit", "Edit the current buffer in external editor"),
-            Command::Env(_, _) => {
-                format!("{:<12}{}", "/env", "Set environment variables (key value)")
-            }
+            Command::Env(_, _) => format!("{:<12}{}", "/env", "Set environment variables (key value)"),
             Command::Help => format!("{:<12}{}", "/help", "Print command help"),
+            Command::History => format!("{:<12}{}", "/history", "Show command history"),
             Command::Quit => format!("{:<12}{}", "/quit", "Quit evaluation and exit"),
             Command::LoadFile(_) => format!("{:<12}{}", "/load", "Load a markdown file"),
+            Command::Reset => format!("{:<12}{}", "/reset", "Reset REPL state (clear variables and input)"),
             Command::Vars => format!("{:<12}{}", "/vars", "List bound variables"),
             Command::Eval(_) => format!("{:<12}{}", "/eval", ""),
             Command::NotFound(_) => format!("{:<12}{}", "/not_found", ""),
@@ -78,12 +93,15 @@ impl Command {
 impl From<String> for Command {
     fn from(s: String) -> Self {
         match s.as_str().split_whitespace().collect::<Vec<&str>>().as_slice() {
+            ["/clear"] => Command::Clear,
             ["/copy"] => Command::Copy,
             ["/edit"] => Command::Edit,
             ["/env", name, value] => Command::Env(name.to_string(), value.to_string()),
             ["/help"] => Command::Help,
+            ["/history"] => Command::History,
             ["/quit"] => Command::Quit,
             ["/load", file_path] => Command::LoadFile(file_path.to_string()),
+            ["/reset"] => Command::Reset,
             ["/vars"] => Command::Vars,
             ["/version"] => Command::Version,
             _ if s.starts_with("/") => Command::NotFound(s),
@@ -95,6 +113,7 @@ impl From<String> for Command {
 pub struct CommandContext {
     pub(crate) engine: mq_lang::DefaultEngine,
     pub(crate) input: Vec<mq_lang::RuntimeValue>,
+    initial_input: Vec<mq_lang::RuntimeValue>,
     pub(crate) hir: mq_hir::Hir,
     pub(crate) source_id: mq_hir::SourceId,
     pub(crate) scope_id: mq_hir::ScopeId,
@@ -109,6 +128,7 @@ impl CommandContext {
 
         Self {
             engine,
+            initial_input: input.clone(),
             input,
             hir,
             source_id,
@@ -116,7 +136,7 @@ impl CommandContext {
         }
     }
 
-    pub fn completions(&self, line: &str, pos: usize) -> (usize, Vec<String>) {
+    pub fn completions(&self, line: &str, pos: usize) -> (usize, Vec<CompletionItem>) {
         let prefix = &line[..pos];
         let start = prefix
             .char_indices()
@@ -126,7 +146,7 @@ impl CommandContext {
             .unwrap_or(0);
         let word = &line[start..pos];
 
-        let mut matches = Vec::new();
+        let mut matches: Vec<CompletionItem> = Vec::new();
 
         if word.starts_with('/') {
             for cmd in Command::iter() {
@@ -135,34 +155,95 @@ impl CommandContext {
                 }
                 let cmd_str = cmd.to_string();
                 if cmd_str.starts_with(word) {
-                    matches.push(cmd_str);
+                    let description = cmd.help();
+                    let desc_part = description.trim_start_matches(&cmd_str).trim().to_string();
+                    matches.push(CompletionItem {
+                        name: cmd_str.clone(),
+                        display: if desc_part.is_empty() {
+                            cmd_str
+                        } else {
+                            format!("{:<12}{}", cmd_str, desc_part)
+                        },
+                    });
+                }
+            }
+        } else if word.starts_with('.') {
+            for (selector, doc) in mq_lang::BUILTIN_SELECTOR_DOC.iter() {
+                if selector.starts_with(word) {
+                    matches.push(CompletionItem {
+                        name: selector.to_string(),
+                        display: format!("{:<20}{}", selector, doc.description),
+                    });
                 }
             }
         } else {
+            let seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut seen_names = seen_names;
+
             for keyword in KEYWORDS {
                 if keyword.starts_with(word) {
-                    matches.push(keyword.to_string());
+                    matches.push(CompletionItem {
+                        name: keyword.to_string(),
+                        display: keyword.to_string(),
+                    });
+                    seen_names.insert(keyword.to_string());
                 }
             }
 
             for (_, symbol) in self.hir.symbols() {
                 if let Some(name) = &symbol.value {
-                    if name.starts_with('_') {
+                    if name.starts_with('_') || seen_names.contains(name.as_str()) {
                         continue;
                     }
-                    if name.starts_with(word) && !matches.contains(&name.to_string()) {
-                        matches.push(name.to_string());
+                    if name.starts_with(word) {
+                        let display = Self::builtin_display(name);
+                        seen_names.insert(name.to_string());
+                        matches.push(CompletionItem {
+                            name: name.to_string(),
+                            display,
+                        });
                     }
                 }
             }
         }
 
-        matches.sort();
+        matches.sort_by(|a, b| a.name.cmp(&b.name));
         (start, matches)
+    }
+
+    fn builtin_display(name: &str) -> String {
+        if let Some(doc) = mq_lang::BUILTIN_FUNCTION_DOC.get(name) {
+            if doc.params.is_empty() {
+                format!("{}()", name)
+            } else {
+                format!("{}({})", name, doc.params.join(", "))
+            }
+        } else {
+            name.to_string()
+        }
     }
 
     pub fn execute(&mut self, to_run: &str) -> miette::Result<CommandOutput> {
         match to_run.to_string().into() {
+            Command::Clear => {
+                print!("\x1b[2J\x1b[H");
+                let _ = std::io::stdout().flush();
+                Ok(CommandOutput::None)
+            }
+            Command::History => Ok(CommandOutput::History),
+            Command::Reset => {
+                let mut hir = mq_hir::Hir::default();
+                let (source_id, scope_id) = hir.add_new_source(None);
+                hir.add_builtin();
+                let mut engine = mq_lang::DefaultEngine::default();
+                engine.load_builtin_module();
+                self.hir = hir;
+                self.source_id = source_id;
+                self.scope_id = scope_id;
+                self.engine = engine;
+                self.input = self.initial_input.clone();
+                Ok(CommandOutput::None)
+            }
             Command::Copy => {
                 #[cfg(all(feature = "clipboard", not(target_os = "android")))]
                 {
@@ -352,10 +433,13 @@ mod tests {
 
     #[test]
     fn test_command_from_string() {
+        assert!(matches!(Command::from("/clear".to_string()), Command::Clear));
         assert!(matches!(Command::from("/copy".to_string()), Command::Copy));
         assert!(matches!(Command::from("/edit".to_string()), Command::Edit));
         assert!(matches!(Command::from("/help".to_string()), Command::Help));
+        assert!(matches!(Command::from("/history".to_string()), Command::History));
         assert!(matches!(Command::from("/quit".to_string()), Command::Quit));
+        assert!(matches!(Command::from("/reset".to_string()), Command::Reset));
         assert!(matches!(Command::from("/vars".to_string()), Command::Vars));
         assert!(matches!(Command::from("/version".to_string()), Command::Version));
 
@@ -381,10 +465,13 @@ mod tests {
 
     #[test]
     fn test_command_display() {
+        assert_eq!(format!("{}", Command::Clear), "/clear");
         assert_eq!(format!("{}", Command::Copy), "/copy");
         assert_eq!(format!("{}", Command::Edit), "/edit");
         assert_eq!(format!("{}", Command::Help), "/help");
+        assert_eq!(format!("{}", Command::History), "/history");
         assert_eq!(format!("{}", Command::Quit), "/quit");
+        assert_eq!(format!("{}", Command::Reset), "/reset");
         assert_eq!(format!("{}", Command::Vars), "/vars");
         assert_eq!(format!("{}", Command::Version), "/version");
         assert_eq!(format!("{}", Command::LoadFile("test.md".to_string())), "/load");
@@ -402,10 +489,13 @@ mod tests {
             assert!(!help.is_empty());
 
             match cmd {
+                Command::Clear => assert!(help.contains("/clear")),
                 Command::Copy => assert!(help.contains("/copy")),
                 Command::Edit => assert!(help.contains("/edit")),
                 Command::Help => assert!(help.contains("/help")),
+                Command::History => assert!(help.contains("/history")),
                 Command::Quit => assert!(help.contains("/quit")),
+                Command::Reset => assert!(help.contains("/reset")),
                 Command::Vars => assert!(help.contains("/vars")),
                 Command::Version => assert!(help.contains("/version")),
                 Command::LoadFile(_) => assert!(help.contains("/load")),
@@ -416,6 +506,10 @@ mod tests {
         }
     }
 
+    fn names(items: &[CompletionItem]) -> Vec<&str> {
+        items.iter().map(|i| i.name.as_str()).collect()
+    }
+
     #[test]
     fn test_completions_basic() {
         let engine = mq_lang::DefaultEngine::default();
@@ -423,7 +517,7 @@ mod tests {
 
         let (start, matches) = ctx.completions("ad", 2);
         assert_eq!(start, 0);
-        assert!(matches.contains(&"add".to_string()));
+        assert!(names(&matches).contains(&"add"));
     }
 
     #[test]
@@ -433,7 +527,7 @@ mod tests {
 
         let (start, matches) = ctx.completions("/he", 3);
         assert_eq!(start, 0);
-        assert!(matches.contains(&"/help".to_string()));
+        assert!(names(&matches).contains(&"/help"));
     }
 
     #[test]
@@ -443,7 +537,7 @@ mod tests {
 
         let (start, matches) = ctx.completions("let x = ad", 10);
         assert_eq!(start, 8);
-        assert!(matches.contains(&"add".to_string()));
+        assert!(names(&matches).contains(&"add"));
     }
 
     #[test]
@@ -452,7 +546,29 @@ mod tests {
         let ctx = CommandContext::new(engine, Vec::new());
 
         let (_, matches) = ctx.completions("_", 1);
-        assert!(matches.iter().all(|m| !m.starts_with('_')));
+        assert!(matches.iter().all(|m| !m.name.starts_with('_')));
+    }
+
+    #[test]
+    fn test_completions_selector() {
+        let engine = mq_lang::DefaultEngine::default();
+        let ctx = CommandContext::new(engine, Vec::new());
+
+        let (start, matches) = ctx.completions(".h1", 3);
+        assert_eq!(start, 0);
+        assert!(names(&matches).contains(&".h1"));
+    }
+
+    #[test]
+    fn test_completions_function_signature() {
+        let engine = mq_lang::DefaultEngine::default();
+        let ctx = CommandContext::new(engine, Vec::new());
+
+        let (_, matches) = ctx.completions("ad", 2);
+        let add_item = matches.iter().find(|i| i.name == "add");
+        assert!(add_item.is_some());
+        // add has params so display should include parentheses
+        assert!(add_item.unwrap().display.contains('('));
     }
 
     #[test]

--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -16,7 +16,7 @@ use crate::command_context::{Command, CommandContext, CommandOutput};
 fn highlight_mq_syntax(line: &str) -> Cow<'_, str> {
     let mut result = line.to_string();
 
-    let commands_pattern = r"^(/copy|/edit|/env|/help|/quit|/load|/vars|/version)\b";
+    let commands_pattern = r"^(/clear|/copy|/edit|/env|/help|/history|/quit|/load|/reset|/vars|/version)\b";
     if let Ok(re) = regex_lite::Regex::new(commands_pattern) {
         result = re
             .replace_all(&result, |caps: &regex_lite::Captures| {
@@ -64,9 +64,63 @@ fn highlight_mq_syntax(line: &str) -> Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Format a markdown node with type-specific colors.
+fn format_markdown_node(node: &mq_markdown::Node) -> String {
+    let s = node.to_string();
+    match node {
+        mq_markdown::Node::Heading(_) => s.bold().bright_cyan().to_string(),
+        mq_markdown::Node::Code(_) => s.bright_yellow().to_string(),
+        mq_markdown::Node::CodeInline(_) => s.yellow().to_string(),
+        mq_markdown::Node::Link(_) | mq_markdown::Node::LinkRef(_) => s.bright_blue().to_string(),
+        mq_markdown::Node::Strong(_) => s.bold().to_string(),
+        mq_markdown::Node::Emphasis(_) => s.italic().to_string(),
+        _ => s,
+    }
+}
+
+/// Format a runtime value with type-appropriate colors.
+fn format_runtime_value(value: &mq_lang::RuntimeValue) -> Option<String> {
+    use mq_lang::RuntimeValue;
+    let s = match value {
+        RuntimeValue::None => return Some("None".dimmed().to_string()),
+        RuntimeValue::Number(n) => n.to_string().bright_magenta().to_string(),
+        RuntimeValue::Boolean(b) => b.to_string().bright_yellow().to_string(),
+        RuntimeValue::String(s) => format!("\"{}\"", s).bright_green().to_string(),
+        RuntimeValue::Markdown(node, _) => format_markdown_node(node),
+        _ => {
+            let s = value.to_string();
+            if s.is_empty() {
+                return None;
+            }
+            s
+        }
+    };
+    Some(s)
+}
+
 /// Get the appropriate prompt symbol based on character availability
 fn get_prompt() -> &'static str {
     if is_char_available() { "❯ " } else { "> " }
+}
+
+fn is_truecolor_supported() -> bool {
+    matches!(std::env::var("COLORTERM").as_deref(), Ok("truecolor") | Ok("24bit"))
+}
+
+fn logo_primary(s: &str) -> ColoredString {
+    if is_truecolor_supported() {
+        s.truecolor(133, 212, 255)
+    } else {
+        s.bright_cyan()
+    }
+}
+
+fn text_muted(s: &str) -> ColoredString {
+    if is_truecolor_supported() {
+        s.truecolor(148, 163, 184)
+    } else {
+        s.white()
+    }
 }
 
 /// Check if a Unicode character is available in the current environment
@@ -102,6 +156,8 @@ fn is_char_available() -> bool {
 pub struct MqLineHelper {
     command_context: Rc<RefCell<CommandContext>>,
     file_completer: FilenameCompleter,
+    /// Tracks whether the current input spans multiple lines (continuation mode).
+    is_continuation: Rc<RefCell<bool>>,
 }
 
 impl MqLineHelper {
@@ -109,17 +165,58 @@ impl MqLineHelper {
         Self {
             command_context,
             file_completer: FilenameCompleter::new(),
+            is_continuation: Rc::new(RefCell::new(false)),
         }
     }
 }
 
 impl Hinter for MqLineHelper {
     type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        // Update continuation state based on whether the buffer has newlines.
+        *self.is_continuation.borrow_mut() = line.contains('\n');
+
+        if pos < line.len() || line.is_empty() || line.starts_with('/') {
+            return None;
+        }
+
+        let (start, completions) = self.command_context.borrow().completions(line, pos);
+        let word = &line[start..pos];
+
+        // Completion hint takes priority when a single match extends the current word.
+        if !word.is_empty() && completions.len() == 1 && completions[0].name.len() > word.len() {
+            return Some(completions[0].name[word.len()..].to_string());
+        }
+
+        // Bracket closing hint: show the matching close bracket right after an open bracket.
+        if word.is_empty() {
+            let closing = match line.chars().last() {
+                Some('(') => Some(")"),
+                Some('[') => Some("]"),
+                Some('{') => Some("}"),
+                _ => None,
+            };
+            if let Some(c) = closing {
+                return Some(c.to_string());
+            }
+        }
+
+        None
+    }
 }
 
 impl Highlighter for MqLineHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str, _default: bool) -> Cow<'b, str> {
-        prompt.cyan().to_string().into()
+        if *self.is_continuation.borrow() {
+            "..  ".dimmed().to_string().into()
+        } else {
+            prompt.cyan().to_string().into()
+        }
+    }
+
+    fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
+        hint.dimmed().to_string().into()
     }
 
     fn highlight_char(&self, _line: &str, _pos: usize, _kind: CmdKind) -> bool {
@@ -158,9 +255,9 @@ impl Completer for MqLineHelper {
 
         let mut completions = matches
             .iter()
-            .map(|cmd| Pair {
-                display: cmd.clone(),
-                replacement: format!("{}{}", cmd, &line[pos..]),
+            .map(|item| Pair {
+                display: item.display.clone(),
+                replacement: format!("{}{}", item.name, &line[pos..]),
             })
             .collect::<Vec<_>>();
 
@@ -197,14 +294,13 @@ impl Repl {
     }
 
     fn print_welcome() {
+        let version = mq_lang::DefaultEngine::version();
+
         println!();
-        println!(
-            "  {}",
-            "mq - A jq-like command-line tool for Markdown processing".bright_cyan()
-        );
+        println!("  {} {}", logo_primary("mq").bold(), text_muted(&format!("v{version}")));
+        println!("  {}", text_muted("Query. Filter. Transform Markdown."));
         println!();
-        println!("  Welcome to mq. Start by typing commands or expressions.");
-        println!("  Type {} to see available commands.", "/help".bright_cyan());
+        println!("  Type {} to see available commands.", logo_primary("/help"));
         println!();
     }
 
@@ -261,20 +357,22 @@ impl Repl {
                     match self.command_context.borrow_mut().execute(&line) {
                         Ok(CommandOutput::String(s)) => println!("{}", s.join("\n")),
                         Ok(CommandOutput::Value(runtime_values)) => {
-                            let lines = runtime_values
-                                .iter()
-                                .filter_map(|runtime_value| {
-                                    if runtime_value.is_none() {
-                                        return Some("None".to_string());
-                                    }
-
-                                    let s = runtime_value.to_string();
-                                    if s.is_empty() { None } else { Some(s) }
-                                })
-                                .collect::<Vec<_>>();
-
+                            let lines: Vec<String> = runtime_values.iter().filter_map(format_runtime_value).collect();
                             if !lines.is_empty() {
                                 println!("{}", lines.join("\n"))
+                            }
+                        }
+                        Ok(CommandOutput::History) => {
+                            let entries: Vec<String> = editor
+                                .history()
+                                .iter()
+                                .enumerate()
+                                .map(|(i, entry)| format!("  {:>4}  {}", i + 1, entry.dimmed()))
+                                .collect();
+                            if entries.is_empty() {
+                                println!("  No history.");
+                            } else {
+                                println!("{}", entries.join("\n"));
                             }
                         }
                         Ok(CommandOutput::None) => (),
@@ -344,6 +442,35 @@ mod tests {
         // Test number highlighting
         let result = highlight_mq_syntax("42");
         assert!(result.contains("42"));
+    }
+
+    #[test]
+    fn test_format_runtime_value_number() {
+        let v = mq_lang::RuntimeValue::Number(42.into());
+        let s = format_runtime_value(&v).unwrap();
+        assert!(s.contains("42"));
+    }
+
+    #[test]
+    fn test_format_runtime_value_boolean() {
+        let v = mq_lang::RuntimeValue::Boolean(true);
+        let s = format_runtime_value(&v).unwrap();
+        assert!(s.contains("true"));
+    }
+
+    #[test]
+    fn test_format_runtime_value_string() {
+        let v = mq_lang::RuntimeValue::String("hello".to_string());
+        let s = format_runtime_value(&v).unwrap();
+        assert!(s.contains("hello"));
+        assert!(s.contains('"'));
+    }
+
+    #[test]
+    fn test_format_runtime_value_none() {
+        let v = mq_lang::RuntimeValue::None;
+        let s = format_runtime_value(&v).unwrap();
+        assert!(s.contains("None"));
     }
 
     #[test]


### PR DESCRIPTION
- Add CompletionItem with display/name separation for richer completion UI
- Add selector completions (.h1, .text, etc.) from BUILTIN_SELECTOR_DOC
- Show function signatures in completion list (e.g. add(x, y))
- Show command descriptions in completion list
- Implement inline hint (ghost text) for single-match completions
- Add bracket closing hint: shows ) ] } after opening bracket
- Add continuation prompt (..  ) for multi-line input via is_continuation flag
- Add colored output: numbers magenta, strings green, booleans yellow, headings bold-cyan, code yellow, links blue, etc.
- Add /clear command to clear the terminal screen
- Add /reset command to restore engine/HIR/input to initial state
- Add /history command to list session history with line numbers