### PR TITLE
✨ feat(lexer): add \uXXXX four-digit Unicode escape sequence support

### DIFF
--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -5,7 +5,7 @@ use miette::{Diagnostic, SourceOffset, SourceSpan};
 use std::borrow::Cow;
 
 use crate::{
-    Module, ModuleLoader, ModuleResolver, Token,
+    Module, ModuleLoader, ModuleResolver, Token, TokenKind,
     error::{runtime::RuntimeError, syntax::SyntaxError},
     module::{self, error::ModuleError},
 };
@@ -176,6 +176,11 @@ impl Diagnostic for Error {
             InnerError::Syntax(SyntaxError::EnvNotFound(_, env)) => Some(Cow::Owned(format!(
                 "Environment variable '{env}' not found. Did you forget to set it?"
             ))),
+            InnerError::Syntax(SyntaxError::UnexpectedToken(token)) if token.kind == TokenKind::Eof => {
+                Some(Cow::Borrowed(
+                    "The source could not be fully parsed from this position. Check for unsupported escape sequences (use \\u{XXXX} for Unicode), invalid characters, or unterminated string literals.",
+                ))
+            }
             InnerError::Syntax(SyntaxError::UnexpectedToken(_)) => Some(Cow::Borrowed(
                 "This token is not valid here. Check for typos, missing operators, or misplaced punctuation.",
             )),
@@ -300,6 +305,13 @@ impl Diagnostic for Error {
             )),
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::EnvNotFound(_, env))) => {
                 Some(Cow::Owned(format!("Environment variable '{env}' not found in module.")))
+            }
+            InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnexpectedToken(token)))
+                if token.kind == TokenKind::Eof =>
+            {
+                Some(Cow::Borrowed(
+                    "The source could not be fully parsed from this position. Check for unsupported escape sequences (use \\u{XXXX} for Unicode), invalid characters, or unterminated string literals.",
+                ))
             }
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnexpectedToken(_))) => Some(Cow::Borrowed(
                 "This token is not valid here. Check for typos, missing operators, or misplaced punctuation.",

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -100,7 +100,11 @@ impl Lexer {
                     });
                     Ok(tokens)
                 } else {
-                    Err(SyntaxError::UnexpectedEOFDetected(module_id))
+                    Err(SyntaxError::UnexpectedToken(Token {
+                        range: eof,
+                        kind: TokenKind::Eof,
+                        module_id,
+                    }))
                 }
             }
             Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => Err(SyntaxError::UnexpectedToken(Token {
@@ -124,6 +128,18 @@ fn unicode(input: Span) -> IResult<Span, char> {
                     char('}'),
                 ),
             ),
+            |span: Span| u32::from_str_radix(span.fragment(), 16),
+        ),
+        char::from_u32,
+    )
+    .parse(input)
+}
+
+/// Parses a 4-digit Unicode escape sequence `\uXXXX`.
+fn unicode4(input: Span) -> IResult<Span, char> {
+    map_opt(
+        map_res(
+            preceded(char('u'), take_while_m_n(4, 4, |c: char| c.is_ascii_hexdigit())),
             |span: Span| u32::from_str_radix(span.fragment(), 16),
         ),
         char::from_u32,
@@ -421,6 +437,7 @@ fn string_segment<'a>(input: Span<'a>) -> IResult<Span<'a>, StringSegment> {
                         value('}', char('}')),
                         hex_escape,
                         unicode,
+                        unicode4,
                     )),
                 )(span)?;
                 let (span, end) = position(span)?;
@@ -533,6 +550,7 @@ fn string_literal(input: Span) -> IResult<Span, Token> {
                     value('W', char('W')), // \W (non-word character)
                     hex_escape,
                     unicode,
+                    unicode4,
                 )),
             )),
         ),
@@ -822,7 +840,7 @@ mod tests {
           Token{range: Range { start: Position {line: 1, column: 46}, end: Position {line: 1, column: 46} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
     #[case("\"test",
           Options::default(),
-          Err(SyntaxError::UnexpectedEOFDetected(1.into())))]
+          Err(SyntaxError::UnexpectedToken(Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 6} }, kind: TokenKind::Eof, module_id: 1.into()})))]
     #[case::new_line("and(\ncontains(\"test\"))",
             Options{include_spaces: true, ignore_errors: true},
             Ok(vec![
@@ -882,7 +900,7 @@ mod tests {
                 ))]
     #[case::error("\"test",
             Options{include_spaces: false, ignore_errors: false},
-            Err(SyntaxError::UnexpectedEOFDetected(1.into())))]
+            Err(SyntaxError::UnexpectedToken(Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 6} }, kind: TokenKind::Eof, module_id: 1.into()})))]
     #[case::error("s\"$$${test}$$\"",
             Options{include_spaces: false, ignore_errors: false},
             Ok(vec![Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 15} },
@@ -1290,6 +1308,54 @@ mod tests {
                           ]), module_id: 1.into()},
                    Token{range: Range { start: Position {line: 1, column: 14}, end: Position {line: 1, column: 14} }, kind: TokenKind::Eof, module_id: 1.into()}]
                 ))]
+    #[case::unicode4_hiragana("\"\\u3041\"",
+        Options::default(),
+        Ok(vec![
+            Token {
+                range: Range { start: Position { line: 1, column: 1 }, end: Position { line: 1, column: 9 } },
+                kind: TokenKind::StringLiteral("ぁ".to_string()),
+                module_id: 1.into(),
+            },
+            Token {
+                range: Range { start: Position { line: 1, column: 9 }, end: Position { line: 1, column: 9 } },
+                kind: TokenKind::Eof,
+                module_id: 1.into(),
+            }
+        ])
+    )]
+    #[case::unicode4_katakana("\"\\u30A1\"",
+        Options::default(),
+        Ok(vec![
+            Token {
+                range: Range { start: Position { line: 1, column: 1 }, end: Position { line: 1, column: 9 } },
+                kind: TokenKind::StringLiteral("ァ".to_string()),
+                module_id: 1.into(),
+            },
+            Token {
+                range: Range { start: Position { line: 1, column: 9 }, end: Position { line: 1, column: 9 } },
+                kind: TokenKind::Eof,
+                module_id: 1.into(),
+            }
+        ])
+    )]
+    #[case::unicode4_in_regex_char_class("\"[\\u3041-\\u3096]+\"",
+        Options::default(),
+        Ok(vec![
+            Token {
+                range: Range { start: Position { line: 1, column: 1 }, end: Position { line: 1, column: 19 } },
+                kind: TokenKind::StringLiteral("[ぁ-ゖ]+".to_string()),
+                module_id: 1.into(),
+            },
+            Token {
+                range: Range { start: Position { line: 1, column: 19 }, end: Position { line: 1, column: 19 } },
+                kind: TokenKind::Eof,
+                module_id: 1.into(),
+            }
+        ])
+    )]
+    #[case::unterminated_string_reports_position("\"unterminated",
+        Options::default(),
+        Err(SyntaxError::UnexpectedToken(Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 14} }, kind: TokenKind::Eof, module_id: 1.into()})))]
 
     fn test_parse(#[case] input: &str, #[case] options: Options, #[case] expected: Result<Vec<Token>, SyntaxError>) {
         assert_eq!(Lexer::new(options).tokenize(input, 1.into()), expected);


### PR DESCRIPTION
- Add unicode4() parser for \uXXXX escape sequences in string literals and string segments
- Replace UnexpectedEOFDetected with UnexpectedToken(Eof) for richer error diagnostics
- Add diagnostic hint for EOF parse errors suggesting escape sequence issues
- Add tests for hiragana, katakana, and regex character class with \uXXXX