### PR TITLE
✨ feat(selector): support variables and expressions in bracket selectors

### DIFF
--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -2580,7 +2580,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
             Some(t) => Shared::clone(t),
             None => return Err(SyntaxError::InsufficientTokens((*bracket_token).clone())),
         };
-        let node = self.parse_primary_expr(&expr_token)?;
+        let node = self.parse_expr(&expr_token)?;
         self.next_token(|kind| matches!(kind, TokenKind::RBracket))?;
         Ok(Some(node))
     }

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -19,9 +19,6 @@ type IfExpr = (Option<Shared<Node>>, Shared<Node>);
 
 static GET_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::from(constants::builtins::GET));
 
-#[derive(Debug)]
-struct ArrayIndex(Option<usize>);
-
 pub struct Parser<'a, 'alloc> {
     tokens: Peekable<core::slice::Iter<'a, Shared<Token>>>,
     token_arena: &'alloc mut Arena<Shared<Token>>,
@@ -2494,53 +2491,98 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
     }
 
     // Parses arguments for table or list item selectors like `.[index1][index2]` (for tables) or `.[index1]` (for lists).
-    // Example: .[0][1] or .[0]
     fn parse_selector_table_args(&mut self, token: Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
-        let token1 = match self.tokens.peek() {
-            Some(token) => Ok(Shared::clone(token)),
-            None => Err(SyntaxError::UnexpectedEOFDetected(self.module_id)),
-        }?;
-
-        let ArrayIndex(i1) = self.parse_int_array_arg(&token1)?;
-        let token2 = match self.tokens.peek() {
-            Some(token) => Ok(Shared::clone(token)),
-            None => Err(SyntaxError::UnexpectedEOFDetected(self.module_id)),
-        }?;
-
-        if let TokenKind::LBracket = &token2.kind {
-            // .[n][n]
-            let ArrayIndex(i2) = self.parse_int_array_arg(&token2)?;
-            Ok(Shared::new(Node {
-                token_id: self.token_arena.alloc(Shared::clone(&token)),
-                expr: Shared::new(Expr::Selector(Selector::Table(i1, i2))),
-            }))
+        let first = self.parse_bracket_expr()?;
+        let has_second = self.is_next_token(|kind| matches!(kind, TokenKind::LBracket));
+        let second = if has_second {
+            Some(self.parse_bracket_expr()?)
         } else {
-            // .[n]
-            Ok(Shared::new(Node {
-                token_id: self.token_arena.alloc(Shared::clone(&token)),
-                expr: Shared::new(Expr::Selector(Selector::List(i1, None))),
-            }))
+            None
+        };
+
+        let is_dynamic_node = |opt: &Option<Shared<Node>>| {
+            opt.as_ref()
+                .is_some_and(|n| !matches!(&*n.expr, Expr::Literal(Literal::Number(_))))
+        };
+        let has_dynamic = is_dynamic_node(&first) || second.as_ref().is_some_and(is_dynamic_node);
+        let has_explicit_args = self.is_next_token(|kind| matches!(kind, TokenKind::LParen));
+
+        if has_dynamic || has_explicit_args {
+            let is_table = second.is_some();
+            let selector = if is_table {
+                Selector::Table(None, None)
+            } else {
+                Selector::List(None, None)
+            };
+
+            let mut args: Args = SmallVec::new();
+
+            // .[][v]: insert None as row placeholder so args[0]=row, args[1]=col positional encoding holds.
+            if is_table && first.is_none() && second.as_ref().is_some_and(|s| s.is_some()) {
+                let placeholder_token_id = self.token_arena.alloc(Shared::clone(&token));
+                args.push(Shared::new(Node {
+                    token_id: placeholder_token_id,
+                    expr: Shared::new(Expr::Literal(Literal::None)),
+                }));
+            } else if let Some(node) = first {
+                args.push(node);
+            }
+
+            if let Some(Some(node)) = second {
+                args.push(node);
+            }
+            if has_explicit_args {
+                args.extend(self.parse_args()?);
+            }
+
+            let token_id = self.token_arena.alloc(Shared::clone(&token));
+            return Ok(Shared::new(Node {
+                token_id,
+                expr: Shared::new(Expr::SelectorCall(selector, args)),
+            }));
         }
+
+        let static_index = |opt: Option<Shared<Node>>| -> Option<usize> {
+            opt.and_then(|n| {
+                if let Expr::Literal(Literal::Number(num)) = &*n.expr {
+                    Some(num.value() as usize)
+                } else {
+                    None
+                }
+            })
+        };
+        let i1 = static_index(first);
+        let selector = match second {
+            None => Selector::List(i1, None),
+            Some(opt) => Selector::Table(i1, static_index(opt)),
+        };
+
+        let token_id = self.token_arena.alloc(Shared::clone(&token));
+        Ok(Shared::new(Node {
+            token_id,
+            expr: Shared::new(Expr::Selector(selector)),
+        }))
     }
 
-    fn parse_int_array_arg(&mut self, token: &Shared<Token>) -> Result<ArrayIndex, SyntaxError> {
-        self.next_token(|token_kind| matches!(token_kind, TokenKind::LBracket))?;
+    fn parse_bracket_expr(&mut self) -> Result<Option<Shared<Node>>, SyntaxError> {
+        let bracket_token = match self.tokens.peek() {
+            Some(t) => Shared::clone(t),
+            None => return Err(SyntaxError::UnexpectedEOFDetected(self.module_id)),
+        };
+        self.next_token(|kind| matches!(kind, TokenKind::LBracket))?;
 
-        let token = match self.tokens.peek() {
-            Some(token) => Ok(Shared::clone(token)),
-            None => return Err(SyntaxError::InsufficientTokens((**token).clone())),
-        }?;
-
-        if let TokenKind::NumberLiteral(n) = &token.kind {
+        if self.is_next_token(|kind| matches!(kind, TokenKind::RBracket)) {
             self.tokens.next();
-            self.next_token(|token_kind| matches!(token_kind, TokenKind::RBracket))?;
-            Ok(ArrayIndex(Some(n.value() as usize)))
-        } else if let TokenKind::RBracket = &token.kind {
-            self.tokens.next();
-            Ok(ArrayIndex(None))
-        } else {
-            Err(SyntaxError::UnexpectedToken((*token).clone()))
+            return Ok(None);
         }
+
+        let expr_token = match self.tokens.next() {
+            Some(t) => Shared::clone(t),
+            None => return Err(SyntaxError::InsufficientTokens((*bracket_token).clone())),
+        };
+        let node = self.parse_primary_expr(&expr_token)?;
+        self.next_token(|kind| matches!(kind, TokenKind::RBracket))?;
+        Ok(Some(node))
     }
 
     fn next_token(&mut self, expected_kinds: fn(&TokenKind) -> bool) -> Result<TokenId, SyntaxError> {
@@ -2673,7 +2715,7 @@ mod tests {
                             expr: Shared::new(Expr::Selector(Selector::Heading(Some(1)))),
                         }),
                         Shared::new(Node {
-                            token_id: 4.into(),
+                            token_id: 5.into(),
                             expr: Shared::new(Expr::Selector(Selector::Table(Some(2), None))),
                         }),
                     ],
@@ -4004,6 +4046,151 @@ mod tests {
         Ok(vec![Shared::new(Node {
             token_id: 8.into(),
             expr: Shared::new(Expr::Selector(Selector::Table(Some(1), Some(2)))),
+        })]))]
+    #[case::selector_call_list_bracket_single_arg(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LParen),
+            token(TokenKind::NumberLiteral(2.into())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 2.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::List(None, None),
+                smallvec![Shared::new(Node {
+                    token_id: 1.into(),
+                    expr: Shared::new(Expr::Literal(Literal::Number(2.into()))),
+                })],
+            )),
+        })]))]
+    #[case::selector_call_table_bracket_single_arg(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LParen),
+            token(TokenKind::NumberLiteral(1.into())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 3.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Table(None, None),
+                smallvec![Shared::new(Node {
+                    token_id: 2.into(),
+                    expr: Shared::new(Expr::Literal(Literal::Number(1.into()))),
+                })],
+            )),
+        })]))]
+    #[case::selector_call_list_bracket_variable(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::Ident(SmolStr::new("v"))),
+            token(TokenKind::RBracket),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 3.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::List(None, None),
+                smallvec![Shared::new(Node {
+                    token_id: 1.into(),
+                    expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token(
+                        "v",
+                        Some(Shared::new(token(TokenKind::Ident(SmolStr::new("v"))))),
+                    ))),
+                })],
+            )),
+        })]))]
+    #[case::selector_call_table_bracket_column_variable(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LBracket),
+            token(TokenKind::Ident(SmolStr::new("v"))),
+            token(TokenKind::RBracket),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 5.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Table(None, None),
+                smallvec![
+                    Shared::new(Node {
+                        token_id: 4.into(),
+                        expr: Shared::new(Expr::Literal(Literal::None)),
+                    }),
+                    Shared::new(Node {
+                        token_id: 2.into(),
+                        expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token(
+                            "v",
+                            Some(Shared::new(token(TokenKind::Ident(SmolStr::new("v"))))),
+                        ))),
+                    }),
+                ],
+            )),
+        })]))]
+    #[case::selector_call_table_bracket_variable(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::Ident(SmolStr::new("v"))),
+            token(TokenKind::RBracket),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 4.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Table(None, None),
+                smallvec![Shared::new(Node {
+                    token_id: 1.into(),
+                    expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token(
+                        "v",
+                        Some(Shared::new(token(TokenKind::Ident(SmolStr::new("v"))))),
+                    ))),
+                })],
+            )),
+        })]))]
+    #[case::selector_call_table_bracket_row_col_args(
+        vec![
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LBracket),
+            token(TokenKind::RBracket),
+            token(TokenKind::LParen),
+            token(TokenKind::NumberLiteral(1.into())),
+            token(TokenKind::Comma),
+            token(TokenKind::NumberLiteral(2.into())),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 4.into(),
+            expr: Shared::new(Expr::SelectorCall(
+                Selector::Table(None, None),
+                smallvec![
+                    Shared::new(Node {
+                        token_id: 2.into(),
+                        expr: Shared::new(Expr::Literal(Literal::Number(1.into()))),
+                    }),
+                    Shared::new(Node {
+                        token_id: 3.into(),
+                        expr: Shared::new(Expr::Literal(Literal::Number(2.into()))),
+                    }),
+                ],
+            )),
         })]))]
     #[case::foreach_error(
         vec![

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -8,7 +8,7 @@ use crate::error::runtime::RuntimeError;
 use crate::eval::builtin::convert::Convert;
 use crate::eval::env::{self, Env};
 use crate::ident::all_symbols;
-use crate::number;
+use crate::number::{self};
 use crate::selector::Selector;
 use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input, parse_mdx_input};
 use csv::ReaderBuilder;
@@ -4714,9 +4714,6 @@ pub fn eval_builtin(
     )
 }
 
-/// Collect numeric (u8) depth values from evaluated selector arguments.
-///
-/// Accepts `Number` values directly and flattens `Array` values recursively.
 fn collect_depth_values(args: &[RuntimeValue]) -> Vec<u8> {
     args.iter()
         .flat_map(|arg| match arg {
@@ -4736,9 +4733,25 @@ fn collect_depth_values(args: &[RuntimeValue]) -> Vec<u8> {
         .collect()
 }
 
-/// Collect string values from evaluated selector arguments.
-///
-/// Accepts `String` values directly and flattens `Array` values.
+fn collect_runtime_values(args: &[RuntimeValue]) -> Vec<RuntimeValue> {
+    args.iter()
+        .flat_map(|arg| match arg {
+            RuntimeValue::Number(n) => vec![(*n).into()],
+            RuntimeValue::Array(arr) => arr
+                .iter()
+                .filter_map(|v| {
+                    if let RuntimeValue::Number(n) = v {
+                        Some((*n).into())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => vec![],
+        })
+        .collect()
+}
+
 fn collect_string_values(args: &[RuntimeValue]) -> Vec<String> {
     args.iter()
         .flat_map(|arg| match arg {
@@ -4772,9 +4785,11 @@ pub fn eval_selector_with_args(node: &mq_markdown::Node, selector: &Selector, ar
     let is_match = match selector {
         Selector::Heading(_) => {
             let depths = collect_depth_values(args);
+
             if depths.is_empty() {
                 return eval_selector(node, selector);
             }
+
             if let mq_markdown::Node::Heading(mq_markdown::Heading { depth, .. }) = node {
                 depths.contains(depth)
             } else {
@@ -4783,14 +4798,51 @@ pub fn eval_selector_with_args(node: &mq_markdown::Node, selector: &Selector, ar
         }
         Selector::Code => {
             let langs = collect_string_values(args);
+
             if langs.is_empty() {
                 return eval_selector(node, selector);
             }
+
             if let mq_markdown::Node::Code(mq_markdown::Code { lang, .. }) = node {
                 let node_lang = lang.as_deref().unwrap_or("");
                 langs.iter().any(|l| l == node_lang)
             } else {
                 false
+            }
+        }
+        Selector::List(..) => {
+            let indices = collect_runtime_values(args);
+
+            if indices.is_empty() {
+                return eval_selector(node, selector);
+            }
+
+            if let mq_markdown::Node::List(mq_markdown::List { index: list_index, .. }) = node {
+                indices.iter().any(|i| match i {
+                    RuntimeValue::Number(n) => *list_index == n.value() as usize,
+                    _ => false,
+                })
+            } else {
+                false
+            }
+        }
+        Selector::Table(..) => {
+            if args.is_empty() {
+                return eval_selector(node, selector);
+            }
+
+            match node {
+                mq_markdown::Node::TableCell(mq_markdown::TableCell { column, row, .. }) => {
+                    let matches_pos = |spec: Option<&RuntimeValue>, actual: usize| -> bool {
+                        match spec {
+                            None | Some(RuntimeValue::None) => true,
+                            Some(RuntimeValue::Number(n)) => actual == n.value() as usize,
+                            _ => false,
+                        }
+                    };
+                    matches_pos(args.first(), *row) && matches_pos(args.get(1), *column)
+                }
+                _ => false,
             }
         }
         _ => return eval_selector(node, selector),
@@ -6570,6 +6622,72 @@ mod tests {
         Node::HorizontalRule(mq_markdown::HorizontalRule { position: None }),
         Selector::Heading(None),
         vec![RuntimeValue::Number(1.into())],
+        false
+    )]
+    #[case::list_index_match(
+        Node::List(mq_markdown::List { index: 2, level: 0, checked: None, ordered: false, values: vec![], position: None }),
+        Selector::List(None, None),
+        vec![RuntimeValue::Number(2.into())],
+        true
+    )]
+    #[case::list_index_no_match(
+        Node::List(mq_markdown::List { index: 0, level: 0, checked: None, ordered: false, values: vec![], position: None }),
+        Selector::List(None, None),
+        vec![RuntimeValue::Number(1.into())],
+        false
+    )]
+    #[case::list_multi_index_match(
+        Node::List(mq_markdown::List { index: 3, level: 0, checked: None, ordered: false, values: vec![], position: None }),
+        Selector::List(None, None),
+        vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into())],
+        true
+    )]
+    #[case::list_no_args_fallback(
+        Node::List(mq_markdown::List { index: 0, level: 0, checked: None, ordered: false, values: vec![], position: None }),
+        Selector::List(None, None),
+        vec![],
+        true
+    )]
+    #[case::list_non_list_node(
+        Node::HorizontalRule(mq_markdown::HorizontalRule { position: None }),
+        Selector::List(None, None),
+        vec![RuntimeValue::Number(0.into())],
+        false
+    )]
+    #[case::table_row_match(
+        Node::TableCell(mq_markdown::TableCell { column: 0, row: 1, values: vec![], position: None }),
+        Selector::Table(None, None),
+        vec![RuntimeValue::Number(1.into())],
+        true
+    )]
+    #[case::table_row_no_match(
+        Node::TableCell(mq_markdown::TableCell { column: 0, row: 0, values: vec![], position: None }),
+        Selector::Table(None, None),
+        vec![RuntimeValue::Number(1.into())],
+        false
+    )]
+    #[case::table_row_and_col_match(
+        Node::TableCell(mq_markdown::TableCell { column: 2, row: 1, values: vec![], position: None }),
+        Selector::Table(None, None),
+        vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())],
+        true
+    )]
+    #[case::table_row_and_col_no_match(
+        Node::TableCell(mq_markdown::TableCell { column: 0, row: 1, values: vec![], position: None }),
+        Selector::Table(None, None),
+        vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())],
+        false
+    )]
+    #[case::table_no_args_fallback(
+        Node::TableCell(mq_markdown::TableCell { column: 0, row: 0, values: vec![], position: None }),
+        Selector::Table(None, None),
+        vec![],
+        true
+    )]
+    #[case::table_non_table_node(
+        Node::HorizontalRule(mq_markdown::HorizontalRule { position: None }),
+        Selector::Table(None, None),
+        vec![RuntimeValue::Number(0.into())],
         false
     )]
     fn test_eval_selector_with_args(

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4776,6 +4776,11 @@ fn collect_string_values(args: &[RuntimeValue]) -> Vec<String> {
 /// Supports filtered matching for selectors that accept arguments:
 /// - `Heading`: filters by depth using numeric or range args (e.g. `.h(1..2)`, `.h(1, 2)`)
 /// - `Code`: filters by language using string args (e.g. `.code("rust")`)
+/// - `List`: filters by list item index using a numeric arg (e.g. `.[v]` where `v` evaluates to an index)
+/// - `Table`: filters table cells by positional args where `args[0]` is the row and `args[1]` is the
+///   column; a `None`/[`RuntimeValue::None`] value in either position acts as a wildcard matching any
+///   row or column respectively (e.g. `.[v][]` matches row `v` of any column, `.[][v]` matches column
+///   `v` of any row)
 /// - All other selectors fall back to [`eval_selector`].
 pub fn eval_selector_with_args(node: &mq_markdown::Node, selector: &Selector, args: &[RuntimeValue]) -> RuntimeValue {
     if args.is_empty() {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2479,6 +2479,9 @@ fn engine() -> DefaultEngine {
 #[case::selector_array_of_dicts_preserves_dict(r##"array({"docs": to_markdown("# Title")}) | .h | first() | is_dict()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::TRUE].into()))]
 #[case::selector_call_h(r##"to_markdown("# h1\n\n## h2\n\ntest") | .h(2).depth | compact() | first()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 #[case::selector_call_code_lang(r##"to_markdown("```rust\ncode\n```") | .code("rust").lang | compact() | first()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("rust".to_string())].into()))]
+#[case::selector_bracket_variable_list(r##"let v = 1 | to_markdown("- a\n- b\n- c") | .[v] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("- b".to_string())].into()))]
+#[case::selector_bracket_variable_table_row(r##"let v = 1 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[v][] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("c".to_string())].into()))]
+#[case::selector_bracket_variable_table_col(r##"let v = 1 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[][v] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2482,6 +2482,8 @@ fn engine() -> DefaultEngine {
 #[case::selector_bracket_variable_list(r##"let v = 1 | to_markdown("- a\n- b\n- c") | .[v] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("- b".to_string())].into()))]
 #[case::selector_bracket_variable_table_row(r##"let v = 1 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[v][] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("c".to_string())].into()))]
 #[case::selector_bracket_variable_table_col(r##"let v = 1 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[][v] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
+#[case::selector_bracket_expr_list(r##"let v = 0 | to_markdown("- a\n- b\n- c") | .[v + 1] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("- b".to_string())].into()))]
+#[case::selector_bracket_expr_table_col(r##"let v = 0 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[][v + 1] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }


### PR DESCRIPTION
Allow dynamic expressions (variables, function calls) inside `.[expr]` and `.[expr1][expr2]` bracket selectors in addition to integer literals.

- `.[v]` → SelectorCall(List, [v])
- `.[v][]` → SelectorCall(Table, [v]) — row filter
- `.[][v]` → SelectorCall(Table, [None, v]) — column filter
- `.list` / `.table` SelectorCall now handles index/column args
- Table eval uses positional matching (args[0]=row, args[1]=col) with None meaning "match any", enabling `.[][v]` semantics