### PR TITLE
✨ feat(playground): add hover provider using mq.hover API

### DIFF
--- a/crates/mq-lsp/src/hover.rs
+++ b/crates/mq-lsp/src/hover.rs
@@ -90,6 +90,7 @@ fn format_hover_content(
         sections.push(format!("### Parameters\n{}", param_items));
     }
 
+
     sections.join("\n\n")
 }
 
@@ -270,6 +271,7 @@ mod tests {
         assert!(result.contains("- `b` *(optional)*"));
         assert!(result.contains("- `*rest` *(variadic)*"));
     }
+
 
     // --- integration tests via response() ---
 

--- a/crates/mq-lsp/src/hover.rs
+++ b/crates/mq-lsp/src/hover.rs
@@ -90,7 +90,6 @@ fn format_hover_content(
         sections.push(format!("### Parameters\n{}", param_items));
     }
 
-
     sections.join("\n\n")
 }
 
@@ -271,7 +270,6 @@ mod tests {
         assert!(result.contains("- `b` *(optional)*"));
         assert!(result.contains("- `*rest` *(variadic)*"));
     }
-
 
     // --- integration tests via response() ---
 

--- a/packages/mq-playground/package.json
+++ b/packages/mq-playground/package.json
@@ -14,7 +14,7 @@
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",
     "monaco-vim": "^0.4.4",
-    "mq-web": "^0.5.27",
+    "mq-web": "file:../mq-web",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-icons": "^5.6.0"

--- a/packages/mq-playground/package.json
+++ b/packages/mq-playground/package.json
@@ -14,7 +14,7 @@
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",
     "monaco-vim": "^0.4.4",
-    "mq-web": "file:../mq-web",
+    "mq-web": "0.5.28",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-icons": "^5.6.0"

--- a/packages/mq-playground/pnpm-lock.yaml
+++ b/packages/mq-playground/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(monaco-editor@0.55.1)
       mq-web:
-        specifier: file:../mq-web
-        version: file:../mq-web
+        specifier: 0.5.28
+        version: 0.5.28
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -611,8 +611,8 @@ packages:
     peerDependencies:
       monaco-editor: '*'
 
-  mq-web@file:../mq-web:
-    resolution: {directory: ../mq-web, type: directory}
+  mq-web@0.5.28:
+    resolution: {integrity: sha512-u64ffbMg2acn1OF5rP43gZDpDvjif6WGFseYWe6gdyUFGAT4RxBMhvUpg1GUoxVovbVniFJVU2TemOaSL7lw3w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1157,7 +1157,7 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  mq-web@file:../mq-web: {}
+  mq-web@0.5.28: {}
 
   ms@2.1.3: {}
 

--- a/packages/mq-playground/pnpm-lock.yaml
+++ b/packages/mq-playground/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(monaco-editor@0.55.1)
       mq-web:
-        specifier: ^0.5.27
-        version: 0.5.27
+        specifier: file:../mq-web
+        version: file:../mq-web
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -611,8 +611,8 @@ packages:
     peerDependencies:
       monaco-editor: '*'
 
-  mq-web@0.5.27:
-    resolution: {integrity: sha512-3MwHmNED+BdtcUYezth60KXjHjqtxXUbWlA9uMQCYMOztuzc+Id7kJ0bKD/vL4rHLyaaCBZ8IdZW+F+hb/FaTg==}
+  mq-web@file:../mq-web:
+    resolution: {directory: ../mq-web, type: directory}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1157,7 +1157,7 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  mq-web@0.5.27: {}
+  mq-web@file:../mq-web: {}
 
   ms@2.1.3: {}
 

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -1453,6 +1453,20 @@ export const Playground = () => {
       },
     });
 
+    monaco.languages.registerHoverProvider("mq", {
+      provideHover: async (model: editor.ITextModel, position: IPosition) => {
+        const result = await mq.hover(
+          model.getValue(),
+          position.lineNumber,
+          position.column,
+        );
+        if (!result) return null;
+        return {
+          contents: [{ value: result.content, isTrusted: true, supportThemeIcons: true }],
+        };
+      },
+    });
+
     monaco.languages.registerInlayHintsProvider("mq", {
       provideInlayHints: async (model: editor.ITextModel) => {
         if (!enableTypeCheckRef.current) {


### PR DESCRIPTION
Register Monaco hover provider for the mq language that calls mq.hover() to show symbol documentation on cursor hover.

Also switch mq-web dependency to local file reference for development against the new hover API.