### PR TITLE
✨ feat(lang): add -> (Arrow) syntax as shorthand for fn

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -2789,6 +2789,19 @@ end
     #[case::selector_call_heading_multi_arg(".h(1,2)", ".h(1, 2)")]
     #[case::selector_call_code_lang(".code(\"rust\")", ".code(\"rust\")")]
     #[case::selector_call_pipe(".h(1)|.text()", ".h(1) | .text()")]
+    #[case::arrow_simple("->(): program;", "->(): program;")]
+    #[case::arrow_multiline(
+        "->(arg1,arg2):
+        program;",
+        "->(arg1, arg2):
+  program;
+"
+    )]
+    #[case::arrow_as_call_arg("map( ->():program;)", "map(->(): program;)")]
+    #[case::arrow_as_call_arg_single_line("map(->(): program;)", "map(->(): program;)")]
+    #[case::arrow_as_call_arg_with_other_args("map(->(): program;, 1, \"test\")", "map(->(): program;, 1, \"test\")")]
+    #[case::nested_arrow_as_call_arg("outer(map(->(): inner();))", "outer(map(->(): inner();))")]
+    #[case::arrow_end("->(): test end", "->(): test end")]
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);
         assert_eq!(result.unwrap(), expected);

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -374,7 +374,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
             TokenKind::Def => self.parse_def(token),
             TokenKind::Macro => self.parse_macro(token),
             TokenKind::Do => self.parse_block(token),
-            TokenKind::Fn => self.parse_fn(token),
+            TokenKind::Fn | TokenKind::Arrow => self.parse_fn(token),
             TokenKind::While => self.parse_while(token),
             TokenKind::Loop => self.parse_loop(token),
             TokenKind::Foreach => self.parse_foreach(token),
@@ -7810,6 +7810,113 @@ mod tests {
             token(TokenKind::Ident(SmolStr::new("args"))),
         ],
         Err(SyntaxError::MacroParametersCannotBeVariadic(Token{range: Range::default(), kind: TokenKind::Macro, module_id: 1.into()})))]
+    #[case::arrow_simple(
+        vec![
+            token(TokenKind::Arrow),
+            token(TokenKind::LParen),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::StringLiteral("result".to_owned())),
+            token(TokenKind::SemiColon),
+        ],
+        Ok(vec![
+            Shared::new(Node {
+                token_id: 0.into(),
+                expr: Shared::new(Expr::Fn(
+                    SmallVec::new(),
+                    vec![
+                        Shared::new(Node {
+                            token_id: 2.into(),
+                            expr: Shared::new(Expr::Literal(Literal::String("result".to_owned()))),
+                        })
+                    ],
+                )),
+            })
+        ]))]
+    #[case::arrow_with_args(
+        vec![
+            token(TokenKind::Arrow),
+            token(TokenKind::LParen),
+            token(TokenKind::Ident(SmolStr::new("x"))),
+            token(TokenKind::Comma),
+            token(TokenKind::Ident(SmolStr::new("y"))),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::Ident(SmolStr::new("contains"))),
+            token(TokenKind::LParen),
+            token(TokenKind::Ident(SmolStr::new("x"))),
+            token(TokenKind::Comma),
+            token(TokenKind::Ident(SmolStr::new("y"))),
+            token(TokenKind::RParen),
+            token(TokenKind::SemiColon),
+        ],
+        Ok(vec![
+            Shared::new(Node {
+                token_id: 0.into(),
+                expr: Shared::new(Expr::Fn(
+                    smallvec![
+                        Param::new(IdentWithToken::new_with_token("x", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("x"))))))),
+                        Param::new(IdentWithToken::new_with_token("y", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("y"))))))),
+                    ],
+                    vec![
+                        Shared::new(Node {
+                            token_id: 4.into(),
+                            expr: Shared::new(Expr::Call(
+                                IdentWithToken::new_with_token("contains", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("contains")))))),
+                                smallvec![
+                                    Shared::new(Node {
+                                        token_id: 2.into(),
+                                        expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("x", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("x")))))))),
+                                    }),
+                                    Shared::new(Node {
+                                        token_id: 3.into(),
+                                        expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("y", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("y")))))))),
+                                    }),
+                                ],
+                            )),
+                        })
+                    ],
+                )),
+            })
+        ]))]
+    #[case::arrow_nested_in_call(
+        vec![
+            token(TokenKind::Ident(SmolStr::new("apply"))),
+            token(TokenKind::LParen),
+            token(TokenKind::Arrow),
+            token(TokenKind::LParen),
+            token(TokenKind::Ident(SmolStr::new("x"))),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::StringLiteral("processed".to_owned())),
+            token(TokenKind::SemiColon),
+            token(TokenKind::RParen),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![
+            Shared::new(Node {
+                token_id: 4.into(),
+                expr: Shared::new(Expr::Call(
+                    IdentWithToken::new_with_token("apply", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("apply")))))),
+                    smallvec![
+                        Shared::new(Node {
+                            token_id: 0.into(),
+                            expr: Shared::new(Expr::Fn(
+                                smallvec![
+                                  Param::new(IdentWithToken::new_with_token("x", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("x"))))))),
+                                ],
+                                vec![
+                                    Shared::new(Node {
+                                        token_id: 2.into(),
+                                        expr: Shared::new(Expr::Literal(Literal::String("processed".to_owned()))),
+                                    })
+                                ],
+                            )),
+                        })
+                    ],
+                )),
+            })
+        ]))]
     fn test_parse(#[case] input: Vec<Token>, #[case] expected: Result<Program, SyntaxError>) {
         let mut arena = Arena::new(10);
         let tokens: Vec<Shared<Token>> = input.into_iter().map(Shared::new).collect();

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -407,7 +407,7 @@ impl<'a> Parser<'a> {
             TokenKind::Def => self.parse_def(leading_trivia),
             TokenKind::Macro => self.parse_macro(leading_trivia),
             TokenKind::Do => self.parse_block(leading_trivia, in_loop),
-            TokenKind::Fn => self.parse_fn(leading_trivia, in_loop),
+            TokenKind::Fn | TokenKind::Arrow => self.parse_fn(leading_trivia, in_loop),
             TokenKind::If => self.parse_if(leading_trivia, in_loop),
             TokenKind::Foreach => self.parse_foreach(leading_trivia),
             TokenKind::Include => self.parse_include(leading_trivia),
@@ -792,6 +792,7 @@ impl<'a> Parser<'a> {
             | TokenKind::Not
             | TokenKind::Minus
             | TokenKind::Fn
+            | TokenKind::Arrow
             | TokenKind::Foreach
             | TokenKind::While
             | TokenKind::Loop
@@ -9303,6 +9304,228 @@ mod tests {
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::arrow_with_program(
+        vec![
+            Shared::new(token(TokenKind::Arrow)),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Colon)),
+            Shared::new(token(TokenKind::Ident("x".into()))),
+            Shared::new(token(TokenKind::SemiColon)),
+            Shared::new(token(TokenKind::Pipe)),
+            Shared::new(token(TokenKind::Ident("y".into()))),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Fn,
+                    token: Some(Shared::new(token(TokenKind::Arrow))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Colon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("x".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::SemiColon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Token,
+                    token: Some(Shared::new(token(TokenKind::Pipe))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::Ident,
+                    token: Some(Shared::new(token(TokenKind::Ident("y".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::arrow_with_parameter_and_program(
+        vec![
+            Shared::new(token(TokenKind::Arrow)),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::Ident("param".into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Colon)),
+            Shared::new(token(TokenKind::Ident("body".into()))),
+            Shared::new(token(TokenKind::SemiColon)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Fn,
+                    token: Some(Shared::new(token(TokenKind::Arrow))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("param".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Colon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("body".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::SemiColon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::arrow_with_multiple_parameters(
+        vec![
+            Shared::new(token(TokenKind::Arrow)),
+            Shared::new(token(TokenKind::LParen)),
+            Shared::new(token(TokenKind::Ident("param1".into()))),
+            Shared::new(token(TokenKind::Comma)),
+            Shared::new(token(TokenKind::Ident("param2".into()))),
+            Shared::new(token(TokenKind::RParen)),
+            Shared::new(token(TokenKind::Colon)),
+            Shared::new(token(TokenKind::StringLiteral("result".into()))),
+            Shared::new(token(TokenKind::SemiColon)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Fn,
+                    token: Some(Shared::new(token(TokenKind::Arrow))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::LParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("param1".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Comma))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("param2".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::RParen))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::Colon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::StringLiteral("result".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::SemiColon))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
                 }),
             ],
             ErrorReporter::default()

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -309,6 +309,10 @@ fn punctuations(input: Span) -> IResult<Span, Token> {
     .parse(input)
 }
 
+fn lambda_op(input: Span) -> IResult<Span, Token> {
+    alt((arrow,)).parse(input)
+}
+
 fn assignment_op(input: Span) -> IResult<Span, Token> {
     alt((
         plus_equal,
@@ -354,7 +358,7 @@ fn unary_op(input: Span) -> IResult<Span, Token> {
 fn control_keywords(input: Span) -> IResult<Span, Token> {
     alt((
         break_, catch_, continue_, def, do_, elif, else_, end, fn_, foreach, if_, let_, loop_, macro_, match_, quote_,
-        try_, unquote_, var, while_, arrow,
+        try_, unquote_, var, while_,
     ))
     .parse(input)
 }
@@ -675,6 +679,7 @@ fn token(input: Span) -> IResult<Span, Token> {
         keywords,
         env,
         literals,
+        lambda_op,
         binary_op,
         punctuations,
         unary_op,
@@ -693,6 +698,7 @@ fn token_include_spaces(input: Span) -> IResult<Span, Token> {
         keywords,
         env,
         literals,
+        lambda_op,
         binary_op,
         punctuations,
         unary_op,

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -286,6 +286,7 @@ define_token_parser!(not_tilde_equal, "!~", TokenKind::NotTildeEqual);
 define_token_parser!(left_shift, "<<", TokenKind::LeftShift);
 define_token_parser!(right_shift, ">>", TokenKind::RightShift);
 define_token_parser!(convert_op, "@", TokenKind::Convert);
+define_token_parser!(arrow, "->", TokenKind::Arrow);
 
 fn punctuations(input: Span) -> IResult<Span, Token> {
     alt((
@@ -353,7 +354,7 @@ fn unary_op(input: Span) -> IResult<Span, Token> {
 fn control_keywords(input: Span) -> IResult<Span, Token> {
     alt((
         break_, catch_, continue_, def, do_, elif, else_, end, fn_, foreach, if_, let_, loop_, macro_, match_, quote_,
-        try_, unquote_, var, while_,
+        try_, unquote_, var, while_, arrow,
     ))
     .parse(input)
 }
@@ -1356,6 +1357,31 @@ mod tests {
     #[case::unterminated_string_reports_position("\"unterminated",
         Options::default(),
         Err(SyntaxError::UnexpectedToken(Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 14} }, kind: TokenKind::Eof, module_id: 1.into()})))]
+    #[case::arrow("->",
+        Options::default(),
+        Ok(vec![
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 3} }, kind: TokenKind::Arrow, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 3} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
+    #[case::arrow_in_expression("map(->(x):upcase;)",
+        Options::default(),
+        Ok(vec![
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 4} }, kind: TokenKind::Ident(SmolStr::new("map")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 5} }, kind: TokenKind::LParen, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 5}, end: Position {line: 1, column: 7} }, kind: TokenKind::Arrow, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 7}, end: Position {line: 1, column: 8} }, kind: TokenKind::LParen, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 8}, end: Position {line: 1, column: 9} }, kind: TokenKind::Ident(SmolStr::new("x")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 9}, end: Position {line: 1, column: 10} }, kind: TokenKind::RParen, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 10}, end: Position {line: 1, column: 11} }, kind: TokenKind::Colon, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 11}, end: Position {line: 1, column: 17} }, kind: TokenKind::Ident(SmolStr::new("upcase")), module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 17}, end: Position {line: 1, column: 18} }, kind: TokenKind::SemiColon, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 18}, end: Position {line: 1, column: 19} }, kind: TokenKind::RParen, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 19}, end: Position {line: 1, column: 19} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
+    #[case::arrow_not_minus("- >",
+        Options::default(),
+        Ok(vec![
+            Token{range: Range { start: Position {line: 1, column: 1}, end: Position {line: 1, column: 2} }, kind: TokenKind::Minus, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 3}, end: Position {line: 1, column: 4} }, kind: TokenKind::Gt, module_id: 1.into()},
+            Token{range: Range { start: Position {line: 1, column: 4}, end: Position {line: 1, column: 4} }, kind: TokenKind::Eof, module_id: 1.into()}]))]
 
     fn test_parse(#[case] input: &str, #[case] options: Options, #[case] expected: Result<Vec<Token>, SyntaxError>) {
         assert_eq!(Lexer::new(options).tokenize(input, 1.into()), expected);

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -46,6 +46,7 @@ pub struct Token {
 /// TokenKind variants are sorted alphabetically for maintainability.
 pub enum TokenKind {
     And,
+    Arrow,
     Convert,
     Asterisk,
     BoolLiteral(bool),
@@ -156,6 +157,7 @@ impl Display for TokenKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match &self {
             TokenKind::And => write!(f, "&&"),
+            TokenKind::Arrow => write!(f, "->"),
             TokenKind::Convert => write!(f, "@"),
             TokenKind::Or => write!(f, "||"),
             TokenKind::Not => write!(f, "!"),
@@ -258,5 +260,14 @@ mod tests {
     #[case(StringSegment::Expr(SmolStr::new(""), Range::default()), "${}")]
     fn string_segment_display_works(#[case] segment: StringSegment, #[case] expected: &str) {
         assert_eq!(segment.to_string(), expected);
+    }
+
+    #[rstest]
+    #[case(TokenKind::Arrow, "->")]
+    #[case(TokenKind::Fn, "fn")]
+    #[case(TokenKind::Minus, "-")]
+    #[case(TokenKind::Gt, ">")]
+    fn token_kind_arrow_display(#[case] kind: TokenKind, #[case] expected: &str) {
+        assert_eq!(kind.to_string(), expected);
     }
 }


### PR DESCRIPTION
Add Arrow (->) as an alternative syntax for anonymous functions, equivalent to fn. Includes lexer token, CST/AST parser support, formatter support, and tests for all layers.

Also fix CST parse_arg() to accept Arrow tokens so -> can be used as a function call argument (e.g. map(->(): ...)).