### PR TITLE
✨ feat(playground): add mq branded theme

### DIFF
--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -61,18 +61,18 @@ type EditorSettings = {
   wordWrap: "on" | "off";
   vimModeEnabled: boolean;
   fontSize: number;
-  theme: "light" | "dark" | "system";
+  theme: "light" | "dark" | "system" | "mq";
   lineNumbers: "on" | "off";
   tabSize: number;
 };
 
 const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
-  version: 1,
+  version: 2,
   minimapEnabled: false,
   wordWrap: "off",
   vimModeEnabled: false,
   fontSize: 12,
-  theme: "system",
+  theme: "mq",
   lineNumbers: "on",
   tabSize: 2,
 };
@@ -80,9 +80,13 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 function loadEditorSettings(): EditorSettings {
   try {
     const raw = localStorage.getItem(EDITOR_SETTINGS_KEY);
-    return raw
-      ? { ...DEFAULT_EDITOR_SETTINGS, ...JSON.parse(raw) }
-      : DEFAULT_EDITOR_SETTINGS;
+    if (!raw) return DEFAULT_EDITOR_SETTINGS;
+    const stored = JSON.parse(raw) as Partial<EditorSettings>;
+    // Migrate from version 1: reset theme to mq default
+    if (!stored.version || stored.version < 2) {
+      return { ...DEFAULT_EDITOR_SETTINGS, ...stored, theme: "mq" };
+    }
+    return { ...DEFAULT_EDITOR_SETTINGS, ...stored };
   } catch {
     return DEFAULT_EDITOR_SETTINGS;
   }
@@ -197,7 +201,7 @@ export const Playground = () => {
     _initialSettings.vimModeEnabled,
   );
   const [fontSize, setFontSize] = useState(_initialSettings.fontSize);
-  const [theme, setTheme] = useState<"light" | "dark" | "system">(
+  const [theme, setTheme] = useState<"light" | "dark" | "system" | "mq">(
     _initialSettings.theme,
   );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -386,15 +390,20 @@ export const Playground = () => {
 
     const themeParam = urlParams.get("theme");
     if (themeParam) {
-      const isDark = themeParam === "dark";
+      const isDark = themeParam === "dark" || themeParam === "mq";
       document.documentElement.style.colorScheme = isDark ? "dark" : "light";
+      if (themeParam === "mq") {
+        document.documentElement.setAttribute("data-theme", "mq");
+      } else {
+        document.documentElement.removeAttribute("data-theme");
+      }
       document.documentElement.style.setProperty(
         "--lightningcss-light",
-        isDark ? " " : "initial"
+        isDark ? " " : "initial",
       );
       document.documentElement.style.setProperty(
         "--lightningcss-dark",
-        isDark ? "initial" : " "
+        isDark ? "initial" : " ",
       );
     }
 
@@ -551,7 +560,15 @@ export const Playground = () => {
       .catch(() => {
         showToast("Failed to copy command", "error");
       });
-  }, [code, inputFormat, isUpdate, listStyle, linkUrlStyle, linkTitleStyle, showToast]);
+  }, [
+    code,
+    inputFormat,
+    isUpdate,
+    listStyle,
+    linkUrlStyle,
+    linkTitleStyle,
+    showToast,
+  ]);
 
   const handleChangeListStyle = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -1049,15 +1066,32 @@ export const Playground = () => {
 
     if (theme === "system") {
       document.documentElement.style.colorScheme = "";
+      document.documentElement.removeAttribute("data-theme");
       document.documentElement.style.removeProperty("--lightningcss-light");
       document.documentElement.style.removeProperty("--lightningcss-dark");
     } else if (theme === "dark") {
       document.documentElement.style.colorScheme = "dark";
+      document.documentElement.removeAttribute("data-theme");
       document.documentElement.style.setProperty("--lightningcss-light", " ");
-      document.documentElement.style.setProperty("--lightningcss-dark", "initial");
+      document.documentElement.style.setProperty(
+        "--lightningcss-dark",
+        "initial",
+      );
+    } else if (theme === "mq") {
+      document.documentElement.style.colorScheme = "dark";
+      document.documentElement.setAttribute("data-theme", "mq");
+      document.documentElement.style.setProperty("--lightningcss-light", " ");
+      document.documentElement.style.setProperty(
+        "--lightningcss-dark",
+        "initial",
+      );
     } else {
       document.documentElement.style.colorScheme = "light";
-      document.documentElement.style.setProperty("--lightningcss-light", "initial");
+      document.documentElement.removeAttribute("data-theme");
+      document.documentElement.style.setProperty(
+        "--lightningcss-light",
+        "initial",
+      );
       document.documentElement.style.setProperty("--lightningcss-dark", " ");
     }
   }, [
@@ -1525,12 +1559,44 @@ export const Playground = () => {
         "editorCursor.foreground": "#000000",
       },
     });
+
+    monaco.editor.defineTheme("mq-branded", {
+      base: "vs-dark",
+      inherit: true,
+      rules: [
+        { token: "comment", foreground: "#4a5568", fontStyle: "italic" },
+        { token: "keyword", foreground: "#67b8e3", fontStyle: "bold" },
+        { token: "function", foreground: "#85d4ff" },
+        { token: "variable", foreground: "#e2e8f0" },
+        { token: "property", foreground: "#e2e8f0" },
+        { token: "string", foreground: "#a8d5f5" },
+        { token: "number", foreground: "#b8d4e8" },
+        { token: "operator", foreground: "#94a3b8", fontStyle: "bold" },
+        { token: "delimiter", foreground: "#94a3b8" },
+        { token: "identifier", foreground: "#e2e8f0" },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+      colors: {
+        "editor.background": "#1e293b",
+        "editor.foreground": "#e2e8f0",
+        "editorLineNumber.foreground": "#4a5568",
+        "editor.lineHighlightBackground": "#2a3444",
+        "editorCursor.foreground": "#67b8e3",
+        "editorIndentGuide.background1": "#2a3444",
+        "editorIndentGuide.activeBackground1": "#4a5568",
+        "editor.selectionBackground": "#32404f",
+        "editor.inactiveSelectionBackground": "#2a3444",
+      },
+    });
   };
 
   const isDarkMode =
     theme === "system"
       ? window.matchMedia("(prefers-color-scheme: dark)").matches
-      : theme === "dark";
+      : theme === "dark" || theme === "mq";
+
+  const monacoTheme =
+    theme === "mq" ? "mq-branded" : isDarkMode ? "mq-dark" : "mq-light";
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -1611,7 +1677,10 @@ export const Playground = () => {
       <div className="playground-content" ref={contentRef}>
         {isOPFSSupported && isSidebarVisible && (
           <>
-            <div className="file-tree-panel" style={isDesktop() ? { width: sidebarWidth } : undefined}>
+            <div
+              className="file-tree-panel"
+              style={isDesktop() ? { width: sidebarWidth } : undefined}
+            >
               <FileTree
                 files={files}
                 onFileSelect={handleFileSelect}
@@ -1745,7 +1814,7 @@ export const Playground = () => {
                   lineNumbers,
                   tabSize,
                 }}
-                theme={isDarkMode ? "mq-dark" : "mq-light"}
+                theme={monacoTheme}
               />
             </div>
           </div>
@@ -1790,7 +1859,7 @@ export const Playground = () => {
                   lineNumbers,
                   tabSize,
                 }}
-                theme={isDarkMode ? "mq-dark" : "mq-light"}
+                theme={monacoTheme}
               />
             </div>
           </div>
@@ -1933,7 +2002,7 @@ export const Playground = () => {
                   fontSize,
                   automaticLayout: true,
                 }}
-                theme={isDarkMode ? "mq-dark" : "mq-light"}
+                theme={monacoTheme}
               />
             )}
             {activeTab === "ast" && (
@@ -1950,7 +2019,7 @@ export const Playground = () => {
                   fontSize,
                   automaticLayout: true,
                 }}
-                theme={isDarkMode ? "mq-dark" : "mq-light"}
+                theme={monacoTheme}
               />
             )}
           </div>

--- a/packages/mq-playground/src/components/ConfirmDialog.css
+++ b/packages/mq-playground/src/components/ConfirmDialog.css
@@ -82,3 +82,43 @@
 .confirm-dialog-button:active {
   transform: translateY(1px);
 }
+
+/* ── mq theme ─────────────────────────────────────────────────── */
+[data-theme="mq"] .confirm-dialog {
+  background-color: #1e293b;
+  border-color: #4a5568;
+}
+
+[data-theme="mq"] .confirm-dialog-header {
+  border-bottom-color: #4a5568;
+}
+
+[data-theme="mq"] .confirm-dialog-header h3 {
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .confirm-dialog-body p {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .confirm-dialog-footer {
+  border-top-color: #4a5568;
+}
+
+[data-theme="mq"] .confirm-dialog-button.cancel {
+  background-color: #2a3444;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .confirm-dialog-button.cancel:hover {
+  background-color: #32404f;
+}
+
+[data-theme="mq"] .confirm-dialog-button.confirm {
+  background-color: #67b8e3;
+  color: #1e293b;
+}
+
+[data-theme="mq"] .confirm-dialog-button.confirm:hover {
+  background-color: #85d4ff;
+}

--- a/packages/mq-playground/src/components/ExamplesModal.css
+++ b/packages/mq-playground/src/components/ExamplesModal.css
@@ -148,3 +148,71 @@
   padding: 1px 6px;
   border-radius: 10px;
 }
+
+/* ── mq theme ─────────────────────────────────────────────────── */
+[data-theme="mq"] .examples-dialog {
+  background-color: #1e293b;
+  border-color: #4a5568;
+}
+
+[data-theme="mq"] .examples-header {
+  border-bottom-color: #4a5568;
+}
+
+[data-theme="mq"] .examples-header h3 {
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .examples-close-btn {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .examples-close-btn:hover {
+  color: #e2e8f0;
+  background-color: #2a3444;
+}
+
+[data-theme="mq"] .examples-sidebar {
+  border-right-color: #4a5568;
+}
+
+[data-theme="mq"] .examples-category-btn {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .examples-category-btn:hover {
+  background-color: #2a3444;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .examples-category-btn.active {
+  background-color: #1e2a38;
+  color: #67b8e3;
+}
+
+[data-theme="mq"] .example-card {
+  background-color: #232e3d;
+  border-color: #4a5568;
+}
+
+[data-theme="mq"] .example-card:hover {
+  border-color: #67b8e3;
+  background-color: #2a3444;
+}
+
+[data-theme="mq"] .example-card-name {
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .example-card-code {
+  color: #94a3b8;
+  background-color: #1e293b;
+}
+
+[data-theme="mq"] .example-card-format {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .example-card-format span {
+  background-color: #3d4a5c;
+}

--- a/packages/mq-playground/src/components/SettingsDialog.tsx
+++ b/packages/mq-playground/src/components/SettingsDialog.tsx
@@ -8,8 +8,8 @@ type SettingsDialogProps = {
   onVimModeToggle: (enabled: boolean) => void;
   fontSize: number;
   onFontSizeChange: (size: number) => void;
-  theme: "light" | "dark" | "system";
-  onThemeChange: (theme: "light" | "dark" | "system") => void;
+  theme: "light" | "dark" | "system" | "mq";
+  onThemeChange: (theme: "light" | "dark" | "system" | "mq") => void;
   minimapEnabled: boolean;
   onMinimapToggle: (enabled: boolean) => void;
   wordWrap: "on" | "off";
@@ -129,9 +129,10 @@ export const SettingsDialog = ({
                 className="settings-select"
                 value={theme}
                 onChange={(e) =>
-                  onThemeChange(e.target.value as "light" | "dark" | "system")
+                  onThemeChange(e.target.value as "light" | "dark" | "system" | "mq")
                 }
               >
+                <option value="mq">mq</option>
                 <option value="system">System</option>
                 <option value="light">Light</option>
                 <option value="dark">Dark</option>

--- a/packages/mq-playground/src/components/Toast.css
+++ b/packages/mq-playground/src/components/Toast.css
@@ -75,3 +75,22 @@
     transform: translateY(0);
   }
 }
+
+/* ── mq theme ─────────────────────────────────────────────────── */
+[data-theme="mq"] .toast-success {
+  background-color: #1a3a2a;
+  color: #68d391;
+  border-color: #2d6a4f;
+}
+
+[data-theme="mq"] .toast-error {
+  background-color: #3a1a1a;
+  color: #fc8181;
+  border-color: #6a2d2d;
+}
+
+[data-theme="mq"] .toast-info {
+  background-color: #1e2a38;
+  color: #67b8e3;
+  border-color: #2d4a6a;
+}

--- a/packages/mq-playground/src/index.css
+++ b/packages/mq-playground/src/index.css
@@ -692,3 +692,130 @@ body {
   background-color: light-dark(#e1e4e8, #3e3e42);
   color: light-dark(#24292e, #cccccc);
 }
+
+/* ── mq theme ─────────────────────────────────────────────────── */
+[data-theme="mq"] {
+  --primary-color: #67b8e3;
+  --secondary-color: #2a3444;
+  --dark-color: #1e293b;
+  --light-color: #e2e8f0;
+  --lighter-blue: #1e2a38;
+  --text-color: #e2e8f0;
+  --code-bg: #1e293b;
+  --select-fg: #e2e8f0;
+  --select-bg: #2a3444;
+  --border: #4a5568;
+  --header-icon-color: #94a3b8;
+  --success-color: #68d391;
+  --info-color: #67b8e3;
+  --warning-color: #f6ad55;
+  --hover-bg: rgba(103, 184, 227, 0.12);
+  --playground-bg: #1e293b;
+  --button-color: #67b8e3;
+  --button-hover-color: #85d4ff;
+  --disabled-bg: #3d4a5c;
+  --header-title-color: #85d4ff;
+  --accent-blue: #67b8e3;
+
+  /* file tree */
+  --tree-bg: #1e293b;
+  --tree-border: #4a5568;
+  --tree-header-bg: #232e3d;
+  --tree-title-color: #94a3b8;
+  --tree-item-color: #e2e8f0;
+  --tree-item-hover-bg: #2a3444;
+  --tree-item-selected-bg: #32404f;
+  --tree-item-selected-color: #e2e8f0;
+  --tree-empty-color: #94a3b8;
+  --scrollbar-track: #1e293b;
+  --scrollbar-thumb: #4a5568;
+  --scrollbar-thumb-hover: #5a6778;
+
+  /* context menu */
+  --context-menu-bg: #232e3d;
+  --context-menu-item-hover-bg: #32404f;
+}
+
+[data-theme="mq"] .playground-header {
+  background-color: #2a3444;
+  border-bottom: 1px solid #4a5568;
+}
+
+[data-theme="mq"] .playground-footer {
+  background-color: #1e293b;
+  border-top: 1px solid #4a5568;
+}
+
+[data-theme="mq"] .editor-header {
+  background-color: #2a3444;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .loading-message,
+[data-theme="mq"] .empty-message {
+  background-color: #2a3444;
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .tab-container,
+[data-theme="mq"] .tab-bar {
+  background-color: #1e293b;
+  border-bottom: 1px solid #4a5568;
+}
+
+[data-theme="mq"] .tab,
+[data-theme="mq"] .tab-item {
+  color: #94a3b8;
+  border-right: 1px solid #4a5568;
+}
+
+[data-theme="mq"] .tab:hover,
+[data-theme="mq"] .tab-item:hover {
+  background-color: #232e3d;
+}
+
+[data-theme="mq"] .tab.active,
+[data-theme="mq"] .tab-item.active {
+  background-color: #2a3444;
+  color: #e2e8f0;
+  border-bottom: 2px solid #67b8e3;
+}
+
+[data-theme="mq"] .tab-close-button {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .tab-close-button:hover {
+  background-color: #32404f;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .settings-dialog {
+  background-color: #1e293b;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .settings-header {
+  border-bottom: 1px solid #4a5568;
+}
+
+[data-theme="mq"] .settings-close-btn {
+  color: #94a3b8;
+}
+
+[data-theme="mq"] .settings-close-btn:hover {
+  background-color: #2a3444;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .settings-select {
+  background-color: #2a3444;
+  border: 1px solid #4a5568;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .dropdown {
+  background-color: #2a3444;
+  border: 1px solid #4a5568;
+  color: #e2e8f0;
+}


### PR DESCRIPTION
Add a new "mq" theme option to the playground with a custom dark color scheme using mq brand colors (#67b8e3 accent, #1e293b background).

- Define mq-branded Monaco editor theme with syntax highlighting
- Add mq theme CSS variables and component styles for all UI elements
- Migrate stored settings from version 1 to set mq as the default theme
- Update SettingsDialog, ConfirmDialog, ExamplesModal, and Toast styles