### PR TITLE
fix(mq-playground): fix theme not being saved due to migration bug

### DIFF
--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -84,9 +84,18 @@ function loadEditorSettings(): EditorSettings {
     const stored = JSON.parse(raw) as Partial<EditorSettings>;
     // Migrate from version 1: reset theme to mq default
     if (!stored.version || stored.version < 2) {
-      return { ...DEFAULT_EDITOR_SETTINGS, ...stored, theme: "mq" };
+      return {
+        ...DEFAULT_EDITOR_SETTINGS,
+        ...stored,
+        theme: "mq",
+        version: DEFAULT_EDITOR_SETTINGS.version,
+      };
     }
-    return { ...DEFAULT_EDITOR_SETTINGS, ...stored };
+    return {
+      ...DEFAULT_EDITOR_SETTINGS,
+      ...stored,
+      version: DEFAULT_EDITOR_SETTINGS.version,
+    };
   } catch {
     return DEFAULT_EDITOR_SETTINGS;
   }
@@ -97,7 +106,11 @@ function saveEditorSettings(settings: Partial<EditorSettings>) {
     const current = loadEditorSettings();
     localStorage.setItem(
       EDITOR_SETTINGS_KEY,
-      JSON.stringify({ ...current, ...settings }),
+      JSON.stringify({
+        ...current,
+        ...settings,
+        version: DEFAULT_EDITOR_SETTINGS.version,
+      }),
     );
   } catch {
     // ignore


### PR DESCRIPTION
The theme setting was not being persisted because the editor settings version was not being updated in localStorage. This caused the migration logic to trigger on every load, resetting the theme to the default "mq" value. This PR ensures that the version is correctly updated during loading (migration) and saving.

---
*PR created automatically by Jules for task [14592687661984850960](https://jules.google.com/task/14592687661984850960) started by @harehare*