### PR TITLE
✨ feat(cli): add `modules` subcommand for built-in module discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "rayon",
  "regex-lite",
  "rstest",
+ "rustc-hash",
  "rustyline",
  "scopeguard",
  "strum",

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -230,7 +230,8 @@ impl Diagnostic for Error {
                 "The provided string is not valid Base64. Check your input.",
             )),
             InnerError::Runtime(RuntimeError::NotDefined(_, name)) => Some(Cow::Owned(format!(
-                "'{name}' is not defined. Did you forget to declare it?"
+                "'{name}' is not defined. Did you forget to declare it? \
+                 If this is a module function, import it with `-m <module>` or run `mq modules` to see available built-in modules."
             ))),
             InnerError::Runtime(RuntimeError::DateTimeFormatError(_, _)) => Some(Cow::Borrowed(
                 "Invalid date/time format. Please check your format string.",

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -230,8 +230,7 @@ impl Diagnostic for Error {
                 "The provided string is not valid Base64. Check your input.",
             )),
             InnerError::Runtime(RuntimeError::NotDefined(_, name)) => Some(Cow::Owned(format!(
-                "'{name}' is not defined. Did you forget to declare it? \
-                 If this is a module function, import it with `-m <module>` or run `mq modules` to see available built-in modules."
+                "'{name}' is not defined. Did you forget to declare it?"
             ))),
             InnerError::Runtime(RuntimeError::DateTimeFormatError(_, _)) => Some(Cow::Borrowed(
                 "Invalid date/time format. Please check your format string.",

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -85,8 +85,9 @@ pub use ident::Ident;
 pub use lexer::Options as LexerOptions;
 pub use lexer::token::{StringSegment, Token, TokenKind};
 pub use module::{
-    BUILTIN_FILE as BUILTIN_MODULE_FILE, Module, ModuleId, ModuleLoader, error::ModuleError,
-    resolver::LocalFsModuleResolver, resolver::ModuleResolver, resolver::module_name,
+    BUILTIN_FILE as BUILTIN_MODULE_FILE, FunctionInfo, Module, ModuleId, ModuleLoader, ParamInfo, STANDARD_MODULES,
+    error::ModuleError, resolver::LocalFsModuleResolver, resolver::ModuleResolver, resolver::module_name,
+    standard_module_functions,
 };
 pub use range::{Position, Range};
 pub use selector::{AttrKind, Selector};

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -85,9 +85,8 @@ pub use ident::Ident;
 pub use lexer::Options as LexerOptions;
 pub use lexer::token::{StringSegment, Token, TokenKind};
 pub use module::{
-    BUILTIN_FILE as BUILTIN_MODULE_FILE, FunctionInfo, Module, ModuleId, ModuleLoader, ParamInfo, STANDARD_MODULES,
-    error::ModuleError, resolver::LocalFsModuleResolver, resolver::ModuleResolver, resolver::module_name,
-    standard_module_functions,
+    BUILTIN_FILE as BUILTIN_MODULE_FILE, Module, ModuleId, ModuleLoader, STANDARD_MODULES, error::ModuleError,
+    load_standard_module, resolver::LocalFsModuleResolver, resolver::ModuleResolver, resolver::module_name,
 };
 pub use range::{Position, Range};
 pub use selector::{AttrKind, Selector};

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod resolver;
 
 use crate::{
-    Arena, ArenaId, Program, Shared, SharedCell, TokenArena,
+    Arena, ArenaId, Program, Shared, TokenArena,
     ast::{node as ast, parser::Parser},
     lexer::{self, Lexer},
     module::{
@@ -77,117 +77,15 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
 
 pub const BUILTIN_FILE: &str = include_str!("../builtin.mq");
 
-/// Information about a single parameter of a module function.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ParamInfo {
-    /// Parameter name.
-    pub name: String,
-    /// Rendered default value, if any.
-    pub default: Option<String>,
-    /// Whether the parameter is variadic (`*name`).
-    pub is_variadic: bool,
-}
-
-/// Information about a public function exported by a standard module.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FunctionInfo {
-    /// Function name.
-    pub name: String,
-    /// Ordered list of parameters.
-    pub params: Vec<ParamInfo>,
-    /// Doc comment lines joined by `\n`, extracted from the source.
-    pub doc: Option<String>,
-}
-
-/// Render an AST expression node as a short source string for display purposes.
-fn render_default(node: &ast::Node) -> String {
-    match &*node.expr {
-        ast::Expr::Literal(lit) => match lit {
-            ast::Literal::String(s) => format!("\"{}\"", s),
-            ast::Literal::Number(n) => n.to_string(),
-            ast::Literal::Bool(b) => b.to_string(),
-            ast::Literal::None => "none".to_string(),
-            ast::Literal::Symbol(i) => format!(":{}", i),
-        },
-        ast::Expr::Ident(ident) => ident.name.to_string(),
-        _ => "...".to_string(),
-    }
-}
-
-/// Scan `source` and build a map of `function_name -> doc_comment`.
+/// Load a single standard module by name and return its parsed AST representation.
 ///
-/// Comment lines (`# ...`) immediately preceding a `def name(` line are collected.
-/// Blank lines reset the buffer; any other content also resets it.
-fn extract_doc_comments(source: &str) -> rustc_hash::FxHashMap<String, String> {
-    let mut map = rustc_hash::FxHashMap::default();
-    let mut comment_lines: Vec<String> = Vec::new();
-
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix('#') {
-            comment_lines.push(rest.trim_start().to_string());
-        } else if let Some(rest) = trimmed.strip_prefix("def ") {
-            if let Some(name) = rest.split('(').next().map(str::trim)
-                && !comment_lines.is_empty()
-            {
-                map.insert(name.to_string(), comment_lines.join("\n"));
-            }
-            comment_lines.clear();
-        } else {
-            comment_lines.clear();
-        }
-    }
-
-    map
-}
-
-/// Returns information about all public functions of each standard module, sorted by module name.
-///
-/// Each entry is `(module_name, vec_of_function_info)`.
-/// Private functions (names starting with `_`) are excluded.
-pub fn standard_module_functions() -> Vec<(String, Vec<FunctionInfo>)> {
-    let mut result: Vec<(String, Vec<FunctionInfo>)> = STANDARD_MODULES
-        .iter()
-        .filter_map(|(name, content_fn)| {
-            let content = content_fn();
-            let doc_map = extract_doc_comments(content);
-            let token_arena: TokenArena = Shared::new(SharedCell::new(Arena::new(64)));
-            let mut loader = ModuleLoader::<LocalFsModuleResolver>::default();
-            loader.load(name.as_str(), content, token_arena).ok().map(|module| {
-                let functions: Vec<FunctionInfo> = module
-                    .functions
-                    .iter()
-                    .filter_map(|node| {
-                        if let ast::Expr::Def(ident, params, _) = &*node.expr {
-                            let fname = ident.name.to_string();
-                            if fname.starts_with('_') {
-                                return None;
-                            }
-                            let param_infos = params
-                                .iter()
-                                .map(|p| ParamInfo {
-                                    name: p.ident.name.to_string(),
-                                    default: p.default.as_ref().map(|d| render_default(d)),
-                                    is_variadic: p.is_variadic,
-                                })
-                                .collect();
-                            let doc = doc_map.get(&fname).cloned();
-                            Some(FunctionInfo {
-                                name: fname,
-                                params: param_infos,
-                                doc,
-                            })
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                (name.to_string(), functions)
-            })
-        })
-        .collect();
-    result.sort_by(|a, b| a.0.cmp(&b.0));
-    result
+/// Returns `None` if the module name is not found in [`STANDARD_MODULES`].
+pub fn load_standard_module(name: &str) -> Option<Module> {
+    use crate::SharedCell;
+    let content = STANDARD_MODULES.get(name).map(|f| f())?;
+    let token_arena: TokenArena = Shared::new(SharedCell::new(Arena::new(64)));
+    let mut loader = ModuleLoader::<LocalFsModuleResolver>::default();
+    loader.load(name, content, token_arena).ok()
 }
 
 impl<T: ModuleResolver> ModuleLoader<T> {

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod resolver;
 
 use crate::{
-    Arena, ArenaId, Program, Shared, TokenArena,
+    Arena, ArenaId, Program, Shared, SharedCell, TokenArena,
     ast::{node as ast, parser::Parser},
     lexer::{self, Lexer},
     module::{
@@ -76,6 +76,119 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
 });
 
 pub const BUILTIN_FILE: &str = include_str!("../builtin.mq");
+
+/// Information about a single parameter of a module function.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParamInfo {
+    /// Parameter name.
+    pub name: String,
+    /// Rendered default value, if any.
+    pub default: Option<String>,
+    /// Whether the parameter is variadic (`*name`).
+    pub is_variadic: bool,
+}
+
+/// Information about a public function exported by a standard module.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionInfo {
+    /// Function name.
+    pub name: String,
+    /// Ordered list of parameters.
+    pub params: Vec<ParamInfo>,
+    /// Doc comment lines joined by `\n`, extracted from the source.
+    pub doc: Option<String>,
+}
+
+/// Render an AST expression node as a short source string for display purposes.
+fn render_default(node: &ast::Node) -> String {
+    match &*node.expr {
+        ast::Expr::Literal(lit) => match lit {
+            ast::Literal::String(s) => format!("\"{}\"", s),
+            ast::Literal::Number(n) => n.to_string(),
+            ast::Literal::Bool(b) => b.to_string(),
+            ast::Literal::None => "none".to_string(),
+            ast::Literal::Symbol(i) => format!(":{}", i),
+        },
+        ast::Expr::Ident(ident) => ident.name.to_string(),
+        _ => "...".to_string(),
+    }
+}
+
+/// Scan `source` and build a map of `function_name -> doc_comment`.
+///
+/// Comment lines (`# ...`) immediately preceding a `def name(` line are collected.
+/// Blank lines reset the buffer; any other content also resets it.
+fn extract_doc_comments(source: &str) -> rustc_hash::FxHashMap<String, String> {
+    let mut map = rustc_hash::FxHashMap::default();
+    let mut comment_lines: Vec<String> = Vec::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            comment_lines.push(rest.trim_start().to_string());
+        } else if let Some(rest) = trimmed.strip_prefix("def ") {
+            if let Some(name) = rest.split('(').next().map(str::trim)
+                && !comment_lines.is_empty()
+            {
+                map.insert(name.to_string(), comment_lines.join("\n"));
+            }
+            comment_lines.clear();
+        } else {
+            comment_lines.clear();
+        }
+    }
+
+    map
+}
+
+/// Returns information about all public functions of each standard module, sorted by module name.
+///
+/// Each entry is `(module_name, vec_of_function_info)`.
+/// Private functions (names starting with `_`) are excluded.
+pub fn standard_module_functions() -> Vec<(String, Vec<FunctionInfo>)> {
+    let mut result: Vec<(String, Vec<FunctionInfo>)> = STANDARD_MODULES
+        .iter()
+        .filter_map(|(name, content_fn)| {
+            let content = content_fn();
+            let doc_map = extract_doc_comments(content);
+            let token_arena: TokenArena = Shared::new(SharedCell::new(Arena::new(64)));
+            let mut loader = ModuleLoader::<LocalFsModuleResolver>::default();
+            loader.load(name.as_str(), content, token_arena).ok().map(|module| {
+                let functions: Vec<FunctionInfo> = module
+                    .functions
+                    .iter()
+                    .filter_map(|node| {
+                        if let ast::Expr::Def(ident, params, _) = &*node.expr {
+                            let fname = ident.name.to_string();
+                            if fname.starts_with('_') {
+                                return None;
+                            }
+                            let param_infos = params
+                                .iter()
+                                .map(|p| ParamInfo {
+                                    name: p.ident.name.to_string(),
+                                    default: p.default.as_ref().map(|d| render_default(d)),
+                                    is_variadic: p.is_variadic,
+                                })
+                                .collect();
+                            let doc = doc_map.get(&fname).cloned();
+                            Some(FunctionInfo {
+                                name: fname,
+                                params: param_infos,
+                                doc,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                (name.to_string(), functions)
+            })
+        })
+        .collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}
 
 impl<T: ModuleResolver> ModuleLoader<T> {
     pub fn new(resolver: T) -> Self {

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -26,7 +26,7 @@ miette = {workspace = true, features = ["fancy"]}
 mimalloc = {workspace = true, features = ["v3"], optional = true}
 mq-dap = {workspace = true, optional = true}
 mq-formatter = {workspace = true}
-mq-lang = {workspace = true, features = ["file-io"]}
+mq-lang = {workspace = true, features = ["file-io", "cst"]}
 mq-markdown = {workspace = true, features = ["json", "html-to-markdown", "color"]}
 mq-repl = {workspace = true}
 rayon = {workspace = true}
@@ -36,6 +36,7 @@ strum = {workspace = true, features = ["derive"], optional = true}
 tabled = {workspace = true}
 url = {workspace = true}
 which = "8.0.2"
+rustc-hash = {workspace = true}
 
 [dev-dependencies]
 assert_cmd = {workspace = true}

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::grep;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use glob::glob;
@@ -12,9 +13,9 @@ use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
 use std::{fs, path::PathBuf};
+use tabled::builder::Builder;
+use tabled::settings::Style;
 use which::which;
-
-use crate::grep;
 
 #[derive(Parser, Debug, Default)]
 #[command(name = "mq")]
@@ -28,7 +29,11 @@ use crate::grep;
     ## To start a REPL session:\n\
     mq repl\n\n\
     ## To format mq file:\n\
-    mq fmt --check file.mq")]
+    mq fmt --check file.mq\n\n\
+    ## To list available built-in modules and their functions:\n\
+    mq modules\n\n\
+    ## To import a built-in module and use its functions:\n\
+    mq -m section 'section(., \"Introduction\")' file.md")]
 #[command(
     about = "mq is a markdown processor that can filter markdown nodes by using jq-like syntax.",
     long_about = None
@@ -232,10 +237,27 @@ impl OutputArgs {
     }
 }
 
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+enum ModulesFormat {
+    /// Colored text output (default)
+    #[default]
+    Text,
+    /// GitHub-flavored Markdown table
+    Markdown,
+    /// Terminal ASCII table
+    Table,
+}
+
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Start a REPL session for interactive query execution
     Repl,
+    /// List available built-in modules and their functions
+    Modules {
+        /// Output format for the module listing
+        #[arg(short = 'F', long, value_enum, default_value_t)]
+        format: ModulesFormat,
+    },
     /// Format mq files based on specified formatting options.
     Fmt {
         /// Number of spaces for indentation
@@ -398,6 +420,100 @@ impl Cli {
         Ok(())
     }
 
+    fn format_function_signature(info: &mq_lang::FunctionInfo) -> String {
+        let params: Vec<String> = info
+            .params
+            .iter()
+            .map(|p| {
+                let name = if p.is_variadic {
+                    format!("*{}", p.name)
+                } else {
+                    p.name.clone()
+                };
+                match &p.default {
+                    Some(default) => format!("{} = {}", name, default),
+                    None => name,
+                }
+            })
+            .collect();
+        format!("{}({})", info.name, params.join(", "))
+    }
+
+    fn list_module_functions(&self, format: &ModulesFormat) -> miette::Result<()> {
+        let modules = mq_lang::standard_module_functions();
+        match format {
+            ModulesFormat::Text => Self::print_modules_text(&modules),
+            ModulesFormat::Markdown => Self::print_modules_markdown(&modules),
+            ModulesFormat::Table => Self::print_modules_table(&modules),
+        }
+        Ok(())
+    }
+
+    fn print_modules_text(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+        let mut output = vec![
+            format!("{}", "Available built-in modules:".bold().cyan()),
+            format!(
+                "Import with {} or load with {}",
+                "-m <module>".green(),
+                "-M <module>".green()
+            ),
+            "".to_string(),
+        ];
+
+        for (name, functions) in modules {
+            output.push(format!("{}:", name.bold().yellow()));
+            if functions.is_empty() {
+                output.push("  (no public functions)".to_string());
+            } else {
+                for func in functions {
+                    if let Some(doc) = &func.doc {
+                        for line in doc.lines() {
+                            output.push(format!("  {}", line.bright_black()));
+                        }
+                    }
+                    output.push(format!("  {}", Self::format_function_signature(func).bright_cyan()));
+                    output.push("".to_string());
+                }
+            }
+            output.push("".to_string());
+        }
+
+        print!("{}", output.join("\n"));
+    }
+
+    fn print_modules_markdown(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+        println!("| Module | Function | Description |");
+        println!("|--------|----------|-------------|");
+        for (name, functions) in modules {
+            for func in functions {
+                let sig = Self::format_function_signature(func);
+                let desc = func.doc.as_deref().and_then(|d| d.lines().next()).unwrap_or("");
+                println!("| {} | `{}` | {} |", name, sig, desc);
+            }
+        }
+    }
+
+    fn print_modules_table(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+        let mut builder = Builder::default();
+        builder.push_record(["Module", "Function", "Description"]);
+
+        for (name, functions) in modules {
+            for func in functions {
+                let sig = Self::format_function_signature(func);
+                let desc = func
+                    .doc
+                    .as_deref()
+                    .and_then(|d| d.lines().next())
+                    .unwrap_or("")
+                    .to_string();
+                builder.push_record([name.as_str(), sig.as_str(), desc.as_str()]);
+            }
+        }
+
+        let table = builder.build().with(Style::rounded()).to_string();
+        println!("{}", table);
+    }
+
     /// List all available subcommands (built-in and external)
     fn list_commands(&self) -> miette::Result<()> {
         let mut output = vec![
@@ -484,6 +600,7 @@ impl Cli {
 
         match &self.commands {
             Some(Commands::Repl) => mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run(),
+            Some(Commands::Modules { format }) => self.list_module_functions(format),
             None if self.query.is_none() => {
                 mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run()
             }
@@ -2062,6 +2179,17 @@ mod tests {
         };
 
         assert!(cli.run().is_ok());
+    }
+
+    #[test]
+    fn test_modules_command() {
+        for format in [ModulesFormat::Text, ModulesFormat::Markdown, ModulesFormat::Table] {
+            let cli = Cli {
+                commands: Some(Commands::Modules { format }),
+                ..Cli::default()
+            };
+            assert!(cli.run().is_ok());
+        }
     }
 
     #[test]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1,4 +1,6 @@
 use crate::grep;
+use crate::module_info::FunctionInfo;
+use crate::module_info::standard_module_functions;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use glob::glob;
@@ -420,7 +422,7 @@ impl Cli {
         Ok(())
     }
 
-    fn format_function_signature(info: &mq_lang::FunctionInfo) -> String {
+    fn format_function_signature(info: &FunctionInfo) -> String {
         let params: Vec<String> = info
             .params
             .iter()
@@ -440,7 +442,7 @@ impl Cli {
     }
 
     fn list_module_functions(&self, format: &ModulesFormat) -> miette::Result<()> {
-        let modules = mq_lang::standard_module_functions();
+        let modules = standard_module_functions();
         match format {
             ModulesFormat::Text => Self::print_modules_text(&modules),
             ModulesFormat::Markdown => Self::print_modules_markdown(&modules),
@@ -449,7 +451,7 @@ impl Cli {
         Ok(())
     }
 
-    fn print_modules_text(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+    fn print_modules_text(modules: &[(String, Vec<FunctionInfo>)]) {
         let mut output = vec![
             format!("{}", "Available built-in modules:".bold().cyan()),
             format!(
@@ -481,7 +483,7 @@ impl Cli {
         print!("{}", output.join("\n"));
     }
 
-    fn print_modules_markdown(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+    fn print_modules_markdown(modules: &[(String, Vec<FunctionInfo>)]) {
         println!("| Module | Function | Description |");
         println!("|--------|----------|-------------|");
         for (name, functions) in modules {
@@ -493,7 +495,7 @@ impl Cli {
         }
     }
 
-    fn print_modules_table(modules: &[(String, Vec<mq_lang::FunctionInfo>)]) {
+    fn print_modules_table(modules: &[(String, Vec<FunctionInfo>)]) {
         let mut builder = Builder::default();
         builder.push_record(["Module", "Function", "Description"]);
 

--- a/crates/mq-run/src/lib.rs
+++ b/crates/mq-run/src/lib.rs
@@ -44,6 +44,7 @@
 
 pub mod cli;
 pub(crate) mod grep;
+pub(crate) mod module_info;
 pub(crate) mod table;
 
 #[cfg(feature = "debugger")]

--- a/crates/mq-run/src/module_info.rs
+++ b/crates/mq-run/src/module_info.rs
@@ -28,17 +28,7 @@ pub struct FunctionInfo {
 }
 
 fn render_default(node: &mq_lang::AstNode) -> String {
-    match &*node.expr {
-        mq_lang::AstExpr::Literal(lit) => match lit {
-            mq_lang::AstLiteral::String(s) => format!("\"{}\"", s),
-            mq_lang::AstLiteral::Number(n) => n.to_string(),
-            mq_lang::AstLiteral::Bool(b) => b.to_string(),
-            mq_lang::AstLiteral::None => "none".to_string(),
-            mq_lang::AstLiteral::Symbol(i) => format!(":{}", i),
-        },
-        mq_lang::AstExpr::Ident(ident) => ident.name.to_string(),
-        _ => "...".to_string(),
-    }
+    node.to_code()
 }
 
 fn extract_doc_comments(source: &str) -> FxHashMap<String, String> {

--- a/crates/mq-run/src/module_info.rs
+++ b/crates/mq-run/src/module_info.rs
@@ -1,0 +1,148 @@
+//! Module introspection for the `mq modules` subcommand.
+//!
+//! Enumerates built-in standard modules, extracts public function signatures
+//! from the AST, and associates doc comments via the CST.
+
+use rustc_hash::FxHashMap;
+
+/// Information about a single parameter of a module function.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParamInfo {
+    /// Parameter name.
+    pub name: String,
+    /// Rendered default value, if any (e.g. `"false"`, `"0"`, `":symbol"`).
+    pub default: Option<String>,
+    /// Whether the parameter is variadic (`*name`).
+    pub is_variadic: bool,
+}
+
+/// Information about a public function exported by a standard module.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionInfo {
+    /// Function name.
+    pub name: String,
+    /// Ordered list of parameters.
+    pub params: Vec<ParamInfo>,
+    /// Doc comment lines joined by `\n`, extracted from the module source.
+    pub doc: Option<String>,
+}
+
+fn render_default(node: &mq_lang::AstNode) -> String {
+    match &*node.expr {
+        mq_lang::AstExpr::Literal(lit) => match lit {
+            mq_lang::AstLiteral::String(s) => format!("\"{}\"", s),
+            mq_lang::AstLiteral::Number(n) => n.to_string(),
+            mq_lang::AstLiteral::Bool(b) => b.to_string(),
+            mq_lang::AstLiteral::None => "none".to_string(),
+            mq_lang::AstLiteral::Symbol(i) => format!(":{}", i),
+        },
+        mq_lang::AstExpr::Ident(ident) => ident.name.to_string(),
+        _ => "...".to_string(),
+    }
+}
+
+fn extract_doc_comments(source: &str) -> FxHashMap<String, String> {
+    let (nodes, _) = mq_lang::parse_recovery(source);
+
+    nodes
+        .iter()
+        .filter(|node| node.is_def())
+        .filter_map(|node| {
+            let name = node
+                .children
+                .first()
+                .and_then(|child| child.token.as_ref())
+                .and_then(|token| match &token.kind {
+                    mq_lang::TokenKind::Ident(s) => Some(s.to_string()),
+                    _ => None,
+                })?;
+
+            // Find the position just after the last blank-line boundary.
+            // A blank line = two consecutive NewLine trivia (ignoring whitespace between them).
+            let trivia = &node.leading_trivia;
+            let start = {
+                let mut last_blank_end = 0;
+                let mut i = 0;
+                while i < trivia.len() {
+                    if matches!(&trivia[i], mq_lang::CstTrivia::NewLine) {
+                        let mut j = i + 1;
+                        while j < trivia.len()
+                            && matches!(
+                                &trivia[j],
+                                mq_lang::CstTrivia::Whitespace(_) | mq_lang::CstTrivia::Tab(_)
+                            )
+                        {
+                            j += 1;
+                        }
+                        if j < trivia.len() && matches!(&trivia[j], mq_lang::CstTrivia::NewLine) {
+                            last_blank_end = j + 1;
+                        }
+                    }
+                    i += 1;
+                }
+                last_blank_end
+            };
+
+            let comments: Vec<String> = trivia[start..]
+                .iter()
+                .filter_map(|t| t.comment())
+                .map(|s| s.trim_start().to_string())
+                .collect();
+
+            if comments.is_empty() {
+                None
+            } else {
+                Some((name, comments.join("\n")))
+            }
+        })
+        .collect()
+}
+
+/// Returns information about all public functions of each standard module, sorted by module name.
+///
+/// Each entry is `(module_name, vec_of_function_info)`.
+/// Private functions (names starting with `_`) are excluded.
+pub fn standard_module_functions() -> Vec<(String, Vec<FunctionInfo>)> {
+    let mut result: Vec<(String, Vec<FunctionInfo>)> = mq_lang::STANDARD_MODULES
+        .iter()
+        .filter_map(|(mod_name, content_fn)| {
+            let content = content_fn();
+            let doc_map = extract_doc_comments(content);
+            let module = mq_lang::load_standard_module(mod_name.as_str())?;
+
+            let functions: Vec<FunctionInfo> = module
+                .functions
+                .iter()
+                .filter_map(|node| {
+                    if let mq_lang::AstExpr::Def(ident, params, _) = &*node.expr {
+                        let fname = ident.name.to_string();
+                        if fname.starts_with('_') {
+                            return None;
+                        }
+                        let param_infos = params
+                            .iter()
+                            .map(|p| ParamInfo {
+                                name: p.ident.name.to_string(),
+                                default: p.default.as_ref().map(|d| render_default(d)),
+                                is_variadic: p.is_variadic,
+                            })
+                            .collect();
+                        let doc = doc_map.get(&fname).cloned();
+                        Some(FunctionInfo {
+                            name: fname,
+                            params: param_infos,
+                            doc,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            Some((mod_name.to_string(), functions))
+        })
+        .collect();
+
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}


### PR DESCRIPTION
- Add `mq modules` subcommand listing all standard modules with their public functions, parameter signatures, and doc comments
- Add `--format` / `-F` option supporting `text` (default, colored), `markdown` (GFM table), and `table` (rounded ASCII table) output
- Add `FunctionInfo` and `ParamInfo` structs to `mq-lang` for structured module introspection extracted from AST (`Expr::Def` params) and source-level `#` doc comments
- Improve `NotDefined` error help to suggest `mq modules` when a function is not found
- Update CLI `--help` after_help with `modules` and `-m` usage examples