### PR TITLE
♻️ refactor(cli): remove built-in fmt subcommand in favor of mq-fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,6 @@ version = "0.5.28"
 dependencies = [
  "clap",
  "colored 3.1.1",
- "itertools",
  "miette",
  "mq-hir",
  "mq-lang",
@@ -2450,7 +2449,6 @@ dependencies = [
  "codspeed-divan-compat",
  "mq-lang",
  "rstest",
- "rustc-hash",
 ]
 
 [[package]]
@@ -2523,7 +2521,6 @@ dependencies = [
  "clap",
  "dashmap",
  "itertools",
- "miette",
  "mq-check",
  "mq-formatter",
  "mq-hir",
@@ -2532,7 +2529,6 @@ dependencies = [
  "rustc-hash",
  "serde_json",
  "tokio",
- "tokio-macros",
  "tower-lsp-server",
  "url",
 ]
@@ -2561,7 +2557,6 @@ dependencies = [
  "arboard",
  "colored 3.1.1",
  "dirs 6.0.0",
- "itertools",
  "miette",
  "mq-hir",
  "mq-lang",
@@ -2581,11 +2576,9 @@ dependencies = [
  "clap",
  "colored 3.1.1",
  "dirs 6.0.0",
- "glob",
  "miette",
  "mimalloc",
  "mq-dap",
- "mq-formatter",
  "mq-lang",
  "mq-markdown",
  "mq-repl",
@@ -2596,7 +2589,6 @@ dependencies = [
  "scopeguard",
  "strum",
  "tabled",
- "url",
  "which",
 ]
 
@@ -2636,7 +2628,6 @@ dependencies = [
 name = "mq-web-api"
 version = "0.5.28"
 dependencies = [
- "async-trait",
  "axum",
  "miette",
  "mimalloc",
@@ -6046,7 +6037,6 @@ dependencies = [
 name = "zed-mq"
 version = "0.1.0"
 dependencies = [
- "serde_json",
  "zed_extension_api",
 ]
 

--- a/assets/mq.sublime-syntax
+++ b/assets/mq.sublime-syntax
@@ -24,7 +24,7 @@ contexts:
   keywords:
     - match: '\b(def|do|let|if|elif|else|end|while|foreach|self|nodes|match|fn|break|continue|include|import|module|var|macro|quote|unquote|loop)\b'
       scope: keyword.control.mq
-    - match: '(<<|>>|<=|>=|==|!=|=~|\|\||&&|\?\?|=|<|>|\||:|;|\?|!|\+|\-|\*|/|%|@)'
+    - match: '(<<|>>|<=|>=|==|!=|=~|\|\||&&|\?\?|=|<|>|\||:|;|\?|!|\+|\-|\*|/|%|@|->)'
       scope: keyword.operator.mq
     - match: '\b(true|false)\b'
       scope: constant.language.boolean.mq

--- a/crates/mq-check/Cargo.toml
+++ b/crates/mq-check/Cargo.toml
@@ -27,7 +27,6 @@ disabled-strategies = ["quick-install"]
 [dependencies]
 clap = {workspace = true, features = ["derive"], optional = true}
 colored = {workspace = true, optional = true}
-itertools = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["cst", "file-io"]}

--- a/crates/mq-formatter/Cargo.toml
+++ b/crates/mq-formatter/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.5.28"
 
 [dependencies]
 mq-lang = {workspace = true, features = ["cst"]}
-rustc-hash = {workspace = true}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -16,7 +16,6 @@ bimap = {workspace = true}
 clap = {workspace = true, features = ["derive"]}
 dashmap = {workspace = true}
 itertools = {workspace = true}
-miette = {workspace = true, features = ["fancy"]}
 mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}
@@ -24,7 +23,6 @@ mq-lang = {workspace = true, features = ["ast-json", "sync", "file-io"]}
 mq-markdown = {workspace = true}
 serde_json = {workspace = true}
 tokio = {workspace = true, features = ["macros", "io-std", "rt-multi-thread"]}
-tokio-macros = {workspace = true}
 tower-lsp-server = {workspace = true}
 url = {workspace = true}
 rustc-hash = {workspace = true}

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.5.28"
 [dependencies]
 colored = {workspace = true}
 dirs = {workspace = true}
-itertools = {workspace = true}
 miette = {workspace = true}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true}

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -21,11 +21,9 @@ use_mimalloc = ["mimalloc"]
 clap = {workspace = true, features = ["derive"]}
 colored = {workspace = true}
 dirs = {workspace = true}
-glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mimalloc = {workspace = true, features = ["v3"], optional = true}
 mq-dap = {workspace = true, optional = true}
-mq-formatter = {workspace = true}
 mq-lang = {workspace = true, features = ["file-io"]}
 mq-markdown = {workspace = true, features = ["json", "html-to-markdown", "color"]}
 mq-repl = {workspace = true}
@@ -34,7 +32,6 @@ regex-lite = {workspace = true, optional = true}
 rustyline = {workspace = true, optional = true, default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {workspace = true, features = ["derive"], optional = true}
 tabled = {workspace = true}
-url = {workspace = true}
 which = "8.0.2"
 
 [dev-dependencies]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use glob::glob;
 use miette::IntoDiagnostic;
 use miette::miette;
 use mq_lang::DefaultEngine;
@@ -26,9 +25,7 @@ use crate::grep;
     ## To read query from file:\n\
     mq -f 'file' file.md\n\n\
     ## To start a REPL session:\n\
-    mq repl\n\n\
-    ## To format mq file:\n\
-    mq fmt --check file.mq")]
+    mq repl\n")]
 #[command(
     about = "mq is a markdown processor that can filter markdown nodes by using jq-like syntax.",
     long_about = None
@@ -236,26 +233,6 @@ impl OutputArgs {
 enum Commands {
     /// Start a REPL session for interactive query execution
     Repl,
-    /// Format mq files based on specified formatting options.
-    Fmt {
-        /// Number of spaces for indentation
-        #[arg(short, long, default_value_t = 2)]
-        indent_width: usize,
-        /// Check if files are formatted without modifying them
-        #[arg(short, long)]
-        check: bool,
-        /// Sort imports
-        #[arg(long, default_value_t = false)]
-        sort_imports: bool,
-        /// Sort functions
-        #[arg(long, default_value_t = false)]
-        sort_functions: bool,
-        /// Sort fields
-        #[arg(long, default_value_t = false)]
-        sort_fields: bool,
-        /// Path to the mq file to format
-        files: Option<Vec<PathBuf>>,
-    },
     /// Start a debug adapter for mq
     #[cfg(feature = "debugger")]
     Dap,
@@ -406,10 +383,6 @@ impl Cli {
                 "  {} - Start a REPL session for interactive query execution",
                 "repl".green()
             ),
-            format!(
-                "  {} - Format mq files based on specified formatting options",
-                "fmt".green()
-            ),
         ];
 
         #[cfg(feature = "debugger")]
@@ -486,47 +459,6 @@ impl Cli {
             Some(Commands::Repl) => mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run(),
             None if self.query.is_none() => {
                 mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run()
-            }
-            Some(Commands::Fmt {
-                indent_width,
-                check,
-                files,
-                sort_imports,
-                sort_fields,
-                sort_functions,
-            }) => {
-                let mut formatter = mq_formatter::Formatter::new(Some(mq_formatter::FormatterConfig {
-                    indent_width: *indent_width,
-                    sort_imports: *sort_imports,
-                    sort_fields: *sort_fields,
-                    sort_functions: *sort_functions,
-                }));
-                let files = match files {
-                    Some(f) => f,
-                    None => &glob("./**/*.mq")
-                        .into_diagnostic()?
-                        .collect::<Result<Vec<_>, _>>()
-                        .into_diagnostic()?,
-                };
-
-                for file in files {
-                    if !file.exists() {
-                        return Err(miette!("File not found: {}", file.display()));
-                    }
-
-                    let content = fs::read_to_string(file).into_diagnostic()?;
-                    let formatted = formatter
-                        .format(&content)
-                        .map_err(|e| miette!("{}: {e}", file.display()))?;
-
-                    if *check && formatted != content {
-                        return Err(miette!("The input is not formatted"));
-                    } else if formatted != content {
-                        fs::write(file, formatted).into_diagnostic()?;
-                    }
-                }
-
-                Ok(())
             }
             #[cfg(feature = "debugger")]
             Some(Commands::Dap) => mq_dap::start().map_err(|e| miette!(e.to_string())),
@@ -1091,66 +1023,6 @@ mod tests {
             commands: None,
             query: Some("self".to_string()),
             files: Some(vec![temp_file_path.clone()]),
-            ..Cli::default()
-        };
-
-        assert!(cli.run().is_ok());
-    }
-
-    #[test]
-    fn test_cli_fmt_command() {
-        let (_, temp_file_path) = create_file("test1.mq", "def math(): 42;");
-        let temp_file_path_clone = temp_file_path.clone();
-
-        defer! {
-            if temp_file_path_clone.exists() {
-                std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
-            }
-        }
-
-        let cli = Cli {
-            input: InputArgs::default(),
-            output: OutputArgs::default(),
-            commands: Some(Commands::Fmt {
-                indent_width: 2,
-                check: false,
-                files: Some(vec![temp_file_path.clone()]),
-                sort_functions: false,
-                sort_fields: false,
-                sort_imports: false,
-            }),
-            query: None,
-            files: Some(vec![temp_file_path]),
-            ..Cli::default()
-        };
-
-        assert!(cli.run().is_ok());
-    }
-
-    #[test]
-    fn test_cli_fmt_command_with_check() {
-        let (_, temp_file_path) = create_file("test2.mq", "def math(): 42;");
-        let temp_file_path_clone = temp_file_path.clone();
-
-        defer! {
-            if temp_file_path_clone.exists() {
-                std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
-            }
-        }
-
-        let cli = Cli {
-            input: InputArgs::default(),
-            output: OutputArgs::default(),
-            commands: Some(Commands::Fmt {
-                indent_width: 2,
-                check: true,
-                files: Some(vec![temp_file_path.clone()]),
-                sort_functions: false,
-                sort_fields: false,
-                sort_imports: false,
-            }),
-            query: None,
-            files: Some(vec![temp_file_path]),
             ..Cli::default()
         };
 
@@ -1981,57 +1853,6 @@ mod tests {
         };
 
         assert!(cli.run().is_ok());
-    }
-
-    #[test]
-    fn test_fmt_file_not_found() {
-        let cli = Cli {
-            input: InputArgs::default(),
-            output: OutputArgs::default(),
-            commands: Some(Commands::Fmt {
-                indent_width: 2,
-                check: false,
-                files: Some(vec![PathBuf::from("nonexistent.mq")]),
-                sort_functions: false,
-                sort_fields: false,
-                sort_imports: false,
-            }),
-            query: None,
-            files: None,
-            ..Cli::default()
-        };
-
-        assert!(cli.run().is_err());
-    }
-
-    #[test]
-    fn test_fmt_check_unformatted_file() {
-        let (_, temp_file) = create_file("test_unformatted.mq", "def   math():    42;");
-        let temp_file_clone = temp_file.clone();
-
-        defer! {
-            if temp_file_clone.exists() {
-                std::fs::remove_file(&temp_file_clone).ok();
-            }
-        }
-
-        let cli = Cli {
-            input: InputArgs::default(),
-            output: OutputArgs::default(),
-            commands: Some(Commands::Fmt {
-                indent_width: 2,
-                check: true,
-                files: Some(vec![temp_file]),
-                sort_functions: false,
-                sort_fields: false,
-                sort_imports: false,
-            }),
-            query: None,
-            files: None,
-            ..Cli::default()
-        };
-
-        assert!(cli.run().is_err());
     }
 
     #[test]

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -54,11 +54,6 @@ fn test_cli_run_with_stdin() -> Result<(), Box<dyn std::error::Error>> {
     "# **title**\n\n- test1\n- test2",
     Some("- test1\n- test2\n")
 )]
-#[case::format(
-    vec!["fmt"],
-    "def test(x):\nadd(x,1);\n| map(array(1,2,3),test)",
-    None
-)]
 #[case::update_file(
     vec!["--unbuffered", "--update", r#".h | select(contains("title")) | ltrimstr("titl")"#],
     "# **title**\n\n- test1\n- test2",

--- a/crates/mq-wasm/Cargo.toml
+++ b/crates/mq-wasm/Cargo.toml
@@ -41,3 +41,6 @@ opfs = ["dep:opfs"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-O4', '--enable-simd', '--enable-bulk-memory', '--enable-nontrapping-float-to-int']
+
+[package.metadata.cargo-machete]
+ignored = ["wasm-bindgen-futures"]

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -18,7 +18,6 @@ use_mimalloc = ["mimalloc"]
 otel = ["opentelemetry", "opentelemetry-otlp", "opentelemetry_sdk", "tracing-opentelemetry"]
 
 [dependencies]
-async-trait = {workspace = true}
 axum = {workspace = true}
 miette = {workspace = true}
 mimalloc = {workspace = true, features = ["v3"], optional = true}

--- a/docs/books/src/start/external_subcommands.md
+++ b/docs/books/src/start/external_subcommands.md
@@ -29,6 +29,7 @@ The following external tools are available to extend mq's functionality:
 - [mq-conv](https://github.com/harehare/mq-conv) - A CLI tool for converting various file formats to Markdown.
 - [mq-crawler](https://github.com/harehare/mq/blob/main/crates/mq-crawler/README.md) - A web crawler that extracts structured data from websites and outputs it in Markdown format.
 - [mq-docs](https://github.com/harehare/mq-docs) - A documentation generator for mq functions, macros, and selectors.
+- [mq-fmt](https://github.com/harehare/mq-fmt) - Formatter for mq query language (.mq) files.
 - [mq-http](https://github.com/harehare/mq-http) - A lightweight HTTP server that executes mq scripts for each request.
 - [mq-lsp](https://github.com/harehare/mq/tree/main/crates/mq-lsp/README.md) - Language Server Protocol (LSP) implementation for mq query files, providing IDE features like completion, hover, and diagnostics.
 - [mq-mcp](https://github.com/harehare/mq-mcp) - Model Context Protocol (MCP) server implementation for AI assistants.

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -8,5 +8,4 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-serde_json = "1"
 zed_extension_api = "0.7.0"


### PR DESCRIPTION
Extract fmt functionality to the standalone external tool mq-fmt. Remove unused dependencies (glob, mq-formatter, itertools, miette, tokio-macros, async-trait, rustc-hash, serde_json, url) from affected crates, and add -> operator to Sublime Text syntax highlighting.