### PR TITLE
🐛 fix(check): use open records for dict literals and improve dead code detection

### DIFF
--- a/crates/mq-check/src/constraint.rs
+++ b/crates/mq-check/src/constraint.rs
@@ -1240,8 +1240,8 @@ pub(super) fn generate_symbol_constraints(
                 }
 
                 if all_string_keys {
-                    // Closed record: all field keys are statically known
-                    let record_ty = Type::record(fields, Type::RowEmpty);
+                    let row_var = ctx.fresh_var();
+                    let record_ty = Type::record(fields, Type::Var(row_var));
                     ctx.set_symbol_type(symbol_id, record_ty);
                 } else {
                     // Fallback: dynamic keys → use Dict type

--- a/crates/mq-check/src/deferred.rs
+++ b/crates/mq-check/src/deferred.rs
@@ -18,6 +18,37 @@ use crate::{
     unify, walk_ancestors,
 };
 
+/// Looks up `field` in a Record type, following row variables through the substitution map.
+///
+/// Returns `Some(field_type)` when found, or `None` when the field is absent and
+/// the row chain ends with `RowEmpty` or a still-free `Var` (no further extension
+/// was ever unified into this record, so the field is genuinely missing).
+fn find_record_field<'a>(ctx: &'a InferenceContext, ty: &'a types::Type, field: &str) -> Option<types::Type> {
+    match ty {
+        types::Type::Record(fields, rest) => {
+            if let Some(ft) = fields.get(field) {
+                return Some(ft.clone());
+            }
+            let resolved = ctx.resolve_type(rest);
+            find_record_field(ctx, &resolved, field)
+        }
+        _ => None,
+    }
+}
+
+/// Returns `true` when the row chain ends with `RowEmpty` or a free type variable,
+/// meaning no further fields can appear — the record is effectively closed.
+fn record_row_is_closed(ctx: &InferenceContext, ty: &types::Type) -> bool {
+    match ty {
+        types::Type::Record(_, rest) => {
+            let resolved = ctx.resolve_type(rest);
+            record_row_is_closed(ctx, &resolved)
+        }
+        types::Type::RowEmpty | types::Type::Var(_) => true,
+        _ => false,
+    }
+}
+
 /// Resolves deferred record field accesses after the first round of unification.
 ///
 /// For each deferred bracket access `v[:key]`, resolves the variable's type
@@ -31,25 +62,17 @@ pub(crate) fn resolve_record_field_accesses(ctx: &mut InferenceContext) -> bool 
 
     let mut resolved_any = false;
     for access in &accesses {
-        // Resolve the variable's type (should now be Record after unification)
         let var_ty = match ctx.get_symbol_type(access.def_id).cloned() {
             Some(ty) => ctx.resolve_type(&ty),
             None => continue,
         };
 
-        if let types::Type::Record(fields, rest) = &var_ty {
-            if let Some(field_ty) = fields.get(&access.field_name) {
-                // Bind the bracket access expression's type to the field type
+        if let types::Type::Record(..) = &var_ty {
+            if let Some(field_ty) = find_record_field(ctx, &var_ty, &access.field_name) {
                 let call_ty = ctx.get_or_create_symbol_type(access.call_symbol_id);
-                ctx.add_constraint(Constraint::Equal(
-                    call_ty,
-                    field_ty.clone(),
-                    None,
-                    ConstraintOrigin::General,
-                ));
+                ctx.add_constraint(Constraint::Equal(call_ty, field_ty, None, ConstraintOrigin::General));
                 resolved_any = true;
-            } else if matches!(rest.as_ref(), types::Type::RowEmpty) {
-                // Field not found in closed record — report error
+            } else if record_row_is_closed(ctx, &var_ty) {
                 ctx.add_error(TypeError::UndefinedField {
                     field: access.field_name.clone(),
                     record_ty: var_ty.display_renumbered(),

--- a/crates/mq-check/src/narrowing.rs
+++ b/crates/mq-check/src/narrowing.rs
@@ -592,6 +592,22 @@ fn compute_narrowed_type(ctx: &InferenceContext, entry: &NarrowingEntry) -> Opti
 /// multiple types at different call sites), so the type checker's inferred
 /// concrete type for a parameter reflects only the observed usage and should
 /// not be used to declare predicate checks on parameters as dead.
+/// Returns `true` when a `Variable` symbol's initializer is a literal value
+/// (Number, String, Bool, None). Variables initialized from calls or expressions
+/// may hold different types at runtime, so dead-code detection is skipped for them.
+fn variable_initialized_from_literal(hir: &Hir, def_id: SymbolId) -> bool {
+    for (_, sym) in hir.symbols() {
+        if sym.parent != Some(def_id) {
+            continue;
+        }
+        return matches!(
+            sym.kind,
+            SymbolKind::Number | SymbolKind::String | SymbolKind::Boolean | SymbolKind::None
+        );
+    }
+    false
+}
+
 fn detect_dead_then_branch(
     ctx: &InferenceContext,
     entry: &NarrowingEntry,
@@ -602,14 +618,13 @@ fn detect_dead_then_branch(
         return None;
     }
 
-    // Skip parameters — they are polymorphic; the inferred concrete type only
-    // reflects observed usage and must not cause predicate checks to be flagged
-    // as dead code.
-    if hir
-        .symbol(entry.def_id)
-        .is_some_and(|s| matches!(s.kind, SymbolKind::Parameter))
-    {
-        return None;
+    let sym = hir.symbol(entry.def_id)?;
+    match sym.kind {
+        SymbolKind::Parameter => return None,
+        SymbolKind::Variable if !variable_initialized_from_literal(hir, entry.def_id) => {
+            return None;
+        }
+        _ => {}
     }
 
     let var_ty = ctx.get_symbol_type(entry.def_id)?;


### PR DESCRIPTION
- Dict literals with all-string keys now use a fresh row variable instead of RowEmpty, allowing dicts with different optional fields to be unified without spurious type mismatches (e.g. arrays of state dicts where some entries omit a field like "n")
- resolve_record_field_accesses now follows row variable chains recursively to find fields added via unification, while still reporting UndefinedField when the row chain ends with no matching field
- detect_dead_then_branch skips Variables initialized from non-literal expressions (calls, field accesses, etc.) since their runtime type may differ from the statically inferred type