### PR TITLE
🐛 fix(parser): add UnmatchedEnd error for stray end keywords

### DIFF
--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -48,8 +48,11 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         // Initial check for invalid starting tokens in a program.
         match self.tokens.peek() {
             Some(token) => match &token.kind {
-                TokenKind::Pipe | TokenKind::SemiColon | TokenKind::End => {
+                TokenKind::Pipe | TokenKind::SemiColon => {
                     return Err(SyntaxError::UnexpectedToken((***token).clone()));
+                }
+                TokenKind::End => {
+                    return Err(SyntaxError::UnmatchedEnd((***token).clone()));
                 }
                 _ => {}
             },
@@ -64,11 +67,16 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                     // Semicolons and 'end' keyword terminate sub-programs (e.g., in 'def', 'fn').
                     // In the root program, after a semicolon or 'end', the parser checks if the next token is EOF.
                     // If the next token is not EOF, it returns an error for the unexpected token.
-                    if root && let Some(token) = self.tokens.peek() {
-                        if let TokenKind::Eof = &token.kind {
-                            break;
-                        } else {
-                            return Err(SyntaxError::UnexpectedToken((***token).clone()));
+                    if root {
+                        match self.tokens.peek() {
+                            Some(next_token) if !matches!(next_token.kind, TokenKind::Eof) => {
+                                if matches!(token.kind, TokenKind::End) {
+                                    return Err(SyntaxError::UnmatchedEnd((**token).clone()));
+                                } else {
+                                    return Err(SyntaxError::UnexpectedToken((***next_token).clone()));
+                                }
+                            }
+                            _ => break,
                         }
                     }
                     // For non-root programs (e.g. function bodies), a semicolon/end explicitly ends the program.
@@ -3042,6 +3050,46 @@ mod tests {
                 )),
             }),
         ]))]
+    #[case::unmatched_end_at_root(
+        // `end` at root level followed by non-EOF: def foo: if (.): . end end | foo
+        vec![
+            token(TokenKind::Def),
+            token(TokenKind::Ident(SmolStr::new("foo"))),
+            token(TokenKind::Colon),
+            token(TokenKind::If),
+            token(TokenKind::LParen),
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::End),    // closes def body
+            token(TokenKind::End),    // unmatched – no open block
+            token(TokenKind::Pipe),   // something after (like `| foo`)
+            token(TokenKind::Ident(SmolStr::new("foo"))),
+            token(TokenKind::Eof),
+        ],
+        Err(SyntaxError::UnmatchedEnd(token(TokenKind::End))))]
+    #[case::unmatched_end_standalone_if(
+        // `end` after a standalone single-line if (no open block): if (.): . end end
+        vec![
+            token(TokenKind::If),
+            token(TokenKind::LParen),
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::Selector(SmolStr::new("."))),
+            token(TokenKind::End),    // unmatched
+            token(TokenKind::End),
+            token(TokenKind::Eof),
+        ],
+        Err(SyntaxError::UnmatchedEnd(token(TokenKind::End))))]
+    #[case::unmatched_end_at_start(
+        // `end` as the very first token at root level
+        vec![
+            token(TokenKind::End),
+            token(TokenKind::Eof),
+        ],
+        Err(SyntaxError::UnmatchedEnd(token(TokenKind::End))))]
     #[case::let_1(
             vec![
                 token(TokenKind::Let),

--- a/crates/mq-lang/src/cst/error.rs
+++ b/crates/mq-lang/src/cst/error.rs
@@ -14,4 +14,6 @@ pub enum ParseError {
     ExpectedClosingBracket(Shared<Token>),
     #[error(transparent)]
     UnknownSelector(selector::UnknownSelector),
+    #[error("Unexpected `end` keyword — no open block to close")]
+    UnmatchedEnd(Shared<Token>),
 }

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -65,6 +65,7 @@ impl ErrorReporter {
                     ParseError::InsufficientTokens(token) => &token.range,
                     ParseError::ExpectedClosingBracket(token) => &token.range,
                     ParseError::UnknownSelector(selector::UnknownSelector(token)) => &token.range,
+                    ParseError::UnmatchedEnd(token) => &token.range,
                     ParseError::UnexpectedEOFDetected => return std::cmp::Ordering::Greater,
                 };
 
@@ -73,6 +74,7 @@ impl ErrorReporter {
                     ParseError::InsufficientTokens(token) => &token.range,
                     ParseError::ExpectedClosingBracket(token) => &token.range,
                     ParseError::UnknownSelector(selector::UnknownSelector(token)) => &token.range,
+                    ParseError::UnmatchedEnd(token) => &token.range,
                     ParseError::UnexpectedEOFDetected => return std::cmp::Ordering::Less,
                 };
 
@@ -101,6 +103,7 @@ impl ErrorReporter {
                         ParseError::InsufficientTokens(token) => token.range,
                         ParseError::ExpectedClosingBracket(token) => token.range,
                         ParseError::UnknownSelector(selector::UnknownSelector(token)) => token.range,
+                        ParseError::UnmatchedEnd(token) => token.range,
                         ParseError::UnexpectedEOFDetected => Range {
                             start: Position {
                                 line: text.lines().count() as u32,
@@ -265,16 +268,14 @@ impl<'a> Parser<'a> {
                     continue;
                 }
                 TokenKind::SemiColon | TokenKind::End => {
+                    let is_end = matches!(token.kind, TokenKind::End);
+                    let end_or_semi_token = Shared::clone(&token);
                     self.pos += 1;
                     let trailing_trivia = self.parse_trailing_trivia();
 
                     nodes.push(Shared::new(Node {
-                        kind: if matches!(token.kind, TokenKind::End) {
-                            NodeKind::End
-                        } else {
-                            NodeKind::Token
-                        },
-                        token: Some(Shared::clone(&token)),
+                        kind: if is_end { NodeKind::End } else { NodeKind::Token },
+                        token: Some(Shared::clone(&end_or_semi_token)),
                         leading_trivia,
                         trailing_trivia,
                         children: Vec::new(),
@@ -283,25 +284,25 @@ impl<'a> Parser<'a> {
                     if root {
                         leading_trivia = self.parse_leading_trivia();
 
-                        if let Some(token) = self.peek() {
-                            let token = Shared::clone(token);
-                            if matches!(token.kind, TokenKind::Eof) {
+                        if let Some(next_token) = self.peek() {
+                            let next_token = Shared::clone(next_token);
+                            if matches!(next_token.kind, TokenKind::Eof) {
                                 self.pos += 1;
 
                                 nodes.push(Shared::new(Node {
                                     kind: NodeKind::Eof,
-                                    token: Some(token),
+                                    token: Some(next_token),
                                     leading_trivia,
                                     trailing_trivia: Vec::new(),
                                     children: Vec::new(),
                                 }));
                                 ranges.push((stmt_start, self.pos));
                                 break;
-                            } else if matches!(token.kind, TokenKind::Pipe) {
+                            } else if matches!(next_token.kind, TokenKind::Pipe) {
                                 self.pos += 1;
                                 nodes.push(Shared::new(Node {
                                     kind: NodeKind::Token,
-                                    token: Some(token),
+                                    token: Some(next_token),
                                     leading_trivia,
                                     trailing_trivia: self.parse_trailing_trivia(),
                                     children: Vec::new(),
@@ -309,8 +310,10 @@ impl<'a> Parser<'a> {
                                 ranges.push((stmt_start, self.pos));
                                 leading_trivia = self.parse_leading_trivia();
                                 continue;
+                            } else if is_end {
+                                self.errors.report(ParseError::UnmatchedEnd(end_or_semi_token));
                             } else {
-                                self.errors.report(ParseError::UnexpectedToken(token));
+                                self.errors.report(ParseError::UnexpectedToken(next_token));
                             }
                         }
                         ranges.push((stmt_start, self.pos));
@@ -10081,11 +10084,99 @@ mod tests {
             ErrorReporter::default()
         )
     )]
+    #[case::unmatched_end_at_root(
+        // `. end end eof` — the first `end` closes a root statement, the second `end` has no
+        // matching open block and should produce `UnmatchedEnd` pointing at the first `end`.
+        vec![
+            Shared::new(token(TokenKind::Selector(".".into()))),
+            Shared::new(token(TokenKind::End)),
+            Shared::new(token(TokenKind::End)),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Self_,
+                    token: Some(Shared::new(token(TokenKind::Selector(".".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::End,
+                    token: Some(Shared::new(token(TokenKind::End))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::with_error(vec![ParseError::UnmatchedEnd(Shared::new(token(TokenKind::End)))], 100)
+        )
+    )]
+    #[case::unmatched_end_at_root_pipe_follows(
+        // `. end end | ident eof` — mirrors the real-world `def foo: if (.): . end end | foo`
+        // scenario where the extra `end` should be flagged, not the pipe after it.
+        vec![
+            Shared::new(token(TokenKind::Selector(".".into()))),
+            Shared::new(token(TokenKind::End)),
+            Shared::new(token(TokenKind::End)),
+            Shared::new(token(TokenKind::Pipe)),
+            Shared::new(token(TokenKind::Ident("foo".into()))),
+            Shared::new(token(TokenKind::Eof)),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Self_,
+                    token: Some(Shared::new(token(TokenKind::Selector(".".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+                Shared::new(Node {
+                    kind: NodeKind::End,
+                    token: Some(Shared::new(token(TokenKind::End))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::with_error(vec![ParseError::UnmatchedEnd(Shared::new(token(TokenKind::End)))], 100)
+        )
+    )]
 
     fn test_parse(#[case] input: Vec<Shared<Token>>, #[case] expected: (Vec<Shared<Node>>, ErrorReporter)) {
         let (nodes, errors) = Parser::new(&input).parse();
         assert_eq!(errors, expected.1);
         assert_eq!(nodes, expected.0);
+    }
+
+    #[test]
+    fn test_unmatched_end_error_message() {
+        // Verify the error message text for `UnmatchedEnd`.
+        let err = ParseError::UnmatchedEnd(Shared::new(token(TokenKind::End)));
+        assert_eq!(err.to_string(), "Unexpected `end` keyword — no open block to close");
+    }
+
+    #[test]
+    fn test_unmatched_end_error_ranges() {
+        // Verify that `error_ranges` correctly extracts the range from an `UnmatchedEnd` error.
+        let end_token = Shared::new(Token {
+            range: Range {
+                start: Position { line: 1, column: 20 },
+                end: Position { line: 1, column: 23 },
+            },
+            kind: TokenKind::End,
+            module_id: 1.into(),
+        });
+        let mut reporter = ErrorReporter::new(100);
+        reporter.report(ParseError::UnmatchedEnd(Shared::clone(&end_token)));
+
+        let ranges = reporter.error_ranges("def foo: if (.): . end end");
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].1.start.line, 1);
+        assert_eq!(ranges[0].1.start.column, 20);
+        assert!(ranges[0].0.contains("end"));
     }
 
     #[test]

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -223,6 +223,11 @@ impl Diagnostic for Error {
             InnerError::Syntax(SyntaxError::UnexpectedEOFAfterToken(_)) => Some(Cow::Borrowed(
                 "An expression was expected here. Check for incomplete expressions after operators or keywords.",
             )),
+            InnerError::Syntax(SyntaxError::UnmatchedEnd(_)) => Some(Cow::Borrowed(
+                "This `end` keyword does not match any open block. \
+                Note: single-line `if` expressions do not require `end`. \
+                Check that each `end` closes a `def`, `fn`, `do`, `while`, `loop`, or `foreach` block.",
+            )),
             InnerError::Runtime(RuntimeError::UserDefined { .. }) => {
                 Some(Cow::Borrowed("A user-defined error occurred during evaluation."))
             }
@@ -360,6 +365,11 @@ impl Diagnostic for Error {
                     "An expression was expected here. Check for incomplete expressions after operators or keywords.",
                 ))
             }
+            InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnmatchedEnd(_))) => Some(Cow::Borrowed(
+                "This `end` keyword does not match any open block. \
+                Note: single-line `if` expressions do not require `end`. \
+                Check that each `end` closes a `def`, `fn`, `do`, `while`, `loop`, or `foreach` block.",
+            )),
             InnerError::Runtime(RuntimeError::UndefinedMacro(_)) => {
                 Some(Cow::Borrowed("Macro expansion error: undefined macro used."))
             }
@@ -401,6 +411,7 @@ impl Diagnostic for Error {
             InnerError::Syntax(SyntaxError::MacroParametersCannotBeVariadic(_)) => "variadic macro parameter",
             InnerError::Syntax(SyntaxError::UnexpectedEOFDetected(_)) => "unexpected end of input",
             InnerError::Syntax(SyntaxError::UnexpectedEOFAfterToken(_)) => "expected expression here",
+            InnerError::Syntax(SyntaxError::UnmatchedEnd(_)) => "unmatched `end` keyword",
             InnerError::Runtime(_) => "error occurred here",
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnexpectedToken(_))) => "unexpected token",
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::InsufficientTokens(_))) => {
@@ -443,6 +454,7 @@ impl Diagnostic for Error {
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnexpectedEOFAfterToken(_))) => {
                 "expected expression here"
             }
+            InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnmatchedEnd(_))) => "unmatched `end` keyword",
             InnerError::Module(_) => "module error here",
         };
 

--- a/crates/mq-lang/src/error/syntax.rs
+++ b/crates/mq-lang/src/error/syntax.rs
@@ -57,6 +57,9 @@ pub enum SyntaxError {
     /// The Token is the keyword or operator that required an expression to follow.
     #[error("Expected an expression after `{}` but reached end of file", if .0.is_eof() { "EOF".to_string() } else { .0.to_string() })]
     UnexpectedEOFAfterToken(Token),
+    /// An `end` keyword was encountered without a matching block opener.
+    #[error("Unexpected `end` keyword — no open block to close")]
+    UnmatchedEnd(Token),
 }
 
 impl SyntaxError {
@@ -79,6 +82,7 @@ impl SyntaxError {
             SyntaxError::MultipleVariadicParameters(token) => Some(token),
             SyntaxError::MacroParametersCannotBeVariadic(token) => Some(token),
             SyntaxError::UnexpectedEOFAfterToken(token) => Some(token),
+            SyntaxError::UnmatchedEnd(token) => Some(token),
         }
     }
 }


### PR DESCRIPTION
Introduce a dedicated `UnmatchedEnd` error variant in both `SyntaxError` and `ParseError` so that a stray `end` at root level (with no matching block opener) is reported with a precise diagnostic instead of the generic `UnexpectedToken` message.

Includes helpful hint text explaining that single-line `if` expressions do not require `end`, and lists the block forms that do.