### PR TITLE
✨ feat(mq-lang): support inline module definitions and module extension

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -235,6 +235,10 @@ impl<T: ModuleResolver> Evaluator<T> {
                         self.eval_import(module_path.to_owned(), &Shared::clone(&self.env))
                             .map_err(|e| e.into_inner_error())?;
                     }
+                    ast::Expr::Module(ident, program) => {
+                        self.eval_module(&RuntimeValue::NONE, ident, program, &Shared::clone(&self.env))
+                            .map_err(|e| e.into_inner_error())?;
+                    }
                     _ => nodes.push(Shared::clone(node)),
                 };
 
@@ -525,12 +529,12 @@ impl<T: ModuleResolver> Evaluator<T> {
     ) -> EvalResult {
         let module_name_to_use = &ident.name.as_str();
 
-        if let Ok(value) = resolve(module_name_to_use, env) {
-            return Ok(value);
-        }
-
-        // Create a new environment for the module exports
-        let module_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
+        let module_env = if let Ok(RuntimeValue::Module(module_env)) = resolve(module_name_to_use, env) {
+            Shared::clone(module_env.exports())
+        } else {
+            // Create a new environment for the module exports
+            Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))))
+        };
 
         for node in program {
             match &*node.expr {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2484,6 +2484,42 @@ fn engine() -> DefaultEngine {
 #[case::selector_bracket_variable_table_col(r##"let v = 1 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[][v] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
 #[case::selector_bracket_expr_list(r##"let v = 0 | to_markdown("- a\n- b\n- c") | .[v + 1] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("- b".to_string())].into()))]
 #[case::selector_bracket_expr_table_col(r##"let v = 0 | to_markdown("| a | b |\n|---|---|\n| c | d |") | .[][v + 1] | compact() | first() | to_string()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
+#[case::module_inline_function("
+    module math:
+        def mysum(a, b): a + b;
+    end
+    | math::mysum(1, 2)
+    ",
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::Number(3.into())].into()))]
+#[case::module_inline_let("
+    module constants:
+        let pi = 314
+    end
+    | constants::pi
+    ",
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::Number(314.into())].into()))]
+#[case::module_hoisting("
+    def call_math(): math::mysum(10, 5);
+    | call_math()
+    | module math:
+        def mysum(a, b): a + b;
+    end
+    ",
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::Number(15.into())].into()))]
+#[case::module_extension("
+    module math:
+        def mysum(a, b): a + b;
+    end
+    module math:
+        def mymul(a, b): a * b;
+    end
+    | math::mysum(2, 3) + math::mymul(2, 3)
+    ",
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::Number(11.into())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }


### PR DESCRIPTION
Handle `Module` expr during top-level eval pass so inline modules are registered before use. In `eval_module`, merge into an existing module env when the same name is defined again instead of discarding prior exports.