### PR TITLE
✨ feat(eval): add partial builtin function for partial application

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1611,7 +1611,6 @@ impl<T: ModuleResolver> Evaluator<T> {
             let new_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(fn_env))));
             let has_variadic = params.iter().any(|p| p.is_variadic);
             let required_params = params.iter().filter(|p| p.default.is_none() && !p.is_variadic).count();
-
             let arg_count = args.len();
             let param_count = params.len();
 
@@ -1634,6 +1633,7 @@ impl<T: ModuleResolver> Evaluator<T> {
             } else if arg_count + 1 >= required_params && arg_count < param_count {
                 true
             } else {
+                // arg_count > param_count: too many arguments
                 return Err(RuntimeError::InvalidNumberOfArguments {
                     token: (*get_token(Shared::clone(&self.token_arena), node.token_id)).clone(),
                     name: ident.to_string(),

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -89,6 +89,44 @@ impl BuiltinFunction {
         BuiltinFunction { name, num_params, func }
     }
 }
+#[mq_macros::mq_fn(name = "partial", params = Range(1, u8::MAX))]
+fn partial_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    if args.is_empty() {
+        return Err(Error::InvalidNumberOfArguments(ident.to_string(), 1, 0));
+    }
+    let fn_value = args.remove(0);
+    let provided = args;
+
+    match fn_value {
+        RuntimeValue::Function(params, program, fn_env) => {
+            if provided.len() >= params.len() {
+                return Err(Error::InvalidNumberOfArguments(
+                    ident.to_string(),
+                    params.len() as u8,
+                    provided.len() as u8 + 1,
+                ));
+            }
+            let partial_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(&fn_env))));
+            let mut remaining = crate::ast::node::Params::new();
+            for (i, param) in params.iter().enumerate() {
+                if i < provided.len() {
+                    #[cfg(not(feature = "sync"))]
+                    partial_env.borrow_mut().define(param.ident.name, provided[i].clone());
+                    #[cfg(feature = "sync")]
+                    partial_env
+                        .write()
+                        .unwrap()
+                        .define(param.ident.name, provided[i].clone());
+                } else {
+                    remaining.push(param.clone());
+                }
+            }
+            Ok(RuntimeValue::Function(remaining, program, partial_env))
+        }
+        other => Err(Error::InvalidTypes(ident.to_string(), vec![other])),
+    }
+}
+
 #[mq_macros::mq_fn(name = "halt", params = Fixed(1))]
 fn halt_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -2983,6 +3021,7 @@ pub fn get_builtin_functions(name: &Ident) -> Option<&'static BuiltinFunction> {
 }
 
 mq_macros::builtin_dispatch! {
+    PARTIAL,
     HALT,
     ERROR,
     PRINT,

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2520,6 +2520,14 @@ fn engine() -> DefaultEngine {
     ",
     vec![RuntimeValue::None],
     Ok(vec![RuntimeValue::Number(11.into())].into()))]
+// partial: explicitly create a partial function with the first arg pre-filled
+#[case::partial_basic("def f(a, b, c): c; | let p = partial(f, 10) | p(42)", vec![RuntimeValue::Number(5.into())], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// partial: the pre-filled arg is accessible in the body of the partial function
+#[case::partial_captured_arg("def f(a, b, c): a; | let p = partial(f, 42) | p(99, 1)", vec![RuntimeValue::Number(5.into())], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// partial: pre-fill multiple args and verify they combine correctly in the final call
+#[case::partial_multiple_args("def f(a, b, c): a + b + c; | let p = partial(f, 10, 20) | p(30)", vec![RuntimeValue::Number(5.into())], Ok(vec![RuntimeValue::Number(60.into())].into()))]
+// partial: 2-param function can be partially applied — the scenario that triggered the redesign
+#[case::partial_two_param("def plus(a, b): a + b; | let plus10 = partial(plus, 10) | plus10(5)", vec![RuntimeValue::Number(0.into())], Ok(vec![RuntimeValue::Number(15.into())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -53,7 +53,7 @@ required-features = ["debugger"]
 
 [package.metadata.binstall]
 pkg-fmt = "bin"
-pkg-url = "{ repo }/releases/download/v{ version }/{ bin }-{ target }{ binary-ext }"
+pkg-url = "{ repo }/releases/download/v{ version }/mq-{ target }{ binary-ext }"
 disabled-strategies = ["quick-install"]
 
 [package.metadata.binstall.overrides.mq-dbg]


### PR DESCRIPTION
- Add `partial(fn, args...)` builtin that pre-fills leading arguments of a user-defined function and returns a new function with the remaining params
- Fix binstall pkg-url format in mq-run Cargo.toml