### PR TITLE
✨ feat(selector): add property selector for dict key access

### DIFF
--- a/crates/mq-ffi/src/lib.rs
+++ b/crates/mq-ffi/src/lib.rs
@@ -172,6 +172,14 @@ pub unsafe extern "C" fn mq_eval(
         }
     };
 
+    if input_c.is_null() {
+        return MqResult {
+            values: ptr::null_mut(),
+            values_len: 0,
+            error_msg: to_c_string("Input pointer is null".to_string()),
+        };
+    }
+
     let input_str = match unsafe { c_str_to_rust_str_slice(input_c) } {
         Ok(s) => s,
         Err(_) => {
@@ -182,6 +190,14 @@ pub unsafe extern "C" fn mq_eval(
             };
         }
     };
+
+    if input_format_c.is_null() {
+        return MqResult {
+            values: ptr::null_mut(),
+            values_len: 0,
+            error_msg: to_c_string("Input format pointer is null".to_string()),
+        };
+    }
 
     let input_format_str = match unsafe { c_str_to_rust_str_slice(input_format_c) } {
         Ok(s) => s.to_lowercase(),

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -2467,6 +2467,19 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
     }
 
     fn parse_selector(&mut self, token: &Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
+        // Handle chained property access: .a.b.c → Block([Selector(Property("a")), ...])
+        if let TokenKind::Selector(_) = &token.kind
+            && matches!(Selector::try_from(&**token), Ok(Selector::Property(_)))
+        {
+            let next_is_property = self
+                .tokens
+                .peek()
+                .is_some_and(|t| matches!(Selector::try_from(&***t), Ok(Selector::Property(_))));
+            if next_is_property {
+                return self.parse_chained_property_selectors(token);
+            }
+        }
+
         if self.is_next_token(|kind| matches!(kind, TokenKind::Selector(_)))
             && let Some(attr_token) = self.tokens.next()
         {
@@ -2496,6 +2509,35 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         }
 
         self.parse_selector_direct(token)
+    }
+
+    fn parse_chained_property_selectors(&mut self, first_token: &Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
+        let first_sel = Selector::try_from(&**first_token).map_err(SyntaxError::UnknownSelector)?;
+        let mut nodes: Program = vec![Shared::new(Node {
+            token_id: self.token_arena.alloc(Shared::clone(first_token)),
+            expr: Shared::new(Expr::Selector(first_sel)),
+        })];
+
+        while self.is_next_token(|kind| matches!(kind, TokenKind::Selector(_))) {
+            let next_is_property = self
+                .tokens
+                .peek()
+                .is_some_and(|t| matches!(Selector::try_from(&***t), Ok(Selector::Property(_))));
+            if !next_is_property {
+                break;
+            }
+            let next_token = self.tokens.next().unwrap();
+            let sel = Selector::try_from(&**next_token).map_err(SyntaxError::UnknownSelector)?;
+            nodes.push(Shared::new(Node {
+                token_id: self.token_arena.alloc(Shared::clone(next_token)),
+                expr: Shared::new(Expr::Selector(sel)),
+            }));
+        }
+
+        Ok(Shared::new(Node {
+            token_id: self.token_arena.alloc(Shared::clone(first_token)),
+            expr: Shared::new(Expr::Block(nodes)),
+        }))
     }
 
     // Parses arguments for table or list item selectors like `.[index1][index2]` (for tables) or `.[index1]` (for lists).

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -982,6 +982,31 @@ impl<'a> Parser<'a> {
                     return Ok(Shared::new(node));
                 }
 
+                // Handle chained property selectors: .a.b.c → Block([Selector(.a), Selector(.b), Selector(.c)])
+                if matches!(selector, Selector::Property(_))
+                    && let Some(peek_token) = self.peek()
+                    && peek_token.is_selector()
+                    && matches!(Selector::try_from(&**peek_token), Ok(Selector::Property(_)))
+                {
+                    let first_token = Shared::clone(node.token.as_ref().unwrap());
+                    let block_leading = node.leading_trivia.clone();
+                    let block_trailing = node.trailing_trivia.clone();
+                    let mut nodes = vec![Shared::new(node)];
+                    while let Some(peek_token) = self.peek()
+                        && peek_token.is_selector()
+                        && matches!(Selector::try_from(&**peek_token), Ok(Selector::Property(_)))
+                    {
+                        nodes.push(self.next_node(|kind| matches!(kind, TokenKind::Selector(_)), NodeKind::Selector)?);
+                    }
+                    return Ok(Shared::new(Node {
+                        kind: NodeKind::Block,
+                        token: Some(first_token),
+                        leading_trivia: block_leading,
+                        trailing_trivia: block_trailing,
+                        children: nodes,
+                    }));
+                }
+
                 if let Some(attr_token) = self.peek()
                     && attr_token.is_selector()
                     && Selector::try_from(&**attr_token)
@@ -7860,6 +7885,80 @@ mod tests {
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_property_chained(
+        vec![
+            Shared::new(token(TokenKind::Selector(".a".into()))),
+            Shared::new(token(TokenKind::Selector(".b".into()))),
+            Shared::new(token(TokenKind::Selector(".c".into()))),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Block,
+                    token: Some(Shared::new(token(TokenKind::Selector(".a".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Selector,
+                            token: Some(Shared::new(token(TokenKind::Selector(".a".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Selector,
+                            token: Some(Shared::new(token(TokenKind::Selector(".b".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Selector,
+                            token: Some(Shared::new(token(TokenKind::Selector(".c".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::selector_property_chained_two(
+        vec![
+            Shared::new(token(TokenKind::Selector(".foo".into()))),
+            Shared::new(token(TokenKind::Selector(".bar".into()))),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Block,
+                    token: Some(Shared::new(token(TokenKind::Selector(".foo".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Selector,
+                            token: Some(Shared::new(token(TokenKind::Selector(".foo".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Selector,
+                            token: Some(Shared::new(token(TokenKind::Selector(".bar".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
                 }),
             ],
             ErrorReporter::default()

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -7848,13 +7848,21 @@ mod tests {
             ErrorReporter::default()
         )
     )]
-    #[case::selector_non_existing(
+    #[case::selector_property(
         vec![
             Shared::new(token(TokenKind::Selector(".notfound".into()))),
         ],
         (
-            vec![],
-            ErrorReporter::with_error(vec![ParseError::UnexpectedEOFDetected, ParseError::UnknownSelector(selector::UnknownSelector(token(TokenKind::Selector(".notfound".into()))))], 100)
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Selector,
+                    token: Some(Shared::new(token(TokenKind::Selector(".notfound".into())))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: Vec::new(),
+                    children: Vec::new(),
+                }),
+            ],
+            ErrorReporter::default()
         )
     )]
     #[case::call_with_selector_attribute(

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -775,20 +775,43 @@ impl<T: ModuleResolver> Evaluator<T> {
         }
     }
 
-    #[inline(always)]
-    fn eval_selector_expr(runtime_value: &RuntimeValue, ident: &Selector) -> RuntimeValue {
+    fn eval_property_selector_expr(runtime_value: &RuntimeValue, property_name: &str) -> RuntimeValue {
         match runtime_value {
-            RuntimeValue::Markdown(node_value, _) => builtin::eval_selector(node_value, ident),
+            RuntimeValue::Array(values) => {
+                let values = values
+                    .iter()
+                    .map(|value| match value {
+                        RuntimeValue::Dict(_) => Self::eval_property_selector_expr(value, property_name),
+                        _ => RuntimeValue::NONE,
+                    })
+                    .collect::<Vec<_>>();
+                RuntimeValue::Array(values)
+            }
+            RuntimeValue::Dict(map) => map
+                .get(&Ident::new(property_name))
+                .cloned()
+                .unwrap_or(RuntimeValue::NONE),
+            _ => RuntimeValue::NONE,
+        }
+    }
+
+    fn eval_selector_expr(runtime_value: &RuntimeValue, selector: &Selector) -> RuntimeValue {
+        if let Selector::Property(property_name) = selector {
+            return Self::eval_property_selector_expr(runtime_value, property_name);
+        }
+
+        match runtime_value {
+            RuntimeValue::Markdown(node_value, _) => builtin::eval_selector(node_value, selector),
             RuntimeValue::Array(values) => {
                 let values = values
                     .iter()
                     .flat_map(|value| match value {
-                        RuntimeValue::Markdown(node_value, _) => match builtin::eval_selector(node_value, ident) {
+                        RuntimeValue::Markdown(node_value, _) => match builtin::eval_selector(node_value, selector) {
                             RuntimeValue::Array(arr) => arr,
                             other => vec![other],
                         },
                         RuntimeValue::Dict(_) => {
-                            vec![Self::eval_selector_expr(value, ident)]
+                            vec![Self::eval_selector_expr(value, selector)]
                         }
                         _ => vec![RuntimeValue::NONE],
                     })
@@ -804,7 +827,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                         let new_v = if *k == type_key {
                             v.clone()
                         } else {
-                            Self::eval_selector_expr(v, ident)
+                            Self::eval_selector_expr(v, selector)
                         };
                         (*k, new_v)
                     })

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4845,6 +4845,7 @@ pub fn eval_selector(node: &mq_markdown::Node, selector: &Selector) -> RuntimeVa
         Selector::Definition => node.is_definition(),
         Selector::Attr(_) => false, // Attribute selectors don't match nodes directly
         Selector::Recursive => return eval_recursive_selector(node),
+        Selector::Property(_) => false,
     };
 
     if is_match {

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -8,7 +8,7 @@ use nom::{
     IResult,
     branch::alt,
     bytes::complete::{escaped_transform, tag, take_while_m_n},
-    character::complete::{alpha1, alphanumeric1, char, multispace0, none_of},
+    character::complete::{alpha1, alphanumeric1, anychar, char, multispace0, none_of},
     combinator::{map, map_opt, map_res, recognize, value},
     multi::{many0, many1},
     sequence::{delimited, pair, preceded},
@@ -594,6 +594,14 @@ fn selector(input: Span) -> IResult<Span, Token> {
             alt((
                 tag(">"),
                 tag("^"),
+                // Quoted property selector: ."key" or ."key with spaces"
+                recognize(pair(
+                    char('"'),
+                    pair(
+                        many0(alt((recognize(pair(char('\\'), anychar)), recognize(none_of("\"\\"))))),
+                        char('"'),
+                    ),
+                )),
                 recognize(many0(alt((alphanumeric1, tag("_"), tag("-"), tag("*"))))),
             )),
         )),

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -139,6 +139,8 @@ pub enum Selector {
     Done,
     /// Matches a specific attribute of a markdown node.
     Attr(AttrKind),
+    /// Matches a specific property of a dict or array.
+    Property(String),
 }
 
 /// Represents an attribute that can be accessed from markdown nodes.
@@ -377,7 +379,17 @@ impl TryFrom<&Token> for Selector {
                 // Attribute selectors - MDX
                 ".name" => Ok(Selector::Attr(AttrKind::Name)),
 
-                _ => parse_bracket_selector(s).ok_or_else(|| UnknownSelector(token.clone())),
+                s => {
+                    if let Some(sel) = parse_bracket_selector(s) {
+                        return Ok(sel);
+                    }
+                    let key = s.strip_prefix('.').unwrap_or("");
+                    if key.is_empty() {
+                        Err(UnknownSelector(token.clone()))
+                    } else {
+                        Ok(Selector::Property(key.to_string()))
+                    }
+                }
             }
         } else {
             Err(UnknownSelector(token.clone()))
@@ -436,6 +448,7 @@ impl Display for Selector {
             Selector::Todo => write!(f, ".todo"),
             Selector::Done => write!(f, ".done"),
             Selector::Attr(attr) => write!(f, "{}", attr),
+            Selector::Property(property) => write!(f, ".{}", property),
         }
     }
 }
@@ -580,6 +593,10 @@ mod tests {
     #[case::attr_align(".align", Selector::Attr(AttrKind::Align), ".align")]
     // Attribute selectors - MDX
     #[case::attr_name(".name", Selector::Attr(AttrKind::Name), ".name")]
+    // Property selectors (dict key access)
+    #[case::property_key(".mykey", Selector::Property("mykey".to_string()), ".mykey")]
+    #[case::property_key_underscore(".my_key", Selector::Property("my_key".to_string()), ".my_key")]
+    #[case::property_key_unknown(".unknown", Selector::Property("unknown".to_string()), ".unknown")]
     fn test_selector_try_from_and_display(
         #[case] input: &str,
         #[case] expected_selector: Selector,
@@ -602,9 +619,9 @@ mod tests {
     }
 
     #[test]
-    fn test_selector_try_from_unknown() {
+    fn test_selector_try_from_invalid() {
         let token = Token {
-            kind: TokenKind::Selector(SmolStr::new(".unknown")),
+            kind: TokenKind::Selector(SmolStr::new(".")),
             range: Range {
                 start: Position::new(0, 0),
                 end: Position::new(0, 0),

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -56,6 +56,35 @@ impl UnknownSelector {
     }
 }
 
+/// Unescapes `\"` and `\\` sequences in a quoted property key.
+fn unescape_property_key(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                result.push(next);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Escapes `"` and `\` characters in a property key for display as `."key"`.
+fn escape_property_key(key: &str) -> String {
+    let mut result = String::with_capacity(key.len() + 2);
+    for c in key.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
 /// A selector for matching specific types of markdown nodes.
 ///
 /// Selectors are used to query and filter markdown documents, similar to CSS selectors
@@ -383,6 +412,10 @@ impl TryFrom<&Token> for Selector {
                     if let Some(sel) = parse_bracket_selector(s) {
                         return Ok(sel);
                     }
+                    // Quoted property selector: ."key" allows using reserved selector names as dict keys
+                    if let Some(quoted) = s.strip_prefix(".\"").and_then(|r| r.strip_suffix('"')) {
+                        return Ok(Selector::Property(unescape_property_key(quoted)));
+                    }
                     let key = s.strip_prefix('.').unwrap_or("");
                     if key.is_empty() {
                         Err(UnknownSelector(token.clone()))
@@ -448,7 +481,7 @@ impl Display for Selector {
             Selector::Todo => write!(f, ".todo"),
             Selector::Done => write!(f, ".done"),
             Selector::Attr(attr) => write!(f, "{}", attr),
-            Selector::Property(property) => write!(f, ".{}", property),
+            Selector::Property(property) => write!(f, ".\"{}\"", escape_property_key(property)),
         }
     }
 }
@@ -593,10 +626,17 @@ mod tests {
     #[case::attr_align(".align", Selector::Attr(AttrKind::Align), ".align")]
     // Attribute selectors - MDX
     #[case::attr_name(".name", Selector::Attr(AttrKind::Name), ".name")]
-    // Property selectors (dict key access)
-    #[case::property_key(".mykey", Selector::Property("mykey".to_string()), ".mykey")]
-    #[case::property_key_underscore(".my_key", Selector::Property("my_key".to_string()), ".my_key")]
-    #[case::property_key_unknown(".unknown", Selector::Property("unknown".to_string()), ".unknown")]
+    // Property selectors: bare form (.key)
+    #[case::property_key(".mykey", Selector::Property("mykey".to_string()), ".\"mykey\"")]
+    #[case::property_key_underscore(".my_key", Selector::Property("my_key".to_string()), ".\"my_key\"")]
+    #[case::property_key_unknown(".unknown", Selector::Property("unknown".to_string()), ".\"unknown\"")]
+    // Property selectors: quoted form (."key") – allows reserved selector names as dict keys
+    #[case::property_quoted_h1(".\"h1\"", Selector::Property("h1".to_string()), ".\"h1\"")]
+    #[case::property_quoted_url(".\"url\"", Selector::Property("url".to_string()), ".\"url\"")]
+    #[case::property_quoted_with_space(".\"my key\"", Selector::Property("my key".to_string()), ".\"my key\"")]
+    #[case::property_quoted_escaped_quote(".\"my\\\"key\"", Selector::Property("my\"key".to_string()), ".\"my\\\"key\"")]
+    #[case::property_quoted_escaped_backslash(".\"my\\\\key\"", Selector::Property("my\\key".to_string()), ".\"my\\\\key\"")]
+    #[case::property_quoted_empty(".\"\"", Selector::Property("".to_string()), ".\"\"")]
     fn test_selector_try_from_and_display(
         #[case] input: &str,
         #[case] expected_selector: Selector,

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2538,6 +2538,12 @@ fn engine() -> DefaultEngine {
 #[case::property_selector_quoted_space(r#"."my key""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("my key"), RuntimeValue::String("val".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("val".to_string())].into()))]
 // property selector: missing key returns None
 #[case::property_selector_quoted_missing(r#"."h1""#, vec![{let d = std::collections::BTreeMap::new(); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
+// nested property selector: .a.b accesses {"a": {"b": 1}}
+#[case::property_selector_nested(r#".a.b"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Number(1.into())); outer.insert(Ident::new("a"), RuntimeValue::Dict(inner)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+// nested property selector: .a.b.c accesses three levels deep
+#[case::property_selector_nested_three(r#".a.b.c"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut mid = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("c"), RuntimeValue::Number(42.into())); mid.insert(Ident::new("b"), RuntimeValue::Dict(inner)); outer.insert(Ident::new("a"), RuntimeValue::Dict(mid)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// nested property selector: missing intermediate key returns None
+#[case::property_selector_nested_missing(r#".a.b"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("a"), RuntimeValue::Number(1.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2528,6 +2528,16 @@ fn engine() -> DefaultEngine {
 #[case::partial_multiple_args("def f(a, b, c): a + b + c; | let p = partial(f, 10, 20) | p(30)", vec![RuntimeValue::Number(5.into())], Ok(vec![RuntimeValue::Number(60.into())].into()))]
 // partial: 2-param function can be partially applied — the scenario that triggered the redesign
 #[case::partial_two_param("def plus(a, b): a + b; | let plus10 = partial(plus, 10) | plus10(5)", vec![RuntimeValue::Number(0.into())], Ok(vec![RuntimeValue::Number(15.into())].into()))]
+// property selector: bare form (.key) for non-reserved names
+#[case::property_selector_bare(r#".score"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("score"), RuntimeValue::Number(42.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// property selector: quoted form (."key") for reserved selector names
+#[case::property_selector_quoted_h1(r#"."h1""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("h1"), RuntimeValue::String("title".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("title".to_string())].into()))]
+#[case::property_selector_quoted_url(r#"."url""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("url"), RuntimeValue::String("https://example.com".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("https://example.com".to_string())].into()))]
+#[case::property_selector_quoted_text(r#"."text""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("text"), RuntimeValue::String("hello".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
+// property selector: quoted form with spaces in key
+#[case::property_selector_quoted_space(r#"."my key""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("my key"), RuntimeValue::String("val".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("val".to_string())].into()))]
+// property selector: missing key returns None
+#[case::property_selector_quoted_missing(r#"."h1""#, vec![{let d = std::collections::BTreeMap::new(); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -208,11 +208,7 @@ impl Hinter for MqLineHelper {
 
 impl Highlighter for MqLineHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str, _default: bool) -> Cow<'b, str> {
-        if *self.is_continuation.borrow() {
-            "..  ".dimmed().to_string().into()
-        } else {
-            prompt.cyan().to_string().into()
-        }
+        prompt.cyan().to_string().into()
     }
 
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {

--- a/docs/books/src/reference/selectors.md
+++ b/docs/books/src/reference/selectors.md
@@ -212,6 +212,57 @@ Text, HTML, YAML, TOML, Math nodes support:
 | --------- | ------ | ---------------- | ------------- |
 | `value`   | String | The text content | `.text.value` |
 
+## Property Selector (Dict Key Access)
+
+Property selectors access values from dict (object) values using dot notation. They work on both single dicts and arrays of dicts.
+
+### Bare Form
+
+Use `.key` to access a dict key by name:
+
+```mq
+# Input dict: {"name": "Alice", "age": 30}
+
+.name   # Returns: "Alice"
+.age    # Returns: 30
+```
+
+### Quoted Form
+
+Use `."key"` to access keys that contain spaces, special characters, or conflict with reserved selector names:
+
+```mq
+# Input dict: {"h1": "title", "my key": "value"}
+
+."h1"       # Returns: "title"  (avoids conflict with .h1 heading selector)
+."my key"   # Returns: "value"  (key with space)
+."url"      # Returns: the "url" key value (avoids conflict with .url attribute)
+```
+
+Escape sequences inside quoted keys: `\"` for a literal `"` and `\\` for a literal `\`.
+
+### Arrays of Dicts
+
+When applied to an array of dicts, the property selector maps over each element:
+
+```mq
+# Input: [{"name": "Alice"}, {"name": "Bob"}, {"name": "Charlie"}]
+
+.name   # Returns: ["Alice", "Bob", "Charlie"]
+```
+
+Non-dict elements in the array return `none`.
+
+### Missing Keys
+
+Accessing a key that doesn't exist returns `none`:
+
+```mq
+# Input dict: {"name": "Alice"}
+
+.age    # Returns: none
+```
+
 ## Combining Selectors with Functions
 
 You can combine selectors with functions like `select()`, `map()`, and `filter()` for powerful transformations:


### PR DESCRIPTION
Unknown selectors are now treated as property selectors, allowing jq-style dict key access with `.key` syntax (e.g. `.username`, `.score`). Array elements are mapped element-wise when the input is an array of dicts.

Also fix mq_eval in mq-ffi to return an error when input or input_format pointers are null, rather than silently treating them as empty strings.