### PR TITLE
✨ feat(selector)!: require quoted form for dict property access

### DIFF
--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -7875,13 +7875,13 @@ mod tests {
     )]
     #[case::selector_property(
         vec![
-            Shared::new(token(TokenKind::Selector(".notfound".into()))),
+            Shared::new(token(TokenKind::Selector(".\"notfound\"".into()))),
         ],
         (
             vec![
                 Shared::new(Node {
                     kind: NodeKind::Selector,
-                    token: Some(Shared::new(token(TokenKind::Selector(".notfound".into())))),
+                    token: Some(Shared::new(token(TokenKind::Selector(".\"notfound\"".into())))),
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: Vec::new(),
@@ -7892,35 +7892,35 @@ mod tests {
     )]
     #[case::selector_property_chained(
         vec![
-            Shared::new(token(TokenKind::Selector(".a".into()))),
-            Shared::new(token(TokenKind::Selector(".b".into()))),
-            Shared::new(token(TokenKind::Selector(".c".into()))),
+            Shared::new(token(TokenKind::Selector(".\"a\"".into()))),
+            Shared::new(token(TokenKind::Selector(".\"b\"".into()))),
+            Shared::new(token(TokenKind::Selector(".\"c\"".into()))),
         ],
         (
             vec![
                 Shared::new(Node {
                     kind: NodeKind::Block,
-                    token: Some(Shared::new(token(TokenKind::Selector(".a".into())))),
+                    token: Some(Shared::new(token(TokenKind::Selector(".\"a\"".into())))),
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: vec![
                         Shared::new(Node {
                             kind: NodeKind::Selector,
-                            token: Some(Shared::new(token(TokenKind::Selector(".a".into())))),
+                            token: Some(Shared::new(token(TokenKind::Selector(".\"a\"".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),
                         }),
                         Shared::new(Node {
                             kind: NodeKind::Selector,
-                            token: Some(Shared::new(token(TokenKind::Selector(".b".into())))),
+                            token: Some(Shared::new(token(TokenKind::Selector(".\"b\"".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),
                         }),
                         Shared::new(Node {
                             kind: NodeKind::Selector,
-                            token: Some(Shared::new(token(TokenKind::Selector(".c".into())))),
+                            token: Some(Shared::new(token(TokenKind::Selector(".\"c\"".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),
@@ -7933,27 +7933,27 @@ mod tests {
     )]
     #[case::selector_property_chained_two(
         vec![
-            Shared::new(token(TokenKind::Selector(".foo".into()))),
-            Shared::new(token(TokenKind::Selector(".bar".into()))),
+            Shared::new(token(TokenKind::Selector(".\"foo\"".into()))),
+            Shared::new(token(TokenKind::Selector(".\"bar\"".into()))),
         ],
         (
             vec![
                 Shared::new(Node {
                     kind: NodeKind::Block,
-                    token: Some(Shared::new(token(TokenKind::Selector(".foo".into())))),
+                    token: Some(Shared::new(token(TokenKind::Selector(".\"foo\"".into())))),
                     leading_trivia: Vec::new(),
                     trailing_trivia: Vec::new(),
                     children: vec![
                         Shared::new(Node {
                             kind: NodeKind::Selector,
-                            token: Some(Shared::new(token(TokenKind::Selector(".foo".into())))),
+                            token: Some(Shared::new(token(TokenKind::Selector(".\"foo\"".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),
                         }),
                         Shared::new(Node {
                             kind: NodeKind::Selector,
-                            token: Some(Shared::new(token(TokenKind::Selector(".bar".into())))),
+                            token: Some(Shared::new(token(TokenKind::Selector(".\"bar\"".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -412,16 +412,11 @@ impl TryFrom<&Token> for Selector {
                     if let Some(sel) = parse_bracket_selector(s) {
                         return Ok(sel);
                     }
-                    // Quoted property selector: ."key" allows using reserved selector names as dict keys
+                    // Quoted property selector: ."key" is the only way to access dict keys
                     if let Some(quoted) = s.strip_prefix(".\"").and_then(|r| r.strip_suffix('"')) {
                         return Ok(Selector::Property(unescape_property_key(quoted)));
                     }
-                    let key = s.strip_prefix('.').unwrap_or("");
-                    if key.is_empty() {
-                        Err(UnknownSelector(token.clone()))
-                    } else {
-                        Ok(Selector::Property(key.to_string()))
-                    }
+                    Err(UnknownSelector(token.clone()))
                 }
             }
         } else {
@@ -626,11 +621,7 @@ mod tests {
     #[case::attr_align(".align", Selector::Attr(AttrKind::Align), ".align")]
     // Attribute selectors - MDX
     #[case::attr_name(".name", Selector::Attr(AttrKind::Name), ".name")]
-    // Property selectors: bare form (.key)
-    #[case::property_key(".mykey", Selector::Property("mykey".to_string()), ".\"mykey\"")]
-    #[case::property_key_underscore(".my_key", Selector::Property("my_key".to_string()), ".\"my_key\"")]
-    #[case::property_key_unknown(".unknown", Selector::Property("unknown".to_string()), ".\"unknown\"")]
-    // Property selectors: quoted form (."key") – allows reserved selector names as dict keys
+    // Property selectors: quoted form (."key") – the only way to access dict keys
     #[case::property_quoted_h1(".\"h1\"", Selector::Property("h1".to_string()), ".\"h1\"")]
     #[case::property_quoted_url(".\"url\"", Selector::Property("url".to_string()), ".\"url\"")]
     #[case::property_quoted_with_space(".\"my key\"", Selector::Property("my key".to_string()), ".\"my key\"")]
@@ -658,10 +649,15 @@ mod tests {
         assert_eq!(selector.to_string(), expected_display);
     }
 
-    #[test]
-    fn test_selector_try_from_invalid() {
+    #[rstest]
+    #[case(".")]
+    #[case(".mykey")]
+    #[case(".my_key")]
+    #[case(".unknown")]
+    #[case(".hedaing")]
+    fn test_selector_try_from_invalid(#[case] input: &str) {
         let token = Token {
-            kind: TokenKind::Selector(SmolStr::new(".")),
+            kind: TokenKind::Selector(SmolStr::new(input)),
             range: Range {
                 start: Position::new(0, 0),
                 end: Position::new(0, 0),

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2528,9 +2528,7 @@ fn engine() -> DefaultEngine {
 #[case::partial_multiple_args("def f(a, b, c): a + b + c; | let p = partial(f, 10, 20) | p(30)", vec![RuntimeValue::Number(5.into())], Ok(vec![RuntimeValue::Number(60.into())].into()))]
 // partial: 2-param function can be partially applied — the scenario that triggered the redesign
 #[case::partial_two_param("def plus(a, b): a + b; | let plus10 = partial(plus, 10) | plus10(5)", vec![RuntimeValue::Number(0.into())], Ok(vec![RuntimeValue::Number(15.into())].into()))]
-// property selector: bare form (.key) for non-reserved names
-#[case::property_selector_bare(r#".score"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("score"), RuntimeValue::Number(42.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
-// property selector: quoted form (."key") for reserved selector names
+// property selector: quoted form (."key") is the only way to access dict keys
 #[case::property_selector_quoted_h1(r#"."h1""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("h1"), RuntimeValue::String("title".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("title".to_string())].into()))]
 #[case::property_selector_quoted_url(r#"."url""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("url"), RuntimeValue::String("https://example.com".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("https://example.com".to_string())].into()))]
 #[case::property_selector_quoted_text(r#"."text""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("text"), RuntimeValue::String("hello".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
@@ -2538,12 +2536,12 @@ fn engine() -> DefaultEngine {
 #[case::property_selector_quoted_space(r#"."my key""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("my key"), RuntimeValue::String("val".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("val".to_string())].into()))]
 // property selector: missing key returns None
 #[case::property_selector_quoted_missing(r#"."h1""#, vec![{let d = std::collections::BTreeMap::new(); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
-// nested property selector: .a.b accesses {"a": {"b": 1}}
-#[case::property_selector_nested(r#".a.b"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Number(1.into())); outer.insert(Ident::new("a"), RuntimeValue::Dict(inner)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(1.into())].into()))]
-// nested property selector: .a.b.c accesses three levels deep
-#[case::property_selector_nested_three(r#".a.b.c"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut mid = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("c"), RuntimeValue::Number(42.into())); mid.insert(Ident::new("b"), RuntimeValue::Dict(inner)); outer.insert(Ident::new("a"), RuntimeValue::Dict(mid)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// nested property selector: ."a"."b" accesses {"a": {"b": 1}}
+#[case::property_selector_nested(r#"."a"."b""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Number(1.into())); outer.insert(Ident::new("a"), RuntimeValue::Dict(inner)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+// nested property selector: ."a"."b"."c" accesses three levels deep
+#[case::property_selector_nested_three(r#"."a"."b"."c""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut mid = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("c"), RuntimeValue::Number(42.into())); mid.insert(Ident::new("b"), RuntimeValue::Dict(inner)); outer.insert(Ident::new("a"), RuntimeValue::Dict(mid)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // nested property selector: missing intermediate key returns None
-#[case::property_selector_nested_missing(r#".a.b"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("a"), RuntimeValue::Number(1.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
+#[case::property_selector_nested_missing(r#"."a"."b""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("a"), RuntimeValue::Number(1.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/docs/books/src/reference/selectors.md
+++ b/docs/books/src/reference/selectors.md
@@ -214,29 +214,25 @@ Text, HTML, YAML, TOML, Math nodes support:
 
 ## Property Selector (Dict Key Access)
 
-Property selectors access values from dict (object) values using dot notation. They work on both single dicts and arrays of dicts.
+Property selectors access values from dict (object) values using quoted dot notation (`."key"`). They work on both single dicts and arrays of dicts.
 
-### Bare Form
-
-Use `.key` to access a dict key by name:
+Use `."key"` to access a dict key by name:
 
 ```mq
 # Input dict: {"name": "Alice", "age": 30}
 
-.name   # Returns: "Alice"
-.age    # Returns: 30
+."name"   # Returns: "Alice"
+."age"    # Returns: 30
 ```
 
-### Quoted Form
-
-Use `."key"` to access keys that contain spaces, special characters, or conflict with reserved selector names:
+Keys with spaces, special characters, or names that match reserved selector names are also supported:
 
 ```mq
 # Input dict: {"h1": "title", "my key": "value"}
 
-."h1"       # Returns: "title"  (avoids conflict with .h1 heading selector)
-."my key"   # Returns: "value"  (key with space)
-."url"      # Returns: the "url" key value (avoids conflict with .url attribute)
+."h1"       # Returns: "title"
+."my key"   # Returns: "value"
+."url"      # Returns: the "url" key value
 ```
 
 Escape sequences inside quoted keys: `\"` for a literal `"` and `\\` for a literal `\`.
@@ -248,7 +244,7 @@ When applied to an array of dicts, the property selector maps over each element:
 ```mq
 # Input: [{"name": "Alice"}, {"name": "Bob"}, {"name": "Charlie"}]
 
-.name   # Returns: ["Alice", "Bob", "Charlie"]
+."name"   # Returns: ["Alice", "Bob", "Charlie"]
 ```
 
 Non-dict elements in the array return `none`.
@@ -260,7 +256,7 @@ Accessing a key that doesn't exist returns `none`:
 ```mq
 # Input dict: {"name": "Alice"}
 
-.age    # Returns: none
+."age"    # Returns: none
 ```
 
 ## Combining Selectors with Functions


### PR DESCRIPTION
Unquoted `.key` selectors are no longer silently treated as property access on dicts. Any `.name` token that does not match a known built-in selector now returns an UnknownSelector parse error, making typos like `.hedaing` immediately visible instead of silently returning no results.

Dict keys must now use the explicit quoted form `."key"`. The quoted form was already supported and is the only unambiguous syntax.

BREAKING CHANGE: bare `.key` property selectors are no longer valid; use `."key"` instead.