### PR TITLE
Fix orphaned documentation page and broken links for selectors

### DIFF
--- a/docs/books/src/SUMMARY.md
+++ b/docs/books/src/SUMMARY.md
@@ -34,5 +34,6 @@
     - [Variable Declarations](reference/variables.md)
     - [Self](reference/self.md)
     - [String Interpolation](reference/string_interpolation.md)
+    - [Selectors](reference/selectors.md)
     - [Nodes](reference/nodes.md)
   - [Builtin selectors and functions](builtins.html)

--- a/docs/books/src/reference/selectors.md
+++ b/docs/books/src/reference/selectors.md
@@ -347,6 +347,5 @@ Note: Not all attributes are settable. Refer to the implementation in `mq-markdo
 
 ## See Also
 
-- [Builtin selectors](builtin_selectors.md) - Complete list of available selectors
-- [Builtin functions](builtin_functions.md) - Functions to use with selectors
+- [Builtin selectors and functions](../builtins.html) - Complete list of available selectors and functions
 - [Nodes](nodes.md) - Details about markdown node types

--- a/docs/books/src/sitemap.xml
+++ b/docs/books/src/sitemap.xml
@@ -145,6 +145,10 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://mqlang.org/book/reference/selectors</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
     <loc>https://mqlang.org/book/reference/nodes</loc>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
This change integrates the `selectors.md` reference page into the documentation's summary and fixes broken links within that file that pointed to non-existent markdown files. The dead links were replaced with a link to the existing `builtins.html` page.

---
*PR created automatically by Jules for task [11243073563046309010](https://jules.google.com/task/11243073563046309010) started by @harehare*