### PR TITLE
♻️ refactor(eval): simplify env scope traversal with macros and iterative loops

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -778,7 +778,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         }
     }
 
-    fn eval_property_selector_expr(runtime_value: &RuntimeValue, property_name: &str) -> RuntimeValue {
+    fn eval_property_selector_expr(runtime_value: &RuntimeValue, property_name: &Ident) -> RuntimeValue {
         match runtime_value {
             RuntimeValue::Array(values) => {
                 let values = values
@@ -790,10 +790,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     .collect::<Vec<_>>();
                 RuntimeValue::Array(values)
             }
-            RuntimeValue::Dict(map) => map
-                .get(&Ident::new(property_name))
-                .cloned()
-                .unwrap_or(RuntimeValue::NONE),
+            RuntimeValue::Dict(map) => map.get(property_name).cloned().unwrap_or(RuntimeValue::NONE),
             _ => RuntimeValue::NONE,
         }
     }

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2020,10 +2020,7 @@ fn set_ref_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
                 _ => {}
             }
 
-            Ok(RuntimeValue::Markdown(
-                Box::new(std::mem::take(node)),
-                std::mem::take(selector),
-            ))
+            Ok(RuntimeValue::Markdown(std::mem::take(node), std::mem::take(selector)))
         }
         [a, ..] => Ok(std::mem::take(a)),
         _ => Ok(RuntimeValue::NONE),

--- a/crates/mq-lang/src/eval/env.rs
+++ b/crates/mq-lang/src/eval/env.rs
@@ -152,6 +152,32 @@ impl std::fmt::Display for Variable {
     }
 }
 
+macro_rules! borrow_env {
+    ($cell:expr) => {{
+        #[cfg(not(feature = "sync"))]
+        {
+            $cell.borrow()
+        }
+        #[cfg(feature = "sync")]
+        {
+            $cell.read().unwrap()
+        }
+    }};
+}
+
+macro_rules! borrow_env_mut {
+    ($cell:expr) => {{
+        #[cfg(not(feature = "sync"))]
+        {
+            $cell.borrow_mut()
+        }
+        #[cfg(feature = "sync")]
+        {
+            $cell.write().unwrap()
+        }
+    }};
+}
+
 impl Env {
     pub fn with_parent(parent: Weak<SharedCell<Env>>) -> Self {
         Self {
@@ -172,26 +198,25 @@ impl Env {
 
     #[inline(always)]
     pub fn resolve(&self, ident: Ident) -> Result<RuntimeValue, EnvError> {
-        match self.context.get(&ident) {
-            Some(o) => Ok(o.clone()),
-            None => match self.parent.as_ref().and_then(|parent| parent.upgrade()) {
-                Some(ref parent_env) => {
-                    #[cfg(not(feature = "sync"))]
-                    let env = parent_env.borrow();
-                    #[cfg(feature = "sync")]
-                    let env = parent_env.read().unwrap();
+        if let Some(o) = self.context.get(&ident) {
+            return Ok(o.clone());
+        }
 
-                    env.resolve(ident)
-                }
-                None => {
-                    // Use optimized string-based builtin lookup
-                    if ident.resolve_with(builtin::get_builtin_functions_by_str).is_some() {
-                        Ok(RuntimeValue::NativeFunction(ident))
-                    } else {
-                        Err(EnvError::InvalidDefinition(ident.to_string()))
-                    }
-                }
-            },
+        let mut current_parent = self.parent.as_ref().and_then(|p| p.upgrade());
+
+        while let Some(parent_cell) = current_parent {
+            let parent_env = borrow_env!(parent_cell);
+
+            if let Some(o) = parent_env.context.get(&ident) {
+                return Ok(o.clone());
+            }
+            current_parent = parent_env.parent.as_ref().and_then(|p| p.upgrade());
+        }
+
+        if ident.resolve_with(builtin::get_builtin_functions_by_str).is_some() {
+            Ok(RuntimeValue::NativeFunction(ident))
+        } else {
+            Err(EnvError::InvalidDefinition(ident.to_string()))
         }
     }
 
@@ -204,7 +229,6 @@ impl Env {
 
     /// Assigns a value to an existing mutable variable
     pub fn assign(&mut self, ident: Ident, runtime_value: RuntimeValue) -> Result<(), EnvError> {
-        // Check if variable exists in current scope
         if self.context.contains_key(&ident) {
             if self.mutable_vars.as_ref().is_some_and(|s| s.contains(&ident)) {
                 self.context.insert(ident, runtime_value);
@@ -214,38 +238,51 @@ impl Env {
             }
         }
 
-        // Try to assign in parent scope
-        match self.parent.as_ref().and_then(|parent| parent.upgrade()) {
-            Some(ref parent_env) => {
-                #[cfg(not(feature = "sync"))]
-                parent_env.borrow_mut().assign(ident, runtime_value)?;
-                #[cfg(feature = "sync")]
-                parent_env.write().unwrap().assign(ident, runtime_value)?;
-                Ok(())
+        let mut current_parent = self.parent.as_ref().and_then(|p| p.upgrade());
+
+        while let Some(parent_cell) = current_parent {
+            let has_key;
+            let is_mutable;
+            let next_parent;
+            {
+                let parent_env = borrow_env!(parent_cell);
+                has_key = parent_env.context.contains_key(&ident);
+                is_mutable = has_key && parent_env.mutable_vars.as_ref().is_some_and(|s| s.contains(&ident));
+                next_parent = parent_env.parent.as_ref().and_then(|p| p.upgrade());
             }
-            None => Err(EnvError::UndefinedVariable(ident.to_string())),
+
+            if has_key {
+                if is_mutable {
+                    borrow_env_mut!(parent_cell).context.insert(ident, runtime_value);
+                    return Ok(());
+                } else {
+                    return Err(EnvError::AssignToImmutable(ident.to_string()));
+                }
+            }
+            current_parent = next_parent;
         }
+
+        Err(EnvError::UndefinedVariable(ident.to_string()))
     }
 
     /// Checks if a variable is mutable
     pub fn is_mutable(&self, ident: Ident) -> bool {
-        // Check if variable exists in current scope
         if self.context.contains_key(&ident) {
             return self.mutable_vars.as_ref().is_some_and(|s| s.contains(&ident));
         }
 
-        // Check parent scope
-        self.parent
-            .as_ref()
-            .and_then(|parent| parent.upgrade())
-            .map(|parent_env| {
-                #[cfg(not(feature = "sync"))]
-                let result = parent_env.borrow().is_mutable(ident);
-                #[cfg(feature = "sync")]
-                let result = parent_env.read().unwrap().is_mutable(ident);
-                result
-            })
-            .unwrap_or(false)
+        let mut current_parent = self.parent.as_ref().and_then(|p| p.upgrade());
+
+        while let Some(parent_cell) = current_parent {
+            let parent_env = borrow_env!(parent_cell);
+
+            if parent_env.context.contains_key(&ident) {
+                return parent_env.mutable_vars.as_ref().is_some_and(|s| s.contains(&ident));
+            }
+            current_parent = parent_env.parent.as_ref().and_then(|p| p.upgrade());
+        }
+
+        false
     }
 
     #[cfg(feature = "debugger")]
@@ -278,11 +315,7 @@ impl Env {
                 .collect(),
             Some(parent_weak) => {
                 if let Some(parent_env) = parent_weak.upgrade() {
-                    #[cfg(not(feature = "sync"))]
-                    let parent_ref = parent_env.borrow();
-                    #[cfg(feature = "sync")]
-                    let parent_ref = parent_env.read().unwrap();
-
+                    let parent_ref = borrow_env!(parent_env);
                     parent_ref.get_global_variables()
                 } else {
                     // If parent is dropped, treat as root

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display, Formatter};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{Token, TokenKind};
+use crate::{Ident, Token, TokenKind};
 
 /// Error type returned when an unknown selector is encountered during parsing.
 #[derive(Error, Clone, Debug, PartialOrd, Eq, Ord, PartialEq)]
@@ -169,7 +169,7 @@ pub enum Selector {
     /// Matches a specific attribute of a markdown node.
     Attr(AttrKind),
     /// Matches a specific property of a dict or array.
-    Property(String),
+    Property(Ident),
 }
 
 /// Represents an attribute that can be accessed from markdown nodes.
@@ -414,7 +414,7 @@ impl TryFrom<&Token> for Selector {
                     }
                     // Quoted property selector: ."key" is the only way to access dict keys
                     if let Some(quoted) = s.strip_prefix(".\"").and_then(|r| r.strip_suffix('"')) {
-                        return Ok(Selector::Property(unescape_property_key(quoted)));
+                        return Ok(Selector::Property(Ident::new(&unescape_property_key(quoted))));
                     }
                     Err(UnknownSelector(token.clone()))
                 }
@@ -476,7 +476,7 @@ impl Display for Selector {
             Selector::Todo => write!(f, ".todo"),
             Selector::Done => write!(f, ".done"),
             Selector::Attr(attr) => write!(f, "{}", attr),
-            Selector::Property(property) => write!(f, ".\"{}\"", escape_property_key(property)),
+            Selector::Property(property) => write!(f, ".\"{}\"", escape_property_key(&property.as_str())),
         }
     }
 }
@@ -622,12 +622,12 @@ mod tests {
     // Attribute selectors - MDX
     #[case::attr_name(".name", Selector::Attr(AttrKind::Name), ".name")]
     // Property selectors: quoted form (."key") – the only way to access dict keys
-    #[case::property_quoted_h1(".\"h1\"", Selector::Property("h1".to_string()), ".\"h1\"")]
-    #[case::property_quoted_url(".\"url\"", Selector::Property("url".to_string()), ".\"url\"")]
-    #[case::property_quoted_with_space(".\"my key\"", Selector::Property("my key".to_string()), ".\"my key\"")]
-    #[case::property_quoted_escaped_quote(".\"my\\\"key\"", Selector::Property("my\"key".to_string()), ".\"my\\\"key\"")]
-    #[case::property_quoted_escaped_backslash(".\"my\\\\key\"", Selector::Property("my\\key".to_string()), ".\"my\\\\key\"")]
-    #[case::property_quoted_empty(".\"\"", Selector::Property("".to_string()), ".\"\"")]
+    #[case::property_quoted_h1(".\"h1\"", Selector::Property("h1".into()), ".\"h1\"")]
+    #[case::property_quoted_url(".\"url\"", Selector::Property("url".into()), ".\"url\"")]
+    #[case::property_quoted_with_space(".\"my key\"", Selector::Property("my key".into()), ".\"my key\"")]
+    #[case::property_quoted_escaped_quote(".\"my\\\"key\"", Selector::Property("my\"key".into()), ".\"my\\\"key\"")]
+    #[case::property_quoted_escaped_backslash(".\"my\\\\key\"", Selector::Property("my\\key".into()), ".\"my\\\\key\"")]
+    #[case::property_quoted_empty(".\"\"", Selector::Property("".into()), ".\"\"")]
     fn test_selector_try_from_and_display(
         #[case] input: &str,
         #[case] expected_selector: Selector,

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -301,7 +301,7 @@ fn engine() -> DefaultEngine {
       Ok(vec![RuntimeValue::FALSE].into()))]
 #[case::test3("select(contains(\"hello\"))",
       vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "hello world".to_string(), position: None}))],
-      Ok(vec![RuntimeValue::Markdown(Box::new(mq_markdown::Node::Text(mq_markdown::Text{value: "hello world".to_string(), position: None})), None )].into()))]
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "hello world".to_string(), position: None}))].into()))]
 #[case::first("first(array(1, 2, 3))",
       vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
       Ok(vec![RuntimeValue::Number(1.into())].into()))]


### PR DESCRIPTION
- Add borrow_env!/borrow_env_mut! macros to eliminate repeated #[cfg(sync)] borrow patterns
- Convert resolve/assign/is_mutable from recursive to iterative scope-chain traversal
- Evaluate is_mutable lazily (only when has_key is true) to skip unnecessary HashSet lookups