### PR TITLE
✨ feat(eval): support .[] iterator for arrays and dicts

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -795,6 +795,9 @@ impl<T: ModuleResolver> Evaluator<T> {
         match runtime_value {
             RuntimeValue::Markdown(node_value, _) => builtin::eval_selector_with_args(node_value, selector, args),
             RuntimeValue::Array(values) => {
+                if let Selector::List(Some(idx), None) = selector {
+                    return values.get(*idx).cloned().unwrap_or(RuntimeValue::NONE);
+                }
                 let values = values
                     .iter()
                     .flat_map(|value| match value {
@@ -862,6 +865,9 @@ impl<T: ModuleResolver> Evaluator<T> {
         match runtime_value {
             RuntimeValue::Markdown(node_value, _) => builtin::eval_selector(node_value, selector),
             RuntimeValue::Array(values) => {
+                if let Selector::List(Some(idx), None) = selector {
+                    return values.get(*idx).cloned().unwrap_or(RuntimeValue::NONE);
+                }
                 let values = values
                     .iter()
                     .flat_map(|value| match value {

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -804,6 +804,9 @@ impl<T: ModuleResolver> Evaluator<T> {
                                 other => vec![other],
                             }
                         }
+                        _ if matches!(selector, Selector::List(None, None)) && args.is_empty() => {
+                            vec![value.clone()]
+                        }
                         RuntimeValue::Dict(_) => {
                             vec![Self::eval_selector_expr_with_args(value, selector, args)]
                         }
@@ -866,6 +869,9 @@ impl<T: ModuleResolver> Evaluator<T> {
                             RuntimeValue::Array(arr) => arr,
                             other => vec![other],
                         },
+                        _ if matches!(selector, Selector::List(None, None)) => {
+                            vec![value.clone()]
+                        }
                         RuntimeValue::Dict(_) => {
                             vec![Self::eval_selector_expr(value, selector)]
                         }
@@ -876,6 +882,9 @@ impl<T: ModuleResolver> Evaluator<T> {
                 RuntimeValue::Array(values)
             }
             RuntimeValue::Dict(map) => {
+                if matches!(selector, Selector::List(None, None)) {
+                    return RuntimeValue::Array(map.values().cloned().collect());
+                }
                 let new_map: BTreeMap<_, _> = map
                     .iter()
                     .map(|(k, v)| {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -1679,6 +1679,41 @@ fn engine() -> DefaultEngine {
 #[case::empty_array_iterator_expand("[]*.[]",
         vec![RuntimeValue::Number(0.into())],
         Ok(vec![RuntimeValue::Number(0.into())].into()))]
+#[case::array_iter_numbers("[1, 2, 3] | .[]",
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Array(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(2.into()),
+            RuntimeValue::Number(3.into()),
+        ])].into()))]
+#[case::array_iter_strings(r#"["a", "b", "c"] | .[]"#,
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Array(vec![
+            RuntimeValue::String("a".to_string()),
+            RuntimeValue::String("b".to_string()),
+            RuntimeValue::String("c".to_string()),
+        ])].into()))]
+#[case::dict_iter_values(r#"{"a": 1, "b": 2, "c": 3} | .[]"#,
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Array(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(2.into()),
+            RuntimeValue::Number(3.into()),
+        ])].into()))]
+#[case::array_of_dicts_iter(r#"[{"a": 1}, {"b": 2}] | .[]"#,
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Array(vec![
+            {
+                let mut d = BTreeMap::new();
+                d.insert(Ident::new("a"), RuntimeValue::Number(1.into()));
+                RuntimeValue::Dict(d)
+            },
+            {
+                let mut d = BTreeMap::new();
+                d.insert(Ident::new("b"), RuntimeValue::Number(2.into()));
+                RuntimeValue::Dict(d)
+            },
+        ])].into()))]
 #[case::array_mul_decimal("[2,1]*0.2",
         vec![RuntimeValue::Number(0.into())],
         Ok(vec![RuntimeValue::Array(vec![

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -1714,6 +1714,18 @@ fn engine() -> DefaultEngine {
                 RuntimeValue::Dict(d)
             },
         ])].into()))]
+#[case::array_index_first("[1, 2, 3] | .[0]",
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Number(1.into())].into()))]
+#[case::array_index_middle("[1, 2, 3] | .[1]",
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Number(2.into())].into()))]
+#[case::array_index_last("[1, 2, 3] | .[2]",
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::Number(3.into())].into()))]
+#[case::array_index_out_of_bounds("[1, 2, 3] | .[5]",
+        vec![RuntimeValue::Number(0.into())],
+        Ok(vec![RuntimeValue::NONE].into()))]
 #[case::array_mul_decimal("[2,1]*0.2",
         vec![RuntimeValue::Number(0.into())],
         Ok(vec![RuntimeValue::Array(vec![


### PR DESCRIPTION
- Arrays: .[] returns all elements as an array (identity passthrough)
- Dicts: .[] returns all values as an array
- Handles both args and no-args eval paths