### PR TITLE
🐛 fix(hir,check): fix false type error for replace/gsub with s-string args

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -1583,6 +1583,8 @@ mod tests {
     #[case::split_wrong_sep("split(\"hello\", 42)", false)] // separator must be string
     #[case::join_wrong_sep("join([\"a\", \"b\"], 42)", false)] // separator must be string
     #[case::replace_wrong_sep("replace(\"hello\", 42, \"r\")", false)] // wrong separator type
+    #[case::replace_too_few_args("replace(\"hello\", \"l\")", false)] // missing replacement arg
+    #[case::replace_too_many_args("replace(\"hello\", \"l\", \"r\", \"extra\")", false)] // too many args
     #[case::gsub_wrong_first("gsub(42, \"l\", \"r\")", false)] // expects string first arg
     #[case::starts_with_num_sep("starts_with(\"hello\", 42)", false)] // expects string prefix
     #[case::ends_with_num_sep("ends_with(\"hello\", 42)", false)] // expects string suffix
@@ -1645,6 +1647,11 @@ mod tests {
     #[case::piped_replace("\"hello\" | replace(\"l\", \"r\")", true)]
     #[case::piped_gsub("\"hello\" | gsub(\"l\", \"r\")", true)]
     #[case::piped_gsub_variable_arg("def slugify(s, separator = \"-\"): s | gsub(\"[^a-z0-9]+\", separator) end", true)] // regression: default param used in gsub should not produce false error
+    #[case::replace_sstring_args("def f(x, v): x | replace(s\"old${v}\", s\"new${v}\") end", true)] // s-string args should not expand segments as separate arguments
+    #[case::replace_chained_sstring(
+        "def f(line, prev, ver): line | replace(s\"version = \\\"${prev}\\\"\", s\"version = \\\"${ver}\\\"\") | replace(s\"old${prev}\", s\"new${ver}\") end",
+        true
+    )] // chained replace with s-string args
     #[case::piped_slice("[1, 2, 3, 4] | slice(1, 3)", true)]
     #[case::piped_repeat("\"x\" | repeat(3)", true)]
     #[case::piped_join_wrong_type("42 | join(\",\")", false)] // number piped to join (expects array)

--- a/crates/mq-check/src/constraint.rs
+++ b/crates/mq-check/src/constraint.rs
@@ -188,7 +188,7 @@ pub(super) fn generate_symbol_constraints(
             let ty = Type::Number;
             ctx.set_symbol_type(symbol_id, ty);
         }
-        SymbolKind::String => {
+        SymbolKind::String | SymbolKind::InterpolatedString => {
             let ty = Type::String;
             ctx.set_symbol_type(symbol_id, ty);
         }

--- a/crates/mq-check/src/constraint/categories.rs
+++ b/crates/mq-check/src/constraint/categories.rs
@@ -60,6 +60,7 @@ pub(super) fn categorize_symbols(hir: &Hir) -> SymbolCategories {
             // Pass 1: literals, variables, parameters, function/macro definitions
             SymbolKind::Number
             | SymbolKind::String
+            | SymbolKind::InterpolatedString
             | SymbolKind::Boolean
             | SymbolKind::Symbol
             | SymbolKind::None

--- a/crates/mq-check/src/narrowing.rs
+++ b/crates/mq-check/src/narrowing.rs
@@ -178,7 +178,7 @@ pub(crate) fn type_name_to_type(name: &str, ctx: &mut InferenceContext) -> Optio
 /// maps unambiguously to a single `Type` (String, Number, Bool, Symbol, None).
 pub(crate) fn literal_symbol_type(hir: &Hir, lit_id: SymbolId) -> Option<Type> {
     match hir.symbol(lit_id)?.kind {
-        SymbolKind::String => Some(Type::String),
+        SymbolKind::String | SymbolKind::InterpolatedString => Some(Type::String),
         SymbolKind::Number => Some(Type::Number),
         SymbolKind::Boolean => Some(Type::Bool),
         SymbolKind::Symbol => Some(Type::Symbol),

--- a/crates/mq-hir/src/hir/lower.rs
+++ b/crates/mq-hir/src/hir/lower.rs
@@ -346,6 +346,19 @@ impl Hir {
                 ..
             } = &**token
         {
+            // Wrap all segments under a single InterpolatedString symbol so that
+            // the parent node (e.g. a Call) sees one argument per s-string, not
+            // one child per text/expr segment.
+            let interp_id = self.add_symbol(Symbol {
+                value: None,
+                kind: SymbolKind::InterpolatedString,
+                source: SourceInfo::new(Some(source_id), Some(node.range())),
+                scope: scope_id,
+                doc: node.comments(),
+                parent,
+                insertion_order: 0,
+            });
+
             segments.iter().for_each(|segment| match segment {
                 mq_lang::StringSegment::Text(text, range) => {
                     self.add_symbol(Symbol {
@@ -354,7 +367,7 @@ impl Hir {
                         source: SourceInfo::new(Some(source_id), Some(*range)),
                         scope: scope_id,
                         doc: node.comments(),
-                        parent,
+                        parent: Some(interp_id),
                         insertion_order: 0,
                     });
                 }
@@ -365,7 +378,7 @@ impl Hir {
                         source: SourceInfo::new(Some(source_id), Some(*range)),
                         scope: scope_id,
                         doc: node.comments(),
-                        parent,
+                        parent: Some(interp_id),
                         insertion_order: 0,
                     });
                 }

--- a/crates/mq-hir/src/symbol.rs
+++ b/crates/mq-hir/src/symbol.rs
@@ -74,6 +74,8 @@ pub enum SymbolKind {
     Ident,
     If,
     Include(SourceId),
+    /// A template string literal (`s"...${expr}..."`).
+    InterpolatedString,
     Keyword,
     Loop,
     Macro(Params),

--- a/crates/mq-lsp/src/semantic_tokens.rs
+++ b/crates/mq-lsp/src/semantic_tokens.rs
@@ -84,7 +84,9 @@ pub fn response(hir: Arc<RwLock<mq_hir::Hir>>, url: Url) -> Vec<SemanticToken> {
                 mq_hir::SymbolKind::Parameter => token_type(ls_types::SemanticTokenType::PARAMETER),
                 mq_hir::SymbolKind::Ref => token_type(ls_types::SemanticTokenType::VARIABLE),
                 mq_hir::SymbolKind::Selector(_) => token_type(ls_types::SemanticTokenType::METHOD),
-                mq_hir::SymbolKind::String => token_type(ls_types::SemanticTokenType::STRING),
+                mq_hir::SymbolKind::String | mq_hir::SymbolKind::InterpolatedString => {
+                    token_type(ls_types::SemanticTokenType::STRING)
+                }
                 mq_hir::SymbolKind::Variable
                 | mq_hir::SymbolKind::DestructuringBinding
                 | mq_hir::SymbolKind::Symbol


### PR DESCRIPTION
s-string segments (text and interpolated expr) were added as direct children of the parent Call symbol in the HIR, causing replace(s"a${x}b", s"c${y}d") to appear as a 6-argument (+ piped input = 7) call instead of a 2-argument one. 