### PR TITLE
🐛 fix(eval): prevent stack overflow when user function shadows a builtin

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1702,6 +1702,14 @@ impl<T: ModuleResolver> Evaluator<T> {
             self.debugger.write().unwrap().push_call_stack(Shared::clone(&node));
 
             let new_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(fn_env))));
+
+            // If the function name matches a built-in, expose the native builtin in the
+            // body's scope so calls to the same name invoke the builtin rather than
+            // recursing back into this user-defined function.
+            if builtin::get_builtin_functions(&ident).is_some() {
+                define(&new_env, ident, RuntimeValue::NativeFunction(ident));
+            }
+
             let has_variadic = params.iter().any(|p| p.is_variadic);
             let required_params = params.iter().filter(|p| p.default.is_none() && !p.is_variadic).count();
             let arg_count = args.len();

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2619,6 +2619,12 @@ fn engine() -> DefaultEngine {
 #[case::paren_free_fn_as_value_preserved("map([\"a\", \"b\"], upcase)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())])].into()))]
 // paren-free calls: passing user-defined function as value to map (no spurious auto-call)
 #[case::paren_free_user_fn_as_value_preserved("def double(x): x * 2; | map([1, 2, 3], double)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])].into()))]
+// shadowing builtin: user-defined function with same name as builtin calls the native builtin inside its body
+#[case::shadow_builtin_upcase("def upcase: upcase() | ltrimstr(\"HELLO\"); | \"hello\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
+// shadowing builtin: user function wraps builtin and adds extra transformation
+#[case::shadow_builtin_with_extra("def upcase(x): upcase(x) | ltrimstr(\"HELLO\"); | upcase(\"hello\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
+// shadowing builtin: outer scope sees user-defined function
+#[case::shadow_builtin_outer_scope("def upcase: upcase(); | \"world\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("WORLD".to_string())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }


### PR DESCRIPTION
When a user-defined function has the same name as a native builtin, calls to that name within the function body now resolve to the native builtin instead of recursing back into the user-defined function.

This is done by binding NativeFunction(ident) into the body's new_env whenever the called function name matches a known builtin. As a result, the outer scope continues to use the user-defined version (override semantics), while the body can safely call the same-named builtin.