### PR TITLE
✨ feat(eval)!: add gmtime/localtime/mktime/strftime and unify time unit to seconds

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -3965,21 +3965,21 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                      name: "get".to_string(),
                                                      args: vec!["bool".into(), "number".into()]})))]
-    #[case::to_date(vec![RuntimeValue::Number(1609459200000_i64.into())],
+    #[case::to_date(vec![RuntimeValue::Number(1609459200_i64.into())],
         vec![
             ast_call("to_date", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("%Y-%m-%d".to_string())))
             ])
         ],
         Ok(vec![RuntimeValue::String("2021-01-01".to_string())]))]
-    #[case::to_date(vec![RuntimeValue::Number(1609459200000_i64.into())],
+    #[case::to_date(vec![RuntimeValue::Number(1609459200_i64.into())],
         vec![
             ast_call("to_date", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("%Y/%m/%d %H:%M:%S".to_string())))
             ])
         ],
         Ok(vec![RuntimeValue::String("2021/01/01 00:00:00".to_string())]))]
-    #[case::to_date(vec![RuntimeValue::Number(1609488000000_i64.into())],
+    #[case::to_date(vec![RuntimeValue::Number(1609488000_i64.into())],
         vec![
             ast_call("to_date", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("%d %b %Y %H:%M".to_string())))
@@ -4279,7 +4279,7 @@ mod tests {
         vec![
             ast_call("from_date", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Number(1742036400000_i64.into())]))]
+        Ok(vec![RuntimeValue::Number(1742036400_i64.into())]))]
     #[case::from_date_invalid_format(vec![RuntimeValue::String("2021-01-01".to_string())],
         vec![
             ast_call("from_date", SmallVec::new())

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -245,11 +245,11 @@ fn broken_down_time_array<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> Ru
     ])
 }
 
-fn broken_down_time_to_naive(arr: &[RuntimeValue]) -> Result<chrono::NaiveDateTime, Error> {
+fn broken_down_time_to_naive(caller: &str, arr: &[RuntimeValue]) -> Result<chrono::NaiveDateTime, Error> {
     let get_i64 = |v: &RuntimeValue| -> Result<i64, Error> {
         match v {
             RuntimeValue::Number(n) => Ok(n.value() as i64),
-            _ => Err(Error::Runtime("mktime: array elements must be numbers".to_string())),
+            _ => Err(Error::Runtime(format!("{caller}: array elements must be numbers"))),
         }
     };
     let year = get_i64(&arr[0])? as i32;
@@ -260,7 +260,7 @@ fn broken_down_time_to_naive(arr: &[RuntimeValue]) -> Result<chrono::NaiveDateTi
     let second = get_i64(&arr[5])? as u32;
     NaiveDate::from_ymd_opt(year, month, day)
         .and_then(|d| d.and_hms_opt(hour, minute, second))
-        .ok_or_else(|| Error::Runtime("mktime: invalid date components".to_string()))
+        .ok_or_else(|| Error::Runtime(format!("{caller}: invalid date components")))
 }
 
 /// Converts Unix timestamp (seconds) to broken-down UTC time array:
@@ -301,7 +301,7 @@ fn localtime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
 fn mktime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::Array(arr)] if arr.len() == 8 => {
-            broken_down_time_to_naive(arr).map(|dt| RuntimeValue::Number(dt.and_utc().timestamp().into()))
+            broken_down_time_to_naive("mktime", arr).map(|dt| RuntimeValue::Number(dt.and_utc().timestamp().into()))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("mktime should always receive exactly one argument"),
@@ -339,7 +339,7 @@ fn date_add_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
             RuntimeValue::String(unit),
         ] if arr.len() == 8 => {
             let amount = n.value() as i64;
-            let dt = broken_down_time_to_naive(arr)?.and_utc();
+            let dt = broken_down_time_to_naive("date_add", arr)?.and_utc();
             let result = match unit.as_str() {
                 "seconds" => dt.checked_add_signed(Duration::seconds(amount)),
                 "minutes" => dt.checked_add_signed(Duration::minutes(amount)),
@@ -390,8 +390,8 @@ fn date_diff_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
             RuntimeValue::Array(arr2),
             RuntimeValue::String(unit),
         ] if arr1.len() == 8 && arr2.len() == 8 => {
-            let dt1 = broken_down_time_to_naive(arr1)?.and_utc();
-            let dt2 = broken_down_time_to_naive(arr2)?.and_utc();
+            let dt1 = broken_down_time_to_naive("date_diff", arr1)?.and_utc();
+            let dt2 = broken_down_time_to_naive("date_diff", arr2)?.and_utc();
             let diff = dt2.signed_duration_since(dt1);
             let result = match unit.as_str() {
                 "seconds" => diff.num_seconds(),
@@ -5491,6 +5491,42 @@ mod tests {
             &Shared::new(SharedCell::new(Env::default())),
         );
         assert!(matches!(result, Err(Error::InvalidTypes(_, _))));
+    }
+
+    #[test]
+    fn test_date_add_malformed_array_error_prefix() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let bad_arr = RuntimeValue::Array(vec![RuntimeValue::String("x".into()); 8]);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_add"),
+            vec![
+                bad_arr,
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::String("days".into()),
+            ],
+            &env,
+        );
+        match result {
+            Err(Error::Runtime(msg)) => assert!(msg.starts_with("date_add:"), "expected date_add prefix, got: {msg}"),
+            other => panic!("expected Runtime error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_date_diff_malformed_array_error_prefix() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let bad_arr = RuntimeValue::Array(vec![RuntimeValue::String("x".into()); 8]);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_diff"),
+            vec![bad_arr.clone(), bad_arr, RuntimeValue::String("days".into())],
+            &env,
+        );
+        match result {
+            Err(Error::Runtime(msg)) => assert!(msg.starts_with("date_diff:"), "expected date_diff prefix, got: {msg}"),
+            other => panic!("expected Runtime error, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -11,7 +11,7 @@ use crate::ident::all_symbols;
 use crate::number::{self};
 use crate::selector::Selector;
 use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input, parse_mdx_input};
-use chrono::{DateTime, Datelike, Local, NaiveDate, Timelike};
+use chrono::{DateTime, Datelike, Duration, Local, Months, NaiveDate, Timelike};
 use csv::ReaderBuilder;
 use itertools::Itertools;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -323,6 +323,96 @@ fn strftime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
             vec![std::mem::take(a), std::mem::take(b)],
         )),
         _ => unreachable!("strftime should always receive exactly two arguments"),
+    }
+}
+
+/// Adds n units to a broken-down time array and returns a new broken-down array (UTC).
+/// Input/output format: [year, month (0-11), day, hour, minute, second, weekday, day-of-year]
+/// Units: "seconds", "minutes", "hours", "days", "weeks", "months", "years"
+/// Month/year arithmetic is calendar-aware (e.g. Jan 31 + 1 month = Feb 28/29).
+#[mq_macros::mq_fn(name = "date_add", params = Fixed(3))]
+fn date_add_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [
+            RuntimeValue::Array(arr),
+            RuntimeValue::Number(n),
+            RuntimeValue::String(unit),
+        ] if arr.len() == 8 => {
+            let amount = n.value() as i64;
+            let dt = broken_down_time_to_naive(arr)?.and_utc();
+            let result = match unit.as_str() {
+                "seconds" => dt.checked_add_signed(Duration::seconds(amount)),
+                "minutes" => dt.checked_add_signed(Duration::minutes(amount)),
+                "hours" => dt.checked_add_signed(Duration::hours(amount)),
+                "days" => dt.checked_add_signed(Duration::days(amount)),
+                "weeks" => dt.checked_add_signed(Duration::weeks(amount)),
+                "months" => {
+                    if amount >= 0 {
+                        dt.checked_add_months(Months::new(amount as u32))
+                    } else {
+                        dt.checked_sub_months(Months::new((-amount) as u32))
+                    }
+                }
+                "years" => {
+                    if amount >= 0 {
+                        dt.checked_add_months(Months::new(amount as u32 * 12))
+                    } else {
+                        dt.checked_sub_months(Months::new((-amount) as u32 * 12))
+                    }
+                }
+                u => {
+                    return Err(Error::Runtime(format!(
+                        "date_add: unknown unit {:?}, expected \"seconds\", \"minutes\", \"hours\", \"days\", \"weeks\", \"months\", or \"years\"",
+                        u
+                    )));
+                }
+            };
+            result
+                .map(|dt| broken_down_time_array(&dt))
+                .ok_or_else(|| Error::Runtime("date_add: arithmetic overflow or invalid date".to_string()))
+        }
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("date_add should always receive exactly three arguments"),
+    }
+}
+
+/// Returns the difference (array2 - array1) in the given unit.
+/// Input format: [year, month (0-11), day, hour, minute, second, weekday, day-of-year]
+/// Units: "seconds", "minutes", "hours", "days", "weeks"
+#[mq_macros::mq_fn(name = "date_diff", params = Fixed(3))]
+fn date_diff_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [
+            RuntimeValue::Array(arr1),
+            RuntimeValue::Array(arr2),
+            RuntimeValue::String(unit),
+        ] if arr1.len() == 8 && arr2.len() == 8 => {
+            let dt1 = broken_down_time_to_naive(arr1)?.and_utc();
+            let dt2 = broken_down_time_to_naive(arr2)?.and_utc();
+            let diff = dt2.signed_duration_since(dt1);
+            let result = match unit.as_str() {
+                "seconds" => diff.num_seconds(),
+                "minutes" => diff.num_minutes(),
+                "hours" => diff.num_hours(),
+                "days" => diff.num_days(),
+                "weeks" => diff.num_weeks(),
+                u => {
+                    return Err(Error::Runtime(format!(
+                        "date_diff: unknown unit {:?}, expected \"seconds\", \"minutes\", \"hours\", \"days\", or \"weeks\"",
+                        u
+                    )));
+                }
+            };
+            Ok(RuntimeValue::Number(result.into()))
+        }
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("date_diff should always receive exactly three arguments"),
     }
 }
 
@@ -3156,6 +3246,8 @@ mq_macros::builtin_dispatch! {
     LOCALTIME,
     MKTIME,
     STRFTIME,
+    DATE_ADD,
+    DATE_DIFF,
     BASE64,
     BASE64D,
     BASE64URL,
@@ -3874,6 +3966,20 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Formats a Unix timestamp (seconds) as a date string using the given strftime format (e.g. \"%Y-%m-%d\").",
             params: &["timestamp", "format"],
+        },
+    );
+    map.insert(
+        SmolStr::new("date_add"),
+        BuiltinFunctionDoc {
+            description: "Adds n units to a broken-down time array and returns a new array. Units: \"seconds\", \"minutes\", \"hours\", \"days\", \"weeks\", \"months\", \"years\". Month/year arithmetic is calendar-aware.",
+            params: &["array", "n", "unit"],
+        },
+    );
+    map.insert(
+        SmolStr::new("date_diff"),
+        BuiltinFunctionDoc {
+            description: "Returns the difference (array2 - array1) in the given unit. Units: \"seconds\", \"minutes\", \"hours\", \"days\", \"weeks\".",
+            params: &["array1", "array2", "unit"],
         },
     );
     map.insert(
@@ -5230,6 +5336,135 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, RuntimeValue::String(expected.into()));
+    }
+
+    fn gmtime_array(secs: i64) -> RuntimeValue {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("gmtime"),
+            vec![RuntimeValue::Number(secs.into())],
+            &env,
+        )
+        .unwrap()
+    }
+
+    // date_add: simple durations
+    #[rstest]
+    #[case(1704067200_i64, 60, "seconds", 1704067260_i64)]
+    #[case(1704067200_i64, 5, "minutes", 1704067500_i64)]
+    #[case(1704067200_i64, 2, "hours", 1704074400_i64)]
+    #[case(1704067200_i64, 1, "days", 1704153600_i64)]
+    #[case(1704067200_i64, -1,  "days",    1703980800_i64)]
+    #[case(1704067200_i64, 1, "weeks", 1704672000_i64)]
+    fn test_date_add_duration(#[case] base: i64, #[case] n: i64, #[case] unit: &str, #[case] expected_secs: i64) {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr = gmtime_array(base);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_add"),
+            vec![arr, RuntimeValue::Number(n.into()), RuntimeValue::String(unit.into())],
+            &env,
+        )
+        .unwrap();
+        // convert result array back to timestamp via mktime and compare
+        let ts = eval_builtin(&RuntimeValue::None, &Ident::new("mktime"), vec![result], &env).unwrap();
+        assert_eq!(ts, RuntimeValue::Number(expected_secs.into()));
+    }
+
+    // date_add: calendar-aware month/year arithmetic
+    #[test]
+    fn test_date_add_months_end_of_month() {
+        // 2024-01-31 + 1 month = 2024-02-29 (leap year)
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr = gmtime_array(1706659200); // 2024-01-31T00:00:00Z
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_add"),
+            vec![
+                arr,
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::String("months".into()),
+            ],
+            &env,
+        )
+        .unwrap();
+        // 2024-02-29T00:00:00Z = 1709164800
+        let ts = eval_builtin(&RuntimeValue::None, &Ident::new("mktime"), vec![result], &env).unwrap();
+        assert_eq!(ts, RuntimeValue::Number(1709164800_i64.into()));
+    }
+
+    #[test]
+    fn test_date_add_years() {
+        // 2024-02-29 + 1 year = 2025-02-28 (non-leap year clamps)
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr = gmtime_array(1709164800); // 2024-02-29T00:00:00Z
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_add"),
+            vec![
+                arr,
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::String("years".into()),
+            ],
+            &env,
+        )
+        .unwrap();
+        // 2025-02-28T00:00:00Z = 1740700800
+        let ts = eval_builtin(&RuntimeValue::None, &Ident::new("mktime"), vec![result], &env).unwrap();
+        assert_eq!(ts, RuntimeValue::Number(1740700800_i64.into()));
+    }
+
+    #[test]
+    fn test_date_add_invalid_unit() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr = gmtime_array(0);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_add"),
+            vec![
+                arr,
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::String("centuries".into()),
+            ],
+            &env,
+        );
+        assert!(matches!(result, Err(Error::Runtime(_))));
+    }
+
+    // date_diff: difference in various units
+    #[rstest]
+    #[case(1704067200_i64, 1704153600_i64, "seconds", 86400_i64)]
+    #[case(1704067200_i64, 1704153600_i64, "minutes", 1440_i64)]
+    #[case(1704067200_i64, 1704153600_i64, "hours", 24_i64)]
+    #[case(1704067200_i64, 1704153600_i64, "days", 1_i64)]
+    #[case(1704067200_i64, 1704672000_i64, "weeks", 1_i64)]
+    #[case(1704153600_i64, 1704067200_i64, "seconds", -86400_i64)]
+    fn test_date_diff(#[case] base1: i64, #[case] base2: i64, #[case] unit: &str, #[case] expected: i64) {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr1 = gmtime_array(base1);
+        let arr2 = gmtime_array(base2);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_diff"),
+            vec![arr1, arr2, RuntimeValue::String(unit.into())],
+            &env,
+        )
+        .unwrap();
+        assert_eq!(result, RuntimeValue::Number(expected.into()));
+    }
+
+    #[test]
+    fn test_date_diff_invalid_unit() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let arr = gmtime_array(0);
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_diff"),
+            vec![arr.clone(), arr, RuntimeValue::String("months".into())],
+            &env,
+        );
+        assert!(matches!(result, Err(Error::Runtime(_))));
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -11,6 +11,7 @@ use crate::ident::all_symbols;
 use crate::number::{self};
 use crate::selector::Selector;
 use crate::{Ident, Shared, SharedCell, Token, get_token, parse_markdown_input, parse_mdx_input};
+use chrono::{DateTime, Datelike, Local, NaiveDate, Timelike};
 use csv::ReaderBuilder;
 use itertools::Itertools;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -225,9 +226,104 @@ fn now_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<Runti
         (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| Error::Runtime(format!("{}", e)))?
-            .as_millis() as i64)
+            .as_secs() as i64)
             .into(),
     ))
+}
+
+/// Array format: [year, month (0-11), day (1-31), hour (0-23), minute (0-59), second (0-60), weekday (0=Sun), day-of-year (0-365)]
+fn broken_down_time_array<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> RuntimeValue {
+    RuntimeValue::Array(vec![
+        RuntimeValue::Number(((dt.year()) as i64).into()),
+        RuntimeValue::Number((dt.month0() as i64).into()),
+        RuntimeValue::Number((dt.day() as i64).into()),
+        RuntimeValue::Number((dt.hour() as i64).into()),
+        RuntimeValue::Number((dt.minute() as i64).into()),
+        RuntimeValue::Number((dt.second() as i64).into()),
+        RuntimeValue::Number((dt.weekday().num_days_from_sunday() as i64).into()),
+        RuntimeValue::Number((dt.ordinal0() as i64).into()),
+    ])
+}
+
+fn broken_down_time_to_naive(arr: &[RuntimeValue]) -> Result<chrono::NaiveDateTime, Error> {
+    let get_i64 = |v: &RuntimeValue| -> Result<i64, Error> {
+        match v {
+            RuntimeValue::Number(n) => Ok(n.value() as i64),
+            _ => Err(Error::Runtime("mktime: array elements must be numbers".to_string())),
+        }
+    };
+    let year = get_i64(&arr[0])? as i32;
+    let month = (get_i64(&arr[1])? + 1) as u32;
+    let day = get_i64(&arr[2])? as u32;
+    let hour = get_i64(&arr[3])? as u32;
+    let minute = get_i64(&arr[4])? as u32;
+    let second = get_i64(&arr[5])? as u32;
+    NaiveDate::from_ymd_opt(year, month, day)
+        .and_then(|d| d.and_hms_opt(hour, minute, second))
+        .ok_or_else(|| Error::Runtime("mktime: invalid date components".to_string()))
+}
+
+/// Converts Unix timestamp (seconds) to broken-down UTC time array:
+/// [year, month (0-11), day, hour, minute, second, weekday (0=Sunday), day-of-year (0-365)]
+#[mq_macros::mq_fn(name = "gmtime", params = Fixed(1))]
+fn gmtime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Number(secs)] => {
+            let secs_val = secs.value() as i64;
+            DateTime::from_timestamp(secs_val, 0)
+                .map(|dt| broken_down_time_array(&dt))
+                .ok_or_else(|| Error::Runtime(format!("Invalid timestamp: {}", secs_val)))
+        }
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("gmtime should always receive exactly one argument"),
+    }
+}
+
+/// Converts Unix timestamp (seconds) to broken-down local time array:
+/// [year, month (0-11), day, hour, minute, second, weekday (0=Sunday), day-of-year (0-365)]
+#[mq_macros::mq_fn(name = "localtime", params = Fixed(1))]
+fn localtime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Number(secs)] => {
+            let secs_val = secs.value() as i64;
+            DateTime::from_timestamp(secs_val, 0)
+                .map(|dt| broken_down_time_array(&dt.with_timezone(&Local)))
+                .ok_or_else(|| Error::Runtime(format!("Invalid timestamp: {}", secs_val)))
+        }
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("localtime should always receive exactly one argument"),
+    }
+}
+
+/// Converts broken-down UTC time array to Unix timestamp (seconds).
+/// Input format: [year, month (0-11), day, hour, minute, second, weekday, day-of-year]
+#[mq_macros::mq_fn(name = "mktime", params = Fixed(1))]
+fn mktime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Array(arr)] if arr.len() == 8 => {
+            broken_down_time_to_naive(arr).map(|dt| RuntimeValue::Number(dt.and_utc().timestamp().into()))
+        }
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("mktime should always receive exactly one argument"),
+    }
+}
+
+/// Formats a Unix timestamp (seconds) as a date string using the given strftime format.
+#[mq_macros::mq_fn(name = "strftime", params = Fixed(2))]
+fn strftime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Number(secs), RuntimeValue::String(fmt)] => {
+            let secs_val = secs.value() as i64;
+            DateTime::from_timestamp(secs_val, 0)
+                .map(|dt| RuntimeValue::String(dt.format(fmt.as_str()).to_string()))
+                .ok_or_else(|| Error::Runtime(format!("strftime: invalid timestamp: {}", secs_val)))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("strftime should always receive exactly two arguments"),
+    }
 }
 
 #[mq_macros::mq_fn(name = "base64", params = Fixed(1))]
@@ -3056,6 +3152,10 @@ mq_macros::builtin_dispatch! {
     FROM_DATE,
     TO_DATE,
     NOW,
+    GMTIME,
+    LOCALTIME,
+    MKTIME,
+    STRFTIME,
     BASE64,
     BASE64D,
     BASE64URL,
@@ -3746,6 +3846,34 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Returns the current timestamp.",
             params: &[],
+        },
+    );
+    map.insert(
+        SmolStr::new("gmtime"),
+        BuiltinFunctionDoc {
+            description: "Converts Unix timestamp (seconds since epoch) to broken-down UTC time array [year, mon (0-11), mday, hour, min, sec, wday (0=Sun), yday (0-365)].",
+            params: &["timestamp"],
+        },
+    );
+    map.insert(
+        SmolStr::new("localtime"),
+        BuiltinFunctionDoc {
+            description: "Converts Unix timestamp (seconds since epoch) to broken-down local time array [year, mon (0-11), mday, hour, min, sec, wday (0=Sun), yday (0-365)].",
+            params: &["timestamp"],
+        },
+    );
+    map.insert(
+        SmolStr::new("mktime"),
+        BuiltinFunctionDoc {
+            description: "Converts broken-down UTC time array [year, mon (0-11), mday, hour, min, sec, wday, yday] to Unix timestamp (seconds since epoch).",
+            params: &["time_array"],
+        },
+    );
+    map.insert(
+        SmolStr::new("strftime"),
+        BuiltinFunctionDoc {
+            description: "Formats a Unix timestamp (seconds) as a date string using the given strftime format (e.g. \"%Y-%m-%d\").",
+            params: &["timestamp", "format"],
         },
     );
     map.insert(
@@ -5010,6 +5138,124 @@ mod tests {
         );
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), expected_error);
+    }
+
+    #[test]
+    fn test_gmtime_epoch() {
+        // Unix epoch (0) → 1970-01-01T00:00:00 UTC (Thursday)
+        // format: [year, mon(0-11), mday, hour, min, sec, wday(0=Sun), yday(0-365)]
+        let ident = Ident::new("gmtime");
+        let args = vec![RuntimeValue::Number(0.into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            RuntimeValue::Array(vec![
+                RuntimeValue::Number(1970.into()), // year
+                RuntimeValue::Number(0.into()),    // mon (Jan=0)
+                RuntimeValue::Number(1.into()),    // mday
+                RuntimeValue::Number(0.into()),    // hour
+                RuntimeValue::Number(0.into()),    // min
+                RuntimeValue::Number(0.into()),    // sec
+                RuntimeValue::Number(4.into()),    // wday (Thu=4)
+                RuntimeValue::Number(0.into()),    // yday
+            ])
+        );
+    }
+
+    #[test]
+    fn test_gmtime_known_date() {
+        // 2024-01-01T00:00:00 UTC = 1704067200 seconds
+        let ident = Ident::new("gmtime");
+        let args = vec![RuntimeValue::Number(1704067200_i64.into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            RuntimeValue::Array(vec![
+                RuntimeValue::Number(2024.into()), // year
+                RuntimeValue::Number(0.into()),    // mon (Jan=0)
+                RuntimeValue::Number(1.into()),    // mday
+                RuntimeValue::Number(0.into()),    // hour
+                RuntimeValue::Number(0.into()),    // min
+                RuntimeValue::Number(0.into()),    // sec
+                RuntimeValue::Number(1.into()),    // wday (Mon=1)
+                RuntimeValue::Number(0.into()),    // yday
+            ])
+        );
+    }
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(1704067200_i64, 1704067200_i64)]
+    #[case(1718454645_i64, 1718454645_i64)]
+    fn test_mktime_roundtrip(#[case] secs: i64, #[case] expected: i64) {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let gmtime_ident = Ident::new("gmtime");
+        let mktime_ident = Ident::new("mktime");
+
+        let arr = eval_builtin(
+            &RuntimeValue::None,
+            &gmtime_ident,
+            vec![RuntimeValue::Number(secs.into())],
+            &env,
+        )
+        .unwrap();
+        let result = eval_builtin(&RuntimeValue::None, &mktime_ident, vec![arr], &env).unwrap();
+        assert_eq!(result, RuntimeValue::Number(expected.into()));
+    }
+
+    #[rstest]
+    #[case(1704067200_i64, "%Y-%m-%d", "2024-01-01")]
+    #[case(0_i64, "%Y-%m-%dT%H:%M:%S", "1970-01-01T00:00:00")]
+    #[case(1704067200_i64, "%Y", "2024")]
+    fn test_strftime(#[case] ts: i64, #[case] fmt: &str, #[case] expected: &str) {
+        let ident = Ident::new("strftime");
+        let args = vec![RuntimeValue::Number(ts.into()), RuntimeValue::String(fmt.into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        )
+        .unwrap();
+        assert_eq!(result, RuntimeValue::String(expected.into()));
+    }
+
+    #[test]
+    fn test_gmtime_invalid_type() {
+        let ident = Ident::new("gmtime");
+        let args = vec![RuntimeValue::String("not a number".into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(matches!(result, Err(Error::InvalidTypes(_, _))));
+    }
+
+    #[test]
+    fn test_mktime_invalid_input() {
+        let ident = Ident::new("mktime");
+        let args = vec![RuntimeValue::String("not an array".into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(matches!(result, Err(Error::InvalidTypes(_, _))));
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -344,19 +344,19 @@ pub fn to_text(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
     }
 }
 
-/// convert from date string to timestamp (milliseconds)
+/// convert from date string to Unix timestamp (seconds)
 #[inline(always)]
 pub fn from_date(date_str: &str) -> Result<RuntimeValue, Error> {
     match chrono::DateTime::parse_from_rfc3339(date_str) {
-        Ok(datetime) => Ok(RuntimeValue::Number(datetime.timestamp_millis().into())),
+        Ok(datetime) => Ok(RuntimeValue::Number(datetime.timestamp().into())),
         Err(e) => Err(Error::Runtime(format!("{}", e))),
     }
 }
 
-/// convert from timestamp (milliseconds) to date string
+/// convert from Unix timestamp (seconds) to date string
 #[inline(always)]
-pub fn to_date(ms: Number, convert: Option<&str>) -> Result<RuntimeValue, Error> {
-    chrono::DateTime::from_timestamp((ms.value() as i64) / 1000, 0)
+pub fn to_date(secs: Number, convert: Option<&str>) -> Result<RuntimeValue, Error> {
+    chrono::DateTime::from_timestamp(secs.value() as i64, 0)
         .map(|dt| {
             convert
                 .map(|f| dt.format(f).to_string())
@@ -819,12 +819,12 @@ mod tests {
 
     // Test from_date
     #[rstest]
-    #[case("2024-01-01T00:00:00Z", 1704067200000)]
-    #[case("2024-06-15T12:30:45Z", 1718454645000)]
-    #[case("2024-12-31T23:59:59Z", 1735689599000)]
-    fn test_from_date_valid(#[case] input: &str, #[case] expected_ms: i64) {
+    #[case("2024-01-01T00:00:00Z", 1704067200)]
+    #[case("2024-06-15T12:30:45Z", 1718454645)]
+    #[case("2024-12-31T23:59:59Z", 1735689599)]
+    fn test_from_date_valid(#[case] input: &str, #[case] expected_secs: i64) {
         let result = from_date(input).unwrap();
-        assert_eq!(result, RuntimeValue::Number(expected_ms.into()));
+        assert_eq!(result, RuntimeValue::Number(expected_secs.into()));
     }
 
     #[rstest]
@@ -838,14 +838,14 @@ mod tests {
 
     // Test to_date
     #[rstest]
-    #[case(1704067200000, None, "2024-01-01T00:00:00Z")]
-    #[case(1704067200000, Some("%Y-%m-%d"), "2024-01-01")]
-    #[case(1718454645000, Some("%Y/%m/%d %H:%M"), "2024/06/15 12:30")]
-    #[case(1704067200000, Some("%d/%m/%Y"), "01/01/2024")]
-    #[case(1704067200000, Some("%H:%M:%S"), "00:00:00")]
-    #[case(1704067200000, Some("%Y"), "2024")]
-    fn test_to_date(#[case] ms: i64, #[case] convert: Option<&str>, #[case] expected: &str) {
-        let result = to_date(ms.into(), convert).unwrap();
+    #[case(1704067200, None, "2024-01-01T00:00:00Z")]
+    #[case(1704067200, Some("%Y-%m-%d"), "2024-01-01")]
+    #[case(1718454645, Some("%Y/%m/%d %H:%M"), "2024/06/15 12:30")]
+    #[case(1704067200, Some("%d/%m/%Y"), "01/01/2024")]
+    #[case(1704067200, Some("%H:%M:%S"), "00:00:00")]
+    #[case(1704067200, Some("%Y"), "2024")]
+    fn test_to_date(#[case] secs: i64, #[case] convert: Option<&str>, #[case] expected: &str) {
+        let result = to_date(secs.into(), convert).unwrap();
         assert_eq!(result, RuntimeValue::String(expected.to_string()));
     }
 

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2625,6 +2625,43 @@ fn engine() -> DefaultEngine {
 #[case::shadow_builtin_with_extra("def upcase(x): upcase(x) | ltrimstr(\"HELLO\"); | upcase(\"hello\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
 // shadowing builtin: outer scope sees user-defined function
 #[case::shadow_builtin_outer_scope("def upcase: upcase(); | \"world\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("WORLD".to_string())].into()))]
+// gmtime: Unix epoch → UTC broken-down array [year, mon(0-11), mday, hour, min, sec, wday(0=Sun), yday(0-365)]
+#[case::gmtime_epoch("gmtime(0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
+    RuntimeValue::Number(1970.into()), // year
+    RuntimeValue::Number(0.into()),    // mon (Jan=0)
+    RuntimeValue::Number(1.into()),    // mday
+    RuntimeValue::Number(0.into()),    // hour
+    RuntimeValue::Number(0.into()),    // min
+    RuntimeValue::Number(0.into()),    // sec
+    RuntimeValue::Number(4.into()),    // wday (Thu=4)
+    RuntimeValue::Number(0.into()),    // yday
+])].into()))]
+#[case::gmtime_known("gmtime(1704067200)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
+    RuntimeValue::Number(2024.into()), // year
+    RuntimeValue::Number(0.into()),    // mon (Jan=0)
+    RuntimeValue::Number(1.into()),    // mday
+    RuntimeValue::Number(0.into()),    // hour
+    RuntimeValue::Number(0.into()),    // min
+    RuntimeValue::Number(0.into()),    // sec
+    RuntimeValue::Number(1.into()),    // wday (Mon=1)
+    RuntimeValue::Number(0.into()),    // yday
+])].into()))]
+// mktime: broken-down UTC array → Unix timestamp (seconds)
+#[case::mktime_epoch("mktime(array(1970, 0, 1, 0, 0, 0, 4, 0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
+#[case::mktime_known("mktime(array(2024, 0, 1, 0, 0, 0, 1, 0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704067200_i64.into())].into()))]
+// gmtime | mktime roundtrip
+#[case::gmtime_mktime_roundtrip("gmtime(1704067200) | mktime", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704067200_i64.into())].into()))]
+// localtime: returns array of 8 elements
+#[case::localtime_len("len(localtime(0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
+// localtime: year element is 1970 (UTC+0 to UTC+14 all land on 1970-01-01 for ts=0; UTC-12 still 1969 so we check >=1969)
+#[case::localtime_year_type("type(localtime(0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("array".to_string())].into()))]
+// strftime: format timestamp as date string (UTC)
+#[case::strftime_date("strftime(1704067200, \"%Y-%m-%d\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("2024-01-01".to_string())].into()))]
+#[case::strftime_datetime("strftime(0, \"%Y-%m-%dT%H:%M:%S\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("1970-01-01T00:00:00".to_string())].into()))]
+#[case::strftime_year("strftime(1704067200, \"%Y\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("2024".to_string())].into()))]
+// now | gmtime / strftime pipeline
+#[case::now_gmtime_len("now | gmtime | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
+#[case::now_strftime_len("now | strftime(\"%Y-%m-%d\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(10.into())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2662,6 +2662,24 @@ fn engine() -> DefaultEngine {
 // now | gmtime / strftime pipeline
 #[case::now_gmtime_len("now | gmtime | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
 #[case::now_strftime_len("now | strftime(\"%Y-%m-%d\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(10.into())].into()))]
+// date_add: add days → result is array of length 8
+#[case::date_add_days_len("gmtime(1704067200) | date_add(1, \"days\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
+// date_add: add days then mktime = original + 86400
+#[case::date_add_days_roundtrip("gmtime(1704067200) | date_add(1, \"days\") | mktime", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704153600_i64.into())].into()))]
+// date_add: add months calendar-aware (2024-01-31 + 1 month = 2024-02-29)
+#[case::date_add_month_clamp("gmtime(1706659200) | date_add(1, \"months\") | mktime", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1709164800_i64.into())].into()))]
+// date_add: add years calendar-aware (2024-02-29 + 1 year = 2025-02-28)
+#[case::date_add_year_clamp("gmtime(1709164800) | date_add(1, \"years\") | mktime", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1740700800_i64.into())].into()))]
+// date_add: pipeline now | gmtime | date_add returns array
+#[case::date_add_now_pipeline("now | gmtime | date_add(7, \"days\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
+// date_diff: 1 day apart
+#[case::date_diff_days("date_diff(gmtime(1704067200), gmtime(1704153600), \"days\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+// date_diff: 24 hours apart
+#[case::date_diff_hours("date_diff(gmtime(1704067200), gmtime(1704153600), \"hours\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(24.into())].into()))]
+// date_diff: negative (reversed order)
+#[case::date_diff_negative("date_diff(gmtime(1704153600), gmtime(1704067200), \"days\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number((-1_i64).into())].into()))]
+// date_diff: same → 0
+#[case::date_diff_zero("date_diff(gmtime(1704067200), gmtime(1704067200), \"seconds\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -10,6 +10,7 @@ name = "mq-run"
 readme = "../../README.md"
 repository = "https://github.com/harehare/mq"
 version = "0.5.29"
+default-run = "mq"
 
 [features]
 debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex-lite", "mq-dap"]


### PR DESCRIPTION
Add new built-in functions for date/time processing:
- gmtime(secs): Unix timestamp → UTC broken-down array
- localtime(secs): Unix timestamp → local broken-down array
- mktime(array): broken-down UTC array → Unix timestamp
- strftime(secs, fmt): Unix timestamp → formatted date string

Broken-down time array format (all four functions):
  [year, month(0-11), day, hour, minute, second, weekday(0=Sun), day-of-year(0-365)]

BREAKING CHANGE: `now` now returns seconds instead of milliseconds. `from_date` now returns seconds instead of milliseconds. `to_date` now accepts seconds instead of milliseconds. Callers must divide by 1000 to obtain milliseconds if needed.