### PR TITLE
Fix build error in mq-lang CBOR conversion

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2719,11 +2719,11 @@ fn runtime_number_to_cbor_value(n: number::Number) -> ciborium::Value {
     if n.is_int() {
         let number_string = n.to_string();
 
-        if let Ok(value) = number_string.parse::<i128>() {
+        if let Ok(value) = number_string.parse::<i64>() {
             return ciborium::Value::Integer(value.into());
         }
 
-        if let Ok(value) = number_string.parse::<u128>() {
+        if let Ok(value) = number_string.parse::<u64>() {
             return ciborium::Value::Integer(value.into());
         }
     }


### PR DESCRIPTION
Fixed build errors in `crates/mq-lang/src/eval/builtin.rs` by changing 128-bit integer parsing to 64-bit for CBOR conversion. The `ciborium` crate's `Integer` type doesn't support 128-bit integers via `From`/`Into`, and since the internal `Number` type is `f64`, 64-bit precision is appropriate. Verified the fix with `cargo build` and `cargo test`.

---
*PR created automatically by Jules for task [10635906690287658448](https://jules.google.com/task/10635906690287658448) started by @harehare*