### PR TITLE
🐛 fix(mq-run): output proper JSON for non-Markdown values with -F json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "rstest",
  "rustyline",
  "scopeguard",
+ "serde_json",
  "strum",
  "tabled",
  "which",

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -29,6 +29,7 @@ mq-lang = {workspace = true, features = ["file-io"]}
 mq-markdown = {workspace = true, features = ["json", "html-to-markdown", "color"]}
 mq-repl = {workspace = true}
 rayon = {workspace = true}
+serde_json = {workspace = true}
 regex-lite = {workspace = true, optional = true}
 rustyline = {workspace = true, optional = true, default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {workspace = true, features = ["derive"], optional = true}

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -853,16 +853,20 @@ impl Cli {
         }
     }
 
+    fn markdown_node_to_json_value(node: &mq_markdown::Node) -> miette::Result<serde_json::Value> {
+        let markdown_json = mq_markdown::Markdown::new(vec![node.clone()]).to_json();
+        serde_json::from_str(&markdown_json)
+            .map_err(|e| miette!("Failed to parse Markdown JSON output: {}", e))
+    }
+
     fn runtime_values_to_json(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
         let json_values: Vec<serde_json::Value> = runtime_values
             .iter()
             .map(|v| match v {
-                mq_lang::RuntimeValue::Markdown(node, _) => {
-                    serde_json::to_value(node.as_ref()).unwrap_or(serde_json::Value::Null)
-                }
-                _ => v.clone().to_json_value(),
+                mq_lang::RuntimeValue::Markdown(node, _) => Self::markdown_node_to_json_value(node.as_ref()),
+                _ => Ok(v.clone().to_json_value()),
             })
-            .collect();
+            .collect::<miette::Result<Vec<_>>>()?;
 
         // Markdown results are always wrapped in an array for consistent AST output.
         // A single non-Markdown value is output directly to avoid double-wrapping

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -853,34 +853,30 @@ impl Cli {
         }
     }
 
-    fn print(&self, runtime_values: mq_lang::RuntimeValues) -> miette::Result<()> {
-        let stdout = io::stdout();
-        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
-            let file = fs::File::create(output_file).into_diagnostic()?;
-            Box::new(BufWriter::new(file))
-        } else if self.output.unbuffered {
-            Box::new(stdout.lock())
-        } else {
-            Box::new(BufWriter::new(stdout.lock()))
-        };
-        let runtime_values = runtime_values.values();
-
-        if matches!(self.output.output_format, OutputFormat::Raw) {
-            for value in runtime_values {
-                match value {
-                    mq_lang::RuntimeValue::Bytes(b) => Self::write_ignore_pipe(&mut handle, b)?,
-                    _ => Self::write_ignore_pipe(&mut handle, value.to_string().as_bytes())?,
+    fn runtime_values_to_json(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
+        let json_values: Vec<serde_json::Value> = runtime_values
+            .iter()
+            .map(|v| match v {
+                mq_lang::RuntimeValue::Markdown(node, _) => {
+                    serde_json::to_value(node.as_ref()).unwrap_or(serde_json::Value::Null)
                 }
-            }
-            if !self.output.unbuffered
-                && let Err(e) = handle.flush()
-                && e.kind() != std::io::ErrorKind::BrokenPipe
-            {
-                return Err(miette!(e));
-            }
-            return Ok(());
-        }
+                _ => v.clone().to_json_value(),
+            })
+            .collect();
 
+        // Markdown results are always wrapped in an array for consistent AST output.
+        // A single non-Markdown value is output directly to avoid double-wrapping
+        // (e.g. a JSON array from json_parse() should not become [[...]]).
+        let output_value = match (runtime_values.len(), runtime_values.first()) {
+            (1, Some(mq_lang::RuntimeValue::Markdown(_, _))) => serde_json::Value::Array(json_values),
+            (1, _) => json_values.into_iter().next().unwrap_or(serde_json::Value::Null),
+            _ => serde_json::Value::Array(json_values),
+        };
+
+        serde_json::to_string_pretty(&output_value).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
+    }
+
+    fn build_markdown(&self, runtime_values: &[mq_lang::RuntimeValue]) -> mq_markdown::Markdown {
         let mut markdown =
             mq_markdown::Markdown::new(runtime_values.iter().flat_map(Self::runtime_value_to_nodes).collect());
         markdown.set_options(mq_markdown::RenderOptions {
@@ -899,21 +895,50 @@ impl Cli {
                 LinkUrlStyle::Angle => mq_markdown::UrlSurroundStyle::Angle,
             },
         });
+        markdown
+    }
+
+    fn print(&self, runtime_values: mq_lang::RuntimeValues) -> miette::Result<()> {
+        let stdout = io::stdout();
+        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
+            let file = fs::File::create(output_file).into_diagnostic()?;
+            Box::new(BufWriter::new(file))
+        } else if self.output.unbuffered {
+            Box::new(stdout.lock())
+        } else {
+            Box::new(BufWriter::new(stdout.lock()))
+        };
+        let runtime_values = runtime_values.values();
 
         match self.output.output_format {
-            OutputFormat::Html => Self::write_ignore_pipe(&mut handle, markdown.to_html().as_bytes())?,
+            OutputFormat::Raw => {
+                for value in runtime_values {
+                    match value {
+                        mq_lang::RuntimeValue::Bytes(b) => Self::write_ignore_pipe(&mut handle, b)?,
+                        _ => Self::write_ignore_pipe(&mut handle, value.to_string().as_bytes())?,
+                    }
+                }
+            }
+            OutputFormat::Json => {
+                let json_str = Self::runtime_values_to_json(runtime_values)?;
+                Self::write_ignore_pipe(&mut handle, json_str.as_bytes())?;
+            }
+            OutputFormat::Html => {
+                let markdown = self.build_markdown(runtime_values);
+                Self::write_ignore_pipe(&mut handle, markdown.to_html().as_bytes())?;
+            }
             OutputFormat::Text => {
+                let markdown = self.build_markdown(runtime_values);
                 Self::write_ignore_pipe(&mut handle, markdown.to_text().as_bytes())?;
             }
             OutputFormat::Markdown if self.output.color_output && !Self::is_no_color() => {
+                let markdown = self.build_markdown(runtime_values);
                 let theme = mq_markdown::ColorTheme::from_env();
                 Self::write_ignore_pipe(&mut handle, markdown.to_colored_string_with_theme(&theme).as_bytes())?;
             }
             OutputFormat::Markdown => {
+                let markdown = self.build_markdown(runtime_values);
                 Self::write_ignore_pipe(&mut handle, markdown.to_string().as_bytes())?;
-            }
-            OutputFormat::Json => {
-                Self::write_ignore_pipe(&mut handle, markdown.to_json()?.as_bytes())?;
             }
             OutputFormat::Table => {
                 let theme = (self.output.color_output && !Self::is_no_color()).then(mq_markdown::ColorTheme::from_env);
@@ -921,9 +946,9 @@ impl Cli {
                 Self::write_ignore_pipe(&mut handle, format!("{}\n", table).as_bytes())?;
             }
             OutputFormat::Grep => {
+                let markdown = self.build_markdown(runtime_values);
                 Self::write_ignore_pipe(&mut handle, markdown.to_string().as_bytes())?;
             }
-            OutputFormat::Raw => unreachable!(),
             OutputFormat::None => {}
         }
 
@@ -1387,9 +1412,9 @@ mod tests {
     }
 
     #[test]
-    fn test_output_format_json() {
-        let (_, temp_file_path) = create_file("test_json.md", "# Test");
-        let (_, output_file) = create_file("test_json_output.json", "");
+    fn test_output_format_json_markdown_input() {
+        let (_, temp_file_path) = create_file("test_json_md_input.md", "# Test");
+        let (_, output_file) = create_file("test_json_md_output.json", "");
         let temp_file_path_clone = temp_file_path.clone();
         let output_file_clone = output_file.clone();
 
@@ -1417,10 +1442,99 @@ mod tests {
 
         assert!(cli.run().is_ok());
         let output_content = fs::read_to_string(&output_file).expect("Failed to read output");
-        assert!(!output_content.is_empty(), "JSON output should not be empty");
+        let parsed: serde_json::Value = serde_json::from_str(&output_content).expect("Output should be valid JSON");
+        assert!(parsed.is_array(), "Markdown JSON output should be an array");
+        let nodes = parsed.as_array().unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0]["type"], "Heading", "Markdown heading should have type=Heading");
+    }
+
+    #[test]
+    fn test_output_format_json_with_json_object_input() {
+        let (_, temp_file_path) = create_file("test_json_obj_input.json", r#"{"id": 1, "name": "Alice"}"#);
+        let (_, output_file) = create_file("test_json_obj_output.json", "");
+        let temp_file_path_clone = temp_file_path.clone();
+        let output_file_clone = output_file.clone();
+
+        defer! {
+            if temp_file_path_clone.exists() {
+                std::fs::remove_file(&temp_file_path_clone).ok();
+            }
+            if output_file_clone.exists() {
+                std::fs::remove_file(&output_file_clone).ok();
+            }
+        }
+
+        let cli = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Json,
+                output_file: Some(output_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![temp_file_path]),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_ok());
+        let output_content = fs::read_to_string(&output_file).expect("Failed to read output");
+        let parsed: serde_json::Value = serde_json::from_str(&output_content).expect("Output should be valid JSON");
+        assert!(parsed.is_object(), "JSON object input should output a JSON object");
+        assert_eq!(parsed["id"], 1.0, "id field should be preserved");
+        assert_eq!(parsed["name"], "Alice", "name field should be preserved");
         assert!(
-            output_content.starts_with('{') || output_content.starts_with('['),
-            "JSON output should be valid JSON"
+            parsed.get("type").is_none(),
+            "Output should not contain Markdown AST 'type' field"
+        );
+    }
+
+    #[test]
+    fn test_output_format_json_with_json_array_input() {
+        let (_, temp_file_path) = create_file(
+            "test_json_arr_input.json",
+            r#"[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]"#,
+        );
+        let (_, output_file) = create_file("test_json_arr_output.json", "");
+        let temp_file_path_clone = temp_file_path.clone();
+        let output_file_clone = output_file.clone();
+
+        defer! {
+            if temp_file_path_clone.exists() {
+                std::fs::remove_file(&temp_file_path_clone).ok();
+            }
+            if output_file_clone.exists() {
+                std::fs::remove_file(&output_file_clone).ok();
+            }
+        }
+
+        let cli = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Json,
+                output_file: Some(output_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![temp_file_path]),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_ok());
+        let output_content = fs::read_to_string(&output_file).expect("Failed to read output");
+        let parsed: serde_json::Value = serde_json::from_str(&output_content).expect("Output should be valid JSON");
+        assert!(parsed.is_array(), "JSON array input should output a JSON array");
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "Array should have 2 elements");
+        assert_eq!(arr[0]["id"], 1.0);
+        assert_eq!(arr[0]["name"], "Alice");
+        assert_eq!(arr[1]["id"], 2.0);
+        assert_eq!(arr[1]["name"], "Bob");
+        assert!(
+            arr[0].get("type").is_none(),
+            "Output should not contain Markdown AST fields"
         );
     }
 

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -854,19 +854,34 @@ impl Cli {
     }
 
     fn runtime_values_to_json(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
-        let json_values: Vec<serde_json::Value> = runtime_values
+        let filtered: Vec<&mq_lang::RuntimeValue> = runtime_values
             .iter()
-            .filter_map(|v| match v {
-                mq_lang::RuntimeValue::Markdown(node, _) if node.is_empty() || node.is_empty_fragment() => None,
-                mq_lang::RuntimeValue::Markdown(node, _) => {
-                    Some(serde_json::to_value(node.as_ref()).unwrap_or(serde_json::Value::Null))
-                }
-                _ => Some(v.clone().to_json_value()),
+            .filter(|v| match v {
+                mq_lang::RuntimeValue::Markdown(node, _) => !node.is_empty() && !node.is_empty_fragment(),
+                _ => true,
             })
             .collect();
 
-        serde_json::to_string_pretty(&serde_json::Value::Array(json_values))
-            .map_err(|e| miette!("Failed to serialize to JSON: {}", e))
+        let all_markdown = filtered
+            .iter()
+            .all(|v| matches!(v, mq_lang::RuntimeValue::Markdown(_, _)));
+
+        let result = if !all_markdown && filtered.len() == 1 {
+            filtered[0].clone().to_json_value()
+        } else {
+            let json_values: Vec<serde_json::Value> = filtered
+                .iter()
+                .map(|v| match v {
+                    mq_lang::RuntimeValue::Markdown(node, _) => {
+                        serde_json::to_value(node.as_ref()).unwrap_or(serde_json::Value::Null)
+                    }
+                    _ => (*v).clone().to_json_value(),
+                })
+                .collect();
+            serde_json::Value::Array(json_values)
+        };
+
+        serde_json::to_string_pretty(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
     }
 
     fn build_markdown(&self, runtime_values: &[mq_lang::RuntimeValue]) -> mq_markdown::Markdown {

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -853,31 +853,20 @@ impl Cli {
         }
     }
 
-    fn markdown_node_to_json_value(node: &mq_markdown::Node) -> miette::Result<serde_json::Value> {
-        let markdown_json = mq_markdown::Markdown::new(vec![node.clone()]).to_json();
-        serde_json::from_str(&markdown_json)
-            .map_err(|e| miette!("Failed to parse Markdown JSON output: {}", e))
-    }
-
     fn runtime_values_to_json(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
         let json_values: Vec<serde_json::Value> = runtime_values
             .iter()
-            .map(|v| match v {
-                mq_lang::RuntimeValue::Markdown(node, _) => Self::markdown_node_to_json_value(node.as_ref()),
-                _ => Ok(v.clone().to_json_value()),
+            .filter_map(|v| match v {
+                mq_lang::RuntimeValue::Markdown(node, _) if node.is_empty() || node.is_empty_fragment() => None,
+                mq_lang::RuntimeValue::Markdown(node, _) => {
+                    Some(serde_json::to_value(node.as_ref()).unwrap_or(serde_json::Value::Null))
+                }
+                _ => Some(v.clone().to_json_value()),
             })
-            .collect::<miette::Result<Vec<_>>>()?;
+            .collect();
 
-        // Markdown results are always wrapped in an array for consistent AST output.
-        // A single non-Markdown value is output directly to avoid double-wrapping
-        // (e.g. a JSON array from json_parse() should not become [[...]]).
-        let output_value = match (runtime_values.len(), runtime_values.first()) {
-            (1, Some(mq_lang::RuntimeValue::Markdown(_, _))) => serde_json::Value::Array(json_values),
-            (1, _) => json_values.into_iter().next().unwrap_or(serde_json::Value::Null),
-            _ => serde_json::Value::Array(json_values),
-        };
-
-        serde_json::to_string_pretty(&output_value).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
+        serde_json::to_string_pretty(&serde_json::Value::Array(json_values))
+            .map_err(|e| miette!("Failed to serialize to JSON: {}", e))
     }
 
     fn build_markdown(&self, runtime_values: &[mq_lang::RuntimeValue]) -> mq_markdown::Markdown {


### PR DESCRIPTION
Non-Markdown runtime values (Dict, Array, etc.) from json_parse() were being converted to Markdown text nodes and serialized as Markdown AST structure ({"type": "Text", "value": "...", "position": null}) instead of proper JSON.

Fix: in -F json mode, Markdown nodes are still wrapped in an array as Markdown AST JSON, while non-Markdown values are serialized directly via to_json_value(). A single non-Markdown value is output directly to avoid double-wrapping (e.g. a JSON array from json_parse() does not become [[...]]).

Also refactor print() into a single match expression using helper functions:
- runtime_values_to_json(): encapsulates JSON serialization logic
- build_markdown(): constructs and configures the Markdown struct

Add tests for JSON output with Markdown input, JSON object input, and JSON array input.