### PR TITLE
✨ feat(lang): add zip builtin function

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -772,3 +772,19 @@ def ngram(s, n):
     end
 end
 
+# Combines two arrays into an array of pairs, where each pair contains elements from the same index in both arrays.
+def zip(arr1, arr2):
+  if (not(is_array(arr1)) || not(is_array(arr2))):
+    error("arguments must be arrays")
+  else:
+    do
+      var result = []
+      | var i = 0
+      | while (i < len(arr1) && i < len(arr2)):
+          result += [[arr1[i], arr2[i]]]
+          | i += 1
+        end
+      | result
+    end
+end
+

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -754,3 +754,13 @@ def test_ngram():
   | assert_eq(result3, [])
 end
 
+def test_zip():
+  let result1 = zip([1, 2, 3], ["a", "b", "c"])
+  | assert_eq(result1, [[1, "a"], [2, "b"], [3, "c"]])
+
+  | let result2 = zip([1, 2], ["x", "y", "z"])
+  | assert_eq(result2, [[1, "x"], [2, "y"]])
+
+  | let result3 = zip([], ["a", "b"])
+  | assert_eq(result3, [])
+end


### PR DESCRIPTION
Adds `zip(arr1, arr2)` that combines two arrays into an array of pairs, truncating to the shorter array's length. Includes tests for equal-length, unequal-length, and empty array cases.