### PR TITLE
✨ feat(mq-lang): add path manipulation builtin functions

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1,6 +1,7 @@
-pub mod bytes;
-pub mod convert;
-pub mod date;
+pub(super) mod bytes;
+pub(super) mod convert;
+pub(super) mod date;
+pub(super) mod path;
 mod range;
 mod regex;
 
@@ -3460,6 +3461,56 @@ fn _diff_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Res
     }
 }
 
+#[mq_macros::mq_fn(name = "basename", params = Fixed(1))]
+fn basename_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::String(path::basename(s))),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("basename should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "dirname", params = Fixed(1))]
+fn dirname_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::String(path::dirname(s))),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("dirname should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "extname", params = Fixed(1))]
+fn extname_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::String(path::extname(s))),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("extname should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "stem", params = Fixed(1))]
+fn stem_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::String(path::stem(s))),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("stem should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "path_join", params = Fixed(2))]
+fn path_join_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(base), RuntimeValue::String(component)] => {
+            path::path_join(base, component).map(RuntimeValue::String)
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("path_join should always receive exactly two arguments"),
+    }
+}
+
 #[cfg(feature = "file-io")]
 #[mq_macros::mq_fn(name = "read_file", params = Fixed(1))]
 fn read_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
@@ -3652,6 +3703,11 @@ mq_macros::builtin_dispatch! {
     SHIFT_LEFT,
     SHIFT_RIGHT,
     _DIFF,
+    BASENAME,
+    DIRNAME,
+    EXTNAME,
+    STEM,
+    PATH_JOIN,
     #[cfg(feature = "file-io")]
     READ_FILE,
 }
@@ -5046,6 +5102,41 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Reads the contents of a file at the given path and returns it as a string.",
             params: &["path"],
+        },
+    );
+    map.insert(
+        SmolStr::new("basename"),
+        BuiltinFunctionDoc {
+            description: "Returns the final component of a path string (e.g. \"file.txt\" from \"/a/b/file.txt\").",
+            params: &["path"],
+        },
+    );
+    map.insert(
+        SmolStr::new("dirname"),
+        BuiltinFunctionDoc {
+            description: "Returns the parent directory of a path string (e.g. \"/a/b\" from \"/a/b/file.txt\"). Returns \".\" if the path has no parent.",
+            params: &["path"],
+        },
+    );
+    map.insert(
+        SmolStr::new("extname"),
+        BuiltinFunctionDoc {
+            description: "Returns the extension of a file path including the leading dot (e.g. \".txt\" from \"file.txt\"). Returns an empty string if there is no extension.",
+            params: &["path"],
+        },
+    );
+    map.insert(
+        SmolStr::new("stem"),
+        BuiltinFunctionDoc {
+            description: "Returns the file name without the extension (e.g. \"file\" from \"/a/b/file.txt\").",
+            params: &["path"],
+        },
+    );
+    map.insert(
+        SmolStr::new("path_join"),
+        BuiltinFunctionDoc {
+            description: "Joins a base path with a component path and returns the resulting path string (e.g. path_join(\"/a/b\", \"c.txt\") → \"/a/b/c.txt\").",
+            params: &["base", "component"],
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/bytes.rs
+++ b/crates/mq-lang/src/eval/builtin/bytes.rs
@@ -3,7 +3,7 @@ use crate::eval::runtime_value::RuntimeValue;
 
 /// Supported binary packing formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PackFormat {
+pub(super) enum PackFormat {
     U8,
     I8,
     U16Be,
@@ -139,12 +139,12 @@ impl PackFormat {
 }
 
 /// Public helpers called from `builtin.rs`.
-pub fn pack_number(fmt: &str, value: f64) -> Result<RuntimeValue, Error> {
+pub(super) fn pack_number(fmt: &str, value: f64) -> Result<RuntimeValue, Error> {
     let fmt: PackFormat = fmt.try_into()?;
     Ok(fmt.pack(value))
 }
 
-pub fn unpack_bytes(fmt: &str, bytes: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn unpack_bytes(fmt: &str, bytes: &[u8]) -> Result<RuntimeValue, Error> {
     let fmt: PackFormat = fmt.try_into()?;
     fmt.unpack(bytes)
 }

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -7,7 +7,7 @@ use sha2::Digest;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ConvertKind {
+pub(super) enum ConvertKind {
     Blockquote,
     Heading(u8),
     HorizontalRule,
@@ -18,7 +18,7 @@ pub(crate) enum ConvertKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Convert {
+pub(super) enum Convert {
     Base64,
     Html,
     Markdown(ConvertKind),
@@ -235,7 +235,7 @@ impl Convert {
 
 /// convert to HTML
 #[inline(always)]
-pub fn to_html(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
+pub(super) fn to_html(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         RuntimeValue::None => Ok(RuntimeValue::NONE),
         RuntimeValue::String(s) => Ok(mq_markdown::to_html(s).into()),
@@ -246,7 +246,7 @@ pub fn to_html(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
 }
 
 /// convert to Markdown string
-pub fn to_markdown_string(args: Vec<RuntimeValue>) -> Result<RuntimeValue, Error> {
+pub(super) fn to_markdown_string(args: Vec<RuntimeValue>) -> Result<RuntimeValue, Error> {
     let args = flatten(args);
 
     Ok(mq_markdown::Markdown::new(
@@ -262,7 +262,7 @@ pub fn to_markdown_string(args: Vec<RuntimeValue>) -> Result<RuntimeValue, Error
 }
 
 /// convert to string
-pub fn to_string(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
+pub(super) fn to_string(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         RuntimeValue::Symbol(s) => Ok(s.as_str().into()),
         o => Ok(o.to_string().into()),
@@ -270,7 +270,7 @@ pub fn to_string(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
 }
 
 /// convert to number
-pub fn to_number(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
+pub(super) fn to_number(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         node @ RuntimeValue::Markdown(_, _) => node
             .markdown_node()
@@ -318,7 +318,7 @@ pub fn to_number(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
 }
 
 /// convert to array
-pub fn to_array(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
+pub(super) fn to_array(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         RuntimeValue::Array(array) => Ok(RuntimeValue::Array(std::mem::take(array))),
         RuntimeValue::String(s) => Ok(RuntimeValue::Array(
@@ -333,7 +333,7 @@ pub fn to_array(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
 }
 
 /// convert to text
-pub fn to_text(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
+pub(super) fn to_text(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         RuntimeValue::None => Ok(RuntimeValue::NONE),
         RuntimeValue::Markdown(node_value, _) => Ok(node_value.value().into()),
@@ -349,7 +349,7 @@ pub fn to_text(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
 
 /// convert from date string to Unix timestamp (seconds)
 #[inline(always)]
-pub fn from_date(date_str: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn from_date(date_str: &str) -> Result<RuntimeValue, Error> {
     match chrono::DateTime::parse_from_rfc3339(date_str) {
         Ok(datetime) => Ok(RuntimeValue::Number(datetime.timestamp().into())),
         Err(e) => Err(Error::Runtime(format!("{}", e))),
@@ -358,7 +358,7 @@ pub fn from_date(date_str: &str) -> Result<RuntimeValue, Error> {
 
 /// convert from Unix timestamp (seconds) to date string
 #[inline(always)]
-pub fn to_date(secs: Number, convert: Option<&str>) -> Result<RuntimeValue, Error> {
+pub(super) fn to_date(secs: Number, convert: Option<&str>) -> Result<RuntimeValue, Error> {
     chrono::DateTime::from_timestamp(secs.value() as i64, 0)
         .map(|dt| {
             convert
@@ -371,13 +371,13 @@ pub fn to_date(secs: Number, convert: Option<&str>) -> Result<RuntimeValue, Erro
 
 /// Encode to base64
 #[inline(always)]
-pub fn base64(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn base64(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(BASE64_STANDARD.encode(input)))
 }
 
 /// Encode to base64 from raw bytes
 #[inline(always)]
-pub fn base64_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn base64_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(
         base64::engine::general_purpose::STANDARD.encode(input),
     ))
@@ -385,7 +385,7 @@ pub fn base64_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
 
 /// Decode from base64
 #[inline(always)]
-pub fn base64d(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn base64d(input: &str) -> Result<RuntimeValue, Error> {
     BASE64_STANDARD
         .decode(input)
         .map_err(Error::InvalidBase64String)
@@ -394,13 +394,13 @@ pub fn base64d(input: &str) -> Result<RuntimeValue, Error> {
 
 /// Encode to base64url
 #[inline(always)]
-pub fn base64url(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn base64url(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(BASE64_URL_SAFE_NO_PAD.encode(input)))
 }
 
 /// Decode from base64url
 #[inline(always)]
-pub fn base64urld(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn base64urld(input: &str) -> Result<RuntimeValue, Error> {
     BASE64_URL_SAFE_NO_PAD
         .decode(input)
         .map_err(Error::InvalidBase64String)
@@ -409,7 +409,7 @@ pub fn base64urld(input: &str) -> Result<RuntimeValue, Error> {
 
 /// URL encode
 #[inline(always)]
-pub fn url_encode(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn url_encode(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(
         utf8_percent_encode(input, NON_ALPHANUMERIC).to_string(),
     ))
@@ -417,7 +417,7 @@ pub fn url_encode(input: &str) -> Result<RuntimeValue, Error> {
 
 /// URL decode
 #[inline(always)]
-pub fn url_decode(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn url_decode(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(
         percent_decode(input.as_bytes()).decode_utf8_lossy().to_string(),
     ))
@@ -429,49 +429,49 @@ pub fn url_decode(input: &str) -> Result<RuntimeValue, Error> {
 /// purposes. It is suitable for non-cryptographic use cases such as content
 /// fingerprinting and cache keys.
 #[inline(always)]
-pub fn md5(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn md5(input: &str) -> Result<RuntimeValue, Error> {
     let digest = md5::compute(input.as_bytes());
     Ok(RuntimeValue::String(bytes_to_hex(&digest.0)))
 }
 
 /// Compute MD5 hash of raw bytes and return lowercase hex string.
 #[inline(always)]
-pub fn md5_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn md5_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
     let digest = md5::compute(input);
     Ok(RuntimeValue::String(bytes_to_hex(&digest.0)))
 }
 
 /// Compute SHA-256 hash and return lowercase hex string.
 #[inline(always)]
-pub fn sha256(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn sha256(input: &str) -> Result<RuntimeValue, Error> {
     let hash = sha2::Sha256::digest(input.as_bytes());
     Ok(RuntimeValue::String(bytes_to_hex(hash.as_slice())))
 }
 
 /// Compute SHA-256 hash of raw bytes and return lowercase hex string.
 #[inline(always)]
-pub fn sha256_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn sha256_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
     let hash = sha2::Sha256::digest(input);
     Ok(RuntimeValue::String(bytes_to_hex(hash.as_slice())))
 }
 
 /// Compute SHA-512 hash and return lowercase hex string.
 #[inline(always)]
-pub fn sha512(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn sha512(input: &str) -> Result<RuntimeValue, Error> {
     let hash = sha2::Sha512::digest(input.as_bytes());
     Ok(RuntimeValue::String(bytes_to_hex(hash.as_slice())))
 }
 
 /// Compute SHA-512 hash of raw bytes and return lowercase hex string.
 #[inline(always)]
-pub fn sha512_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn sha512_bytes(input: &[u8]) -> Result<RuntimeValue, Error> {
     let hash = sha2::Sha512::digest(input);
     Ok(RuntimeValue::String(bytes_to_hex(hash.as_slice())))
 }
 
 /// Parse a lowercase or uppercase hex string into raw bytes.
 #[inline(always)]
-pub fn from_hex(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn from_hex(input: &str) -> Result<RuntimeValue, Error> {
     if !input.len().is_multiple_of(2) {
         return Err(Error::Runtime(format!(
             "from_hex: odd-length hex string: \"{}\"",
@@ -492,7 +492,7 @@ pub fn from_hex(input: &str) -> Result<RuntimeValue, Error> {
 
 /// Decode bytes as a UTF-8 string, returning an error if the bytes are not valid UTF-8.
 #[inline(always)]
-pub fn utf8(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn utf8(input: &[u8]) -> Result<RuntimeValue, Error> {
     String::from_utf8(input.to_vec())
         .map(RuntimeValue::String)
         .map_err(|e| Error::Runtime(format!("utf8: {}", e)))
@@ -500,7 +500,7 @@ pub fn utf8(input: &[u8]) -> Result<RuntimeValue, Error> {
 
 /// Encode raw bytes as a lowercase hex string.
 #[inline(always)]
-pub fn to_hex(input: &[u8]) -> Result<RuntimeValue, Error> {
+pub(super) fn to_hex(input: &[u8]) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(bytes_to_hex(input)))
 }
 
@@ -515,7 +515,7 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
 
 /// Shell escape for safe use in shell commands
 #[inline(always)]
-pub fn shell_escape(input: &str) -> Result<RuntimeValue, Error> {
+pub(super) fn shell_escape(input: &str) -> Result<RuntimeValue, Error> {
     // If the string is empty, return empty quotes
     if input.is_empty() {
         return Ok(RuntimeValue::String("''".to_string()));
@@ -540,7 +540,7 @@ pub fn shell_escape(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(format!("'{}'", escaped)))
 }
 
-pub fn flatten(args: Vec<RuntimeValue>) -> Vec<RuntimeValue> {
+pub(super) fn flatten(args: Vec<RuntimeValue>) -> Vec<RuntimeValue> {
     let mut result = Vec::new();
     for arg in args {
         match arg {

--- a/crates/mq-lang/src/eval/builtin/date.rs
+++ b/crates/mq-lang/src/eval/builtin/date.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Duration, Months, Utc};
 
 /// Date/time units used by `date_add` and `date_diff`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DateUnit {
+pub(super) enum DateUnit {
     Seconds,
     Minutes,
     Hours,
@@ -80,14 +80,14 @@ impl DateUnit {
 }
 
 /// Public helper called from `builtin.rs` for `date_add`.
-pub fn add(dt: DateTime<Utc>, amount: i64, unit: &str) -> Result<DateTime<Utc>, Error> {
+pub(super) fn add(dt: DateTime<Utc>, amount: i64, unit: &str) -> Result<DateTime<Utc>, Error> {
     let unit = DateUnit::try_from(unit)?;
     unit.apply_add(dt, amount)
         .ok_or_else(|| Error::Runtime("date_add: arithmetic overflow or invalid date".to_string()))
 }
 
 /// Public helper called from `builtin.rs` for `date_diff`.
-pub fn diff(diff: Duration, unit: &str) -> Result<i64, Error> {
+pub(super) fn diff(diff: Duration, unit: &str) -> Result<i64, Error> {
     let unit = DateUnit::try_from(unit)?;
     unit.apply_diff(diff)
 }

--- a/crates/mq-lang/src/eval/builtin/path.rs
+++ b/crates/mq-lang/src/eval/builtin/path.rs
@@ -1,0 +1,104 @@
+use std::path::Path;
+
+use super::Error;
+
+/// Returns the final component of a path string, or the empty string if the path ends with a separator.
+pub(super) fn basename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Returns the parent directory of a path string, or "." if the path has no parent.
+pub(super) fn dirname(path: &str) -> String {
+    Path::new(path)
+        .parent()
+        .map(|p| {
+            let s = p.to_string_lossy();
+            if s.is_empty() { ".".to_owned() } else { s.into_owned() }
+        })
+        .unwrap_or_else(|| ".".to_owned())
+}
+
+/// Returns the extension of the file name, including the leading dot (e.g. `".txt"`).
+/// Returns an empty string if there is no extension.
+pub(super) fn extname(path: &str) -> String {
+    Path::new(path)
+        .extension()
+        .map(|s| format!(".{}", s.to_string_lossy()))
+        .unwrap_or_default()
+}
+
+/// Returns the file name without the extension.
+/// Returns an empty string if the path has no file name component.
+pub(super) fn stem(path: &str) -> String {
+    Path::new(path)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Joins a base path with a component path, returning the resulting path string.
+pub(super) fn path_join(base: &str, component: &str) -> Result<String, Error> {
+    let joined = Path::new(base).join(component);
+    joined
+        .to_str()
+        .map(|s| s.to_owned())
+        .ok_or_else(|| Error::Runtime("path_join: resulting path is not valid UTF-8".to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("/path/to/file.txt", "file.txt")]
+    #[case("/path/to/dir/", "dir")]
+    #[case("file.txt", "file.txt")]
+    #[case("/", "")]
+    #[case(".", "")]
+    fn test_basename(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(basename(input), expected);
+    }
+
+    #[rstest]
+    #[case("/path/to/file.txt", "/path/to")]
+    #[case("/path/to/dir/", "/path/to")]
+    #[case("file.txt", ".")]
+    #[case("/file.txt", "/")]
+    #[case(".", ".")]
+    fn test_dirname(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(dirname(input), expected);
+    }
+
+    #[rstest]
+    #[case("/path/to/file.txt", ".txt")]
+    #[case("/path/to/file.tar.gz", ".gz")]
+    #[case("/path/to/file", "")]
+    #[case("file.txt", ".txt")]
+    #[case(".hidden", "")]
+    fn test_extname(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(extname(input), expected);
+    }
+
+    #[rstest]
+    #[case("/path/to/file.txt", "file")]
+    #[case("/path/to/file.tar.gz", "file.tar")]
+    #[case("/path/to/file", "file")]
+    #[case("file.txt", "file")]
+    #[case(".hidden", ".hidden")]
+    fn test_stem(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(stem(input), expected);
+    }
+
+    #[rstest]
+    #[case("/path/to", "file.txt", "/path/to/file.txt")]
+    #[case("/path/to/", "file.txt", "/path/to/file.txt")]
+    #[case(".", "file.txt", "./file.txt")]
+    #[case("/a", "b/c", "/a/b/c")]
+    fn test_path_join(#[case] base: &str, #[case] component: &str, #[case] expected: &str) {
+        assert_eq!(path_join(base, component).unwrap(), expected);
+    }
+}


### PR DESCRIPTION
Add basename, dirname, extname, stem, path_join builtins to mq-lang, implemented in a new eval/builtin/path module.

Also restrict visibility of builtin submodule declarations and their items from pub/pub(crate) to pub(super), since they are only used within builtin.rs.