### PR TITLE
✨ feat(mq-lang): add `value as name` variable binding syntax

### DIFF
--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -277,6 +277,9 @@ impl Formatter {
             mq_lang::CstNodeKind::InterpolatedString => {
                 self.append_interpolated_string(&node, indent_level_consider_new_line);
             }
+            mq_lang::CstNodeKind::As => {
+                self.format_as_binding(&node, indent_level_consider_new_line);
+            }
             mq_lang::CstNodeKind::Let | mq_lang::CstNodeKind::Var => {
                 self.format_var_decl(&node, indent_level_consider_new_line, indent_level)
             }
@@ -715,6 +718,20 @@ impl Formatter {
 
             self.format_node(mq_lang::Shared::clone(child), indent_level);
         });
+    }
+
+    fn format_as_binding(&mut self, node: &mq_lang::Shared<mq_lang::CstNode>, indent_level: usize) {
+        if let Some(expr) = node.children.first() {
+            self.format_node(mq_lang::Shared::clone(expr), indent_level);
+        }
+        if !self.output.ends_with(' ') {
+            self.append_space();
+        }
+        self.output.push_str("as");
+        self.append_space();
+        if let Some(name) = node.children.get(1) {
+            self.format_node(mq_lang::Shared::clone(name), indent_level);
+        }
     }
 
     fn format_quote(&mut self, node: &mq_lang::Shared<mq_lang::CstNode>, indent_level: usize) {
@@ -2833,6 +2850,9 @@ end
     #[case::bytes_literal_hex(r#"b"\xf0\x9f\x99\x82""#, r#"b"\xf0\x9f\x99\x82""#)]
     #[case::bytes_literal_with_pipe(r#"b"abc"  |  len"#, r#"b"abc" | len"#)]
     #[case::bytes_literal_in_call(r#"len(b"abc")"#, r#"len(b"abc")"#)]
+    #[case::as_binding_basic("42 as x | x", "42 as x | x")]
+    #[case::as_binding_spaces("42  as  x  |  x", "42 as x | x")]
+    #[case::as_binding_selector(".text as title | title", ".text as title | title")]
     fn test_format(#[case] code: &str, #[case] expected: &str) {
         let result = Formatter::new(None).format(code);
         assert_eq!(result.unwrap(), expected);

--- a/crates/mq-hir/src/hir/lower.rs
+++ b/crates/mq-hir/src/hir/lower.rs
@@ -163,6 +163,9 @@ impl Hir {
             mq_lang::CstNodeKind::InterpolatedString => {
                 self.add_interpolated_string(node, source_id, scope_id, parent);
             }
+            mq_lang::CstNodeKind::As => {
+                self.add_as_binding(node, source_id, scope_id, parent);
+            }
             mq_lang::CstNodeKind::Let | mq_lang::CstNodeKind::Var => {
                 self.add_var_decl(node, source_id, scope_id, parent);
             }
@@ -624,6 +627,44 @@ impl Hir {
                 children.iter().skip(1).for_each(|child| {
                     self.add_expr(child, source_id, scope_id, Some(symbol_id));
                 });
+            }
+        }
+    }
+
+    fn add_as_binding(
+        &mut self,
+        node: &mq_lang::Shared<mq_lang::CstNode>,
+        source_id: SourceId,
+        scope_id: ScopeId,
+        parent: Option<SymbolId>,
+    ) {
+        if matches!(node.kind, mq_lang::CstNodeKind::As) {
+            let _keyword_id = self.insert_symbol(Symbol {
+                value: node.name(),
+                kind: SymbolKind::Keyword,
+                source: SourceInfo::new(Some(source_id), Some(node.range())),
+                scope: scope_id,
+                doc: node.comments(),
+                parent,
+                insertion_order: 0,
+            });
+
+            let children = node.children_without_token();
+            // children[0] is the expression being bound, children[1] is the binding name
+            if let Some(name_node) = children.get(1) {
+                let symbol_id = self.insert_symbol(Symbol {
+                    value: name_node.name(),
+                    kind: SymbolKind::Variable,
+                    source: SourceInfo::new(Some(source_id), Some(name_node.range())),
+                    scope: scope_id,
+                    doc: node.comments(),
+                    parent,
+                    insertion_order: 0,
+                });
+
+                if let Some(expr_node) = children.first() {
+                    self.add_expr(expr_node, source_id, scope_id, Some(symbol_id));
+                }
             }
         }
     }

--- a/crates/mq-lang/src/ast/code.rs
+++ b/crates/mq-lang/src/ast/code.rs
@@ -77,6 +77,10 @@ impl Node {
                 format_args(args, buf, indent);
                 buf.push(')');
             }
+            Expr::As(ident, value) => {
+                value.format_to_code(buf, indent);
+                write!(buf, " as {}", ident).unwrap();
+            }
             Expr::Let(pattern, value) => {
                 buf.push_str("let ");
                 format_pattern(pattern, buf);

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -133,7 +133,8 @@ impl Node {
                 let end = block.range(arena).end;
                 Range { start, end }
             }
-            Expr::Let(_, node)
+            Expr::As(_, node)
+            | Expr::Let(_, node)
             | Expr::Var(_, node)
             | Expr::Assign(_, node)
             | Expr::Quote(node)
@@ -332,6 +333,7 @@ impl Display for Literal {
 #[cfg_attr(feature = "ast-json", derive(Serialize, Deserialize))]
 #[derive(PartialEq, PartialOrd, Debug, Clone)]
 pub enum Expr {
+    As(IdentWithToken, Shared<Node>),
     Block(Program),
     Call(IdentWithToken, Args),
     CallDynamic(Shared<Node>, Args),

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -370,7 +370,36 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
 
     fn parse_equality_expr(&mut self, initial_token: &Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
         let lhs = self.parse_primary_expr(initial_token)?;
-        Self::parse_binary_op(self, 0, lhs) // Start from precedence 0 to include assignment
+        let lhs = Self::parse_binary_op(self, 0, lhs)?;
+
+        if let Some(token) = self.tokens.peek()
+            && matches!(token.kind, TokenKind::As)
+        {
+            return self.parse_as_binding(lhs);
+        }
+
+        Ok(lhs)
+    }
+
+    fn parse_as_binding(&mut self, expr: Shared<Node>) -> Result<Shared<Node>, SyntaxError> {
+        let as_token = self.tokens.next().unwrap();
+        let as_token_id = self.token_arena.alloc(Shared::clone(as_token));
+
+        let name_token = match self.tokens.next() {
+            Some(token) => token,
+            None => return Err(SyntaxError::UnexpectedEOFDetected(self.module_id)),
+        };
+
+        match &name_token.kind {
+            TokenKind::Ident(name) => {
+                let ident = IdentWithToken::new_with_token(name, Some(Shared::clone(name_token)));
+                Ok(Shared::new(Node {
+                    token_id: as_token_id,
+                    expr: Shared::new(Expr::As(ident, expr)),
+                }))
+            }
+            _ => Err(SyntaxError::UnexpectedToken((**name_token).clone())),
+        }
     }
 
     fn parse_primary_expr(&mut self, token: &Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
@@ -929,6 +958,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         matches!(
             token_kind,
             Some(TokenKind::And)
+                | Some(TokenKind::As)
                 | Some(TokenKind::Asterisk)
                 | Some(TokenKind::Catch)
                 | Some(TokenKind::Colon)
@@ -8622,6 +8652,42 @@ mod tests {
             };
             assert_eq!(actual, sel);
         }
+    }
+
+    #[test]
+    fn test_parse_as_binding() {
+        let mut arena = Arena::new(10);
+        let tokens = [
+            Shared::new(Token {
+                range: Range::default(),
+                kind: TokenKind::NumberLiteral(42.into()),
+                module_id: 1.into(),
+            }),
+            Shared::new(Token {
+                range: Range::default(),
+                kind: TokenKind::As,
+                module_id: 1.into(),
+            }),
+            Shared::new(Token {
+                range: Range::default(),
+                kind: TokenKind::Ident("x".into()),
+                module_id: 1.into(),
+            }),
+            Shared::new(Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: 1.into(),
+            }),
+        ];
+        let result = Parser::new(tokens.iter(), &mut arena, Module::TOP_LEVEL_MODULE_ID).parse();
+        assert!(result.is_ok());
+        let program = result.unwrap();
+        assert_eq!(program.len(), 1);
+        let Expr::As(ident, inner) = &*program[0].expr else {
+            panic!("expected Expr::As, got {:?}", program[0].expr);
+        };
+        assert_eq!(ident.name.as_str(), "x");
+        assert!(matches!(*inner.expr, Expr::Literal(Literal::Number(_))));
     }
 
     #[test]

--- a/crates/mq-lang/src/cst/node.rs
+++ b/crates/mq-lang/src/cst/node.rs
@@ -75,6 +75,7 @@ pub struct Node {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum NodeKind {
     Array,
+    As,
     Assign,
     BinaryOp(BinaryOp),
     Block,

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -396,6 +396,30 @@ impl<'a> Parser<'a> {
             lhs = Shared::new(op);
         }
 
+        if self.try_next_token(|kind| matches!(kind, TokenKind::As)) {
+            let as_leading_trivia = self.parse_leading_trivia();
+            let as_token = self.advance().unwrap();
+            let as_trailing_trivia = self.parse_trailing_trivia();
+
+            let name_leading_trivia = self.parse_leading_trivia();
+            let name_node = match self.peek().map(|t| &t.kind) {
+                Some(TokenKind::Ident(_)) => self.parse_ident(name_leading_trivia)?,
+                Some(_) => {
+                    return Err(ParseError::UnexpectedToken(Shared::clone(self.peek().unwrap())));
+                }
+                None => return Err(ParseError::UnexpectedEOFDetected),
+            };
+
+            let as_node = Node {
+                kind: NodeKind::As,
+                token: Some(Shared::clone(as_token)),
+                leading_trivia: as_leading_trivia,
+                trailing_trivia: as_trailing_trivia,
+                children: vec![lhs, name_node],
+            };
+            return Ok(Shared::new(as_node));
+        }
+
         Ok(lhs)
     }
 

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1081,6 +1081,11 @@ impl<T: ModuleResolver> Evaluator<T> {
                 program.clone(),
                 Shared::clone(env),
             )),
+            ast::Expr::As(ident, node) => {
+                let val = self.eval_expr(runtime_value, node, env)?;
+                define(env, ident.name, val);
+                Ok(runtime_value.clone())
+            }
             ast::Expr::Let(pattern, node) => {
                 let val = self.eval_expr(runtime_value, node, env)?;
                 if let Pattern::Ident(ident) = pattern {

--- a/crates/mq-lang/src/lexer.rs
+++ b/crates/mq-lang/src/lexer.rs
@@ -636,6 +636,7 @@ fn ident_or_keyword(input: Span) -> IResult<Span, Token> {
 
     if at_word_boundary {
         let keyword_kind = match base_frag {
+            "as" => Some(TokenKind::As),
             "break" => Some(TokenKind::Break),
             "catch" => Some(TokenKind::Catch),
             "continue" => Some(TokenKind::Continue),

--- a/crates/mq-lang/src/lexer/token.rs
+++ b/crates/mq-lang/src/lexer/token.rs
@@ -47,6 +47,7 @@ pub struct Token {
 pub enum TokenKind {
     And,
     Arrow,
+    As,
     Convert,
     Asterisk,
     BoolLiteral(bool),
@@ -159,6 +160,7 @@ impl Display for TokenKind {
         match &self {
             TokenKind::And => write!(f, "&&"),
             TokenKind::Arrow => write!(f, "->"),
+            TokenKind::As => write!(f, "as"),
             TokenKind::Convert => write!(f, "@"),
             TokenKind::Or => write!(f, "||"),
             TokenKind::Not => write!(f, "!"),

--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -211,6 +211,13 @@ impl Macro {
                     expr: Shared::new(Expr::Foreach(ident.clone(), expanded_collection, expanded_program)),
                 }))
             }
+            Expr::As(ident, value) => {
+                let expanded_value = self.expand_node(value, evaluator)?;
+                Ok(Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::As(ident.clone(), expanded_value)),
+                }))
+            }
             Expr::Let(pattern, value) => {
                 let expanded_value = self.expand_node(value, evaluator)?;
                 Ok(Shared::new(Node {
@@ -627,6 +634,13 @@ impl Macro {
                     )),
                 })
             }
+            Expr::As(ident, value) => {
+                let substituted_value = self.substitute_node(value, substitutions);
+                Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::As(ident.clone(), substituted_value)),
+                })
+            }
             Expr::Let(pattern, value) => {
                 let substituted_value = self.substitute_node(value, substitutions);
                 Shared::new(Node {
@@ -961,6 +975,13 @@ impl Macro {
                         substituted_collection,
                         substituted_program,
                     )),
+                })
+            }
+            Expr::As(ident, value) => {
+                let substituted_value = self.substitute_in_quote(value, substitutions);
+                Shared::new(Node {
+                    token_id: node.token_id,
+                    expr: Shared::new(Expr::As(ident.clone(), substituted_value)),
                 })
             }
             Expr::Let(pattern, value) => {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2701,6 +2701,18 @@ fn engine() -> DefaultEngine {
 #[case::bytes_literal_type_name(r#"type(b"abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("bytes".to_string())].into()))]
 #[case::bytes_literal_is_empty(r#"is_empty(b"")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::bytes_literal_not_empty(r#"is_empty(b"a")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(false)].into()))]
+// as binding: bind value to name and access it later
+#[case::as_binding_basic("42 as x | x", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// as binding: bind returns original pipeline value (not bound value)
+#[case::as_binding_passthrough("42 as x | \"hello\"", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
+// as binding: bind literal to name, use in expression
+#[case::as_binding_in_expression("1 as a | 2 as b | add(a, b)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(3.into())].into()))]
+// as binding: bind selector result to name
+#[case::as_binding_selector("let v = \"hello\" | v as s | upcase(s)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("HELLO".to_string())].into()))]
+// as binding: multiple bindings in same pipeline
+#[case::as_binding_multiple("1 as a | 2 as b | add(a, b)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(3.into())].into()))]
+// as binding: bind in def body
+#[case::as_binding_in_def("def double_add(x): x as a | add(a, a); | double_add(5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(10.into())].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-lang/tests/property_based_tests.rs
+++ b/crates/mq-lang/tests/property_based_tests.rs
@@ -41,7 +41,8 @@ mod strategies {
             .prop_filter("Avoid reserved keywords", |s| {
                 !matches!(
                     s.as_str(),
-                    "if" | "else"
+                    "as" | "if"
+                        | "else"
                         | "elif"
                         | "let"
                         | "var"


### PR DESCRIPTION
Implements jq-style `expr as name` binding across all language layers