### PR TITLE
👷 ci(setup-node): disable package manager cache to prevent cache poisoning

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           node-version-file: .tool-versions
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - name: Install dependencies
         working-directory: packages/mq-web
         run: pnpm install --frozen-lockfile
@@ -68,6 +69,7 @@ jobs:
         with:
           node-version-file: .tool-versions
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - name: Install dependencies
         working-directory: packages/mq-nodejs
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
+          package-manager-cache: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false


### PR DESCRIPTION
Add `package-manager-cache: false` to all setup-node steps in npm-publish.yml and pages.yml.