### PR TITLE
✨ feat(builtin): add frontmatter() for YAML/TOML frontmatter parsing

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -883,7 +883,7 @@ def frontmatter(v):
   if (is_yaml(v)):
     do import "yaml" | yaml::yaml_parse(v);
   elif (is_toml(v)):
-    do import "toml" | toml::toml_parse(v);
+    do import "toml" | v | .value | toml::toml_parse;
   else: None
 end
 

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -878,3 +878,12 @@ def omit(d, keys):
     end
 end
 
+# Parses frontmatter from a markdown node, supporting both YAML and TOML formats.
+def frontmatter(v):
+  if (is_yaml(v)):
+    do import "yaml" | yaml::yaml_parse(v);
+  elif (is_toml(v)):
+    do import "toml" | toml::toml_parse(v);
+  else: None
+end
+

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -881,7 +881,7 @@ end
 # Parses frontmatter from a markdown node, supporting both YAML and TOML formats.
 def frontmatter(v):
   if (is_yaml(v)):
-    do import "yaml" | yaml::yaml_parse(v);
+    do import "yaml" | v | .value | yaml::yaml_parse;
   elif (is_toml(v)):
     do import "toml" | v | .value | toml::toml_parse;
   else: None

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -831,3 +831,24 @@ def test_omit():
   | assert_eq(result3, {"key": "value"})
 end
 
+def test_frontmatter():
+  # YAML frontmatter is parsed into a dict
+  let result1 = do "---\ntitle: Hello\nauthor: World\n---\n\n# Heading" | to_markdown() | first() | frontmatter();
+  | assert_eq(result1["title"], "Hello")
+  | assert_eq(result1["author"], "World")
+
+  # TOML frontmatter is parsed into a dict
+  | let result2 = do "+++\ntitle = \"Hello\"\nauthor = \"World\"\n+++\n\n# Heading" | to_markdown() | first() | frontmatter();
+  | assert_eq(result2["title"], "Hello")
+  | assert_eq(result2["author"], "World")
+
+  # Non-frontmatter node returns None
+  | let result3 = do "# Heading" | to_markdown() | first() | frontmatter();
+  | assert_eq(result3, None)
+
+  # YAML frontmatter with nested values
+  | let result4 = do "---\ntitle: My Post\ntags:\n  - rust\n  - markdown\n---\n" | to_markdown() | first() | frontmatter();
+  | assert_eq(result4["title"], "My Post")
+  | assert_eq(result4["tags"], ["rust", "markdown"])
+end
+

--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -111,7 +111,13 @@ end
 def test_to_front_matter():
   let input = {title: "title", date: "2024-06-01", tags: ["test", "yaml"], draft: false}
   | let result = yaml::to_front_matter(input)
-  | assert_eq(result, "---\ntitle: title\ndate: 2024-06-01\ntags: \n  - test\n  - yaml\ndraft: false\n---")
+  | assert_eq(result, "---\ndate: 2024-06-01\ndraft: false\ntags: \n  - test\n  - yaml\ntitle: title\n---")
+end
+
+def test_to_frontmatter():
+  let input = {title: "title", date: "2024-06-01", tags: ["test", "yaml"], draft: false}
+  | let result = yaml::to_frontmatter(input)
+  | assert_eq(result, "---\ndate: 2024-06-01\ndraft: false\ntags: \n  - test\n  - yaml\ntitle: title\n---")
 end
 
 # -- XML Tests --

--- a/crates/mq-lang/modules/yaml.mq
+++ b/crates/mq-lang/modules/yaml.mq
@@ -26,7 +26,7 @@ def _yaml_stringify_value(value, indent_level):
       if (is_empty(keys(value))):
         "{}"
       else:
-        join(map(keys(value), fn(k): "\n" + indent + k + ": " + _yaml_stringify_value(value[k], indent_level + 1);), "")
+        join(map(sort(keys(value)), fn(k): "\n" + indent + k + ": " + _yaml_stringify_value(value[k], indent_level + 1);), "")
     else:
       to_string(value)
 end
@@ -47,7 +47,7 @@ def yaml_stringify(data):
     if (is_empty(keys(data))):
       "{}"
     else:
-      join(map(keys(data), fn(k): k + ": " + _yaml_stringify_value(data[k], 1);), "\n")
+      join(map(sort(keys(data)), fn(k): k + ": " + _yaml_stringify_value(data[k], 1);), "\n")
   else:
     _yaml_stringify_value(data, 0)
 end
@@ -99,7 +99,13 @@ def yaml_to_json(data):
 end
 
 # Converts a data structure to a YAML front matter string.
+# deprecated: use to_frontmatter instead
 def to_front_matter(data):
+  "---\n" + yaml_stringify(data) + "\n---"
+end
+
+# Converts a data structure to a YAML front matter string.
+def to_frontmatter(data):
   "---\n" + yaml_stringify(data) + "\n---"
 end
 

--- a/docs/books/src/start/example.md
+++ b/docs/books/src/start/example.md
@@ -621,5 +621,6 @@ $ mq -A 'let headers = count_by(fn(x): x | select(.h);)
 Extract frontmatter metadata from markdown files:
 
 ```mq
-import "yaml" | if (.yaml): yaml::yaml_parse() | get(:title)
+.yaml | frontmatter()
 ```
+


### PR DESCRIPTION
Adds a new `frontmatter()` builtin that detects and parses both YAML and TOML frontmatter from markdown nodes using the existing yaml/toml import modules.

Updates example docs to use the simpler frontmatter() call.