### PR TITLE
✨ feat(cli): add --doc flag to query built-in reference document

### DIFF
--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -112,6 +112,12 @@ impl Hir {
             return;
         }
 
+        // Mark as loaded before processing so that inline `import` expressions
+        // inside builtin.mq (e.g. `do import "yaml" | ...`) do not re-enter
+        // this function when add_expr → add_import_expr → add_code → add_nodes
+        // calls add_builtin() again.
+        self.builtin.loaded = true;
+
         let (nodes, _) = mq_lang::parse_recovery(mq_lang::BUILTIN_MODULE_FILE);
 
         nodes.iter().for_each(|node| {
@@ -182,8 +188,6 @@ impl Hir {
                 });
             }
         }
-
-        self.builtin.loaded = true;
     }
 
     pub fn add_nodes(&mut self, url: Url, nodes: &[mq_lang::Shared<mq_lang::CstNode>]) -> (SourceId, ScopeId) {

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -86,7 +86,7 @@ pub use ident::Ident;
 pub use lexer::Options as LexerOptions;
 pub use lexer::token::{StringSegment, Token, TokenKind};
 pub use module::{
-    BUILTIN_FILE as BUILTIN_MODULE_FILE, Module, ModuleId, ModuleLoader, error::ModuleError,
+    BUILTIN_FILE as BUILTIN_MODULE_FILE, Module, ModuleId, ModuleLoader, STANDARD_MODULES, error::ModuleError,
     resolver::LocalFsModuleResolver, resolver::ModuleResolver, resolver::module_name,
 };
 pub use range::{Position, Range};

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -15,6 +15,7 @@ use std::{fs, path::PathBuf};
 use which::which;
 
 use crate::grep;
+use crate::reference;
 
 #[derive(Parser, Debug, Default)]
 #[command(name = "mq")]
@@ -525,8 +526,8 @@ impl Cli {
 
     /// Runs a query against the generated reference Markdown document.
     fn run_doc(&self) -> miette::Result<()> {
-        let markdown = crate::reference::generate();
-        let input = mq_lang::parse_markdown_input(&markdown).map_err(|e| miette!(e.to_string()))?;
+        let markdown = reference::generate();
+        let input = mq_lang::parse_markdown_input(&markdown)?;
 
         let query = self.get_query()?;
         let mut engine = self.create_engine()?;

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -66,6 +66,19 @@ pub struct Cli {
     #[arg(long)]
     list: bool,
 
+    /// Use the built-in reference document as input instead of a file.
+    ///
+    /// Generates a Markdown document containing all built-in functions,
+    /// selectors, and standard module functions, then runs QUERY against it.
+    /// Omit QUERY to print the full reference as Markdown.
+    ///
+    /// Examples:
+    ///   mq --doc '.'          # full reference
+    ///   mq --doc '.h'         # section headings only
+    ///   mq --doc '.table'     # all function/selector tables
+    #[arg(long, default_value_t = false)]
+    doc: bool,
+
     /// Number of files to process before switching to parallel processing
     #[arg(short = 'P', default_value_t = 10)]
     parallel_threshold: usize,
@@ -519,9 +532,28 @@ impl Cli {
         Ok(())
     }
 
+    /// Runs a query against the generated reference Markdown document.
+    ///
+    /// When `--doc` is set, the reference document is used as the sole input
+    /// instead of any file or stdin. If no query was supplied, the identity
+    /// query `self` is used so the full document is printed.
+    fn run_doc(&self) -> miette::Result<()> {
+        let markdown = crate::reference::generate();
+        let input = mq_lang::parse_markdown_input(&markdown).map_err(|e| miette!(e.to_string()))?;
+
+        let query = self.query.as_deref().unwrap_or("self");
+        let mut engine = self.create_engine()?;
+        let runtime_values = engine.eval(query, input.into_iter()).map_err(|e| *e)?;
+        self.print(runtime_values)
+    }
+
     pub fn run(&self) -> miette::Result<()> {
         if self.list {
             return self.list_commands();
+        }
+
+        if self.doc {
+            return self.run_doc();
         }
 
         if (self.output.before_context.is_some()

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -67,15 +67,6 @@ pub struct Cli {
     list: bool,
 
     /// Use the built-in reference document as input instead of a file.
-    ///
-    /// Generates a Markdown document containing all built-in functions,
-    /// selectors, and standard module functions, then runs QUERY against it.
-    /// Omit QUERY to print the full reference as Markdown.
-    ///
-    /// Examples:
-    ///   mq --doc '.'          # full reference
-    ///   mq --doc '.h'         # section headings only
-    ///   mq --doc '.table'     # all function/selector tables
     #[arg(long, default_value_t = false)]
     doc: bool,
 
@@ -252,7 +243,7 @@ pub enum LinkUrlStyle {
 #[derive(Clone, Debug, clap::Args, Default)]
 struct InputArgs {
     /// Aggregate all input files/content into a single array
-    #[arg(short = 'A', long, default_value_t = false)]
+    #[arg(short = 'A', long, default_value_t = false, default_value_if("doc", "true", "true"))]
     aggregate: bool,
 
     /// load filter from the file
@@ -533,17 +524,13 @@ impl Cli {
     }
 
     /// Runs a query against the generated reference Markdown document.
-    ///
-    /// When `--doc` is set, the reference document is used as the sole input
-    /// instead of any file or stdin. If no query was supplied, the identity
-    /// query `self` is used so the full document is printed.
     fn run_doc(&self) -> miette::Result<()> {
         let markdown = crate::reference::generate();
         let input = mq_lang::parse_markdown_input(&markdown).map_err(|e| miette!(e.to_string()))?;
 
-        let query = self.query.as_deref().unwrap_or("self");
+        let query = self.get_query()?;
         let mut engine = self.create_engine()?;
-        let runtime_values = engine.eval(query, input.into_iter()).map_err(|e| *e)?;
+        let runtime_values = engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
         self.print(runtime_values)
     }
 

--- a/crates/mq-run/src/lib.rs
+++ b/crates/mq-run/src/lib.rs
@@ -45,6 +45,7 @@
 pub mod cli;
 pub(crate) mod grep;
 pub(crate) mod json;
+pub(crate) mod reference;
 pub(crate) mod table;
 
 #[cfg(feature = "debugger")]

--- a/crates/mq-run/src/reference.rs
+++ b/crates/mq-run/src/reference.rs
@@ -174,10 +174,10 @@ mod tests {
     #[test]
     fn test_generate_contains_sections() {
         let md = generate();
-        assert!(md.contains("# Built-in Functions"));
-        assert!(md.contains("# Selectors"));
-        assert!(md.contains("# Module: csv"));
-        assert!(md.contains("# Module: yaml"));
+        assert!(md.contains("## Built-in Functions"));
+        assert!(md.contains("## Selectors"));
+        assert!(md.contains("## Module: csv"));
+        assert!(md.contains("## Module: yaml"));
     }
 
     #[test]

--- a/crates/mq-run/src/reference.rs
+++ b/crates/mq-run/src/reference.rs
@@ -56,6 +56,7 @@ fn append_builtin_functions(md: &mut String) {
     if fns.is_empty() {
         return;
     }
+    md.push_str("\n\n### builtin.mq\n\n");
     md.push_str("| name | params | description |\n");
     md.push_str("|------|--------|-------------|\n");
     for (fn_name, params, desc) in &fns {

--- a/crates/mq-run/src/reference.rs
+++ b/crates/mq-run/src/reference.rs
@@ -175,7 +175,6 @@ mod tests {
         let md = generate();
         assert!(md.contains("# Built-in Functions"));
         assert!(md.contains("# Selectors"));
-        assert!(md.contains("# Module: builtin"));
         assert!(md.contains("# Module: csv"));
         assert!(md.contains("# Module: yaml"));
     }

--- a/crates/mq-run/src/reference.rs
+++ b/crates/mq-run/src/reference.rs
@@ -1,0 +1,256 @@
+use mq_lang::{
+    BUILTIN_FUNCTION_DOC, BUILTIN_MODULE_FILE, BUILTIN_SELECTOR_DOC, CstNode, CstNodeKind, STANDARD_MODULES, Shared,
+    TokenKind,
+};
+
+/// Generates a Markdown reference document covering:
+/// - Native built-in functions (from `BUILTIN_FUNCTION_DOC`)
+/// - Selectors (from `BUILTIN_SELECTOR_DOC`)
+/// - The `builtin` standard library (`builtin.mq` user-facing functions)
+/// - Each importable standard module
+///
+/// Function signatures and doc comments are extracted from the CST produced by
+/// `mq_lang::parse_recovery`, so no hand-written text scanning is involved.
+///
+/// The returned string can be fed into `mq_lang::parse_markdown_input` so that
+/// the caller can query it with any mq expression.
+pub fn generate() -> String {
+    let mut md = String::with_capacity(64 * 1024);
+
+    append_native_functions(&mut md);
+    append_selectors(&mut md);
+    append_module_section(&mut md, "builtin", BUILTIN_MODULE_FILE, true);
+
+    let mut modules: Vec<_> = STANDARD_MODULES.iter().collect();
+    modules.sort_by_key(|(k, _)| *k);
+    for (name, get_source) in modules {
+        let source = get_source();
+        append_module_section(&mut md, name, source, false);
+    }
+
+    md
+}
+
+fn append_native_functions(md: &mut String) {
+    md.push_str("# Built-in Functions\n\n");
+    md.push_str("| name | params | description |\n");
+    md.push_str("|------|--------|-------------|\n");
+
+    let mut entries: Vec<_> = BUILTIN_FUNCTION_DOC.iter().collect();
+    entries.sort_by_key(|(k, _)| *k);
+
+    for (name, doc) in entries {
+        if name.starts_with('_') {
+            continue;
+        }
+        let params = doc.params.join(", ");
+        md.push_str(&format!(
+            "| {} | {} | {} |\n",
+            cell(name),
+            cell(&params),
+            cell(doc.description),
+        ));
+    }
+    md.push('\n');
+}
+
+fn append_selectors(md: &mut String) {
+    md.push_str("# Selectors\n\n");
+    md.push_str("| selector | description |\n");
+    md.push_str("|----------|-------------|\n");
+
+    let mut entries: Vec<_> = BUILTIN_SELECTOR_DOC.iter().collect();
+    entries.sort_by_key(|(k, _)| *k);
+
+    for (name, doc) in entries {
+        md.push_str(&format!("| {} | {} |\n", cell(name), cell(doc.description)));
+    }
+    md.push('\n');
+}
+
+fn append_module_section(md: &mut String, name: &str, source: &str, is_builtin: bool) {
+    if is_builtin {
+        md.push_str("# Module: builtin\n\n");
+        md.push_str("The standard library, always available without import.\n\n");
+    } else {
+        md.push_str(&format!("\n# Module: {name}\n\n"));
+        md.push_str(&format!("import \"{name}\" |\n\n"));
+    }
+
+    let fns = extract_functions_from_cst(source, is_builtin);
+    if fns.is_empty() {
+        return;
+    }
+    md.push_str("| name | params | description |\n");
+    md.push_str("|------|--------|-------------|\n");
+    for (fn_name, params, desc) in &fns {
+        md.push_str(&format!(
+            "| {} | {} | {} |\n",
+            cell(fn_name),
+            cell(&params.join(", ")),
+            cell(desc),
+        ));
+    }
+}
+
+/// Parses `.mq` source with the CST and returns `(name, params, description)`
+/// for each public function.
+///
+/// When `skip_native` is true (used for `builtin.mq`), functions that appear
+/// in `BUILTIN_FUNCTION_DOC` are skipped so they aren't duplicated in the
+/// native-functions section.
+fn extract_functions_from_cst(source: &str, skip_native: bool) -> Vec<(String, Vec<String>, String)> {
+    let (nodes, _) = mq_lang::parse_recovery(source);
+    let mut result = Vec::new();
+
+    for node in &nodes {
+        if !node.is_def() {
+            continue;
+        }
+        if let Some(info) = def_info(node, skip_native) {
+            result.push(info);
+        }
+    }
+
+    result
+}
+
+/// Extracts `(name, params, description)` from a CST `Def` node.
+///
+/// - `name`: the `Ident` token text of the first child
+/// - `params`: `Ident` tokens that appear between `(` and `)` in children
+/// - `description`: leading-trivia `Comment` tokens joined with a space
+///
+/// Returns `None` for private functions (names starting with `_`).
+fn def_info(node: &Shared<CstNode>, skip_native: bool) -> Option<(String, Vec<String>, String)> {
+    // Function name: first child with NodeKind::Ident
+    let name_node = node.children.iter().find(|c| matches!(c.kind, CstNodeKind::Ident))?;
+    let name = ident_text(name_node)?;
+
+    if name.starts_with('_') {
+        return None;
+    }
+    if skip_native && BUILTIN_FUNCTION_DOC.contains_key(name.as_str()) {
+        return None;
+    }
+
+    // Params: Ident children that sit between ( and ) — i.e. before the first
+    // Colon/Do token encountered after the function-name child.
+    let params: Vec<String> = node
+        .children
+        .iter()
+        .skip(1) // skip function name
+        .take_while(|c| {
+            c.token
+                .as_ref()
+                .is_none_or(|t| !matches!(t.kind, TokenKind::Colon | TokenKind::Do))
+        })
+        .filter(|c| matches!(c.kind, CstNodeKind::Ident))
+        .filter_map(ident_text)
+        .collect();
+
+    // Description: leading-trivia Comment tokens on the Def node itself
+    let desc = node
+        .comments()
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    Some((name, params, desc))
+}
+
+fn ident_text(node: &Shared<CstNode>) -> Option<String> {
+    node.token.as_ref().and_then(|t| match &t.kind {
+        TokenKind::Ident(s) => Some(s.to_string()),
+        _ => None,
+    })
+}
+
+/// Escapes `|` and newlines so text is safe inside a Markdown table cell.
+fn cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_contains_sections() {
+        let md = generate();
+        assert!(md.contains("# Built-in Functions"));
+        assert!(md.contains("# Selectors"));
+        assert!(md.contains("# Module: builtin"));
+        assert!(md.contains("# Module: csv"));
+        assert!(md.contains("# Module: yaml"));
+    }
+
+    #[test]
+    fn test_generate_has_table_headers() {
+        let md = generate();
+        assert!(md.contains("| name | params | description |"));
+        assert!(md.contains("| selector | description |"));
+    }
+
+    #[test]
+    fn test_builtin_functions_excludes_internal() {
+        let md = generate();
+        assert!(!md.contains("| _sort_by_impl |"));
+        assert!(!md.contains("| _csv_parse |"));
+    }
+
+    #[test]
+    fn test_module_builtin_has_mq_defined_functions() {
+        let md = generate();
+        // builtin.mq defines is_array, map, filter etc.
+        assert!(md.contains("is_array"));
+        assert!(md.contains("map"));
+    }
+
+    #[test]
+    fn test_generate_is_parseable() {
+        let md = generate();
+        let nodes = mq_lang::parse_markdown_input(&md);
+        assert!(nodes.is_ok());
+        assert!(!nodes.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_cell_escapes_pipe() {
+        assert_eq!(cell("a|b"), "a\\|b");
+    }
+
+    #[test]
+    fn test_extract_functions_from_cst_skips_private() {
+        let src = "def _internal(x): x;\ndef public(x): x;";
+        let fns = extract_functions_from_cst(src, false);
+        assert_eq!(fns.len(), 1);
+        assert_eq!(fns[0].0, "public");
+    }
+
+    #[test]
+    fn test_extract_functions_captures_doc() {
+        let src = "# Does something useful\ndef useful(x): x;";
+        let fns = extract_functions_from_cst(src, false);
+        assert_eq!(fns.len(), 1);
+        assert!(fns[0].2.contains("Does something useful"));
+    }
+
+    #[test]
+    fn test_extract_functions_captures_params() {
+        let src = "def csv_parse(input, has_header): expr;";
+        let fns = extract_functions_from_cst(src, false);
+        assert_eq!(fns[0].1, vec!["input", "has_header"]);
+    }
+
+    #[test]
+    fn test_extract_functions_default_param() {
+        // Note: mq keywords (nodes, self, fn, etc.) cannot be used as parameter names.
+        // Use non-keyword names to test default value parsing.
+        let src = "def section(items, pattern, depth = false): items;";
+        let fns = extract_functions_from_cst(src, false);
+        assert!(!fns.is_empty(), "should parse function with default param");
+        assert_eq!(fns[0].1, vec!["items", "pattern", "depth"]);
+    }
+}

--- a/crates/mq-run/src/reference.rs
+++ b/crates/mq-run/src/reference.rs
@@ -17,22 +17,22 @@ use mq_lang::{
 pub fn generate() -> String {
     let mut md = String::with_capacity(64 * 1024);
 
-    append_native_functions(&mut md);
+    append_builtin_functions(&mut md);
     append_selectors(&mut md);
-    append_module_section(&mut md, "builtin", BUILTIN_MODULE_FILE, true);
 
     let mut modules: Vec<_> = STANDARD_MODULES.iter().collect();
     modules.sort_by_key(|(k, _)| *k);
+
     for (name, get_source) in modules {
         let source = get_source();
-        append_module_section(&mut md, name, source, false);
+        append_module_section(&mut md, name, source);
     }
 
     md
 }
 
-fn append_native_functions(md: &mut String) {
-    md.push_str("# Built-in Functions\n\n");
+fn append_builtin_functions(md: &mut String) {
+    md.push_str("## Built-in Functions\n\n");
     md.push_str("| name | params | description |\n");
     md.push_str("|------|--------|-------------|\n");
 
@@ -51,33 +51,8 @@ fn append_native_functions(md: &mut String) {
             cell(doc.description),
         ));
     }
-    md.push('\n');
-}
 
-fn append_selectors(md: &mut String) {
-    md.push_str("# Selectors\n\n");
-    md.push_str("| selector | description |\n");
-    md.push_str("|----------|-------------|\n");
-
-    let mut entries: Vec<_> = BUILTIN_SELECTOR_DOC.iter().collect();
-    entries.sort_by_key(|(k, _)| *k);
-
-    for (name, doc) in entries {
-        md.push_str(&format!("| {} | {} |\n", cell(name), cell(doc.description)));
-    }
-    md.push('\n');
-}
-
-fn append_module_section(md: &mut String, name: &str, source: &str, is_builtin: bool) {
-    if is_builtin {
-        md.push_str("# Module: builtin\n\n");
-        md.push_str("The standard library, always available without import.\n\n");
-    } else {
-        md.push_str(&format!("\n# Module: {name}\n\n"));
-        md.push_str(&format!("import \"{name}\" |\n\n"));
-    }
-
-    let fns = extract_functions_from_cst(source, is_builtin);
+    let fns = extract_functions_from_cst(BUILTIN_MODULE_FILE, true);
     if fns.is_empty() {
         return;
     }
@@ -93,12 +68,39 @@ fn append_module_section(md: &mut String, name: &str, source: &str, is_builtin: 
     }
 }
 
-/// Parses `.mq` source with the CST and returns `(name, params, description)`
-/// for each public function.
-///
-/// When `skip_native` is true (used for `builtin.mq`), functions that appear
-/// in `BUILTIN_FUNCTION_DOC` are skipped so they aren't duplicated in the
-/// native-functions section.
+fn append_selectors(md: &mut String) {
+    md.push_str("## Selectors\n\n");
+    md.push_str("| selector | description |\n");
+    md.push_str("|----------|-------------|\n");
+
+    let mut entries: Vec<_> = BUILTIN_SELECTOR_DOC.iter().collect();
+    entries.sort_by_key(|(k, _)| *k);
+
+    for (name, doc) in entries {
+        md.push_str(&format!("| {} | {} |\n", cell(name), cell(doc.description)));
+    }
+}
+
+fn append_module_section(md: &mut String, name: &str, source: &str) {
+    md.push_str(&format!("\n## Module: {name}\n\n"));
+    md.push_str(&format!("import \"{name}\" |\n\n"));
+
+    let fns = extract_functions_from_cst(source, false);
+    if fns.is_empty() {
+        return;
+    }
+    md.push_str("| name | params | description |\n");
+    md.push_str("|------|--------|-------------|\n");
+    for (fn_name, params, desc) in &fns {
+        md.push_str(&format!(
+            "| {} | {} | {} |\n",
+            cell(fn_name),
+            cell(&params.join(", ")),
+            cell(desc),
+        ));
+    }
+}
+
 fn extract_functions_from_cst(source: &str, skip_native: bool) -> Vec<(String, Vec<String>, String)> {
     let (nodes, _) = mq_lang::parse_recovery(source);
     let mut result = Vec::new();
@@ -115,13 +117,6 @@ fn extract_functions_from_cst(source: &str, skip_native: bool) -> Vec<(String, V
     result
 }
 
-/// Extracts `(name, params, description)` from a CST `Def` node.
-///
-/// - `name`: the `Ident` token text of the first child
-/// - `params`: `Ident` tokens that appear between `(` and `)` in children
-/// - `description`: leading-trivia `Comment` tokens joined with a space
-///
-/// Returns `None` for private functions (names starting with `_`).
 fn def_info(node: &Shared<CstNode>, skip_native: bool) -> Option<(String, Vec<String>, String)> {
     // Function name: first child with NodeKind::Ident
     let name_node = node.children.iter().find(|c| matches!(c.kind, CstNodeKind::Ident))?;
@@ -167,7 +162,6 @@ fn ident_text(node: &Shared<CstNode>) -> Option<String> {
     })
 }
 
-/// Escapes `|` and newlines so text is safe inside a Markdown table cell.
 fn cell(s: &str) -> String {
     s.replace('|', "\\|").replace('\n', " ")
 }


### PR DESCRIPTION
Add a new --doc flag that generates a Markdown reference document containing all built-in functions, selectors, and standard module functions, then runs the given mq query against it.

- Add crates/mq-run/src/reference.rs to generate reference Markdown by extracting function signatures and doc comments from the CST
- Export STANDARD_MODULES from mq-lang for use in reference generation
- Fix re-entrant builtin loading in hir.rs by moving `loaded = true` before processing to prevent infinite recursion when builtin.mq contains inline import expressions