### PR TITLE
🐛 fix(table): flush current_row before finalizing table on block boundary

### DIFF
--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -365,7 +365,10 @@ def test_section_by_level_empty():
 end
 
 | let table_md = "| Name | Age | City |\n| --- | --- | --- |\n| Alice | 30 | Tokyo |\n| Bob | 25 | Osaka |\n"
-| let table_nodes = to_markdown(table_md) |
+| let table_nodes = to_markdown(table_md)
+| let table_md_followed_by_paragraph = "| N | A |\n| - | - |\n| x | 1 |\n| y | 2 |\n\nText.\n"
+| let table_md_followed_by_heading = "| N | A |\n| - | - |\n| x | 1 |\n| y | 2 |\n\n# H\n"
+| let table_md_followed_by_break = "| N | A |\n| - | - |\n| x | 1 |\n| y | 2 |\n\n---\n" |
 
 def test_table_tables():
   let result = table::tables(table_nodes)
@@ -379,6 +382,37 @@ end
 def test_table_tables_empty():
   let result = table::tables([])
   | assert_eq(result, [])
+end
+
+def test_table_tables_followed_by_paragraph():
+  let md_nodes = to_markdown(table_md_followed_by_paragraph)
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 1)
+  | let t = result[0]
+  | assert_eq(len(t[:rows]), 2)
+end
+
+def test_table_tables_followed_by_heading():
+  let md_nodes = to_markdown(table_md_followed_by_heading)
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 1)
+  | let t = result[0]
+  | assert_eq(len(t[:rows]), 2)
+end
+
+def test_table_tables_followed_by_break():
+  let md_nodes = to_markdown(table_md_followed_by_break)
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 1)
+  | let t = result[0]
+  | assert_eq(len(t[:rows]), 2)
+end
+
+def test_table_to_csv_followed_by_paragraph():
+  let md_nodes = to_markdown(table_md_followed_by_paragraph)
+  | let t = first(table::tables(md_nodes))
+  | let result = table::to_csv(t)
+  | assert_eq(result, "N,A\nx,1\ny,2")
 end
 
 def test_table_set_align():

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -29,7 +29,12 @@ def tables(md_nodes):
                 current_row += node
             elif (is_table_align(node)): current_align = node
             else: do
-                if (!is_empty(current_rows)) do
+                if (!is_empty(current_row)) do
+                    current_rows += [current_row]
+                    | current_row = []
+                    | current_row_index = -1
+                  end
+                | if (!is_empty(current_rows)) do
                     tables += [{type: :table, align: current_align, header: current_rows[0], rows: current_rows[1:]}]
                     | current_align = []
                     | current_rows = []


### PR DESCRIPTION
When `tables()` encountered a non-table node (paragraph, heading, thematic break) it flushed `current_rows` to the result without first committing the in-progress `current_row` buffer. This silently dropped the last data row of any table followed by a non-table block.

https://github.com/harehare/mq/issues/1839