### PR TITLE
docs: add AUR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Invoke-WebRequest -Uri https://github.com/harehare/mq/releases/download/v0.6.0/m
 brew install mq
 ```
 
+### Arch
+
+```sh
+# Using yay (ArchLinux)
+yay -S mq-bin
+```
+
 ### Docker
 
 ```sh


### PR DESCRIPTION
As an Arch Linux user, I packaged mq for AUR and added installation instructions to the README.

AUR package:
https://aur.archlinux.org/packages/mq-bin

It works on my machine, but it would be great if someone else could test the package as well.
