### PR TITLE
✨ feat(markdown): add Obsidian callout and embed support

### DIFF
--- a/crates/mq-check/src/constraint/helpers.rs
+++ b/crates/mq-check/src/constraint/helpers.rs
@@ -134,7 +134,8 @@ pub(crate) fn attr_kind_to_type(attr_kind: &mq_lang::AttrKind) -> Type {
         | AttrKind::Ident
         | AttrKind::Label
         | AttrKind::Align
-        | AttrKind::Name => Type::String,
+        | AttrKind::Name
+        | AttrKind::Kind => Type::String,
         AttrKind::Depth | AttrKind::Level | AttrKind::Index | AttrKind::Column | AttrKind::Row => Type::Number,
         AttrKind::Ordered | AttrKind::Checked => Type::Bool,
         AttrKind::Values | AttrKind::Children => Type::array(Type::Markdown),

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -23,7 +23,7 @@ chrono = {workspace = true}
 dirs = {workspace = true}
 itertools = {workspace = true}
 miette = {workspace = true}
-mq-markdown = {workspace = true, features = ["html-to-markdown", "wikilink"]}
+mq-markdown = {workspace = true, features = ["html-to-markdown", "obsidian"]}
 nom = {workspace = true}
 nom_locate = {workspace = true}
 percent-encoding = {workspace = true}

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -234,6 +234,7 @@ def is_mdx(mdx):
 end
 
 # Checks if markdown is a callout block
+# Deprecated: use .callout selector instead
 def is_callout(md):
   let first_line = do to_text(md) | split("\n") | first();
   | to_md_name(md) == "blockquote" && starts_with(first_line, "[!") && contains(first_line, "]")

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -234,10 +234,8 @@ def is_mdx(mdx):
 end
 
 # Checks if markdown is a callout block
-# Deprecated: use .callout selector instead
 def is_callout(md):
-  let first_line = do to_text(md) | split("\n") | first();
-  | to_md_name(md) == "blockquote" && starts_with(first_line, "[!") && contains(first_line, "]")
+  to_md_name(md) == "callout"
 end
 
 # Returns an array of length n filled with the given value.

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -5575,6 +5575,8 @@ pub fn eval_selector(node: &mq_markdown::Node, selector: &Selector) -> RuntimeVa
         Selector::Link => node.is_link(),
         Selector::LinkRef => node.is_link_ref(),
         Selector::WikiLink => node.is_wikilink(),
+        Selector::Callout => node.is_callout(),
+        Selector::Embed => node.is_embed(),
         Selector::Image => node.is_image(),
         Selector::Heading(depth) => node.is_heading(*depth),
         Selector::HorizontalRule => node.is_horizontal_rule(),

--- a/crates/mq-lang/src/selector.rs
+++ b/crates/mq-lang/src/selector.rs
@@ -130,6 +130,10 @@ pub enum Selector {
     LinkRef,
     /// Matches Obsidian-style wikilink elements (e.g., `[[target]]` or `[[target|text]]`).
     WikiLink,
+    /// Matches Obsidian-style callout elements (e.g., `> [!NOTE]` or `> [!WARNING] title`).
+    Callout,
+    /// Matches Obsidian-style embed elements (e.g., `![[target]]` or `![[target|display]]`).
+    Embed,
     /// Matches strong/bold elements (e.g., `**text**`).
     Strong,
     /// Matches code block elements.
@@ -229,6 +233,8 @@ pub enum AttrKind {
 
     /// The name attribute for MDX JSX elements.
     Name,
+    /// The kind/type of an Obsidian callout (e.g. `"NOTE"`, `"WARNING"`).
+    Kind,
 }
 
 impl Display for AttrKind {
@@ -254,6 +260,7 @@ impl Display for AttrKind {
             AttrKind::Row => write!(f, ".row"),
             AttrKind::Align => write!(f, ".align"),
             AttrKind::Name => write!(f, ".name"),
+            AttrKind::Kind => write!(f, ".kind"),
         }
     }
 }
@@ -290,6 +297,8 @@ impl Selector {
             ".link" => Some(Selector::Link),
             ".link_ref" => Some(Selector::LinkRef),
             ".wikilink" => Some(Selector::WikiLink),
+            ".callout" => Some(Selector::Callout),
+            ".embed" => Some(Selector::Embed),
             ".[]" | ".list" | ".li" => Some(Selector::List(None, None)),
             ".task" => Some(Selector::Task),
             ".todo" => Some(Selector::Todo),
@@ -325,6 +334,7 @@ impl Selector {
             ".row" => Some(Selector::Attr(AttrKind::Row)),
             ".align" => Some(Selector::Attr(AttrKind::Align)),
             ".name" => Some(Selector::Attr(AttrKind::Name)),
+            ".kind" => Some(Selector::Attr(AttrKind::Kind)),
             _ => None,
         }
     }
@@ -384,6 +394,8 @@ impl Display for Selector {
             Selector::Link => write!(f, ".link"),
             Selector::LinkRef => write!(f, ".link_ref"),
             Selector::WikiLink => write!(f, ".wikilink"),
+            Selector::Callout => write!(f, ".callout"),
+            Selector::Embed => write!(f, ".embed"),
             Selector::Strong => write!(f, ".strong"),
             Selector::Code => write!(f, ".code"),
             Selector::Math => write!(f, ".math"),

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3175,6 +3175,60 @@ fn engine() -> DefaultEngine {
     r#"to_markdown("[[target]]") | first() | .link"#,
     vec![RuntimeValue::None],
     Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::WikiLink(mq_markdown::WikiLink { target: "target".to_string(), text: None, position: None }))].into()))]
+// callout selector
+#[case::callout_select_type(
+    r#"to_markdown("> [!NOTE]\n> body") | first() | .callout | type"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("markdown".to_string())].into()))]
+#[case::callout_kind_attr(
+    r#"to_markdown("> [!WARNING]\n> body") | first() | .callout | .kind"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("WARNING".to_string())].into()))]
+#[case::callout_note_kind_attr(
+    r#"to_markdown("> [!NOTE]\n> body") | first() | .callout | .kind"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("NOTE".to_string())].into()))]
+#[case::callout_title_attr(
+    r#"to_markdown("> [!NOTE] My Title\n> body") | first() | .callout | .title"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("My Title".to_string())].into()))]
+#[case::callout_no_title_attr(
+    r#"to_markdown("> [!NOTE]\n> body") | first() | .callout | .title"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::NONE].into()))]
+#[case::callout_value_attr(
+    r#"to_markdown("> [!NOTE]\n> body") | first() | .callout | .value"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("body".to_string())].into()))]
+#[case::callout_no_match_on_blockquote(
+    r#"to_markdown("> plain quote") | first() | .callout"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::NONE].into()))]
+#[case::callout_kind_lowercase_normalized(
+    r#"to_markdown("> [!tip]\n> body") | first() | .callout | .kind"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("TIP".to_string())].into()))]
+// embed selector
+#[case::embed_select_type(
+    r#"to_markdown("![[image.png]]") | first() | .embed | type"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("markdown".to_string())].into()))]
+#[case::embed_url_attr(
+    r#"to_markdown("![[image.png]]") | first() | .embed | .url"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("image.png".to_string())].into()))]
+#[case::embed_value_attr(
+    r#"to_markdown("![[image.png|300]]") | first() | .embed | .value"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("300".to_string())].into()))]
+#[case::embed_value_falls_back_to_target(
+    r#"to_markdown("![[note.md]]") | first() | .embed | .value"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::String("note.md".to_string())].into()))]
+#[case::embed_no_match_on_wikilink(
+    r#"to_markdown("[[target]]") | first() | .embed"#,
+    vec![RuntimeValue::None],
+    Ok(vec![RuntimeValue::NONE].into()))]
 fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<RuntimeValue>, #[case] expected: MqResult) {
     assert_eq!(engine.eval(program, input.into_iter()), expected);
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3204,10 +3204,10 @@ fn engine() -> DefaultEngine {
     r#"to_markdown("> plain quote") | first() | .callout"#,
     vec![RuntimeValue::None],
     Ok(vec![RuntimeValue::NONE].into()))]
-#[case::callout_kind_lowercase_normalized(
+#[case::callout_kind_lowercase_preserved(
     r#"to_markdown("> [!tip]\n> body") | first() | .callout | .kind"#,
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::String("TIP".to_string())].into()))]
+    Ok(vec![RuntimeValue::String("tip".to_string())].into()))]
 // embed selector
 #[case::embed_select_type(
     r#"to_markdown("![[image.png]]") | first() | .embed | type"#,

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -32,9 +32,12 @@ harness = false
 name = "benchmark"
 
 [features]
+callout = []
 color = []
 default = ["std"]
+embed = []
 html-to-markdown = ["dep:scraper", "dep:ego-tree", "dep:serde_yaml"]
 json = ["dep:serde", "dep:serde_json", "smol_str/serde"]
+obsidian = ["wikilink", "callout", "embed"]
 std = []
 wikilink = []

--- a/crates/mq-markdown/benches/benchmark.rs
+++ b/crates/mq-markdown/benches/benchmark.rs
@@ -108,19 +108,6 @@ fn from_markdown_str_with_embeds() -> mq_markdown::Markdown {
     mq_markdown::Markdown::from_markdown_str(&embed_doc()).unwrap()
 }
 
-// Embed: isolate expand_embeds alone.
-#[cfg(feature = "embed")]
-#[divan::bench(name = "expand_embeds/with_embeds")]
-fn expand_embeds_with(bencher: divan::Bencher) {
-    let doc = embed_doc();
-    // parse without embed expansion to isolate the step
-    let nodes = mq_markdown::Markdown::from_markdown_str(&plain_doc()).unwrap().nodes;
-    // substitute embed-containing nodes for a fair measurement
-    let embed_nodes = mq_markdown::Markdown::from_markdown_str(&doc).unwrap().nodes;
-    let _ = nodes; // suppress unused warning
-    bencher.bench(|| mq_markdown::Node::expand_embeds(embed_nodes.clone()));
-}
-
 // Early-exit check for embeds.
 #[cfg(feature = "embed")]
 #[divan::bench(name = "contains_check/with_embeds")]

--- a/crates/mq-markdown/benches/benchmark.rs
+++ b/crates/mq-markdown/benches/benchmark.rs
@@ -16,6 +16,30 @@ fn plain_doc() -> String {
         .collect()
 }
 
+// 100 callouts of various kinds.
+fn callout_doc() -> String {
+    (0..100)
+        .map(|i| {
+            let kind = ["NOTE", "WARNING", "TIP", "INFO"][i % 4];
+            format!("> [!{kind}] Title {i}\n> Body text for callout {i}.\n\n")
+        })
+        .collect()
+}
+
+// 100 plain blockquotes (no callout header).
+fn plain_blockquote_doc() -> String {
+    (0..100)
+        .map(|i| format!("> Plain blockquote {i} without any callout header.\n\n"))
+        .collect()
+}
+
+// 100 embeds spread through paragraphs.
+fn embed_doc() -> String {
+    (0..100)
+        .map(|i| format!("# Heading {i}\n\nSee ![[note{i}.md]] for details.\n\n"))
+        .collect()
+}
+
 // Full end-to-end: mdast parse + expand_wikilinks (wikilinks present, early-exit skipped).
 #[cfg(feature = "wikilink")]
 #[divan::bench(name = "from_markdown_str/with_wikilinks")]
@@ -61,4 +85,53 @@ fn contains_check_with() {
 fn contains_check_without() {
     let doc = plain_doc();
     divan::black_box(doc.contains("[["));
+}
+
+// Callout: end-to-end parse with callout headers (mdast + try_parse_callout per blockquote).
+#[cfg(feature = "callout")]
+#[divan::bench(name = "from_markdown_str/with_callouts")]
+fn from_markdown_str_with_callouts() -> mq_markdown::Markdown {
+    mq_markdown::Markdown::from_markdown_str(&callout_doc()).unwrap()
+}
+
+// Callout: end-to-end parse with plain blockquotes — measures overhead of callout check on non-callout docs.
+#[cfg(feature = "callout")]
+#[divan::bench(name = "from_markdown_str/plain_blockquotes")]
+fn from_markdown_str_plain_blockquotes() -> mq_markdown::Markdown {
+    mq_markdown::Markdown::from_markdown_str(&plain_blockquote_doc()).unwrap()
+}
+
+// Embed: end-to-end parse with embeds.
+#[cfg(feature = "embed")]
+#[divan::bench(name = "from_markdown_str/with_embeds")]
+fn from_markdown_str_with_embeds() -> mq_markdown::Markdown {
+    mq_markdown::Markdown::from_markdown_str(&embed_doc()).unwrap()
+}
+
+// Embed: isolate expand_embeds alone.
+#[cfg(feature = "embed")]
+#[divan::bench(name = "expand_embeds/with_embeds")]
+fn expand_embeds_with(bencher: divan::Bencher) {
+    let doc = embed_doc();
+    // parse without embed expansion to isolate the step
+    let nodes = mq_markdown::Markdown::from_markdown_str(&plain_doc()).unwrap().nodes;
+    // substitute embed-containing nodes for a fair measurement
+    let embed_nodes = mq_markdown::Markdown::from_markdown_str(&doc).unwrap().nodes;
+    let _ = nodes; // suppress unused warning
+    bencher.bench(|| mq_markdown::Node::expand_embeds(embed_nodes.clone()));
+}
+
+// Early-exit check for embeds.
+#[cfg(feature = "embed")]
+#[divan::bench(name = "contains_check/with_embeds")]
+fn contains_check_embed_with() {
+    let doc = embed_doc();
+    divan::black_box(doc.contains("![["));
+}
+
+#[cfg(feature = "embed")]
+#[divan::bench(name = "contains_check/without_embeds")]
+fn contains_check_embed_without() {
+    let doc = plain_doc();
+    divan::black_box(doc.contains("![["));
 }

--- a/crates/mq-markdown/src/lib.rs
+++ b/crates/mq-markdown/src/lib.rs
@@ -93,6 +93,12 @@ pub use node::{
 #[cfg(feature = "wikilink")]
 pub use node::WikiLink;
 
+#[cfg(feature = "callout")]
+pub use node::Callout;
+
+#[cfg(feature = "embed")]
+pub use node::Embed;
+
 #[cfg(feature = "html-to-markdown")]
 pub use html_to_markdown::{ConversionOptions, convert_html_to_markdown};
 

--- a/crates/mq-markdown/src/markdown.rs
+++ b/crates/mq-markdown/src/markdown.rs
@@ -251,14 +251,21 @@ impl Markdown {
         .map_err(|e| miette!(e.reason))?;
         let nodes = Node::from_mdast_node(root);
 
-        #[cfg(feature = "embed")]
+        #[cfg(all(feature = "embed", feature = "wikilink"))]
+        let nodes = if content.contains("[[") {
+            Node::expand_inline_links(nodes)
+        } else {
+            nodes
+        };
+
+        #[cfg(all(feature = "embed", not(feature = "wikilink")))]
         let nodes = if content.contains("![[") {
             Node::expand_embeds(nodes)
         } else {
             nodes
         };
 
-        #[cfg(feature = "wikilink")]
+        #[cfg(all(feature = "wikilink", not(feature = "embed")))]
         let nodes = if content.contains("[[") {
             Node::expand_wikilinks(nodes)
         } else {
@@ -271,9 +278,9 @@ impl Markdown {
         })
     }
 
-    /// Parses markdown without running `expand_wikilinks`. Used in benchmarks to
-    /// isolate the `expand_wikilinks` step from the mdast parse cost.
-    #[cfg(feature = "wikilink")]
+    /// Parses markdown without running any expand pass. Used in benchmarks to
+    /// isolate expand cost from the mdast parse cost.
+    #[cfg(any(feature = "wikilink", feature = "embed"))]
     pub fn from_markdown_str_no_expand(content: &str) -> miette::Result<Vec<Node>> {
         let root = markdown::to_mdast(
             content,

--- a/crates/mq-markdown/src/markdown.rs
+++ b/crates/mq-markdown/src/markdown.rs
@@ -251,6 +251,13 @@ impl Markdown {
         .map_err(|e| miette!(e.reason))?;
         let nodes = Node::from_mdast_node(root);
 
+        #[cfg(feature = "embed")]
+        let nodes = if content.contains("![[") {
+            Node::expand_embeds(nodes)
+        } else {
+            nodes
+        };
+
         #[cfg(feature = "wikilink")]
         let nodes = if content.contains("[[") {
             Node::expand_wikilinks(nodes)
@@ -478,6 +485,38 @@ mod tests {
         feature = "wikilink",
         case::wikilink_in_heading("# See [[target]]", 1, "# See [[target]]\n")
     )]
+    // callout round-trips
+    #[cfg_attr(
+        feature = "callout",
+        case::callout_note("> [!NOTE]\n> body", 1, "> [!NOTE]\n> body\n")
+    )]
+    #[cfg_attr(
+        feature = "callout",
+        case::callout_with_title("> [!WARNING] My Title\n> content", 1, "> [!WARNING] My Title\n> content\n")
+    )]
+    #[cfg_attr(feature = "callout", case::callout_empty_body("> [!TIP]", 1, "> [!TIP]\n"))]
+    #[cfg_attr(
+        feature = "callout",
+        case::callout_multiline("> [!NOTE]\n> line 1\n> line 2", 1, "> [!NOTE]\n> line 1\n> line 2\n")
+    )]
+    // plain blockquote stays Blockquote — not treated as callout
+    #[cfg_attr(feature = "callout", case::plain_blockquote("> plain quote", 1, "> plain quote\n"))]
+    // plain blockquote with list items — second item must not be over-indented
+    #[case::blockquote_with_list("> - item 1\n> - item 2", 1, "> - item 1\n> - item 2\n")]
+    // embed round-trips
+    #[cfg_attr(feature = "embed", case::embed_plain("![[note.md]]", 1, "![[note.md]]\n"))]
+    #[cfg_attr(
+        feature = "embed",
+        case::embed_with_display("![[image.png|400]]", 1, "![[image.png|400]]\n")
+    )]
+    #[cfg_attr(
+        feature = "embed",
+        case::embed_in_paragraph("See ![[note]] and read more.", 3, "See ![[note]] and read more.\n")
+    )]
+    #[cfg_attr(
+        all(feature = "embed", feature = "wikilink"),
+        case::embed_and_wikilink("![[embed]] and [[link]]", 3, "![[embed]] and [[link]]\n")
+    )]
     fn test_markdown_from_str(#[case] input: &str, #[case] expected_nodes: usize, #[case] expected_output: &str) {
         let md = input.parse::<Markdown>().unwrap();
         assert_eq!(md.nodes.len(), expected_nodes);
@@ -498,6 +537,30 @@ mod tests {
         let md = Markdown::from_mdx_str(input).unwrap();
         assert_eq!(md.nodes.len(), expected_nodes);
         assert_eq!(md.to_string(), expected_output);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case("> [!NOTE]\n> body")]
+    #[case("> [!WARNING] Custom Title\n> line 1\n> line 2")]
+    #[case("> [!TIP]")]
+    #[case("> plain blockquote")]
+    fn test_callout_round_trip_idempotent(#[case] input: &str) {
+        let first = input.parse::<Markdown>().unwrap().to_string();
+        let second = first.parse::<Markdown>().unwrap().to_string();
+        assert_eq!(first, second, "callout round-trip must be idempotent for {input:?}");
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    #[case("![[note.md]]")]
+    #[case("![[image.png|400]]")]
+    #[case("![[note#Heading]]")]
+    #[case("See ![[note]] for details.")]
+    fn test_embed_round_trip_idempotent(#[case] input: &str) {
+        let first = input.parse::<Markdown>().unwrap().to_string();
+        let second = first.parse::<Markdown>().unwrap().to_string();
+        assert_eq!(first, second, "embed round-trip must be idempotent for {input:?}");
     }
 
     /// Round-tripping a link whose text equals its URL must be idempotent.

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -2504,107 +2504,113 @@ impl Node {
         })
     }
 
-    /// Recursively scans a node list and converts `![[target]]` / `![[target|display]]`
-    /// patterns inside `Text` nodes into `Embed` nodes.
-    #[cfg(feature = "embed")]
-    pub fn expand_embeds(nodes: Vec<Node>) -> Vec<Node> {
-        let mut result = Vec::with_capacity(nodes.len());
-        for node in nodes {
-            Self::expand_embeds_into(node, &mut result);
-        }
-        result
-    }
-
-    /// Returns true if any `Text` descendant of this node contains `![[`.
-    #[cfg(feature = "embed")]
-    fn values_need_embed_expansion(values: &[Node]) -> bool {
+    /// Returns true if any `Text` descendant contains `[[`, covering both
+    /// embed (`![[`) and wikilink (`[[`) patterns.
+    #[cfg(any(feature = "embed", feature = "wikilink"))]
+    fn values_contain_links(values: &[Node]) -> bool {
         values.iter().any(|n| match n {
-            Node::Text(t) => t.value.contains("![["),
-            Node::Heading(h) => Self::values_need_embed_expansion(&h.values),
-            Node::Blockquote(b) => Self::values_need_embed_expansion(&b.values),
+            Node::Text(t) => t.value.contains("[["),
+            Node::Heading(h) => Self::values_contain_links(&h.values),
+            Node::Blockquote(b) => Self::values_contain_links(&b.values),
             #[cfg(feature = "callout")]
-            Node::Callout(c) => Self::values_need_embed_expansion(&c.values),
-            Node::List(l) => Self::values_need_embed_expansion(&l.values),
-            Node::Strong(s) => Self::values_need_embed_expansion(&s.values),
-            Node::Emphasis(e) => Self::values_need_embed_expansion(&e.values),
-            Node::Delete(d) => Self::values_need_embed_expansion(&d.values),
-            Node::TableCell(tc) => Self::values_need_embed_expansion(&tc.values),
-            Node::TableRow(tr) => Self::values_need_embed_expansion(&tr.values),
-            Node::Footnote(f) => Self::values_need_embed_expansion(&f.values),
+            Node::Callout(c) => Self::values_contain_links(&c.values),
+            Node::List(l) => Self::values_contain_links(&l.values),
+            Node::Strong(s) => Self::values_contain_links(&s.values),
+            Node::Emphasis(e) => Self::values_contain_links(&e.values),
+            Node::Delete(d) => Self::values_contain_links(&d.values),
+            Node::TableCell(tc) => Self::values_contain_links(&tc.values),
+            Node::TableRow(tr) => Self::values_contain_links(&tr.values),
+            Node::Footnote(f) => Self::values_contain_links(&f.values),
             _ => false,
         })
     }
 
-    #[cfg(feature = "embed")]
-    fn expand_embeds_into(node: Node, out: &mut Vec<Node>) {
+    /// Shared tree walker used by all expand functions. Recurses into container
+    /// nodes and delegates `Text` node processing to `parse_into`.
+    #[cfg(any(feature = "embed", feature = "wikilink"))]
+    fn expand_with(nodes: Vec<Node>, parse_into: fn(&str, Option<Position>, &mut Vec<Node>)) -> Vec<Node> {
+        let mut result = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            Self::expand_with_into(node, &mut result, parse_into);
+        }
+        result
+    }
+
+    #[cfg(any(feature = "embed", feature = "wikilink"))]
+    fn expand_with_into(node: Node, out: &mut Vec<Node>, parse_into: fn(&str, Option<Position>, &mut Vec<Node>)) {
         match node {
-            Node::Text(Text { ref value, .. }) if !value.contains("![[") => out.push(node),
-            Node::Text(Text { value, position }) => {
-                Self::parse_embeds_into(&value, position, out);
-            }
+            Node::Text(Text { ref value, .. }) if !value.contains("[[") => out.push(node),
+            Node::Text(Text { value, position }) => parse_into(&value, position, out),
             Node::Heading(mut h) => {
-                if Self::values_need_embed_expansion(&h.values) {
-                    h.values = Self::expand_embeds(h.values);
+                if Self::values_contain_links(&h.values) {
+                    h.values = Self::expand_with(h.values, parse_into);
                 }
                 out.push(Node::Heading(h));
             }
             Node::Blockquote(mut b) => {
-                if Self::values_need_embed_expansion(&b.values) {
-                    b.values = Self::expand_embeds(b.values);
+                if Self::values_contain_links(&b.values) {
+                    b.values = Self::expand_with(b.values, parse_into);
                 }
                 out.push(Node::Blockquote(b));
             }
             #[cfg(feature = "callout")]
             Node::Callout(mut c) => {
-                if Self::values_need_embed_expansion(&c.values) {
-                    c.values = Self::expand_embeds(c.values);
+                if Self::values_contain_links(&c.values) {
+                    c.values = Self::expand_with(c.values, parse_into);
                 }
                 out.push(Node::Callout(c));
             }
             Node::List(mut l) => {
-                if Self::values_need_embed_expansion(&l.values) {
-                    l.values = Self::expand_embeds(l.values);
+                if Self::values_contain_links(&l.values) {
+                    l.values = Self::expand_with(l.values, parse_into);
                 }
                 out.push(Node::List(l));
             }
             Node::Strong(mut s) => {
-                if Self::values_need_embed_expansion(&s.values) {
-                    s.values = Self::expand_embeds(s.values);
+                if Self::values_contain_links(&s.values) {
+                    s.values = Self::expand_with(s.values, parse_into);
                 }
                 out.push(Node::Strong(s));
             }
             Node::Emphasis(mut e) => {
-                if Self::values_need_embed_expansion(&e.values) {
-                    e.values = Self::expand_embeds(e.values);
+                if Self::values_contain_links(&e.values) {
+                    e.values = Self::expand_with(e.values, parse_into);
                 }
                 out.push(Node::Emphasis(e));
             }
             Node::Delete(mut d) => {
-                if Self::values_need_embed_expansion(&d.values) {
-                    d.values = Self::expand_embeds(d.values);
+                if Self::values_contain_links(&d.values) {
+                    d.values = Self::expand_with(d.values, parse_into);
                 }
                 out.push(Node::Delete(d));
             }
             Node::TableCell(mut tc) => {
-                if Self::values_need_embed_expansion(&tc.values) {
-                    tc.values = Self::expand_embeds(tc.values);
+                if Self::values_contain_links(&tc.values) {
+                    tc.values = Self::expand_with(tc.values, parse_into);
                 }
                 out.push(Node::TableCell(tc));
             }
             Node::TableRow(mut tr) => {
-                if Self::values_need_embed_expansion(&tr.values) {
-                    tr.values = Self::expand_embeds(tr.values);
+                if Self::values_contain_links(&tr.values) {
+                    tr.values = Self::expand_with(tr.values, parse_into);
                 }
                 out.push(Node::TableRow(tr));
             }
             Node::Footnote(mut f) => {
-                if Self::values_need_embed_expansion(&f.values) {
-                    f.values = Self::expand_embeds(f.values);
+                if Self::values_contain_links(&f.values) {
+                    f.values = Self::expand_with(f.values, parse_into);
                 }
                 out.push(Node::Footnote(f));
             }
             other => out.push(other),
         }
+    }
+
+    /// Recursively scans a node list and converts `![[target]]` / `![[target|display]]`
+    /// patterns inside `Text` nodes into `Embed` nodes.
+    #[cfg(feature = "embed")]
+    pub fn expand_embeds(nodes: Vec<Node>) -> Vec<Node> {
+        Self::expand_with(nodes, Self::parse_embeds_into)
     }
 
     /// Splits a text string on `![[...]]` patterns, pushing a mix of `Text`
@@ -2675,103 +2681,7 @@ impl Node {
     /// patterns inside `Text` nodes into `WikiLink` nodes.
     #[cfg(feature = "wikilink")]
     pub fn expand_wikilinks(nodes: Vec<Node>) -> Vec<Node> {
-        let mut result = Vec::with_capacity(nodes.len());
-        for node in nodes {
-            Self::expand_wikilinks_into(node, &mut result);
-        }
-        result
-    }
-
-    /// Returns true if any `Text` descendant of this node contains `[[`.
-    #[cfg(feature = "wikilink")]
-    fn values_need_expansion(values: &[Node]) -> bool {
-        values.iter().any(|n| match n {
-            Node::Text(t) => t.value.contains("[["),
-            Node::Heading(h) => Self::values_need_expansion(&h.values),
-            Node::Blockquote(b) => Self::values_need_expansion(&b.values),
-            #[cfg(feature = "callout")]
-            Node::Callout(c) => Self::values_need_expansion(&c.values),
-            Node::List(l) => Self::values_need_expansion(&l.values),
-            Node::Strong(s) => Self::values_need_expansion(&s.values),
-            Node::Emphasis(e) => Self::values_need_expansion(&e.values),
-            Node::Delete(d) => Self::values_need_expansion(&d.values),
-            Node::TableCell(tc) => Self::values_need_expansion(&tc.values),
-            Node::TableRow(tr) => Self::values_need_expansion(&tr.values),
-            Node::Footnote(f) => Self::values_need_expansion(&f.values),
-            _ => false,
-        })
-    }
-
-    #[cfg(feature = "wikilink")]
-    fn expand_wikilinks_into(node: Node, out: &mut Vec<Node>) {
-        match node {
-            Node::Text(Text { ref value, .. }) if !value.contains("[[") => out.push(node),
-            Node::Text(Text { value, position }) => {
-                Self::parse_wikilinks_into(&value, position, out);
-            }
-            Node::Heading(mut h) => {
-                if Self::values_need_expansion(&h.values) {
-                    h.values = Self::expand_wikilinks(h.values);
-                }
-                out.push(Node::Heading(h));
-            }
-            Node::Blockquote(mut b) => {
-                if Self::values_need_expansion(&b.values) {
-                    b.values = Self::expand_wikilinks(b.values);
-                }
-                out.push(Node::Blockquote(b));
-            }
-            #[cfg(feature = "callout")]
-            Node::Callout(mut c) => {
-                if Self::values_need_expansion(&c.values) {
-                    c.values = Self::expand_wikilinks(c.values);
-                }
-                out.push(Node::Callout(c));
-            }
-            Node::List(mut l) => {
-                if Self::values_need_expansion(&l.values) {
-                    l.values = Self::expand_wikilinks(l.values);
-                }
-                out.push(Node::List(l));
-            }
-            Node::Strong(mut s) => {
-                if Self::values_need_expansion(&s.values) {
-                    s.values = Self::expand_wikilinks(s.values);
-                }
-                out.push(Node::Strong(s));
-            }
-            Node::Emphasis(mut e) => {
-                if Self::values_need_expansion(&e.values) {
-                    e.values = Self::expand_wikilinks(e.values);
-                }
-                out.push(Node::Emphasis(e));
-            }
-            Node::Delete(mut d) => {
-                if Self::values_need_expansion(&d.values) {
-                    d.values = Self::expand_wikilinks(d.values);
-                }
-                out.push(Node::Delete(d));
-            }
-            Node::TableCell(mut tc) => {
-                if Self::values_need_expansion(&tc.values) {
-                    tc.values = Self::expand_wikilinks(tc.values);
-                }
-                out.push(Node::TableCell(tc));
-            }
-            Node::TableRow(mut tr) => {
-                if Self::values_need_expansion(&tr.values) {
-                    tr.values = Self::expand_wikilinks(tr.values);
-                }
-                out.push(Node::TableRow(tr));
-            }
-            Node::Footnote(mut f) => {
-                if Self::values_need_expansion(&f.values) {
-                    f.values = Self::expand_wikilinks(f.values);
-                }
-                out.push(Node::Footnote(f));
-            }
-            other => out.push(other),
-        }
+        Self::expand_with(nodes, Self::parse_wikilinks_into)
     }
 
     /// Splits a text string on `[[...]]` patterns, pushing a mix of `Text`
@@ -2842,6 +2752,90 @@ impl Node {
         let mut result = Vec::new();
         Self::parse_wikilinks_into(text, position, &mut result);
         result
+    }
+
+    /// Recursively scans a node list and converts both `![[target]]` (embed) and
+    /// `[[target]]` (wikilink) patterns in a single tree traversal. More efficient
+    /// than running `expand_embeds` followed by `expand_wikilinks` separately, which
+    /// traverses the tree and scans each `Text` node twice.
+    #[cfg(all(feature = "embed", feature = "wikilink"))]
+    pub fn expand_inline_links(nodes: Vec<Node>) -> Vec<Node> {
+        Self::expand_with(nodes, Self::parse_inline_links_into)
+    }
+
+    /// Splits a text string on `![[...]]` and `[[...]]` patterns in a single pass,
+    /// pushing a mix of `Text`, `Embed`, and `WikiLink` nodes into `out`.
+    /// A `[[` immediately preceded by `!` is treated as an embed; otherwise as a wikilink.
+    #[cfg(all(feature = "embed", feature = "wikilink"))]
+    fn parse_inline_links_into(text: &str, position: Option<Position>, out: &mut Vec<Node>) {
+        let mut last_end = 0;
+        let mut search_from = 0;
+        let mut found_any = false;
+
+        while let Some(open_rel) = text[search_from..].find("[[") {
+            let open = search_from + open_rel;
+            let inner_start = open + 2;
+
+            let Some(close_rel) = text[inner_start..].find("]]") else {
+                break;
+            };
+            let close = inner_start + close_rel;
+            let content = &text[inner_start..close];
+
+            if content.contains('[') || content.contains(']') {
+                search_from = open + 1;
+                continue;
+            }
+
+            let is_embed = text.as_bytes()[..open].last() == Some(&b'!');
+            let token_start = if is_embed { open - 1 } else { open };
+
+            found_any = true;
+            if last_end < token_start {
+                out.push(Node::Text(Text {
+                    value: text[last_end..token_start].to_string(),
+                    position: position.clone(),
+                }));
+            }
+
+            let (target, opt_part) = if let Some(pipe) = content.find('|') {
+                (content[..pipe].trim(), Some(content[pipe + 1..].trim()))
+            } else {
+                (content.trim(), None)
+            };
+
+            if is_embed {
+                out.push(Node::Embed(Embed {
+                    target: target.to_string(),
+                    display: opt_part.map(|s| s.to_string()),
+                    position: position.clone(),
+                }));
+            } else {
+                out.push(Node::WikiLink(WikiLink {
+                    target: target.to_string(),
+                    text: opt_part.map(|s| s.to_string()),
+                    position: position.clone(),
+                }));
+            }
+
+            last_end = close + 2;
+            search_from = close + 2;
+        }
+
+        if !found_any {
+            out.push(Node::Text(Text {
+                value: text.to_string(),
+                position,
+            }));
+            return;
+        }
+
+        if last_end < text.len() {
+            out.push(Node::Text(Text {
+                value: text[last_end..].to_string(),
+                position,
+            }));
+        }
     }
 
     pub(crate) fn from_mdast_node(node: mdast::Node) -> Vec<Node> {
@@ -4007,6 +4001,61 @@ mod tests {
     )]
     fn test_expand_wikilinks_footnote(#[case] input: Node, #[case] expected: Vec<Node>) {
         let result = Node::expand_wikilinks(vec![input]);
+        assert_eq!(result, expected);
+    }
+
+    #[cfg(all(feature = "embed", feature = "wikilink"))]
+    #[rstest]
+    // embed only
+    #[case("![[note.md]]", vec![
+        Node::Embed(Embed{target: "note.md".to_string(), display: None, position: None}),
+    ])]
+    // wikilink only
+    #[case("[[target]]", vec![
+        Node::WikiLink(WikiLink{target: "target".to_string(), text: None, position: None}),
+    ])]
+    // embed and wikilink in same text
+    #[case("![[embed]] and [[link]]", vec![
+        Node::Embed(Embed{target: "embed".to_string(), display: None, position: None}),
+        Node::Text(Text{value: " and ".to_string(), position: None}),
+        Node::WikiLink(WikiLink{target: "link".to_string(), text: None, position: None}),
+    ])]
+    // wikilink before embed
+    #[case("[[link]] and ![[embed]]", vec![
+        Node::WikiLink(WikiLink{target: "link".to_string(), text: None, position: None}),
+        Node::Text(Text{value: " and ".to_string(), position: None}),
+        Node::Embed(Embed{target: "embed".to_string(), display: None, position: None}),
+    ])]
+    // embed with display hint
+    #[case("![[image.png|400]]", vec![
+        Node::Embed(Embed{target: "image.png".to_string(), display: Some("400".to_string()), position: None}),
+    ])]
+    // wikilink with display text
+    #[case("[[page|display]]", vec![
+        Node::WikiLink(WikiLink{target: "page".to_string(), text: Some("display".to_string()), position: None}),
+    ])]
+    // surrounding text
+    #[case("before ![[note]] after [[link]] end", vec![
+        Node::Text(Text{value: "before ".to_string(), position: None}),
+        Node::Embed(Embed{target: "note".to_string(), display: None, position: None}),
+        Node::Text(Text{value: " after ".to_string(), position: None}),
+        Node::WikiLink(WikiLink{target: "link".to_string(), text: None, position: None}),
+        Node::Text(Text{value: " end".to_string(), position: None}),
+    ])]
+    // plain text with no links
+    #[case("just plain text", vec![
+        Node::Text(Text{value: "just plain text".to_string(), position: None}),
+    ])]
+    // multibyte characters
+    #[case("日本語 ![[ファイル]] と [[ページ]]", vec![
+        Node::Text(Text{value: "日本語 ".to_string(), position: None}),
+        Node::Embed(Embed{target: "ファイル".to_string(), display: None, position: None}),
+        Node::Text(Text{value: " と ".to_string(), position: None}),
+        Node::WikiLink(WikiLink{target: "ページ".to_string(), text: None, position: None}),
+    ])]
+    fn test_parse_inline_links_into(#[case] input: &str, #[case] expected: Vec<Node>) {
+        let mut result = Vec::new();
+        Node::parse_inline_links_into(input, None, &mut result);
         assert_eq!(result, expected);
     }
 

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -1066,6 +1066,9 @@ impl Node {
                     _ => format!("[!{}]", kind),
                 };
                 let header_line = format!("{}> {}{}", bs, be, header);
+                if values.is_empty() {
+                    return header_line;
+                }
                 let body = render_values_block(&values, options, theme);
                 if body.trim().is_empty() {
                     header_line
@@ -2439,7 +2442,7 @@ impl Node {
             },
             #[cfg(feature = "callout")]
             Node::Callout(c) => match attr {
-                attr_keys::KIND => c.kind = value_str.to_uppercase(),
+                attr_keys::KIND => c.kind = value_str,
                 attr_keys::TITLE => c.title = if value_str.is_empty() { None } else { Some(value_str) },
                 _ => (),
             },
@@ -2458,20 +2461,33 @@ impl Node {
     /// falls back to a plain `Blockquote`.
     #[cfg(feature = "callout")]
     fn try_parse_callout(values: Vec<Node>, position: Option<Position>) -> Node {
-        let first_text = match values.first() {
-            Some(Node::Text(t)) => t.value.clone(),
-            _ => return Node::Blockquote(Blockquote { values, position }),
+        // Peek without cloning so plain blockquotes pay no allocation cost.
+        if !matches!(values.first(), Some(Node::Text(t)) if t.value.starts_with("[!")) {
+            return Node::Blockquote(Blockquote { values, position });
+        }
+
+        let mut iter = values.into_iter();
+        // SAFETY: the peek above guarantees at least one Text node exists.
+        let first_text = match iter.next().unwrap() {
+            Node::Text(t) => t.value,
+            _ => unreachable!(),
         };
 
         let Some(rest) = first_text.strip_prefix("[!") else {
-            return Node::Blockquote(Blockquote { values, position });
+            unreachable!()
         };
 
         let Some(bracket_end) = rest.find(']') else {
+            // Malformed `[!…` without closing `]` — treat as plain blockquote.
+            let mut values = vec![Node::Text(Text {
+                value: first_text,
+                position: None,
+            })];
+            values.extend(iter);
             return Node::Blockquote(Blockquote { values, position });
         };
 
-        let kind = rest[..bracket_end].to_uppercase();
+        let kind = rest[..bracket_end].to_string();
         let after_bracket = &rest[bracket_end + 1..];
 
         let (title, remaining_body) = if let Some(nl) = after_bracket.find('\n') {
@@ -2485,16 +2501,18 @@ impl Node {
             (if t.is_empty() { None } else { Some(t.to_string()) }, String::new())
         };
 
-        let mut body: Vec<Node> = values.into_iter().skip(1).collect();
-        if !remaining_body.trim().is_empty() {
-            body.insert(
-                0,
-                Node::Text(Text {
-                    value: remaining_body,
-                    position: None,
-                }),
-            );
-        }
+        let body = if !remaining_body.trim().is_empty() {
+            let rest_nodes: Vec<Node> = iter.collect();
+            let mut b = Vec::with_capacity(rest_nodes.len() + 1);
+            b.push(Node::Text(Text {
+                value: remaining_body,
+                position: None,
+            }));
+            b.extend(rest_nodes);
+            b
+        } else {
+            iter.collect()
+        };
 
         Node::Callout(Callout {
             kind,
@@ -5527,11 +5545,11 @@ mod tests {
         vec![Node::Text(Text { value: "[!TIP]".to_string(), position: None })],
         Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None })
     )]
-    // lowercase kind is normalised to uppercase
+    // lowercase kind is preserved as-is
     #[case(
         vec![Node::Text(Text { value: "[!note]\ncontent".to_string(), position: None })],
         Node::Callout(Callout {
-            kind: "NOTE".to_string(),
+            kind: "note".to_string(),
             title: None,
             values: vec![Node::Text(Text { value: "content".to_string(), position: None })],
             position: None,
@@ -5639,11 +5657,11 @@ mod tests {
         "kind", "WARNING",
         Node::Callout(Callout { kind: "WARNING".to_string(), title: None, values: vec![], position: None })
     )]
-    // set_attr normalises kind to uppercase
+    // set_attr stores kind as-is without case conversion
     #[case(
         Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }),
         "kind", "tip",
-        Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None })
+        Node::Callout(Callout { kind: "tip".to_string(), title: None, values: vec![], position: None })
     )]
     #[case(
         Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }),

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -409,6 +409,40 @@ pub struct Link {
     pub position: Option<Position>,
 }
 
+/// An Obsidian-style callout (admonition): `> [!TYPE]` or `> [!TYPE] title`.
+#[cfg(feature = "callout")]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(
+    feature = "json",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", tag = "type")
+)]
+pub struct Callout {
+    /// The callout type in uppercase (e.g. `"NOTE"`, `"WARNING"`, `"TIP"`).
+    pub kind: String,
+    /// Optional custom title after the `[!TYPE]` marker.
+    pub title: Option<String>,
+    /// Body content nodes (the lines after the header).
+    pub values: Vec<Node>,
+    pub position: Option<Position>,
+}
+
+/// An Obsidian-style file embed: `![[target]]` or `![[target|display]]`.
+#[cfg(feature = "embed")]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(
+    feature = "json",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", tag = "type")
+)]
+pub struct Embed {
+    /// The target file or note name (e.g. `"image.png"`, `"note.md"`).
+    pub target: String,
+    /// Optional display hint after `|` (size for images, heading for notes).
+    pub display: Option<String>,
+    pub position: Option<Position>,
+}
+
 /// An Obsidian-style wikilink: `[[target]]` or `[[target|text]]`.
 #[cfg(feature = "wikilink")]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -729,6 +763,10 @@ pub struct HorizontalRule {
 pub enum Node {
     Blockquote(Blockquote),
     Break(Break),
+    #[cfg(feature = "callout")]
+    Callout(Callout),
+    #[cfg(feature = "embed")]
+    Embed(Embed),
     Definition(Definition),
     Delete(Delete),
     Heading(Heading),
@@ -893,6 +931,8 @@ impl Node {
             | Node::Delete(Delete { values, .. })
             | Node::Emphasis(Emphasis { values, .. })
             | Node::Strong(Strong { values, .. }) => Self::Fragment(Fragment { values }),
+            #[cfg(feature = "callout")]
+            Node::Callout(Callout { values, .. }) => Self::Fragment(Fragment { values }),
             node @ Node::Fragment(_) => node,
             _ => Self::Empty,
         }
@@ -915,6 +955,27 @@ impl Node {
             | Node::Delete(Delete { values, .. })
             | Node::Emphasis(Emphasis { values, .. })
             | Node::Strong(Strong { values, .. }) => {
+                if let Node::Fragment(Fragment { values: new_values }) = fragment {
+                    let new_values = values
+                        .iter()
+                        .zip(new_values)
+                        .map(|(current_value, new_value)| {
+                            if new_value.is_empty() {
+                                current_value.clone()
+                            } else if new_value.is_fragment() {
+                                let mut current_value = current_value.clone();
+                                Self::_apply_fragment(&mut current_value, new_value);
+                                current_value
+                            } else {
+                                new_value
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    *values = new_values;
+                }
+            }
+            #[cfg(feature = "callout")]
+            Node::Callout(Callout { values, .. }) => {
                 if let Node::Fragment(Fragment { values: new_values }) = fragment {
                     let new_values = values
                         .iter()
@@ -990,11 +1051,37 @@ impl Node {
             }
             Self::Blockquote(Blockquote { values, .. }) => {
                 let (bs, be) = &theme.blockquote_marker;
-                render_values(&values, options, theme)
+                render_values_block(&values, options, theme)
                     .split('\n')
                     .map(|line| format!("{}> {}{}", bs, be, line))
                     .join("\n")
             }
+            #[cfg(feature = "callout")]
+            Self::Callout(Callout {
+                kind, title, values, ..
+            }) => {
+                let (bs, be) = &theme.blockquote_marker;
+                let header = match title.as_deref() {
+                    Some(t) if !t.is_empty() => format!("[!{}] {}", kind, t),
+                    _ => format!("[!{}]", kind),
+                };
+                let header_line = format!("{}> {}{}", bs, be, header);
+                let body = render_values_block(&values, options, theme);
+                if body.trim().is_empty() {
+                    header_line
+                } else {
+                    let body_lines = body
+                        .split('\n')
+                        .map(|line| format!("{}> {}{}", bs, be, line))
+                        .join("\n");
+                    format!("{}\n{}", header_line, body_lines)
+                }
+            }
+            #[cfg(feature = "embed")]
+            Self::Embed(Embed { target, display, .. }) => match display.as_deref() {
+                Some(d) if !d.is_empty() => format!("![[{}|{}]]", target, d),
+                _ => format!("![[{}]]", target),
+            },
             Self::Code(Code {
                 value,
                 lang,
@@ -1230,6 +1317,8 @@ impl Node {
             Self::Emphasis(v) => v.values,
             Self::List(l) => l.values,
             Self::Strong(v) => v.values,
+            #[cfg(feature = "callout")]
+            Self::Callout(v) => v.values,
             _ => vec![self.clone()],
         }
     }
@@ -1244,6 +1333,8 @@ impl Node {
             Self::List(v) => v.values.get(index).cloned(),
             Self::TableCell(v) => v.values.get(index).cloned(),
             Self::TableRow(v) => v.values.get(index).cloned(),
+            #[cfg(feature = "callout")]
+            Self::Callout(v) => v.values.get(index).cloned(),
             _ => None,
         }
     }
@@ -1268,6 +1359,10 @@ impl Node {
             Self::LinkRef(l) => l.ident,
             #[cfg(feature = "wikilink")]
             Self::WikiLink(w) => w.text.unwrap_or(w.target),
+            #[cfg(feature = "callout")]
+            Self::Callout(v) => values_to_value(v.values),
+            #[cfg(feature = "embed")]
+            Self::Embed(e) => e.display.unwrap_or(e.target),
             Self::Math(v) => v.value,
             Self::List(l) => values_to_value(l.values),
             Self::TableCell(c) => values_to_value(c.values),
@@ -1317,6 +1412,10 @@ impl Node {
             Self::LinkRef(_) => "link_ref".into(),
             #[cfg(feature = "wikilink")]
             Self::WikiLink(_) => "wikilink".into(),
+            #[cfg(feature = "callout")]
+            Self::Callout(_) => "callout".into(),
+            #[cfg(feature = "embed")]
+            Self::Embed(_) => "embed".into(),
             Self::Math(_) => "math".into(),
             Self::List(_) => "list".into(),
             Self::TableAlign(_) => "table_align".into(),
@@ -1363,6 +1462,10 @@ impl Node {
             Self::LinkRef(l) => l.position = pos,
             #[cfg(feature = "wikilink")]
             Self::WikiLink(w) => w.position = pos,
+            #[cfg(feature = "callout")]
+            Self::Callout(c) => c.position = pos,
+            #[cfg(feature = "embed")]
+            Self::Embed(e) => e.position = pos,
             Self::Math(v) => v.position = pos,
             Self::Code(c) => c.position = pos,
             Self::TableCell(c) => c.position = pos,
@@ -1402,6 +1505,10 @@ impl Node {
             Self::LinkRef(l) => l.position.clone(),
             #[cfg(feature = "wikilink")]
             Self::WikiLink(w) => w.position.clone(),
+            #[cfg(feature = "callout")]
+            Self::Callout(c) => c.position.clone(),
+            #[cfg(feature = "embed")]
+            Self::Embed(e) => e.position.clone(),
             Self::Math(v) => v.position.clone(),
             Self::Code(c) => c.position.clone(),
             Self::TableCell(c) => c.position.clone(),
@@ -1501,6 +1608,18 @@ impl Node {
     #[cfg(feature = "wikilink")]
     pub fn is_wikilink(&self) -> bool {
         matches!(self, Self::WikiLink(_))
+    }
+
+    /// Returns `true` if this node is an Obsidian-style callout (`> [!TYPE]`).
+    #[cfg(feature = "callout")]
+    pub fn is_callout(&self) -> bool {
+        matches!(self, Self::Callout(_))
+    }
+
+    /// Returns `true` if this node is an Obsidian-style embed (`![[target]]`).
+    #[cfg(feature = "embed")]
+    pub fn is_embed(&self) -> bool {
+        matches!(self, Self::Embed(_))
     }
 
     pub fn is_text(&self) -> bool {
@@ -1775,6 +1894,22 @@ impl Node {
                 }
                 Self::WikiLink(w)
             }
+            #[cfg(feature = "callout")]
+            Self::Callout(mut c) => {
+                if let Some(node) = c.values.first() {
+                    c.values[0] = node.with_value(value);
+                }
+                Self::Callout(c)
+            }
+            #[cfg(feature = "embed")]
+            Self::Embed(mut e) => {
+                if e.display.is_some() {
+                    e.display = Some(value.to_string());
+                } else {
+                    e.target = value.to_string();
+                }
+                Self::Embed(e)
+            }
         }
     }
 
@@ -1862,6 +1997,15 @@ impl Node {
             }
             #[cfg(feature = "wikilink")]
             a @ Self::WikiLink(_) => a,
+            #[cfg(feature = "callout")]
+            Self::Callout(mut c) => {
+                if c.values.get(index).is_some() {
+                    c.values[index] = c.values[index].with_value(value);
+                }
+                Self::Callout(c)
+            }
+            #[cfg(feature = "embed")]
+            a @ Self::Embed(_) => a,
             a => a,
         }
     }
@@ -1939,6 +2083,22 @@ impl Node {
             Node::WikiLink(WikiLink { target, text, .. }) => match attr {
                 attr_keys::URL => Some(AttrValue::String(target.clone())),
                 attr_keys::VALUE => Some(AttrValue::String(text.clone().unwrap_or_else(|| target.clone()))),
+                _ => None,
+            },
+            #[cfg(feature = "callout")]
+            Node::Callout(Callout {
+                kind, title, values, ..
+            }) => match attr {
+                attr_keys::KIND => Some(AttrValue::String(kind.clone())),
+                attr_keys::TITLE => title.clone().map(AttrValue::String),
+                attr_keys::VALUE => Some(AttrValue::String(values_to_string(values, &RenderOptions::default()))),
+                attr_keys::VALUES | attr_keys::CHILDREN => Some(AttrValue::Array(values.clone())),
+                _ => None,
+            },
+            #[cfg(feature = "embed")]
+            Node::Embed(Embed { target, display, .. }) => match attr {
+                attr_keys::URL => Some(AttrValue::String(target.clone())),
+                attr_keys::VALUE => Some(AttrValue::String(display.clone().unwrap_or_else(|| target.clone()))),
                 _ => None,
             },
             Node::LinkRef(LinkRef { ident, label, .. }) => match attr {
@@ -2277,6 +2437,237 @@ impl Node {
                 attr_keys::VALUE => w.text = if value_str.is_empty() { None } else { Some(value_str) },
                 _ => (),
             },
+            #[cfg(feature = "callout")]
+            Node::Callout(c) => match attr {
+                attr_keys::KIND => c.kind = value_str.to_uppercase(),
+                attr_keys::TITLE => c.title = if value_str.is_empty() { None } else { Some(value_str) },
+                _ => (),
+            },
+            #[cfg(feature = "embed")]
+            Node::Embed(e) => match attr {
+                attr_keys::URL => e.target = value_str,
+                attr_keys::VALUE => e.display = if value_str.is_empty() { None } else { Some(value_str) },
+                _ => (),
+            },
+        }
+    }
+
+    /// Tries to parse a `Blockquote`'s converted nodes as an Obsidian callout.
+    ///
+    /// Returns a `Callout` node when the first text starts with `[!TYPE]`, otherwise
+    /// falls back to a plain `Blockquote`.
+    #[cfg(feature = "callout")]
+    fn try_parse_callout(values: Vec<Node>, position: Option<Position>) -> Node {
+        let first_text = match values.first() {
+            Some(Node::Text(t)) => t.value.clone(),
+            _ => return Node::Blockquote(Blockquote { values, position }),
+        };
+
+        let Some(rest) = first_text.strip_prefix("[!") else {
+            return Node::Blockquote(Blockquote { values, position });
+        };
+
+        let Some(bracket_end) = rest.find(']') else {
+            return Node::Blockquote(Blockquote { values, position });
+        };
+
+        let kind = rest[..bracket_end].to_uppercase();
+        let after_bracket = &rest[bracket_end + 1..];
+
+        let (title, remaining_body) = if let Some(nl) = after_bracket.find('\n') {
+            let t = after_bracket[..nl].trim();
+            (
+                if t.is_empty() { None } else { Some(t.to_string()) },
+                after_bracket[nl + 1..].to_string(),
+            )
+        } else {
+            let t = after_bracket.trim();
+            (if t.is_empty() { None } else { Some(t.to_string()) }, String::new())
+        };
+
+        let mut body: Vec<Node> = values.into_iter().skip(1).collect();
+        if !remaining_body.trim().is_empty() {
+            body.insert(
+                0,
+                Node::Text(Text {
+                    value: remaining_body,
+                    position: None,
+                }),
+            );
+        }
+
+        Node::Callout(Callout {
+            kind,
+            title,
+            values: body,
+            position,
+        })
+    }
+
+    /// Recursively scans a node list and converts `![[target]]` / `![[target|display]]`
+    /// patterns inside `Text` nodes into `Embed` nodes.
+    #[cfg(feature = "embed")]
+    pub fn expand_embeds(nodes: Vec<Node>) -> Vec<Node> {
+        let mut result = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            Self::expand_embeds_into(node, &mut result);
+        }
+        result
+    }
+
+    /// Returns true if any `Text` descendant of this node contains `![[`.
+    #[cfg(feature = "embed")]
+    fn values_need_embed_expansion(values: &[Node]) -> bool {
+        values.iter().any(|n| match n {
+            Node::Text(t) => t.value.contains("![["),
+            Node::Heading(h) => Self::values_need_embed_expansion(&h.values),
+            Node::Blockquote(b) => Self::values_need_embed_expansion(&b.values),
+            #[cfg(feature = "callout")]
+            Node::Callout(c) => Self::values_need_embed_expansion(&c.values),
+            Node::List(l) => Self::values_need_embed_expansion(&l.values),
+            Node::Strong(s) => Self::values_need_embed_expansion(&s.values),
+            Node::Emphasis(e) => Self::values_need_embed_expansion(&e.values),
+            Node::Delete(d) => Self::values_need_embed_expansion(&d.values),
+            Node::TableCell(tc) => Self::values_need_embed_expansion(&tc.values),
+            Node::TableRow(tr) => Self::values_need_embed_expansion(&tr.values),
+            Node::Footnote(f) => Self::values_need_embed_expansion(&f.values),
+            _ => false,
+        })
+    }
+
+    #[cfg(feature = "embed")]
+    fn expand_embeds_into(node: Node, out: &mut Vec<Node>) {
+        match node {
+            Node::Text(Text { ref value, .. }) if !value.contains("![[") => out.push(node),
+            Node::Text(Text { value, position }) => {
+                Self::parse_embeds_into(&value, position, out);
+            }
+            Node::Heading(mut h) => {
+                if Self::values_need_embed_expansion(&h.values) {
+                    h.values = Self::expand_embeds(h.values);
+                }
+                out.push(Node::Heading(h));
+            }
+            Node::Blockquote(mut b) => {
+                if Self::values_need_embed_expansion(&b.values) {
+                    b.values = Self::expand_embeds(b.values);
+                }
+                out.push(Node::Blockquote(b));
+            }
+            #[cfg(feature = "callout")]
+            Node::Callout(mut c) => {
+                if Self::values_need_embed_expansion(&c.values) {
+                    c.values = Self::expand_embeds(c.values);
+                }
+                out.push(Node::Callout(c));
+            }
+            Node::List(mut l) => {
+                if Self::values_need_embed_expansion(&l.values) {
+                    l.values = Self::expand_embeds(l.values);
+                }
+                out.push(Node::List(l));
+            }
+            Node::Strong(mut s) => {
+                if Self::values_need_embed_expansion(&s.values) {
+                    s.values = Self::expand_embeds(s.values);
+                }
+                out.push(Node::Strong(s));
+            }
+            Node::Emphasis(mut e) => {
+                if Self::values_need_embed_expansion(&e.values) {
+                    e.values = Self::expand_embeds(e.values);
+                }
+                out.push(Node::Emphasis(e));
+            }
+            Node::Delete(mut d) => {
+                if Self::values_need_embed_expansion(&d.values) {
+                    d.values = Self::expand_embeds(d.values);
+                }
+                out.push(Node::Delete(d));
+            }
+            Node::TableCell(mut tc) => {
+                if Self::values_need_embed_expansion(&tc.values) {
+                    tc.values = Self::expand_embeds(tc.values);
+                }
+                out.push(Node::TableCell(tc));
+            }
+            Node::TableRow(mut tr) => {
+                if Self::values_need_embed_expansion(&tr.values) {
+                    tr.values = Self::expand_embeds(tr.values);
+                }
+                out.push(Node::TableRow(tr));
+            }
+            Node::Footnote(mut f) => {
+                if Self::values_need_embed_expansion(&f.values) {
+                    f.values = Self::expand_embeds(f.values);
+                }
+                out.push(Node::Footnote(f));
+            }
+            other => out.push(other),
+        }
+    }
+
+    /// Splits a text string on `![[...]]` patterns, pushing a mix of `Text`
+    /// and `Embed` nodes into `out`.
+    #[cfg(feature = "embed")]
+    fn parse_embeds_into(text: &str, position: Option<Position>, out: &mut Vec<Node>) {
+        let mut last_end = 0;
+        let mut search_from = 0;
+        let mut found_any = false;
+
+        while let Some(bang_rel) = text[search_from..].find("![[") {
+            let bang = search_from + bang_rel;
+            let inner_start = bang + 3;
+
+            let Some(close_rel) = text[inner_start..].find("]]") else {
+                search_from = bang + 1;
+                continue;
+            };
+            let close = inner_start + close_rel;
+            let content = &text[inner_start..close];
+
+            if content.contains('[') || content.contains(']') {
+                search_from = bang + 1;
+                continue;
+            }
+
+            found_any = true;
+            if last_end < bang {
+                out.push(Node::Text(Text {
+                    value: text[last_end..bang].to_string(),
+                    position: position.clone(),
+                }));
+            }
+            let (target, display) = if let Some(pipe) = content.find('|') {
+                (
+                    content[..pipe].trim().to_string(),
+                    Some(content[pipe + 1..].trim().to_string()),
+                )
+            } else {
+                (content.trim().to_string(), None)
+            };
+            out.push(Node::Embed(Embed {
+                target,
+                display,
+                position: position.clone(),
+            }));
+            last_end = close + 2;
+            search_from = close + 2;
+        }
+
+        if !found_any {
+            out.push(Node::Text(Text {
+                value: text.to_string(),
+                position,
+            }));
+            return;
+        }
+
+        if last_end < text.len() {
+            out.push(Node::Text(Text {
+                value: text[last_end..].to_string(),
+                position,
+            }));
         }
     }
 
@@ -2298,6 +2689,8 @@ impl Node {
             Node::Text(t) => t.value.contains("[["),
             Node::Heading(h) => Self::values_need_expansion(&h.values),
             Node::Blockquote(b) => Self::values_need_expansion(&b.values),
+            #[cfg(feature = "callout")]
+            Node::Callout(c) => Self::values_need_expansion(&c.values),
             Node::List(l) => Self::values_need_expansion(&l.values),
             Node::Strong(s) => Self::values_need_expansion(&s.values),
             Node::Emphasis(e) => Self::values_need_expansion(&e.values),
@@ -2327,6 +2720,13 @@ impl Node {
                     b.values = Self::expand_wikilinks(b.values);
                 }
                 out.push(Node::Blockquote(b));
+            }
+            #[cfg(feature = "callout")]
+            Node::Callout(mut c) => {
+                if Self::values_need_expansion(&c.values) {
+                    c.values = Self::expand_wikilinks(c.values);
+                }
+                out.push(Node::Callout(c));
             }
             Node::List(mut l) => {
                 if Self::values_need_expansion(&l.values) {
@@ -2537,10 +2937,16 @@ impl Node {
                 }
             },
             mdast::Node::Blockquote(mdast::Blockquote { position, .. }) => {
-                vec![Self::Blockquote(Blockquote {
-                    values: Self::mdast_children_to_node(node),
-                    position: position.map(|p| p.clone().into()),
-                })]
+                let values = Self::mdast_children_to_node(node);
+                let pos = position.map(|p| p.clone().into());
+                #[cfg(feature = "callout")]
+                {
+                    vec![Self::try_parse_callout(values, pos)]
+                }
+                #[cfg(not(feature = "callout"))]
+                {
+                    vec![Self::Blockquote(Blockquote { values, position: pos })]
+                }
             }
             mdast::Node::Definition(mdast::Definition {
                 url,
@@ -2992,6 +3398,35 @@ pub(crate) fn render_values(values: &[Node], options: &RenderOptions, theme: &Co
                             .join("\n")
                     )
                 }
+            } else {
+                pre_position = None;
+                value.render_with_theme(options, theme)
+            }
+        })
+        .collect::<String>()
+}
+
+/// Like `render_values` but without column-offset–based indentation.
+///
+/// Inside blockquotes and callouts, node positions include the `> ` prefix offset,
+/// so applying column-based spacing causes double-indentation. This variant preserves
+/// blank lines between values (via newline counting) but ignores the column position.
+pub(crate) fn render_values_block(values: &[Node], options: &RenderOptions, theme: &ColorTheme<'_>) -> String {
+    let mut pre_position: Option<Position> = None;
+    values
+        .iter()
+        .map(|value| {
+            if let Some(pos) = value.position() {
+                let new_line_count = pre_position
+                    .as_ref()
+                    .map(|p: &Position| pos.start.line - p.end.line)
+                    .unwrap_or_default();
+                pre_position = Some(pos);
+                format!(
+                    "{}{}",
+                    "\n".repeat(new_line_count),
+                    value.render_with_theme(options, theme)
+                )
             } else {
                 pre_position = None;
                 value.render_with_theme(options, theme)
@@ -5012,5 +5447,477 @@ mod tests {
     #[case(AttrValue::Boolean(false), Some(0))]
     fn test_attr_value_as_i64(#[case] value: AttrValue, #[case] expected: Option<i64>) {
         assert_eq!(value.as_i64(), expected);
+    }
+
+    // --- Callout tests ---
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    // basic [!NOTE] with body on next line
+    #[case(
+        vec![Node::Text(Text { value: "[!NOTE]\nbody text".to_string(), position: None })],
+        Node::Callout(Callout {
+            kind: "NOTE".to_string(),
+            title: None,
+            values: vec![Node::Text(Text { value: "body text".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    // [!WARNING] with custom title
+    #[case(
+        vec![Node::Text(Text { value: "[!WARNING] My Title\nbody".to_string(), position: None })],
+        Node::Callout(Callout {
+            kind: "WARNING".to_string(),
+            title: Some("My Title".to_string()),
+            values: vec![Node::Text(Text { value: "body".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    // [!TIP] with no body
+    #[case(
+        vec![Node::Text(Text { value: "[!TIP]".to_string(), position: None })],
+        Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None })
+    )]
+    // lowercase kind is normalised to uppercase
+    #[case(
+        vec![Node::Text(Text { value: "[!note]\ncontent".to_string(), position: None })],
+        Node::Callout(Callout {
+            kind: "NOTE".to_string(),
+            title: None,
+            values: vec![Node::Text(Text { value: "content".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    // not a callout — plain text stays Blockquote
+    #[case(
+        vec![Node::Text(Text { value: "plain quote".to_string(), position: None })],
+        Node::Blockquote(Blockquote {
+            values: vec![Node::Text(Text { value: "plain quote".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    // [! without closing ] — stays Blockquote
+    #[case(
+        vec![Node::Text(Text { value: "[!UNCLOSED".to_string(), position: None })],
+        Node::Blockquote(Blockquote {
+            values: vec![Node::Text(Text { value: "[!UNCLOSED".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    // first node is not Text — stays Blockquote
+    #[case(
+        vec![Node::Code(Code { value: "code".to_string(), lang: None, fence: true, meta: None, position: None })],
+        Node::Blockquote(Blockquote {
+            values: vec![Node::Code(Code { value: "code".to_string(), lang: None, fence: true, meta: None, position: None })],
+            position: None,
+        })
+    )]
+    // multi-paragraph callout (header-only node + separate body node)
+    #[case(
+        vec![
+            Node::Text(Text { value: "[!NOTE]".to_string(), position: None }),
+            Node::Text(Text { value: "second paragraph".to_string(), position: None }),
+        ],
+        Node::Callout(Callout {
+            kind: "NOTE".to_string(),
+            title: None,
+            values: vec![Node::Text(Text { value: "second paragraph".to_string(), position: None })],
+            position: None,
+        })
+    )]
+    fn test_try_parse_callout(#[case] values: Vec<Node>, #[case] expected: Node) {
+        let result = Node::try_parse_callout(values, None);
+        assert_eq!(result, expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    // basic render
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None,
+            values: vec![Node::Text(Text { value: "content".to_string(), position: None })],
+            position: None }),
+        "> [!NOTE]\n> content"
+    )]
+    // with title
+    #[case(
+        Node::Callout(Callout { kind: "WARNING".to_string(), title: Some("Heads up".to_string()),
+            values: vec![Node::Text(Text { value: "watch out".to_string(), position: None })],
+            position: None }),
+        "> [!WARNING] Heads up\n> watch out"
+    )]
+    // empty body
+    #[case(
+        Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None }),
+        "> [!TIP]"
+    )]
+    // multiline body: single Text with embedded '\n' — each line prefixed with "> "
+    #[case(
+        Node::Callout(Callout { kind: "INFO".to_string(), title: None,
+            values: vec![Node::Text(Text { value: "line one\nline two".to_string(), position: None })],
+            position: None }),
+        "> [!INFO]\n> line one\n> line two"
+    )]
+    // two separate position-less Text values are concatenated inline (no implicit newline)
+    #[case(
+        Node::Callout(Callout { kind: "INFO".to_string(), title: None,
+            values: vec![
+                Node::Text(Text { value: "part a".to_string(), position: None }),
+                Node::Text(Text { value: "part b".to_string(), position: None }),
+            ],
+            position: None }),
+        "> [!INFO]\n> part apart b"
+    )]
+    fn test_callout_render(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.to_string_with(&RenderOptions::default()), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case(Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }), "kind", Some(AttrValue::String("NOTE".to_string())))]
+    #[case(Node::Callout(Callout { kind: "WARNING".to_string(), title: Some("Title".to_string()), values: vec![], position: None }), "title", Some(AttrValue::String("Title".to_string())))]
+    #[case(Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None }), "title", None)]
+    #[case(Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![Node::Text(Text { value: "body".to_string(), position: None })], position: None }), "value", Some(AttrValue::String("body".to_string())))]
+    #[case(Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![Node::Text(Text { value: "body".to_string(), position: None })], position: None }), "children", Some(AttrValue::Array(vec![Node::Text(Text { value: "body".to_string(), position: None })])))]
+    fn test_callout_attr(#[case] node: Node, #[case] attr: &str, #[case] expected: Option<AttrValue>) {
+        assert_eq!(node.attr(attr), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }),
+        "kind", "WARNING",
+        Node::Callout(Callout { kind: "WARNING".to_string(), title: None, values: vec![], position: None })
+    )]
+    // set_attr normalises kind to uppercase
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }),
+        "kind", "tip",
+        Node::Callout(Callout { kind: "TIP".to_string(), title: None, values: vec![], position: None })
+    )]
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }),
+        "title", "My title",
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: Some("My title".to_string()), values: vec![], position: None })
+    )]
+    // empty string clears title
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: Some("old".to_string()), values: vec![], position: None }),
+        "title", "",
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None })
+    )]
+    fn test_callout_set_attr(#[case] mut node: Node, #[case] attr: &str, #[case] value: &str, #[case] expected: Node) {
+        node.set_attr(attr, value);
+        assert_eq!(node, expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    // with_value changes first body node
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None,
+            values: vec![Node::Text(Text { value: "old".to_string(), position: None })],
+            position: None }),
+        "new",
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None,
+            values: vec![Node::Text(Text { value: "new".to_string(), position: None })],
+            position: None })
+    )]
+    fn test_callout_with_value(#[case] node: Node, #[case] value: &str, #[case] expected: Node) {
+        assert_eq!(node.with_value(value), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case(Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }), "callout")]
+    fn test_callout_name(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.name(), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case(
+        Node::Callout(Callout { kind: "NOTE".to_string(), title: None,
+            values: vec![Node::Text(Text { value: "body".to_string(), position: None })],
+            position: None }),
+        "body"
+    )]
+    fn test_callout_value(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.value(), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    #[case(Node::Callout(Callout { kind: "NOTE".to_string(), title: None, values: vec![], position: None }), true)]
+    #[case(Node::Blockquote(Blockquote { values: vec![], position: None }), false)]
+    #[case(Node::Text(Text { value: "test".to_string(), position: None }), false)]
+    fn test_is_callout(#[case] node: Node, #[case] expected: bool) {
+        assert_eq!(node.is_callout(), expected);
+    }
+
+    #[cfg(feature = "callout")]
+    #[test]
+    fn test_callout_end_to_end() {
+        use crate::Markdown;
+        // plain blockquote stays as Blockquote
+        let plain = Markdown::from_markdown_str("> just a quote").unwrap();
+        assert!(plain.nodes[0].is_blockquote());
+
+        // [!NOTE] is parsed as Callout
+        let note = Markdown::from_markdown_str("> [!NOTE]\n> body").unwrap();
+        assert!(note.nodes[0].is_callout());
+        assert_eq!(note.nodes[0].attr("kind"), Some(AttrValue::String("NOTE".to_string())));
+
+        // [!WARNING] with title
+        let warn = Markdown::from_markdown_str("> [!WARNING] Watch out\n> content").unwrap();
+        assert!(warn.nodes[0].is_callout());
+        assert_eq!(
+            warn.nodes[0].attr("title"),
+            Some(AttrValue::String("Watch out".to_string()))
+        );
+    }
+
+    // --- Embed tests ---
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // plain embed
+    #[case("![[target]]", vec![Node::Embed(Embed { target: "target".to_string(), display: None, position: None })])]
+    // embed with display hint (image size)
+    #[case("![[image.png|400]]", vec![Node::Embed(Embed { target: "image.png".to_string(), display: Some("400".to_string()), position: None })])]
+    // embed with section reference in target
+    #[case("![[note#Heading]]", vec![Node::Embed(Embed { target: "note#Heading".to_string(), display: None, position: None })])]
+    // embed at start of text
+    #[case("![[note]] rest", vec![
+        Node::Embed(Embed { target: "note".to_string(), display: None, position: None }),
+        Node::Text(Text { value: " rest".to_string(), position: None }),
+    ])]
+    // embed in middle
+    #[case("before ![[note]] after", vec![
+        Node::Text(Text { value: "before ".to_string(), position: None }),
+        Node::Embed(Embed { target: "note".to_string(), display: None, position: None }),
+        Node::Text(Text { value: " after".to_string(), position: None }),
+    ])]
+    // multiple embeds
+    #[case("![[a]] and ![[b]]", vec![
+        Node::Embed(Embed { target: "a".to_string(), display: None, position: None }),
+        Node::Text(Text { value: " and ".to_string(), position: None }),
+        Node::Embed(Embed { target: "b".to_string(), display: None, position: None }),
+    ])]
+    // multibyte target
+    #[case("![[ノート]]", vec![Node::Embed(Embed { target: "ノート".to_string(), display: None, position: None })])]
+    // no embed — plain text unchanged
+    #[case("plain text", vec![Node::Text(Text { value: "plain text".to_string(), position: None })])]
+    // unclosed embed — treated as plain text
+    #[case("![[unclosed", vec![Node::Text(Text { value: "![[unclosed".to_string(), position: None })])]
+    // lone ! before non-embed — treated as plain text
+    #[case("! not an embed", vec![Node::Text(Text { value: "! not an embed".to_string(), position: None })])]
+    fn test_parse_embeds_in_text(#[case] input: &str, #[case] expected: Vec<Node>) {
+        let mut result = Vec::new();
+        Node::parse_embeds_into(input, None, &mut result);
+        assert_eq!(result, expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // plain embed renders without display
+    #[case(
+        Node::Embed(Embed { target: "note.md".to_string(), display: None, position: None }),
+        "![[note.md]]"
+    )]
+    // embed with display hint
+    #[case(
+        Node::Embed(Embed { target: "image.png".to_string(), display: Some("400".to_string()), position: None }),
+        "![[image.png|400]]"
+    )]
+    // embed with section reference
+    #[case(
+        Node::Embed(Embed { target: "note#Intro".to_string(), display: None, position: None }),
+        "![[note#Intro]]"
+    )]
+    fn test_embed_render(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.to_string_with(&RenderOptions::default()), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), "url", Some(AttrValue::String("note".to_string())))]
+    // value returns target when no display
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), "value", Some(AttrValue::String("note".to_string())))]
+    // url always returns target regardless of display
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: Some("400".to_string()), position: None }), "url", Some(AttrValue::String("note".to_string())))]
+    // value returns display when present
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: Some("400".to_string()), position: None }), "value", Some(AttrValue::String("400".to_string())))]
+    // unknown attr returns None
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), "unknown", None)]
+    fn test_embed_attr(#[case] node: Node, #[case] attr: &str, #[case] expected: Option<AttrValue>) {
+        assert_eq!(node.attr(attr), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // set url changes target
+    #[case(
+        Node::Embed(Embed { target: "old".to_string(), display: None, position: None }),
+        "url", "new",
+        Node::Embed(Embed { target: "new".to_string(), display: None, position: None })
+    )]
+    // set value changes display
+    #[case(
+        Node::Embed(Embed { target: "note".to_string(), display: None, position: None }),
+        "value", "800",
+        Node::Embed(Embed { target: "note".to_string(), display: Some("800".to_string()), position: None })
+    )]
+    // empty value clears display
+    #[case(
+        Node::Embed(Embed { target: "note".to_string(), display: Some("400".to_string()), position: None }),
+        "value", "",
+        Node::Embed(Embed { target: "note".to_string(), display: None, position: None })
+    )]
+    fn test_embed_set_attr(#[case] mut node: Node, #[case] attr: &str, #[case] value: &str, #[case] expected: Node) {
+        node.set_attr(attr, value);
+        assert_eq!(node, expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // no display: with_value sets target
+    #[case(
+        Node::Embed(Embed { target: "old".to_string(), display: None, position: None }),
+        "new",
+        Node::Embed(Embed { target: "new".to_string(), display: None, position: None })
+    )]
+    // with display: with_value sets display
+    #[case(
+        Node::Embed(Embed { target: "note".to_string(), display: Some("400".to_string()), position: None }),
+        "800",
+        Node::Embed(Embed { target: "note".to_string(), display: Some("800".to_string()), position: None })
+    )]
+    fn test_embed_with_value(#[case] node: Node, #[case] value: &str, #[case] expected: Node) {
+        assert_eq!(node.with_value(value), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), "embed")]
+    fn test_embed_name(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.name(), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // value returns display when present
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: Some("400".to_string()), position: None }), "400")]
+    // value returns target when no display
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), "note")]
+    fn test_embed_value(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.value(), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    #[case(Node::Embed(Embed { target: "note".to_string(), display: None, position: None }), true)]
+    #[case(Node::Text(Text { value: "test".to_string(), position: None }), false)]
+    #[case(Node::Image(Image { alt: "".to_string(), url: "img.png".to_string(), title: None, position: None }), false)]
+    fn test_is_embed(#[case] node: Node, #[case] expected: bool) {
+        assert_eq!(node.is_embed(), expected);
+    }
+
+    #[cfg(feature = "embed")]
+    #[test]
+    fn test_embed_end_to_end() {
+        use crate::Markdown;
+        let md = Markdown::from_markdown_str("See ![[note.md]] for details.").unwrap();
+        let embed = md.nodes.iter().find(|n| n.is_embed());
+        assert!(embed.is_some());
+        assert_eq!(
+            embed.unwrap().attr("url"),
+            Some(AttrValue::String("note.md".to_string()))
+        );
+    }
+
+    #[cfg(all(feature = "callout", feature = "wikilink"))]
+    #[rstest]
+    // callout body containing a wikilink
+    #[case("> [!NOTE]\n> See [[note]]", 1, "> [!NOTE]\n> See [[note]]\n")]
+    fn test_callout_with_wikilink(#[case] input: &str, #[case] expected_nodes: usize, #[case] expected_output: &str) {
+        use crate::Markdown;
+        let md = Markdown::from_markdown_str(input).unwrap();
+        assert_eq!(md.nodes.len(), expected_nodes);
+        assert_eq!(md.to_string(), expected_output);
+    }
+
+    #[cfg(feature = "callout")]
+    #[rstest]
+    // callout body with bold
+    #[case("> [!NOTE]\n> **important**", 1, "> [!NOTE]\n> **important**\n")]
+    // callout body with inline code
+    #[case("> [!NOTE]\n> Use `code`", 1, "> [!NOTE]\n> Use `code`\n")]
+    // multiple callouts in one document
+    #[case(
+        "> [!NOTE]\n> first\n\n> [!WARNING]\n> second",
+        2,
+        "> [!NOTE]\n> first\n\n> [!WARNING]\n> second\n"
+    )]
+    // callout after heading
+    #[case("# Title\n\n> [!NOTE]\n> body", 2, "# Title\n\n> [!NOTE]\n> body\n")]
+    // callout body with a multi-item list — second item must not be over-indented
+    #[case("> [!NOTE]\n> - item 1\n> - item 2", 1, "> [!NOTE]\n> - item 1\n> - item 2\n")]
+    fn test_callout_combined_with_other_nodes(
+        #[case] input: &str,
+        #[case] expected_nodes: usize,
+        #[case] expected_output: &str,
+    ) {
+        use crate::Markdown;
+        let md = Markdown::from_markdown_str(input).unwrap();
+        assert_eq!(md.nodes.len(), expected_nodes);
+        assert_eq!(md.to_string(), expected_output);
+    }
+
+    #[cfg(feature = "embed")]
+    #[rstest]
+    // embed inside list item
+    #[case("- ![[note.md]]", 1, "- ![[note.md]]\n")]
+    // embed inside heading
+    #[case("# See ![[note]]", 1, "# See ![[note]]\n")]
+    // embed inside bold
+    #[case("**![[note]]**", 1, "**![[note]]**\n")]
+    fn test_embed_combined_with_other_nodes(
+        #[case] input: &str,
+        #[case] expected_nodes: usize,
+        #[case] expected_output: &str,
+    ) {
+        use crate::Markdown;
+        let md = Markdown::from_markdown_str(input).unwrap();
+        assert_eq!(md.nodes.len(), expected_nodes);
+        assert_eq!(md.to_string(), expected_output);
+    }
+
+    #[cfg(all(feature = "callout", feature = "embed"))]
+    #[rstest]
+    // wikilink inside callout body + embed as separate node
+    #[case("> [!NOTE]\n> [[link]]\n\n![[embed]]", 2, "> [!NOTE]\n> [[link]]\n\n![[embed]]\n")]
+    fn test_callout_and_embed_together(
+        #[case] input: &str,
+        #[case] expected_nodes: usize,
+        #[case] expected_output: &str,
+    ) {
+        use crate::Markdown;
+        let md = Markdown::from_markdown_str(input).unwrap();
+        assert_eq!(md.nodes.len(), expected_nodes);
+        assert_eq!(md.to_string(), expected_output);
+    }
+
+    #[cfg(all(feature = "embed", feature = "wikilink"))]
+    #[test]
+    fn test_embed_does_not_conflict_with_wikilink() {
+        use crate::Markdown;
+        // ![[embed]] must become Embed, not WikiLink with preceding "!"
+        let md = Markdown::from_markdown_str("![[embed]] and [[link]]").unwrap();
+        let embed = md.nodes.iter().find(|n| n.is_embed());
+        let wikilink = md.nodes.iter().find(|n| n.is_wikilink());
+        assert!(embed.is_some(), "expected Embed node");
+        assert!(wikilink.is_some(), "expected WikiLink node");
     }
 }

--- a/crates/mq-markdown/src/node/attr_value.rs
+++ b/crates/mq-markdown/src/node/attr_value.rs
@@ -20,6 +20,7 @@ pub mod attr_keys {
     pub(crate) const ORDERED: &str = "ordered";
     pub(crate) const CHECKED: &str = "checked";
     pub(crate) const COLUMN: &str = "column";
+    #[cfg(feature = "callout")]
     pub(crate) const KIND: &str = "kind";
     pub(crate) const ROW: &str = "row";
 }

--- a/crates/mq-markdown/src/node/attr_value.rs
+++ b/crates/mq-markdown/src/node/attr_value.rs
@@ -20,6 +20,7 @@ pub mod attr_keys {
     pub(crate) const ORDERED: &str = "ordered";
     pub(crate) const CHECKED: &str = "checked";
     pub(crate) const COLUMN: &str = "column";
+    pub(crate) const KIND: &str = "kind";
     pub(crate) const ROW: &str = "row";
 }
 


### PR DESCRIPTION
- Add `Callout` node for `> [!TYPE]` / `> [!TYPE] title` syntax
- Add `Embed` node for `![[target]]` / `![[target|display]]` syntax
- Add `callout`, `embed`, and `obsidian` feature flags to mq-markdown
- Introduce `render_values_block` to fix list over-indentation inside blockquotes and callouts
- Add benchmarks for callout, embed, and plain-blockquote parsing
- Deprecate `is_callout` builtin in favour of `.callout` selector
- Add comprehensive unit and round-trip tests for both node types