### PR TITLE
✨ feat(mq-markdown): improve html-to-markdown conversion 

### DIFF
--- a/crates/mq-markdown/examples/html_convert.rs
+++ b/crates/mq-markdown/examples/html_convert.rs
@@ -1,0 +1,31 @@
+use mq_markdown::{ConversionOptions, convert_html_to_markdown};
+use std::env;
+use std::fs;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: html_convert <file.html>");
+        std::process::exit(1);
+    }
+
+    let path = &args[1];
+    let html = fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!("Failed to read {}: {}", path, e);
+        std::process::exit(1);
+    });
+
+    let options = ConversionOptions {
+        extract_scripts_as_code_blocks: false,
+        generate_front_matter: false,
+        use_title_as_h1: false,
+    };
+
+    match convert_html_to_markdown(&html, options) {
+        Ok(md) => print!("{}", md),
+        Err(e) => {
+            eprintln!("Conversion error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/mq-markdown/src/html_to_markdown.rs
+++ b/crates/mq-markdown/src/html_to_markdown.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "html-to-markdown")]
 pub mod converter;
+mod iframe;
 pub mod node;
 pub mod options;
 pub mod parser;

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use miette::miette;
 
+use super::iframe::detect_embed;
 use super::node::HtmlElement;
 use super::node::HtmlNode;
 use super::options::ConversionOptions;
@@ -28,6 +29,22 @@ fn extract_text_from_pre_children(nodes: &[HtmlNode]) -> String {
         }
     }
     text_content
+}
+
+fn normalize_unicode_whitespace(text: &str) -> String {
+    if text
+        .chars()
+        .any(|c| matches!(c, '\u{00A0}' | '\u{202F}' | '\u{2009}'))
+    {
+        text.chars()
+            .map(|c| match c {
+                '\u{00A0}' | '\u{202F}' | '\u{2009}' => ' ',
+                _ => c,
+            })
+            .collect()
+    } else {
+        text.to_owned()
+    }
 }
 
 #[derive(PartialEq, Debug, Clone, Copy)]
@@ -68,6 +85,20 @@ fn escape_table_cell_content(content: &str) -> String {
 }
 
 fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result<String> {
+    let mut caption_text: Option<String> = None;
+    for node in &table_element.children {
+        if let HtmlNode::Element(el) = node
+            && el.tag_name == "caption"
+        {
+            let text = convert_children_to_string(&el.children)?;
+            let trimmed = text.trim().to_string();
+            if !trimmed.is_empty() {
+                caption_text = Some(trimmed);
+            }
+            break;
+        }
+    }
+
     let mut header_cells: Vec<String> = Vec::new();
     let mut header_alignments: Vec<Alignment> = Vec::new();
     let mut body_rows: Vec<Vec<String>> = Vec::new();
@@ -188,7 +219,12 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
         }
         markdown_table.push_str(" |\n");
     }
-    Ok(markdown_table.trim_end_matches('\n').to_string())
+    let table_md = markdown_table.trim_end_matches('\n').to_string();
+    if let Some(caption) = caption_text {
+        Ok(format!("{}\n\n{}", caption, table_md))
+    } else {
+        Ok(table_md)
+    }
 }
 
 fn process_url_for_markdown(url: &str) -> String {
@@ -271,7 +307,14 @@ fn handle_dl_element(element: &HtmlElement, options: ConversionOptions) -> miett
         match child_node {
             HtmlNode::Element(dt_el) if dt_el.tag_name == "dt" => {
                 let dt_text = convert_children_to_string(&dt_el.children)?;
-                dl_content_parts.push(format!("**{}**", dt_text.trim()));
+                let dt_trimmed = dt_text.trim();
+                // Avoid double-bold when <dt> already contains <strong>
+                let dt_formatted = if dt_trimmed.starts_with("**") && dt_trimmed.ends_with("**") {
+                    dt_trimmed.to_string()
+                } else {
+                    format!("**{}**", dt_trimmed)
+                };
+                dl_content_parts.push(dt_formatted);
             }
             HtmlNode::Element(dd_el) if dd_el.tag_name == "dd" => {
                 let dd_markdown_block = convert_nodes_to_markdown(&dd_el.children, options)?;
@@ -332,7 +375,16 @@ fn handle_embedded_content_element(element: &HtmlElement) -> miette::Result<Opti
     let mut src_url: Option<String> = None;
     let mut additional_info = String::new();
     match tag_name {
-        "iframe" | "embed" => src_url = element.attributes.get("src").and_then(|opt| opt.as_ref().cloned()),
+        "iframe" => {
+            let src = element.attributes.get("src").and_then(|opt| opt.as_ref().cloned());
+            if let Some(ref s) = src
+                && let Some((description, canonical_url)) = detect_embed(s)
+            {
+                return Ok(Some(format!("[{}]({})", description, canonical_url)));
+            }
+            src_url = src;
+        }
+        "embed" => src_url = element.attributes.get("src").and_then(|opt| opt.as_ref().cloned()),
         "video" | "audio" => {
             src_url = element.attributes.get("src").and_then(|opt| opt.as_ref().cloned());
             if src_url.is_none() {
@@ -469,19 +521,19 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
     for node in nodes {
         match node {
             HtmlNode::Text(text) => {
-                let trimmed = text.trim_start_matches('\n').trim_end_matches('\n');
-                let trimmed = if trimmed.starts_with(" ") {
+                let normalized = normalize_unicode_whitespace(text);
+                let trimmed = normalized.trim_start_matches('\n').trim_end_matches('\n');
+                let trimmed = if trimmed.starts_with(' ') {
                     format!(" {}", trimmed.trim_start())
                 } else {
                     trimmed.to_owned()
                 };
-                let trimmed = if trimmed.ends_with(" ") {
+                let trimmed = if trimmed.ends_with(' ') {
                     format!("{} ", trimmed.trim_end())
                 } else {
-                    trimmed.to_owned()
+                    trimmed
                 };
-
-                parts.push(trimmed.to_string());
+                parts.push(trimmed);
             }
             HtmlNode::Element(element) => {
                 let link_text = convert_children_to_string(&element.children)?;
@@ -573,6 +625,75 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                     "u" => {
                         parts.push(format!("<u>{}</u>", link_text));
                     }
+                    "sub" => parts.push(format!("<sub>{}</sub>", link_text)),
+                    "sup" => parts.push(format!("<sup>{}</sup>", link_text)),
+                    "q" => {
+                        if !link_text.is_empty() {
+                            parts.push(format!("\"{}\"", link_text));
+                        }
+                    }
+                    "cite" => {
+                        if !link_text.is_empty() {
+                            parts.push(format!("*{}*", link_text));
+                        }
+                    }
+                    "ins" => {
+                        if !link_text.is_empty() {
+                            parts.push(link_text);
+                        }
+                    }
+                    "mark" => parts.push(format!("<mark>{}</mark>", link_text)),
+                    "summary" => {
+                        if !link_text.is_empty() {
+                            parts.push(format!("**{}**", link_text));
+                        }
+                    }
+                    "abbr" => {
+                        if !link_text.is_empty() {
+                            if let Some(Some(title)) = element.attributes.get("title")
+                                && !title.is_empty()
+                            {
+                                parts.push(format!("{} ({})", link_text, title));
+                            } else {
+                                parts.push(link_text);
+                            }
+                        }
+                    }
+                    "picture" => parts.push(link_text),
+                    "ruby" => {
+                        let mut base = String::new();
+                        let mut annotation = String::new();
+                        for child in &element.children {
+                            match child {
+                                HtmlNode::Text(t) => base.push_str(t),
+                                HtmlNode::Element(el) if el.tag_name == "rt" => {
+                                    annotation.push_str(&convert_children_to_string(&el.children)?);
+                                }
+                                HtmlNode::Element(el) if el.tag_name == "rp" => {}
+                                HtmlNode::Element(el) => {
+                                    base.push_str(&convert_children_to_string(&el.children)?);
+                                }
+                                HtmlNode::Comment(_) => {}
+                            }
+                        }
+                        let base = base.trim();
+                        let annotation = annotation.trim();
+                        if !annotation.is_empty() {
+                            parts.push(format!("{}({})", base, annotation));
+                        } else if !base.is_empty() {
+                            parts.push(base.to_string());
+                        }
+                    }
+                    "dfn" => {
+                        if !link_text.is_empty() {
+                            parts.push(format!("*{}*", link_text));
+                        }
+                    }
+                    "time" | "small" | "bdi" => {
+                        if !link_text.is_empty() {
+                            parts.push(link_text);
+                        }
+                    }
                     "span" => parts.push(link_text),
                     "nav" | "aside" | "noscript" => {} // skip
                     _ => parts.push(link_text),
@@ -601,7 +722,7 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                         // Skip navigational/sidebar/noscript noise entirely
                     }
                     "html" | "head" | "header" | "footer" | "body" | "div" | "main" | "article" | "section"
-                    | "hgroup" => {
+                    | "hgroup" | "details" | "figure" => {
                         let markdown_block = convert_nodes_to_markdown(&element.children, options)?;
 
                         if !markdown_block.is_empty() {
@@ -628,6 +749,24 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                             markdown_blocks.push((dl_md, false));
                         }
                     }
+                    "summary" => {
+                        let summary_text = convert_children_to_string(&element.children)?;
+                        if !summary_text.is_empty() {
+                            markdown_blocks.push((format!("**{}**", summary_text.trim()), false));
+                        }
+                    }
+                    "figcaption" => {
+                        let caption = handle_paragraph_element(element)?;
+                        if !caption.is_empty() {
+                            markdown_blocks.push((caption, false));
+                        }
+                    }
+                    "address" => {
+                        let content = convert_children_to_string(&element.children)?;
+                        if !content.is_empty() {
+                            markdown_blocks.push((format!("*{}*", content.trim()), false));
+                        }
+                    }
                     "script" => {
                         if let Some(script_md) = handle_script_element(element, options)? {
                             markdown_blocks.push((script_md, false));
@@ -641,7 +780,8 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                     }
                     "svg" => markdown_blocks.push((handle_svg_element(element)?, false)),
                     "strong" | "em" | "a" | "code" | "span" | "img" | "br" | "input" | "s" | "strike" | "del"
-                    | "kbd" => {
+                    | "kbd" | "sub" | "sup" | "q" | "cite" | "mark" | "abbr" | "picture" | "ruby"
+                    | "dfn" | "time" | "small" | "bdi" => {
                         let inline_md = convert_children_to_string(&[HtmlNode::Element(element.clone())])?;
                         if !inline_md.is_empty() {
                             markdown_blocks.push((inline_md.trim().to_string(), true));

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -21,11 +21,7 @@ fn extract_text_from_pre_children(nodes: &[HtmlNode]) -> String {
             HtmlNode::Element(el) => {
                 text_content.push_str(&extract_text_from_pre_children(&el.children));
             }
-            HtmlNode::Comment(comment) => {
-                text_content.push_str("<!--");
-                text_content.push_str(comment);
-                text_content.push_str("-->");
-            }
+            HtmlNode::Comment(_) => {}
         }
     }
     text_content
@@ -263,11 +259,43 @@ fn handle_blockquote_element(element: &HtmlElement, options: ConversionOptions) 
     }
 }
 
+/// Strips the common leading whitespace (dedent) from a multi-line string.
+/// Lines that are entirely whitespace are ignored when computing the minimum indent.
+fn dedent(text: &str) -> String {
+    let min_indent = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    if min_indent == 0 {
+        return text.to_owned();
+    }
+    text.lines()
+        .map(|line| {
+            if line.len() >= min_indent {
+                &line[min_indent..]
+            } else {
+                line.trim_start()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn handle_pre_element(element: &HtmlElement, _options: ConversionOptions) -> miette::Result<String> {
     let mut lang_specifier = String::new();
-    let text_content = if let Some(HtmlNode::Element(code_element)) = element.children.first()
-        && code_element.tag_name == "code"
-    {
+    // Find <code> among children, skipping leading whitespace-only text nodes.
+    let code_child = element.children.iter().find_map(|n| {
+        if let HtmlNode::Element(el) = n
+            && el.tag_name == "code"
+        {
+            Some(el)
+        } else {
+            None
+        }
+    });
+    let text_content = if let Some(code_element) = code_child {
         if let Some(Some(class_attr)) = code_element.attributes.get("class") {
             for class_name in class_attr.split_whitespace() {
                 if let Some(lang) = class_name.strip_prefix("language-") {
@@ -279,19 +307,24 @@ fn handle_pre_element(element: &HtmlElement, _options: ConversionOptions) -> mie
                 }
             }
         }
+        // Extract code content plus any sibling text nodes outside <code> (e.g. <pre><code>…</code>\nextra</pre>).
         let mut text = extract_text_from_pre_children(&code_element.children);
-        text.push_str(&extract_text_from_pre_children(&element.children[1..]));
+        let non_code: Vec<&HtmlNode> = element
+            .children
+            .iter()
+            .filter(|n| !matches!(n, HtmlNode::Element(el) if el.tag_name == "code"))
+            .collect();
+        text.push_str(&extract_text_from_pre_children(
+            non_code.iter().copied().cloned().collect::<Vec<_>>().as_slice(),
+        ));
         text
     } else {
         extract_text_from_pre_children(&element.children)
     };
 
     let text_content = text_content.strip_prefix('\n').unwrap_or(&text_content);
-    Ok(format!(
-        "```{}\n{}\n```",
-        lang_specifier,
-        text_content.trim_end_matches('\n')
-    ))
+    let text_content = dedent(text_content.trim_end_matches('\n'));
+    Ok(format!("```{}\n{}\n```", lang_specifier, text_content))
 }
 
 fn handle_table_element(element: &HtmlElement, _options: ConversionOptions) -> miette::Result<String> {
@@ -322,9 +355,7 @@ fn handle_dl_element(element: &HtmlElement, options: ConversionOptions) -> miett
                 }
             }
             HtmlNode::Text(text) if text.trim().is_empty() => {}
-            HtmlNode::Comment(comment) => {
-                dl_content_parts.push(format!("<!--{}-->", comment));
-            }
+            HtmlNode::Comment(_) => {}
             _ => {
                 let unexpected_block = convert_nodes_to_markdown(std::slice::from_ref(child_node), options)?;
                 if !unexpected_block.is_empty() {
@@ -520,17 +551,35 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
             HtmlNode::Text(text) => {
                 let normalized = normalize_unicode_whitespace(text);
                 let trimmed = normalized.trim_start_matches('\n').trim_end_matches('\n');
-                let trimmed = if trimmed.starts_with(' ') {
-                    format!(" {}", trimmed.trim_start())
+                // Collapse internal newline+whitespace sequences (HTML whitespace collapsing).
+                let collapsed = if trimmed.contains('\n') {
+                    let leading_space = trimmed.starts_with(' ');
+                    let trailing_space = trimmed.ends_with(' ');
+                    let inner = trimmed
+                        .split('\n')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    match (leading_space, trailing_space) {
+                        (true, true) => format!(" {} ", inner),
+                        (true, false) => format!(" {}", inner),
+                        (false, true) => format!("{} ", inner),
+                        (false, false) => inner,
+                    }
                 } else {
-                    trimmed.to_owned()
+                    let trimmed = if trimmed.starts_with(' ') {
+                        format!(" {}", trimmed.trim_start())
+                    } else {
+                        trimmed.to_owned()
+                    };
+                    if trimmed.ends_with(' ') {
+                        format!("{} ", trimmed.trim_end())
+                    } else {
+                        trimmed
+                    }
                 };
-                let trimmed = if trimmed.ends_with(' ') {
-                    format!("{} ", trimmed.trim_end())
-                } else {
-                    trimmed
-                };
-                parts.push(trimmed);
+                parts.push(collapsed);
             }
             HtmlNode::Element(element) => {
                 let link_text = convert_children_to_string(&element.children)?;
@@ -696,9 +745,7 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                     _ => parts.push(link_text),
                 }
             }
-            HtmlNode::Comment(comment) => {
-                parts.push(format!("<!--{}-->", comment));
-            }
+            HtmlNode::Comment(_) => {}
         }
     }
     Ok(parts.join("").to_string())
@@ -791,9 +838,13 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                             }
                         }
                     }
-                    "strong" | "em" | "code" | "span" | "img" | "br" | "input" | "s" | "strike" | "del" | "kbd"
-                    | "sub" | "sup" | "q" | "cite" | "mark" | "abbr" | "picture" | "ruby" | "dfn" | "time"
-                    | "small" | "bdi" => {
+                    "br" => {
+                        // Hard line break — must not be trimmed or it becomes empty.
+                        markdown_blocks.push(("  \n".to_string(), true));
+                    }
+                    "strong" | "em" | "code" | "span" | "img" | "input" | "s" | "strike" | "del" | "kbd" | "sub"
+                    | "sup" | "q" | "cite" | "mark" | "abbr" | "picture" | "ruby" | "dfn" | "time" | "small"
+                    | "bdi" => {
                         let inline_md = convert_children_to_string(&[HtmlNode::Element(element.clone())])?;
                         if !inline_md.is_empty() {
                             markdown_blocks.push((inline_md.trim().to_string(), true));
@@ -809,9 +860,7 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                     }
                 }
             }
-            HtmlNode::Comment(comment) => {
-                markdown_blocks.push((format!("<!--{}-->", comment), false));
-            }
+            HtmlNode::Comment(_) => {}
         }
     }
 

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -32,10 +32,7 @@ fn extract_text_from_pre_children(nodes: &[HtmlNode]) -> String {
 }
 
 fn normalize_unicode_whitespace(text: &str) -> String {
-    if text
-        .chars()
-        .any(|c| matches!(c, '\u{00A0}' | '\u{202F}' | '\u{2009}'))
-    {
+    if text.chars().any(|c| matches!(c, '\u{00A0}' | '\u{202F}' | '\u{2009}')) {
         text.chars()
             .map(|c| match c {
                 '\u{00A0}' | '\u{202F}' | '\u{2009}' => ' ',
@@ -779,18 +776,35 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                         }
                     }
                     "svg" => markdown_blocks.push((handle_svg_element(element)?, false)),
-                    "strong" | "em" | "a" | "code" | "span" | "img" | "br" | "input" | "s" | "strike" | "del"
-                    | "kbd" | "sub" | "sup" | "q" | "cite" | "mark" | "abbr" | "picture" | "ruby"
-                    | "dfn" | "time" | "small" | "bdi" => {
+                    "a" => {
+                        // <a> without href is used as a transparent section container in some HTML.
+                        // Treat it as a block pass-through in that case so block children are preserved.
+                        if element.attributes.get("href").and_then(|v| v.as_deref()).is_some() {
+                            let inline_md = convert_children_to_string(&[HtmlNode::Element(element.clone())])?;
+                            if !inline_md.is_empty() {
+                                markdown_blocks.push((inline_md.trim().to_string(), true));
+                            }
+                        } else {
+                            let block_md = convert_nodes_to_markdown(&element.children, options)?;
+                            if !block_md.is_empty() {
+                                markdown_blocks.push((block_md, false));
+                            }
+                        }
+                    }
+                    "strong" | "em" | "code" | "span" | "img" | "br" | "input" | "s" | "strike" | "del" | "kbd"
+                    | "sub" | "sup" | "q" | "cite" | "mark" | "abbr" | "picture" | "ruby" | "dfn" | "time"
+                    | "small" | "bdi" => {
                         let inline_md = convert_children_to_string(&[HtmlNode::Element(element.clone())])?;
                         if !inline_md.is_empty() {
                             markdown_blocks.push((inline_md.trim().to_string(), true));
                         }
                     }
                     _ => {
-                        let children_content_str = convert_children_to_string(&element.children)?;
-                        if !children_content_str.is_empty() {
-                            markdown_blocks.push((children_content_str, false));
+                        // Unknown/custom elements (e.g. <astro-island>, <button>, web components):
+                        // recurse as blocks so any block-level children are preserved correctly.
+                        let block_md = convert_nodes_to_markdown(&element.children, options)?;
+                        if !block_md.is_empty() {
+                            markdown_blocks.push((block_md, false));
                         }
                     }
                 }

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -644,7 +644,12 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         }
                     }
                     "input" => {
-                        if let Some(Some(type_attr)) = element.attributes.get("type") {
+                        // Skip inputs used as CSS toggle triggers (not actual form inputs)
+                        let is_ui_toggle = element.attributes.get("role").and_then(|v| v.as_deref()) == Some("button")
+                            || element.attributes.get("aria-haspopup").and_then(|v| v.as_deref()) == Some("true");
+                        if is_ui_toggle {
+                            // nothing
+                        } else if let Some(Some(type_attr)) = element.attributes.get("type") {
                             match type_attr.to_lowercase().as_str() {
                                 "checkbox" | "radio" => {
                                     if element.attributes.contains_key("checked") {
@@ -751,6 +756,67 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
     Ok(parts.join("").to_string())
 }
 
+/// Returns true if the element is a CSS-only UI widget (dropdown or tab switcher).
+///
+/// Two patterns are detected:
+/// 1. A direct child `<input>` with `role="button"` or `aria-haspopup` — used for CSS dropdowns
+///    (e.g., Wikipedia's language switcher).
+/// 2. All direct children are `<input>` or `<label>` elements — used for CSS-only tabs/toggles
+///    (e.g., tab bars built with radio inputs and labels).
+fn is_css_dropdown_widget(element: &HtmlElement) -> bool {
+    // Pattern 1: checkbox/radio used as dropdown toggle trigger
+    let has_toggle_input = element.children.iter().any(|child| {
+        matches!(child, HtmlNode::Element(el)
+            if el.tag_name == "input"
+            && (el.attributes.get("role").and_then(|v| v.as_deref()) == Some("button")
+                || el.attributes.get("aria-haspopup").and_then(|v| v.as_deref()) == Some("true")))
+    });
+    if has_toggle_input {
+        return true;
+    }
+
+    // Pattern 2: CSS tab/toggle widget built from alternating <input> and <label> siblings.
+    // Both element types must be present; a lone <input> (e.g. standalone checkbox) is not a widget.
+    let has_any_input = element
+        .children
+        .iter()
+        .any(|child| matches!(child, HtmlNode::Element(el) if el.tag_name == "input"));
+    let has_any_label = element
+        .children
+        .iter()
+        .any(|child| matches!(child, HtmlNode::Element(el) if el.tag_name == "label"));
+    if has_any_input && has_any_label {
+        return element.children.iter().all(|child| match child {
+            HtmlNode::Text(t) => t.trim().is_empty(),
+            HtmlNode::Comment(_) => true,
+            HtmlNode::Element(el) => matches!(el.tag_name.as_str(), "input" | "label"),
+        });
+    }
+
+    false
+}
+
+/// Returns true if the element wraps a heading with only auxiliary UI siblings.
+/// In this pattern (e.g., Wikipedia's `<div class="mw-heading">`), the heading is the
+/// meaningful content and the siblings are UI chrome (edit links, toggle buttons, etc.).
+fn is_heading_with_aux_siblings(element: &HtmlElement) -> bool {
+    let has_heading = element.children.iter().any(|child| {
+        matches!(child, HtmlNode::Element(el)
+            if matches!(el.tag_name.as_str(), "h1" | "h2" | "h3" | "h4" | "h5" | "h6"))
+    });
+    if !has_heading {
+        return false;
+    }
+    element.children.iter().all(|child| match child {
+        HtmlNode::Text(t) => t.trim().is_empty(),
+        HtmlNode::Comment(_) => true,
+        HtmlNode::Element(el) => matches!(
+            el.tag_name.as_str(),
+            "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span" | "input" | "label" | "button"
+        ),
+    })
+}
+
 pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions) -> miette::Result<String> {
     let mut markdown_blocks: Vec<MarkdownBlock> = Vec::new();
     for node in nodes {
@@ -767,10 +833,22 @@ pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions)
                     }
                     "html" | "head" | "header" | "footer" | "body" | "div" | "main" | "article" | "section"
                     | "hgroup" | "details" | "figure" => {
-                        let markdown_block = convert_nodes_to_markdown(&element.children, options)?;
-
-                        if !markdown_block.is_empty() {
-                            markdown_blocks.push((markdown_block, false));
+                        if is_css_dropdown_widget(element) {
+                            // Skip CSS-only dropdown widgets (language switchers, nav menus, etc.)
+                        } else if is_heading_with_aux_siblings(element) {
+                            // Heading wrapper div: only extract the heading, drop UI chrome siblings
+                            for child in &element.children {
+                                if let HtmlNode::Element(el) = child
+                                    && matches!(el.tag_name.as_str(), "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+                                {
+                                    markdown_blocks.push((handle_heading_element(el)?, false));
+                                }
+                            }
+                        } else {
+                            let markdown_block = convert_nodes_to_markdown(&element.children, options)?;
+                            if !markdown_block.is_empty() {
+                                markdown_blocks.push((markdown_block, false));
+                            }
                         }
                     }
                     "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {

--- a/crates/mq-markdown/src/html_to_markdown/iframe.rs
+++ b/crates/mq-markdown/src/html_to_markdown/iframe.rs
@@ -1,0 +1,208 @@
+/// Detects the embed platform from an iframe `src` URL and returns
+/// `(description, canonical_url)` for known platforms.
+///
+/// Detection is performed with lightweight string operations — no regex dependency.
+pub(super) fn detect_embed(src: &str) -> Option<(String, String)> {
+    detect_youtube(src)
+        .or_else(|| detect_vimeo(src))
+        .or_else(|| detect_instagram(src))
+        .or_else(|| detect_dailymotion(src))
+        .or_else(|| detect_twitch(src))
+        .or_else(|| detect_spotify(src))
+        .or_else(|| detect_vk(src))
+        .or_else(|| detect_google_docs(src))
+}
+
+/// Returns the first path segment that immediately follows `needle` in `src`.
+/// Stops at the next `/`, `?`, `#`, or end of string.
+fn path_segment_after<'a>(src: &'a str, needle: &str) -> Option<&'a str> {
+    let start = src.find(needle).map(|i| i + needle.len())?;
+    let rest = &src[start..];
+    let end = rest
+        .find(['/', '?', '#'])
+        .unwrap_or(rest.len());
+    let segment = &rest[..end];
+    if segment.is_empty() { None } else { Some(segment) }
+}
+
+/// Returns the value of a URL query parameter by name.
+fn query_param<'a>(src: &'a str, key: &str) -> Option<&'a str> {
+    let query_start = src.find('?').map(|i| i + 1)?;
+    for part in src[query_start..].split('&') {
+        if let Some((k, v)) = part.split_once('=')
+            && k == key
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn detect_youtube(src: &str) -> Option<(String, String)> {
+    if !src.contains("youtube.com/embed/") && !src.contains("youtube-nocookie.com/embed/") {
+        return None;
+    }
+    let video_id = path_segment_after(src, "/embed/")?;
+    Some((
+        "YouTube Video".to_string(),
+        format!("https://www.youtube.com/watch?v={}", video_id),
+    ))
+}
+
+fn detect_vimeo(src: &str) -> Option<(String, String)> {
+    if !src.contains("player.vimeo.com/video/") {
+        return None;
+    }
+    let video_id = path_segment_after(src, "/video/")?;
+    Some((
+        "Vimeo Video".to_string(),
+        format!("https://vimeo.com/{}", video_id),
+    ))
+}
+
+fn detect_instagram(src: &str) -> Option<(String, String)> {
+    if !src.contains("instagram.com/p/") {
+        return None;
+    }
+    let post_id = path_segment_after(src, "/p/")?;
+    Some((
+        "Instagram Post".to_string(),
+        format!("https://www.instagram.com/p/{}/", post_id),
+    ))
+}
+
+fn detect_dailymotion(src: &str) -> Option<(String, String)> {
+    if !src.contains("dailymotion.com/embed/video/") {
+        return None;
+    }
+    let video_id = path_segment_after(src, "/embed/video/")?;
+    Some((
+        "Dailymotion Video".to_string(),
+        format!("https://www.dailymotion.com/video/{}", video_id),
+    ))
+}
+
+fn detect_twitch(src: &str) -> Option<(String, String)> {
+    if src.contains("player.twitch.tv") {
+        if let Some(channel) = query_param(src, "channel") {
+            return Some((
+                "Twitch Stream".to_string(),
+                format!("https://www.twitch.tv/{}", channel),
+            ));
+        }
+        if let Some(video) = query_param(src, "video") {
+            return Some((
+                "Twitch Video".to_string(),
+                format!("https://www.twitch.tv/videos/{}", video),
+            ));
+        }
+    }
+    if src.contains("clips.twitch.tv")
+        && let Some(clip) = query_param(src, "clip")
+    {
+        return Some((
+            "Twitch Clip".to_string(),
+            format!("https://clips.twitch.tv/{}", clip),
+        ));
+    }
+    None
+}
+
+fn detect_spotify(src: &str) -> Option<(String, String)> {
+    if !src.contains("open.spotify.com/embed/") {
+        return None;
+    }
+    let kind = path_segment_after(src, "/embed/")?;
+    let needle = format!("/embed/{}/", kind);
+    let id = path_segment_after(src, &needle)?;
+    let label = match kind {
+        "track" => "Spotify Track",
+        "album" => "Spotify Album",
+        "playlist" => "Spotify Playlist",
+        "episode" => "Spotify Episode",
+        "show" => "Spotify Podcast",
+        _ => "Spotify",
+    };
+    Some((
+        label.to_string(),
+        format!("https://open.spotify.com/{}/{}", kind, id),
+    ))
+}
+
+fn detect_vk(src: &str) -> Option<(String, String)> {
+    if !src.contains("vk.com/video_ext.php") {
+        return None;
+    }
+    let oid = query_param(src, "oid")?;
+    let vid = query_param(src, "id")?;
+    Some((
+        "VK Video".to_string(),
+        format!("https://vk.com/video{}_{}", oid, vid),
+    ))
+}
+
+fn detect_google_docs(src: &str) -> Option<(String, String)> {
+    if !src.contains("docs.google.com") {
+        return None;
+    }
+    let doc_id = path_segment_after(src, "/d/")?;
+    if src.contains("/presentation/") {
+        Some((
+            "Google Slides".to_string(),
+            format!("https://docs.google.com/presentation/d/{}/", doc_id),
+        ))
+    } else if src.contains("/document/") {
+        Some((
+            "Google Docs".to_string(),
+            format!("https://docs.google.com/document/d/{}/", doc_id),
+        ))
+    } else if src.contains("/spreadsheets/") {
+        Some((
+            "Google Sheets".to_string(),
+            format!("https://docs.google.com/spreadsheets/d/{}/", doc_id),
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("https://www.youtube.com/embed/dQw4w9WgXcQ", Some(("YouTube Video", "https://www.youtube.com/watch?v=dQw4w9WgXcQ")))]
+    #[case("https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1", Some(("YouTube Video", "https://www.youtube.com/watch?v=dQw4w9WgXcQ")))]
+    #[case("https://www.youtube-nocookie.com/embed/abc123XYZ", Some(("YouTube Video", "https://www.youtube.com/watch?v=abc123XYZ")))]
+    #[case("https://player.vimeo.com/video/123456789", Some(("Vimeo Video", "https://vimeo.com/123456789")))]
+    #[case("https://www.instagram.com/p/B1BKr9Wo8YX/embed/", Some(("Instagram Post", "https://www.instagram.com/p/B1BKr9Wo8YX/")))]
+    #[case("https://www.dailymotion.com/embed/video/x7zflst", Some(("Dailymotion Video", "https://www.dailymotion.com/video/x7zflst")))]
+    #[case("https://player.twitch.tv/?channel=monstercat&parent=example.com", Some(("Twitch Stream", "https://www.twitch.tv/monstercat")))]
+    #[case("https://player.twitch.tv/?video=v123456789&parent=example.com", Some(("Twitch Video", "https://www.twitch.tv/videos/v123456789")))]
+    #[case("https://clips.twitch.tv/embed?clip=FuriousObliqueDonutDansGame", Some(("Twitch Clip", "https://clips.twitch.tv/FuriousObliqueDonutDansGame")))]
+    #[case("https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh", Some(("Spotify Track", "https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh")))]
+    #[case("https://open.spotify.com/embed/album/1DFixLWuPkv3KT3TnV35m3", Some(("Spotify Album", "https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3")))]
+    #[case("https://open.spotify.com/embed/playlist/37i9dQZF1DXcBWIGoYBM5M", Some(("Spotify Playlist", "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")))]
+    #[case("https://open.spotify.com/embed/episode/64Q5MbCIFuuEaCf6fxJblG", Some(("Spotify Episode", "https://open.spotify.com/episode/64Q5MbCIFuuEaCf6fxJblG")))]
+    #[case("https://vk.com/video_ext.php?oid=-49423435&id=456245092&hash=e1611aefe899c4f8", Some(("VK Video", "https://vk.com/video-49423435_456245092")))]
+    #[case("https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed", Some(("Google Slides", "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/")))]
+    #[case("https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/preview", Some(("Google Docs", "https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/")))]
+    #[case("https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/htmlview", Some(("Google Sheets", "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/")))]
+    #[case("https://example.com/embed/video/abc", None)]
+    #[case("https://www.youtube.com/watch?v=dQw4w9WgXcQ", None)]
+    fn test_detect_embed(
+        #[case] src: &str,
+        #[case] expected: Option<(&str, &str)>,
+    ) {
+        let result = detect_embed(src);
+        match (result, expected) {
+            (Some((desc, url)), Some((exp_desc, exp_url))) => {
+                assert_eq!(desc, exp_desc);
+                assert_eq!(url, exp_url);
+            }
+            (None, None) => {}
+            (got, exp) => panic!("expected {:?}, got {:?}", exp, got),
+        }
+    }
+}

--- a/crates/mq-markdown/src/html_to_markdown/iframe.rs
+++ b/crates/mq-markdown/src/html_to_markdown/iframe.rs
@@ -18,9 +18,7 @@ pub(super) fn detect_embed(src: &str) -> Option<(String, String)> {
 fn path_segment_after<'a>(src: &'a str, needle: &str) -> Option<&'a str> {
     let start = src.find(needle).map(|i| i + needle.len())?;
     let rest = &src[start..];
-    let end = rest
-        .find(['/', '?', '#'])
-        .unwrap_or(rest.len());
+    let end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let segment = &rest[..end];
     if segment.is_empty() { None } else { Some(segment) }
 }
@@ -54,10 +52,7 @@ fn detect_vimeo(src: &str) -> Option<(String, String)> {
         return None;
     }
     let video_id = path_segment_after(src, "/video/")?;
-    Some((
-        "Vimeo Video".to_string(),
-        format!("https://vimeo.com/{}", video_id),
-    ))
+    Some(("Vimeo Video".to_string(), format!("https://vimeo.com/{}", video_id)))
 }
 
 fn detect_instagram(src: &str) -> Option<(String, String)> {
@@ -100,10 +95,7 @@ fn detect_twitch(src: &str) -> Option<(String, String)> {
     if src.contains("clips.twitch.tv")
         && let Some(clip) = query_param(src, "clip")
     {
-        return Some((
-            "Twitch Clip".to_string(),
-            format!("https://clips.twitch.tv/{}", clip),
-        ));
+        return Some(("Twitch Clip".to_string(), format!("https://clips.twitch.tv/{}", clip)));
     }
     None
 }
@@ -123,10 +115,7 @@ fn detect_spotify(src: &str) -> Option<(String, String)> {
         "show" => "Spotify Podcast",
         _ => "Spotify",
     };
-    Some((
-        label.to_string(),
-        format!("https://open.spotify.com/{}/{}", kind, id),
-    ))
+    Some((label.to_string(), format!("https://open.spotify.com/{}/{}", kind, id)))
 }
 
 fn detect_vk(src: &str) -> Option<(String, String)> {
@@ -135,10 +124,7 @@ fn detect_vk(src: &str) -> Option<(String, String)> {
     }
     let oid = query_param(src, "oid")?;
     let vid = query_param(src, "id")?;
-    Some((
-        "VK Video".to_string(),
-        format!("https://vk.com/video{}_{}", oid, vid),
-    ))
+    Some(("VK Video".to_string(), format!("https://vk.com/video{}_{}", oid, vid)))
 }
 
 fn detect_google_docs(src: &str) -> Option<(String, String)> {
@@ -191,10 +177,7 @@ mod tests {
     #[case("https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/htmlview", Some(("Google Sheets", "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/")))]
     #[case("https://example.com/embed/video/abc", None)]
     #[case("https://www.youtube.com/watch?v=dQw4w9WgXcQ", None)]
-    fn test_detect_embed(
-        #[case] src: &str,
-        #[case] expected: Option<(&str, &str)>,
-    ) {
+    fn test_detect_embed(#[case] src: &str, #[case] expected: Option<(&str, &str)>) {
         let result = detect_embed(src);
         match (result, expected) {
             (Some((desc, url)), Some((exp_desc, exp_url))) => {

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -563,7 +563,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
 #[case::dl_with_inline_elements(
     "<dl><dt><strong>Term</strong></dt><dd><em>Definition</em></dd></dl>",
     ConversionOptions::default(),
-    "****Term****\n  *Definition*"
+    "**Term**\n  *Definition*"
 )]
 #[case::dl_dd_with_paragraph(
     "<dl><dt>Term</dt><dd><p>Paragraph in definition.</p></dd></dl>",
@@ -1209,6 +1209,337 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     "> Q\n\nP"
 )]
 #[case::pre_spacing("<pre>code</pre><p>P</p>", ConversionOptions::default(), "```\ncode\n```\n\nP")]
+// --- <dt> double-bold fix ---
+#[case::dl_dt_with_strong_no_double_bold(
+    "<dl><dt><strong>Term</strong></dt><dd>Definition</dd></dl>",
+    ConversionOptions::default(),
+    "**Term**\n  Definition"
+)]
+#[case::dl_dt_with_em_wraps_in_bold(
+    "<dl><dt><em>italic term</em></dt><dd>Definition</dd></dl>",
+    ConversionOptions::default(),
+    "***italic term***\n  Definition"
+)]
+// --- <table> <caption> ---
+#[case::table_with_caption(
+    "<table><caption>Monthly Sales</caption><thead><tr><th>Month</th><th>Amount</th></tr></thead><tbody><tr><td>Jan</td><td>100</td></tr></tbody></table>",
+    ConversionOptions::default(),
+    "Monthly Sales\n\n| Month | Amount |\n|---|---|\n| Jan | 100 |"
+)]
+#[case::table_with_caption_inline_elements(
+    "<table><caption><strong>Bold</strong> Caption</caption><thead><tr><th>H</th></tr></thead><tbody><tr><td>C</td></tr></tbody></table>",
+    ConversionOptions::default(),
+    "**Bold** Caption\n\n| H |\n|---|\n| C |"
+)]
+#[case::table_without_caption_unchanged(
+    "<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>C</td></tr></tbody></table>",
+    ConversionOptions::default(),
+    "| H |\n|---|\n| C |"
+)]
+// --- <abbr> ---
+#[case::abbr_with_title(
+    "<p>The <abbr title=\"HyperText Markup Language\">HTML</abbr> standard.</p>",
+    ConversionOptions::default(),
+    "The HTML (HyperText Markup Language) standard."
+)]
+#[case::abbr_without_title(
+    "<p>Use <abbr>CSS</abbr> for styling.</p>",
+    ConversionOptions::default(),
+    "Use CSS for styling."
+)]
+#[case::abbr_standalone(
+    "<abbr title=\"Cascading Style Sheets\">CSS</abbr>",
+    ConversionOptions::default(),
+    "CSS (Cascading Style Sheets)"
+)]
+// --- <picture> ---
+#[case::picture_with_source_and_img(
+    "<picture><source srcset=\"img.webp\" type=\"image/webp\"><img src=\"img.png\" alt=\"A photo\"></picture>",
+    ConversionOptions::default(),
+    "![A photo](img.png)"
+)]
+#[case::picture_img_only(
+    "<picture><img src=\"photo.jpg\" alt=\"Landscape\"></picture>",
+    ConversionOptions::default(),
+    "![Landscape](photo.jpg)"
+)]
+#[case::picture_in_paragraph(
+    "<p>See <picture><img src=\"icon.svg\" alt=\"icon\"></picture> here.</p>",
+    ConversionOptions::default(),
+    "See ![icon](icon.svg) here."
+)]
+// --- <ruby> / <rt> ---
+#[case::ruby_with_rt(
+    "<ruby>漢字<rt>かんじ</rt></ruby>",
+    ConversionOptions::default(),
+    "漢字(かんじ)"
+)]
+#[case::ruby_in_paragraph(
+    "<p>This is <ruby>漢字<rt>かんじ</rt></ruby>.</p>",
+    ConversionOptions::default(),
+    "This is 漢字(かんじ)."
+)]
+#[case::ruby_no_rt(
+    "<ruby>漢字</ruby>",
+    ConversionOptions::default(),
+    "漢字"
+)]
+#[case::ruby_with_rp(
+    "<ruby>漢字<rp>(</rp><rt>かんじ</rt><rp>)</rp></ruby>",
+    ConversionOptions::default(),
+    "漢字(かんじ)"
+)]
+// --- <time> ---
+#[case::time_with_datetime(
+    "<time datetime=\"2024-01-01\">January 1, 2024</time>",
+    ConversionOptions::default(),
+    "January 1, 2024"
+)]
+#[case::time_in_paragraph(
+    "<p>Published on <time datetime=\"2024-06-14\">June 14, 2024</time>.</p>",
+    ConversionOptions::default(),
+    "Published on June 14, 2024."
+)]
+// --- <small> ---
+#[case::small_in_paragraph(
+    "<p>Normal text <small>fine print</small>.</p>",
+    ConversionOptions::default(),
+    "Normal text fine print."
+)]
+// --- <address> ---
+#[case::address_block(
+    "<address>John Doe, 123 Main St, Springfield</address>",
+    ConversionOptions::default(),
+    "*John Doe, 123 Main St, Springfield*"
+)]
+#[case::address_with_links(
+    "<address>Contact: <a href=\"mailto:test@example.com\">test@example.com</a></address>",
+    ConversionOptions::default(),
+    "*Contact: [test@example.com](mailto:test@example.com)*"
+)]
+// --- <dfn> ---
+#[case::dfn_in_paragraph(
+    "<p>The term <dfn>Markdown</dfn> refers to a markup language.</p>",
+    ConversionOptions::default(),
+    "The term *Markdown* refers to a markup language."
+)]
+// --- <bdi> ---
+#[case::bdi_in_paragraph(
+    "<p>Hello <bdi>مرحبا</bdi> world.</p>",
+    ConversionOptions::default(),
+    "Hello مرحبا world."
+)]
+// --- iframe platform detection ---
+#[case::iframe_youtube(
+    "<iframe src=\"https://www.youtube.com/embed/dQw4w9WgXcQ\"></iframe>",
+    ConversionOptions::default(),
+    "[YouTube Video](https://www.youtube.com/watch?v=dQw4w9WgXcQ)"
+)]
+#[case::iframe_youtube_with_params(
+    "<iframe src=\"https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1\"></iframe>",
+    ConversionOptions::default(),
+    "[YouTube Video](https://www.youtube.com/watch?v=dQw4w9WgXcQ)"
+)]
+#[case::iframe_youtube_nocookie(
+    "<iframe src=\"https://www.youtube-nocookie.com/embed/abc123XYZ\"></iframe>",
+    ConversionOptions::default(),
+    "[YouTube Video](https://www.youtube.com/watch?v=abc123XYZ)"
+)]
+#[case::iframe_vimeo(
+    "<iframe src=\"https://player.vimeo.com/video/123456789\"></iframe>",
+    ConversionOptions::default(),
+    "[Vimeo Video](https://vimeo.com/123456789)"
+)]
+#[case::iframe_vimeo_with_hash(
+    "<iframe src=\"https://player.vimeo.com/video/987654321?h=abcdef&badge=0\"></iframe>",
+    ConversionOptions::default(),
+    "[Vimeo Video](https://vimeo.com/987654321)"
+)]
+#[case::iframe_instagram(
+    "<iframe src=\"https://www.instagram.com/p/B1BKr9Wo8YX/embed/\"></iframe>",
+    ConversionOptions::default(),
+    "[Instagram Post](https://www.instagram.com/p/B1BKr9Wo8YX/)"
+)]
+#[case::iframe_dailymotion(
+    "<iframe src=\"https://www.dailymotion.com/embed/video/x7zflst\"></iframe>",
+    ConversionOptions::default(),
+    "[Dailymotion Video](https://www.dailymotion.com/video/x7zflst)"
+)]
+#[case::iframe_twitch_channel(
+    "<iframe src=\"https://player.twitch.tv/?channel=monstercat&parent=example.com\"></iframe>",
+    ConversionOptions::default(),
+    "[Twitch Stream](https://www.twitch.tv/monstercat)"
+)]
+#[case::iframe_twitch_video(
+    "<iframe src=\"https://player.twitch.tv/?video=v123456789&parent=example.com\"></iframe>",
+    ConversionOptions::default(),
+    "[Twitch Video](https://www.twitch.tv/videos/v123456789)"
+)]
+#[case::iframe_twitch_clip(
+    "<iframe src=\"https://clips.twitch.tv/embed?clip=FuriousObliqueDonutDansGame\"></iframe>",
+    ConversionOptions::default(),
+    "[Twitch Clip](https://clips.twitch.tv/FuriousObliqueDonutDansGame)"
+)]
+#[case::iframe_spotify_track(
+    "<iframe src=\"https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh\"></iframe>",
+    ConversionOptions::default(),
+    "[Spotify Track](https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh)"
+)]
+#[case::iframe_spotify_playlist(
+    "<iframe src=\"https://open.spotify.com/embed/playlist/37i9dQZF1DXcBWIGoYBM5M\"></iframe>",
+    ConversionOptions::default(),
+    "[Spotify Playlist](https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M)"
+)]
+#[case::iframe_spotify_episode(
+    "<iframe src=\"https://open.spotify.com/embed/episode/64Q5MbCIFuuEaCf6fxJblG\"></iframe>",
+    ConversionOptions::default(),
+    "[Spotify Episode](https://open.spotify.com/episode/64Q5MbCIFuuEaCf6fxJblG)"
+)]
+#[case::iframe_vk_video(
+    "<iframe src=\"https://vk.com/video_ext.php?oid=-49423435&id=456245092&hash=e1611aefe899c4f8\"></iframe>",
+    ConversionOptions::default(),
+    "[VK Video](https://vk.com/video-49423435_456245092)"
+)]
+#[case::iframe_google_slides(
+    "<iframe src=\"https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed\"></iframe>",
+    ConversionOptions::default(),
+    "[Google Slides](https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/)"
+)]
+#[case::iframe_google_docs(
+    "<iframe src=\"https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/preview\"></iframe>",
+    ConversionOptions::default(),
+    "[Google Docs](https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/)"
+)]
+#[case::iframe_google_sheets(
+    "<iframe src=\"https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/htmlview\"></iframe>",
+    ConversionOptions::default(),
+    "[Google Sheets](https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/)"
+)]
+#[case::iframe_unknown_falls_back_to_title(
+    "<iframe src=\"https://example.com/embed\" title=\"My Embed\"></iframe>",
+    ConversionOptions::default(),
+    "[My Embed](https://example.com/embed \"My Embed\")"
+)]
+// --- Unicode whitespace normalization ---
+#[case::nbsp_in_paragraph(
+    "<p>text\u{00A0}content</p>",
+    ConversionOptions::default(),
+    "text content"
+)]
+#[case::narrow_nbsp_in_paragraph(
+    "<p>text\u{202F}content</p>",
+    ConversionOptions::default(),
+    "text content"
+)]
+#[case::thin_space_in_paragraph(
+    "<p>text\u{2009}content</p>",
+    ConversionOptions::default(),
+    "text content"
+)]
+// --- <details> / <summary> ---
+#[case::details_with_summary(
+    "<details><summary>Summary Title</summary><p>Content here.</p></details>",
+    ConversionOptions::default(),
+    "**Summary Title**\n\nContent here."
+)]
+#[case::details_without_summary(
+    "<details><p>Content only</p></details>",
+    ConversionOptions::default(),
+    "Content only"
+)]
+#[case::details_summary_empty(
+    "<details><summary></summary><p>Content</p></details>",
+    ConversionOptions::default(),
+    "Content"
+)]
+#[case::summary_standalone(
+    "<summary>Standalone</summary>",
+    ConversionOptions::default(),
+    "**Standalone**"
+)]
+// --- <sub> / <sup> ---
+#[case::sub_in_paragraph(
+    "<p>H<sub>2</sub>O</p>",
+    ConversionOptions::default(),
+    "H<sub>2</sub>O"
+)]
+#[case::sup_in_paragraph(
+    "<p>x<sup>2</sup></p>",
+    ConversionOptions::default(),
+    "x<sup>2</sup>"
+)]
+#[case::sub_standalone(
+    "<sub>2</sub>",
+    ConversionOptions::default(),
+    "<sub>2</sub>"
+)]
+#[case::sup_standalone(
+    "<sup>th</sup>",
+    ConversionOptions::default(),
+    "<sup>th</sup>"
+)]
+#[case::sub_empty("<sub></sub>", ConversionOptions::default(), "<sub></sub>")]
+#[case::sup_empty("<sup></sup>", ConversionOptions::default(), "<sup></sup>")]
+// --- <q> ---
+#[case::q_in_paragraph(
+    "<p>He said <q>hello</q>.</p>",
+    ConversionOptions::default(),
+    "He said \"hello\"."
+)]
+#[case::q_standalone(
+    "<q>quoted text</q>",
+    ConversionOptions::default(),
+    "\"quoted text\""
+)]
+// --- <cite> ---
+#[case::cite_in_paragraph(
+    "<p>Read <cite>Hamlet</cite>.</p>",
+    ConversionOptions::default(),
+    "Read *Hamlet*."
+)]
+#[case::cite_standalone(
+    "<cite>Source Title</cite>",
+    ConversionOptions::default(),
+    "*Source Title*"
+)]
+// --- <ins> ---
+#[case::ins_standalone(
+    "<ins>inserted text</ins>",
+    ConversionOptions::default(),
+    "inserted text"
+)]
+#[case::ins_in_paragraph(
+    "<p>This was <ins>added</ins> here.</p>",
+    ConversionOptions::default(),
+    "This was added here."
+)]
+// --- <mark> ---
+#[case::mark_in_paragraph(
+    "<p>This is <mark>highlighted</mark>.</p>",
+    ConversionOptions::default(),
+    "This is <mark>highlighted</mark>."
+)]
+#[case::mark_standalone(
+    "<mark>important</mark>",
+    ConversionOptions::default(),
+    "<mark>important</mark>"
+)]
+// --- <figure> / <figcaption> ---
+#[case::figure_with_img_and_caption(
+    "<figure><img src=\"photo.jpg\" alt=\"A photo\"><figcaption>Caption here</figcaption></figure>",
+    ConversionOptions::default(),
+    "![A photo](photo.jpg)\n\nCaption here"
+)]
+#[case::figure_img_only(
+    "<figure><img src=\"photo.jpg\" alt=\"A photo\"></figure>",
+    ConversionOptions::default(),
+    "![A photo](photo.jpg)"
+)]
+#[case::figcaption_standalone(
+    "<figcaption>Just a caption</figcaption>",
+    ConversionOptions::default(),
+    "Just a caption"
+)]
 fn test_html_to_markdown(#[case] html: &str, #[case] options: ConversionOptions, #[case] expected: &str) {
     assert_conversion_with_options(html, expected, options);
 }

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -1269,21 +1269,13 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     "See ![icon](icon.svg) here."
 )]
 // --- <ruby> / <rt> ---
-#[case::ruby_with_rt(
-    "<ruby>漢字<rt>かんじ</rt></ruby>",
-    ConversionOptions::default(),
-    "漢字(かんじ)"
-)]
+#[case::ruby_with_rt("<ruby>漢字<rt>かんじ</rt></ruby>", ConversionOptions::default(), "漢字(かんじ)")]
 #[case::ruby_in_paragraph(
     "<p>This is <ruby>漢字<rt>かんじ</rt></ruby>.</p>",
     ConversionOptions::default(),
     "This is 漢字(かんじ)."
 )]
-#[case::ruby_no_rt(
-    "<ruby>漢字</ruby>",
-    ConversionOptions::default(),
-    "漢字"
-)]
+#[case::ruby_no_rt("<ruby>漢字</ruby>", ConversionOptions::default(), "漢字")]
 #[case::ruby_with_rp(
     "<ruby>漢字<rp>(</rp><rt>かんじ</rt><rp>)</rp></ruby>",
     ConversionOptions::default(),
@@ -1421,21 +1413,9 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     "[My Embed](https://example.com/embed \"My Embed\")"
 )]
 // --- Unicode whitespace normalization ---
-#[case::nbsp_in_paragraph(
-    "<p>text\u{00A0}content</p>",
-    ConversionOptions::default(),
-    "text content"
-)]
-#[case::narrow_nbsp_in_paragraph(
-    "<p>text\u{202F}content</p>",
-    ConversionOptions::default(),
-    "text content"
-)]
-#[case::thin_space_in_paragraph(
-    "<p>text\u{2009}content</p>",
-    ConversionOptions::default(),
-    "text content"
-)]
+#[case::nbsp_in_paragraph("<p>text\u{00A0}content</p>", ConversionOptions::default(), "text content")]
+#[case::narrow_nbsp_in_paragraph("<p>text\u{202F}content</p>", ConversionOptions::default(), "text content")]
+#[case::thin_space_in_paragraph("<p>text\u{2009}content</p>", ConversionOptions::default(), "text content")]
 // --- <details> / <summary> ---
 #[case::details_with_summary(
     "<details><summary>Summary Title</summary><p>Content here.</p></details>",
@@ -1452,62 +1432,22 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "Content"
 )]
-#[case::summary_standalone(
-    "<summary>Standalone</summary>",
-    ConversionOptions::default(),
-    "**Standalone**"
-)]
+#[case::summary_standalone("<summary>Standalone</summary>", ConversionOptions::default(), "**Standalone**")]
 // --- <sub> / <sup> ---
-#[case::sub_in_paragraph(
-    "<p>H<sub>2</sub>O</p>",
-    ConversionOptions::default(),
-    "H<sub>2</sub>O"
-)]
-#[case::sup_in_paragraph(
-    "<p>x<sup>2</sup></p>",
-    ConversionOptions::default(),
-    "x<sup>2</sup>"
-)]
-#[case::sub_standalone(
-    "<sub>2</sub>",
-    ConversionOptions::default(),
-    "<sub>2</sub>"
-)]
-#[case::sup_standalone(
-    "<sup>th</sup>",
-    ConversionOptions::default(),
-    "<sup>th</sup>"
-)]
+#[case::sub_in_paragraph("<p>H<sub>2</sub>O</p>", ConversionOptions::default(), "H<sub>2</sub>O")]
+#[case::sup_in_paragraph("<p>x<sup>2</sup></p>", ConversionOptions::default(), "x<sup>2</sup>")]
+#[case::sub_standalone("<sub>2</sub>", ConversionOptions::default(), "<sub>2</sub>")]
+#[case::sup_standalone("<sup>th</sup>", ConversionOptions::default(), "<sup>th</sup>")]
 #[case::sub_empty("<sub></sub>", ConversionOptions::default(), "<sub></sub>")]
 #[case::sup_empty("<sup></sup>", ConversionOptions::default(), "<sup></sup>")]
 // --- <q> ---
-#[case::q_in_paragraph(
-    "<p>He said <q>hello</q>.</p>",
-    ConversionOptions::default(),
-    "He said \"hello\"."
-)]
-#[case::q_standalone(
-    "<q>quoted text</q>",
-    ConversionOptions::default(),
-    "\"quoted text\""
-)]
+#[case::q_in_paragraph("<p>He said <q>hello</q>.</p>", ConversionOptions::default(), "He said \"hello\".")]
+#[case::q_standalone("<q>quoted text</q>", ConversionOptions::default(), "\"quoted text\"")]
 // --- <cite> ---
-#[case::cite_in_paragraph(
-    "<p>Read <cite>Hamlet</cite>.</p>",
-    ConversionOptions::default(),
-    "Read *Hamlet*."
-)]
-#[case::cite_standalone(
-    "<cite>Source Title</cite>",
-    ConversionOptions::default(),
-    "*Source Title*"
-)]
+#[case::cite_in_paragraph("<p>Read <cite>Hamlet</cite>.</p>", ConversionOptions::default(), "Read *Hamlet*.")]
+#[case::cite_standalone("<cite>Source Title</cite>", ConversionOptions::default(), "*Source Title*")]
 // --- <ins> ---
-#[case::ins_standalone(
-    "<ins>inserted text</ins>",
-    ConversionOptions::default(),
-    "inserted text"
-)]
+#[case::ins_standalone("<ins>inserted text</ins>", ConversionOptions::default(), "inserted text")]
 #[case::ins_in_paragraph(
     "<p>This was <ins>added</ins> here.</p>",
     ConversionOptions::default(),
@@ -1519,11 +1459,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "This is <mark>highlighted</mark>."
 )]
-#[case::mark_standalone(
-    "<mark>important</mark>",
-    ConversionOptions::default(),
-    "<mark>important</mark>"
-)]
+#[case::mark_standalone("<mark>important</mark>", ConversionOptions::default(), "<mark>important</mark>")]
 // --- <figure> / <figcaption> ---
 #[case::figure_with_img_and_caption(
     "<figure><img src=\"photo.jpg\" alt=\"A photo\"><figcaption>Caption here</figcaption></figure>",

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -591,7 +591,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
 #[case::dl_ignore_comments_and_whitespace_nodes(
     "<dl>\n  <!-- comment --> <dt>Term</dt> \n <dd>Def</dd> </dl>",
     ConversionOptions::default(),
-    "<!-- comment -->\n**Term**\n  Def"
+    "**Term**\n  Def"
 )]
 #[case::ol_nested(
     "<ol><li>Parent 1<ol><li>Child A</li><li>Child B</li></ol></li><li>Parent 2</li></ol>",
@@ -1168,7 +1168,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
 #[case::dl_with_comment_and_whitespace(
     "<dl><dt>Term</dt><!-- comment --><dd>Def</dd>   </dl>",
     ConversionOptions::default(),
-    "**Term**\n<!-- comment -->\n  Def"
+    "**Term**\n  Def"
 )]
 #[case::dl_with_unexpected_element(
     "<dl><dt>Term</dt><p>Unexpected</p><dd>Def</dd></dl>",
@@ -1526,12 +1526,12 @@ fn test_smart_extraction_falls_back_to_full_document() {
 }
 
 #[test]
-fn test_html_comment_preserved() {
-    // This tests the parser's Comment handling
+fn test_html_comment_stripped() {
+    // HTML comments are stripped from the Markdown output.
     let html = "<p>Text</p><!-- Comment --><p>More</p>";
     let md = convert_html_to_markdown(html, ConversionOptions::default()).unwrap();
     assert!(md.contains("Text"));
-    assert!(md.contains("<!-- Comment -->"));
+    assert!(!md.contains("<!--"));
     assert!(md.contains("More"));
 }
 

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -1484,6 +1484,18 @@ fn test_html_to_markdown(#[case] html: &str, #[case] options: ConversionOptions,
 #[case::nav_skipped("<html><body><nav><a href='/'>Home</a></nav><p>Content</p></body></html>", "")]
 #[case::aside_skipped("<html><body><aside>Sidebar</aside><p>Content</p></body></html>", "")]
 #[case::noscript_skipped("<html><body><noscript>Enable JavaScript</noscript><p>Content</p></body></html>", "")]
+#[case::css_dropdown_skipped(
+    r#"<div><input type="checkbox" role="button" aria-haspopup="true"><label>Menu</label><div class="content"><ul><li>Item</li></ul></div></div>"#,
+    "Item"
+)]
+#[case::css_tab_widget_skipped(
+    r#"<div class="tabs"><input type="radio" id="tab1"><label for="tab1">Tab 1</label><input type="radio" id="tab2"><label for="tab2">Tab 2</label></div><p>Content</p>"#,
+    "Tab 1"
+)]
+#[case::heading_wrapper_strips_edit_link(
+    r#"<div class="mw-heading"><h2 id="Intro">Intro</h2><span class="mw-editsection"><span>[</span><a href="/edit">edit</a><span>]</span></span></div>"#,
+    "[edit]"
+)]
 fn test_noisy_elements_skipped(#[case] html: &str, #[case] expected_excluded: &str) {
     let md = convert_html_to_markdown(html, ConversionOptions::default()).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

Improves the HTML-to-Markdown converter quality based on real-world page testing.

- Filter out UI noise (CSS dropdowns, edit links, toggle markers)
- Fix `<br>`, `<pre><code>`, and whitespace handling
- Support `<a>` without `href` and unknown custom elements as block containers
- Add iframe platform detection (YouTube, Vimeo, Spotify, etc.) and new inline elements

## Notes

Considering replacing the custom converter with
[spider-rs/html2md](https://github.com/spider-rs/html2md) in the future.
These are interim improvements in the meantime.
