### PR TITLE
Allow pipeline expressions as function arguments

### DIFF
--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -2381,7 +2381,29 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
     // This typically involves a recursive call to `parse_expr`.
     #[inline(always)]
     fn parse_arg_expr(&mut self, token: &Shared<Token>) -> Result<Shared<Node>, SyntaxError> {
-        self.parse_expr(token)
+        let first = self.parse_expr(token)?;
+        if !self.is_next_token(|kind| matches!(kind, TokenKind::Pipe)) {
+            return Ok(first);
+        }
+
+        let token_id = first.token_id;
+        let mut program = vec![first];
+        while self.is_next_token(|kind| matches!(kind, TokenKind::Pipe)) {
+            let pipe_token = self.tokens.next().unwrap();
+            let next_token = match self.tokens.next() {
+                Some(token) if token.kind == TokenKind::Eof => {
+                    return Err(SyntaxError::UnexpectedEOFAfterToken((**pipe_token).clone()));
+                }
+                Some(token) => token,
+                None => return Err(SyntaxError::UnexpectedEOFAfterToken((**pipe_token).clone())),
+            };
+            program.push(self.parse_expr(next_token)?);
+        }
+
+        Ok(Shared::new(Node {
+            token_id,
+            expr: Shared::new(Expr::Block(program)),
+        }))
     }
 
     fn parse_set_attr_call_with_selector(

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2627,6 +2627,8 @@ fn engine() -> DefaultEngine {
 #[case::paren_free_fn_as_value_preserved("map([\"a\", \"b\"], upcase)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())])].into()))]
 // paren-free calls: passing user-defined function as value to map (no spurious auto-call)
 #[case::paren_free_user_fn_as_value_preserved("def double(x): x * 2; | map([1, 2, 3], double)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])].into()))]
+// pipeline expressions inside function arguments are treated like implicit do...end blocks
+#[case::pipeline_expr_as_function_arg(r#"array("a" | upcase(), "b" | upcase())"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())])].into()))]
 // shadowing builtin: user-defined function with same name as builtin calls the native builtin inside its body
 #[case::shadow_builtin_upcase("def upcase: upcase() | ltrimstr(\"HELLO\"); | \"hello\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
 // shadowing builtin: user function wraps builtin and adds extra transformation

--- a/docs/books/src/reference/functions.md
+++ b/docs/books/src/reference/functions.md
@@ -145,6 +145,15 @@ multiply(10, 3)
 - Default values are evaluated when the function is called, not when it is defined
 - Default values can be any valid expression
 
+## Pipeline Expressions As Arguments
+
+Pipeline expressions can be passed directly as function arguments. The pipeline is treated as one argument until the next comma or closing parenthesis.
+
+```mq
+array("a" | upcase(), "b" | upcase())
+# Output: ["A", "B"]
+```
+
 ## Parenthesis-Free Calls
 
 Functions with 0 or 1 required parameters can be called without parentheses when used as pipeline steps.


### PR DESCRIPTION
Fixes #1842.

## Summary
- parse pipe-delimited function arguments as implicit block expressions
- add regression coverage for comma-separated pipeline arguments
- document pipeline expressions as function arguments in the function reference

## Validation
- `just test-doc`
- `just test-all`

Post-rebase `just test-all` completed with nextest summary: `7065 tests run: 7065 passed, 0 skipped`.
