### PR TITLE
 fix(mq-lang): handle "v"/"V" prefix in semver_parse

### DIFF
--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -514,6 +514,27 @@ def test_semver_parse_with_pre_and_build():
   | assert_eq(v["build"], "exp.sha.5114f85")
 end
 
+def test_semver_parse_with_lowercase_v_prefix():
+  let v = semver::semver_parse("v1.2.3")
+  | assert_eq(v["major"], 1)
+  | assert_eq(v["minor"], 2)
+  | assert_eq(v["patch"], 3)
+end
+
+def test_semver_parse_with_uppercase_v_prefix():
+  let v = semver::semver_parse("V1.2.3")
+  | assert_eq(v["major"], 1)
+  | assert_eq(v["minor"], 2)
+  | assert_eq(v["patch"], 3)
+end
+
+def test_semver_parse_with_v_prefix_and_prerelease():
+  let v = semver::semver_parse("v1.0.0-alpha.1+build.5")
+  | assert_eq(v["major"], 1)
+  | assert_eq(v["pre"], "alpha.1")
+  | assert_eq(v["build"], "build.5")
+end
+
 def test_semver_to_string_basic():
   let v = semver::semver_parse("1.2.3")
   | assert_eq(semver::semver_to_string(v), "1.2.3")

--- a/crates/mq-lang/modules/semver.mq
+++ b/crates/mq-lang/modules/semver.mq
@@ -57,7 +57,8 @@ end
 
 # Parses a SemVer string into a dict with major, minor, patch, pre, and build fields.
 def semver_parse(s):
-  let v = to_string(s)
+  let raw = to_string(s)
+  | let v = ltrimstr(ltrimstr(raw, "v"), "V")
   | let build_parts = split(v, "\\+")
   | let build = if (len(build_parts) > 1): build_parts[1] else: ""
   | let pre_parts = split(build_parts[0], "-")


### PR DESCRIPTION
* Strip an optional leading v or V before parsing in semver_parse, so conventional tag formats like "v1.2.3"
* Adds tests for lowercase/uppercase v-prefixed versions and a v-prefixed version with pre-release/build metadata.

Fixes #1869