### PR TITLE
✨ feat(playground): add HTTP module cache management UI to settings

### DIFF
--- a/packages/mq-playground/package.json
+++ b/packages/mq-playground/package.json
@@ -14,7 +14,7 @@
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",
     "monaco-vim": "^0.4.4",
-    "mq-web": "0.6.2",
+    "mq-web": "0.6.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-icons": "^5.6.0"

--- a/packages/mq-playground/pnpm-lock.yaml
+++ b/packages/mq-playground/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(monaco-editor@0.55.1)
       mq-web:
-        specifier: 0.6.2
-        version: 0.6.2
+        specifier: 0.6.3
+        version: 0.6.3
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -620,8 +620,8 @@ packages:
     peerDependencies:
       monaco-editor: '*'
 
-  mq-web@0.6.2:
-    resolution: {integrity: sha512-EHMyro6NQAtnHlRa/6nsXgnLEpwqeL5E9p5jCdxC/uzwRf1Wqiuld11/i0gz+ysQIaQgfTlO87OBdpbuSj5OHg==}
+  mq-web@0.6.3:
+    resolution: {integrity: sha512-0pdN7BpSXuVqHEM11VvwlYiUsTxMlUjxkbMZw0eXveYtk8qObACB819i8C5FzfEexbAkv5t4AWcHxc5vnmvscQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1177,7 +1177,7 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  mq-web@0.6.2: {}
+  mq-web@0.6.3: {}
 
   ms@2.1.3: {}
 

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -2607,6 +2607,14 @@ img{max-width:100%}
         shareMode={shareMode}
         onShareModeChange={setShareMode}
         isOPFSSupported={isOPFSSupported}
+        onClearHttpCache={async () => {
+          await mq.clearHttpCache();
+          showToast("HTTP module cache cleared", "success");
+        }}
+        onClearAllHttpCache={async () => {
+          await mq.clearAllHttpCache();
+          showToast("All HTTP cache cleared", "success");
+        }}
       />
 
       <ToastContainer toasts={toasts} onClose={dismissToast} />

--- a/packages/mq-playground/src/components/SettingsDialog.css
+++ b/packages/mq-playground/src/components/SettingsDialog.css
@@ -104,3 +104,27 @@ input[type="checkbox"] {
     height: 18px;
     cursor: pointer;
 }
+
+.cache-clear-btn {
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: 1px solid light-dark(#cbd5e0, #3e3e42);
+    background-color: light-dark(#f7fafc, #2d2d30);
+    color: light-dark(#2d3748, #d4d4d4);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.cache-clear-btn:hover {
+    background-color: light-dark(#edf2f7, #3e3e42);
+}
+
+.cache-clear-btn--danger {
+    border-color: light-dark(#fc8181, #e53e3e);
+    color: light-dark(#c53030, #fc8181);
+}
+
+.cache-clear-btn--danger:hover {
+    background-color: light-dark(#fff5f5, #3d1515);
+}

--- a/packages/mq-playground/src/components/SettingsDialog.css
+++ b/packages/mq-playground/src/components/SettingsDialog.css
@@ -106,18 +106,22 @@ input[type="checkbox"] {
 }
 
 .cache-clear-btn {
-    padding: 4px 12px;
+    padding: 6px 12px;
     border-radius: 4px;
     border: 1px solid light-dark(#cbd5e0, #3e3e42);
     background-color: light-dark(#f7fafc, #2d2d30);
     color: light-dark(#2d3748, #d4d4d4);
     font-size: 0.85rem;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: background-color 0.2s, border-color 0.2s;
 }
 
 .cache-clear-btn:hover {
     background-color: light-dark(#edf2f7, #3e3e42);
+}
+
+.cache-clear-btn:active {
+    transform: translateY(1px);
 }
 
 .cache-clear-btn--danger {

--- a/packages/mq-playground/src/components/SettingsDialog.tsx
+++ b/packages/mq-playground/src/components/SettingsDialog.tsx
@@ -21,6 +21,8 @@ type SettingsDialogProps = {
   shareMode: "current" | "all";
   onShareModeChange: (mode: "current" | "all") => void;
   isOPFSSupported: boolean;
+  onClearHttpCache?: () => Promise<void>;
+  onClearAllHttpCache?: () => Promise<void>;
 };
 
 export const SettingsDialog = ({
@@ -43,6 +45,8 @@ export const SettingsDialog = ({
   shareMode,
   onShareModeChange,
   isOPFSSupported,
+  onClearHttpCache,
+  onClearAllHttpCache,
 }: SettingsDialogProps) => {
   if (!isOpen) return null;
 
@@ -164,6 +168,33 @@ export const SettingsDialog = ({
                   <option value="all">All Files</option>
                 </select>
               </div>
+            </div>
+          )}
+          {isOPFSSupported && (onClearHttpCache || onClearAllHttpCache) && (
+            <div className="settings-section">
+              <h4>Cache</h4>
+              {onClearHttpCache && (
+                <div className="settings-item">
+                  <label>HTTP Module Cache</label>
+                  <button
+                    className="cache-clear-btn"
+                    onClick={onClearHttpCache}
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
+              {onClearAllHttpCache && (
+                <div className="settings-item">
+                  <label>All HTTP Cache</label>
+                  <button
+                    className="cache-clear-btn cache-clear-btn--danger"
+                    onClick={onClearAllHttpCache}
+                  >
+                    Clear All
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/packages/mq-playground/src/index.css
+++ b/packages/mq-playground/src/index.css
@@ -858,6 +858,25 @@ body {
   color: #e2e8f0;
 }
 
+[data-theme="mq"] .cache-clear-btn {
+  background-color: #2a3444;
+  border: 1px solid #4a5568;
+  color: #e2e8f0;
+}
+
+[data-theme="mq"] .cache-clear-btn:hover {
+  background-color: #32404f;
+}
+
+[data-theme="mq"] .cache-clear-btn--danger {
+  border-color: #e53e3e;
+  color: #fc8181;
+}
+
+[data-theme="mq"] .cache-clear-btn--danger:hover {
+  background-color: #3d1515;
+}
+
 [data-theme="mq"] .dropdown {
   background-color: #2a3444;
   border: 1px solid #4a5568;


### PR DESCRIPTION
Add Cache section to SettingsDialog with buttons to clear mutable HTTP module cache or all HTTP cache. Wire clearHttpCache / clearAllHttpCache from mq-web into Playground and update the mq-web dependency to the local workspace package.