### PR TITLE
🐛 fix(mq-lang): escape embedded double-quotes in csv_stringify

### DIFF
--- a/crates/mq-lang/modules/csv.mq
+++ b/crates/mq-lang/modules/csv.mq
@@ -23,14 +23,18 @@ def csv_stringify(data, delimiter):
   let headers = if (is_array(data) && len(data) > 0 && is_dict(first(data))):
     keys(first(data))
   else: first(data)
-  | let header_line = join(headers, delimiter)
+  | let header_line = join(map(headers, fn(header):
+      let s = to_string(header)
+      | if (csv_needs_quote(header, delimiter)):
+          "\"" + replace(s, "\"", "\"\"") + "\""
+        else: s;), delimiter)
   | let data = if (is_dict(first(data))): data else: data[1:len(data)]
   | let process_row = fn(row):
       if (is_dict(row)):
         join(map(headers, fn(header):
           if (row[header]):
             if (csv_needs_quote(row[header], delimiter)):
-              "\"" + to_string(row[header]) + "\""
+              "\"" + replace(to_string(row[header]), "\"", "\"\"") + "\""
             else:
               to_string(row[header])
           else:
@@ -39,7 +43,7 @@ def csv_stringify(data, delimiter):
         join(map(row, fn(field):
           let s = to_string(field)
           | if (csv_needs_quote(field, delimiter)):
-              s"\"${s}\""
+              "\"" + replace(s, "\"", "\"\"") + "\""
             else: s;), delimiter)
     end
   | let data_lines = map(data, process_row)

--- a/crates/mq-lang/modules/module_tests.mq
+++ b/crates/mq-lang/modules/module_tests.mq
@@ -34,6 +34,47 @@ def test_csv_to_json_for_array():
   | assert_eq(result, "[[\"a\",\"b\",\"c\"],[\"1,2\",\"2,3\",\"3,4\"],[\"4\",\"5\",\"6\"],[\"multi\\nline\",\"7\",\"8\"],[\"9\",\"10\",\"quoted,comma\"],[\"\",\"11\",\"12\"],[\"13\",\"14\",\"15\"]]")
 end
 
+def test_csv_stringify_plain_for_array():
+  let result = csv::csv_stringify([["a", "b"], ["1", "2"], ["3", "4"]], ",")
+  | assert_eq(result, "a,b\n1,2\n3,4")
+end
+
+def test_csv_stringify_plain_for_dict():
+  let result = csv::csv_stringify([{"a": "1", "b": "2"}, {"a": "3", "b": "4"}], ",")
+  | assert_eq(result, "a,b\n1,2\n3,4")
+end
+
+def test_csv_stringify_escapes_quotes_for_array():
+  let result = csv::csv_stringify([["a", "b"], ["he said \"hi\"", "plain"]], ",")
+  | assert_eq(result, "a,b\n\"he said \"\"hi\"\"\",plain")
+end
+
+def test_csv_stringify_escapes_quotes_for_dict():
+  let result = csv::csv_stringify([{"a": "he said \"hi\"", "b": "plain"}], ",")
+  | assert_eq(result, "a,b\n\"he said \"\"hi\"\"\",plain")
+end
+
+def test_csv_stringify_escapes_multiple_quotes():
+  let result = csv::csv_stringify([["a"], ["\"\"\""]], ",")
+  | assert_eq(result, "a\n\"\"\"\"\"\"\"\"")
+end
+
+def test_csv_stringify_escapes_quote_and_delimiter_together():
+  let result = csv::csv_stringify([["a", "b"], ["x\",y", "plain"]], ",")
+  | assert_eq(result, "a,b\n\"x\"\",y\",plain")
+end
+
+def test_csv_stringify_escapes_quotes_in_header():
+  let result = csv::csv_stringify([["he said \"hi\""], ["v"]], ",")
+  | assert_eq(result, "\"he said \"\"hi\"\"\"\nv")
+end
+
+def test_csv_stringify_roundtrip_with_quotes():
+  let original = [{"a": "he said \"hi\"", "b": "x,y"}]
+  | let result = csv::csv_parse(csv::csv_stringify(original, ","), true)
+  | assert_eq(result, original)
+end
+
 | let psv_input = "a|b|c\n\"1,2\"|\"2,3\"|\"3,4\"\n4|5|6\n\"multi\nline\"|7|8\n9|10|\"quoted,comma\"\n\"\"|11|12\n13|14|15\n" |
 
 def test_psv_parse_for_dict():


### PR DESCRIPTION
Quoted CSV fields and header cells containing `"` were wrapped in quotes without doubling the embedded quote per RFC 4180, producing invalid CSV. Also add coverage for plain, multi-quote, header, and round-trip cases.

Close #1868