### PR TITLE
🐛 fix(mq-markdown): filter recursively-empty fragments when rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "itertools 0.15.0",
  "markdown",
  "miette",
+ "proptest",
  "rstest",
  "rustc-hash",
  "scraper",

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -25,6 +25,7 @@ smol_str = {workspace = true}
 
 [dev-dependencies]
 divan = {workspace = true}
+proptest = {workspace = true}
 rstest = {workspace = true}
 
 [[bench]]

--- a/crates/mq-markdown/src/node.rs
+++ b/crates/mq-markdown/src/node.rs
@@ -1305,7 +1305,7 @@ impl Node {
             }
             Self::Fragment(Fragment { values }) => values
                 .iter()
-                .filter(|value| !value.is_empty())
+                .filter(|value| !value.is_empty() && !value.is_empty_fragment())
                 .map(|value| value.render_with_theme(options, theme))
                 .join("\n"),
             Self::Empty => String::new(),
@@ -4359,6 +4359,24 @@ mod tests {
         Node::Text(Text{value: "".to_string(), position: None}),
         Node::Text(Text{value: "world".to_string(), position: None})
     ]}), RenderOptions::default(), "hello\n\nworld")]
+    #[case::fragment_filters_nested_empty_fragment(Node::Fragment(Fragment{values: vec![
+        Node::Fragment(Fragment{values: vec![Node::Empty, Node::Empty]}),
+        Node::Text(Text{value: "hello".to_string(), position: None}),
+        Node::Fragment(Fragment{values: vec![Node::Empty]}),
+    ]}), RenderOptions::default(), "hello")]
+    #[case::fragment_filters_deeply_nested_empty_fragment(Node::Fragment(Fragment{values: vec![
+        Node::Fragment(Fragment{values: vec![
+            Node::Fragment(Fragment{values: vec![Node::Empty]}),
+            Node::Empty,
+        ]}),
+        Node::Text(Text{value: "hello".to_string(), position: None}),
+    ]}), RenderOptions::default(), "hello")]
+    #[case::fragment_keeps_nested_fragment_with_blank_line_text(Node::Fragment(Fragment{values: vec![
+        Node::Fragment(Fragment{values: vec![Node::Empty]}),
+        Node::Text(Text{value: "hello".to_string(), position: None}),
+        Node::Fragment(Fragment{values: vec![Node::Text(Text{value: "".to_string(), position: None})]}),
+        Node::Text(Text{value: "world".to_string(), position: None}),
+    ]}), RenderOptions::default(), "hello\n\nworld")]
     #[cfg_attr(feature = "wikilink", case::wikilink(Node::WikiLink(WikiLink{target: "target".to_string(), text: None, position: None}), RenderOptions::default(), "[[target]]"))]
     #[cfg_attr(feature = "wikilink", case::wikilink_with_text(Node::WikiLink(WikiLink{target: "target".to_string(), text: Some("display text".to_string()), position: None}), RenderOptions::default(), "[[target|display text]]"))]
     #[cfg_attr(feature = "wikilink", case::wikilink_same_text(Node::WikiLink(WikiLink{target: "target".to_string(), text: Some("target".to_string()), position: None}), RenderOptions::default(), "[[target]]"))]
@@ -4641,6 +4659,37 @@ mod tests {
     #[case(Node::Empty, Node::Empty)]
     fn test_to_fragment(#[case] node: Node, #[case] expected: Node) {
         assert_eq!(node.to_fragment(), expected);
+    }
+
+    // Regression coverage for the 0.6.2 blank-line bug: `eval_markdown_node`
+    // replaces a non-matching `select()` result with `child_node.to_fragment()`,
+    // not `Node::Empty` directly. For container nodes this yields a `Fragment`
+    // wrapping the (now `Empty`) children, which must still render to "" with
+    // no stray blank lines, while a partially-matching container must render
+    // only the surviving content.
+    #[rstest]
+    #[case::blockquote_all_empty(Node::Blockquote(Blockquote{values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::blockquote_mixed(Node::Blockquote(Blockquote{values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::delete_all_empty(Node::Delete(Delete{values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::delete_mixed(Node::Delete(Delete{values: vec![Node::Text(Text{value: "kept".to_string(), position: None}), Node::Empty], position: None}), "kept")]
+    #[case::heading_all_empty(Node::Heading(Heading{depth: 1, values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::heading_mixed(Node::Heading(Heading{depth: 1, values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::emphasis_all_empty(Node::Emphasis(Emphasis{values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::emphasis_mixed(Node::Emphasis(Emphasis{values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::list_all_empty(Node::List(List{index: 0, level: 0, checked: None, ordered: false, values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::list_mixed(Node::List(List{index: 0, level: 0, checked: None, ordered: false, values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::strong_all_empty(Node::Strong(Strong{values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::strong_mixed(Node::Strong(Strong{values: vec![Node::Text(Text{value: "kept".to_string(), position: None}), Node::Empty], position: None}), "kept")]
+    #[case::link_all_empty(Node::Link(Link{url: Url(attr_keys::URL.to_string()), title: None, values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::link_mixed(Node::Link(Link{url: Url(attr_keys::URL.to_string()), title: None, values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::link_ref_all_empty(Node::LinkRef(LinkRef{ident: "id".to_string(), values: vec![Node::Empty, Node::Empty], label: None, position: None}), "")]
+    #[case::link_ref_mixed(Node::LinkRef(LinkRef{ident: "id".to_string(), values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], label: None, position: None}), "kept")]
+    #[case::footnote_all_empty(Node::Footnote(Footnote{ident: "id".to_string(), values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::footnote_mixed(Node::Footnote(Footnote{ident: "id".to_string(), values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    #[case::table_cell_all_empty(Node::TableCell(TableCell{column: 0, row: 0, values: vec![Node::Empty, Node::Empty], position: None}), "")]
+    #[case::table_cell_mixed(Node::TableCell(TableCell{column: 0, row: 0, values: vec![Node::Empty, Node::Text(Text{value: "kept".to_string(), position: None})], position: None}), "kept")]
+    fn test_to_fragment_then_render_skips_non_matching(#[case] node: Node, #[case] expected: &str) {
+        assert_eq!(node.to_fragment().to_string_with(&RenderOptions::default()), expected);
     }
 
     #[rstest]

--- a/crates/mq-markdown/tests/fragment_property_tests.rs
+++ b/crates/mq-markdown/tests/fragment_property_tests.rs
@@ -1,0 +1,72 @@
+//! Property-based regression coverage for `Node::Fragment` rendering.
+//!
+//! `select()` on a non-matching container node is implemented via
+//! `to_fragment()`, which turns the container into a `Fragment` wrapping its
+//! (now `Empty`) children instead of collapsing straight to `Node::Empty`.
+//! The renderer must treat any such recursively-empty `Fragment` the same as
+//! a literal `Node::Empty`, no matter how deeply it is nested, or stray
+//! blank lines leak into the output (the 0.6.2 regression this guards).
+
+use mq_markdown::{Fragment, Node, RenderOptions, Text};
+use proptest::prelude::*;
+
+fn leaf() -> impl Strategy<Value = Node> {
+    prop_oneof![
+        Just(Node::Empty),
+        "[a-z]{1,5}".prop_map(|s| Node::Text(Text {
+            value: s,
+            position: None
+        })),
+    ]
+}
+
+fn fragment_tree() -> impl Strategy<Value = Node> {
+    leaf().prop_recursive(4, 64, 6, |inner| {
+        prop::collection::vec(inner, 0..6).prop_map(|values| Node::Fragment(Fragment { values }))
+    })
+}
+
+fn all_empty_fragment_tree() -> impl Strategy<Value = Node> {
+    Just(Node::Empty).prop_recursive(4, 64, 6, |inner| {
+        prop::collection::vec(inner, 0..6).prop_map(|values| Node::Fragment(Fragment { values }))
+    })
+}
+
+/// Independently re-derives the expected output: walk the tree collecting
+/// the value of every `Text` leaf in document order. `Empty` contributes
+/// nothing and `Fragment` is transparent. Does not call into
+/// `render_with_theme`/`is_empty_fragment`, so it can't share their bugs.
+fn expected_leaf_values(node: &Node, out: &mut Vec<String>) {
+    match node {
+        Node::Empty => {}
+        Node::Fragment(Fragment { values }) => {
+            for v in values {
+                expected_leaf_values(v, out);
+            }
+        }
+        Node::Text(Text { value, .. }) => out.push(value.clone()),
+        other => out.push(other.to_string_with(&RenderOptions::default())),
+    }
+}
+
+proptest! {
+    /// A fragment tree built only from `Empty` and `Fragment` must render to
+    /// an empty string at any nesting depth/shape. This is exactly the
+    /// shape produced for a fully non-matching container.
+    #[test]
+    fn all_empty_fragment_tree_renders_empty(tree in all_empty_fragment_tree()) {
+        prop_assert_eq!(tree.to_string_with(&RenderOptions::default()), String::new());
+    }
+
+    /// Rendering a fragment tree must equal joining the in-order rendered
+    /// values of its `Text` leaves with "\n", regardless of how deeply
+    /// `Empty`/`Fragment` nesting separates them. `Empty` contributes
+    /// nothing; `Fragment` is transparent; `Text` (including `Text("")`,
+    /// used by `br()`) always survives and contributes its own line.
+    #[test]
+    fn fragment_render_matches_leaf_order(tree in fragment_tree()) {
+        let mut expected = Vec::new();
+        expected_leaf_values(&tree, &mut expected);
+        prop_assert_eq!(tree.to_string_with(&RenderOptions::default()), expected.join("\n"));
+    }
+}

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -251,6 +251,21 @@ In {year}, the snowfall was above average.
     "<root>text</root>",
     Some("{\"text\": \"text\", \"attributes\": {}, \"tag\": \"root\", \"children\": []}\n")
 )]
+#[case::select_skips_non_matching_wrapped_list_items(
+    vec!["--unbuffered", r#"select(.code.lang == "bash") | to_text()"#],
+    "- An [Amazon Bedrock Knowledge Base](https://aws.amazon.com/bedrock/knowledge-bases/)\n  indexes **one configurable [Confluence](https://www.atlassian.com/software/confluence)\n  space** (the space key is an OpenTofu variable)\n- [Confluence](https://www.atlassian.com/software/confluence) credentials are\n  rendered by OpenTofu into an [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)\n  secret - the only credential store the Bedrock connector accepts\n\n```bash\necho \"hello\"\n```\n",
+    Some("echo \"hello\"\n")
+)]
+#[case::select_skips_non_matching_wrapped_list_items_markdown_format(
+    vec!["--unbuffered", r#"select(.code.lang == "bash")"#],
+    "- An [Amazon Bedrock Knowledge Base](https://aws.amazon.com/bedrock/knowledge-bases/)\n  indexes **one configurable [Confluence](https://www.atlassian.com/software/confluence)\n  space** (the space key is an OpenTofu variable)\n- [Confluence](https://www.atlassian.com/software/confluence) credentials are\n  rendered by OpenTofu into an [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)\n  secret - the only credential store the Bedrock connector accepts\n\n```bash\necho \"hello\"\n```\n",
+    Some("```bash\necho \"hello\"\n```\n")
+)]
+#[case::select_skips_non_matching_container_nodes(
+    vec!["--unbuffered", "select(.h1)"],
+    "- [Link](http://a) **bold** item\n- another *em* ~~del~~ item\n\n> [Quoted link](http://b)\n\n| [Cell link](http://c) | **Cell bold** |\n| --- | --- |\n| a | b |\n\n[^1]: [Footnote link](http://d)\n\n# DONE\n",
+    Some("# DONE\n")
+)]
 fn test_cli_commands(
     #[case] args: Vec<&str>,
     #[case] input: &str,


### PR DESCRIPTION
https://github.com/harehare/mq/issues/1922