### PR TITLE
✨ feat(mq-lint): add UnusedParameter, ConstantStringConcat, and NegatedCondition rules

### DIFF
--- a/crates/mq-lint/src/message.rs
+++ b/crates/mq-lint/src/message.rs
@@ -42,6 +42,9 @@ pub enum RuleId {
     BooleanComparison,
     RedundantBooleanLiteral,
     UnnecessaryInterpolation,
+    UnusedParameter,
+    ConstantStringConcat,
+    NegatedCondition,
 }
 
 impl RuleId {
@@ -77,6 +80,9 @@ impl RuleId {
         RuleId::BooleanComparison,
         RuleId::RedundantBooleanLiteral,
         RuleId::UnnecessaryInterpolation,
+        RuleId::UnusedParameter,
+        RuleId::ConstantStringConcat,
+        RuleId::NegatedCondition,
     ];
 
     /// The rule's `snake_case` identifier, as used in config and CLI flags.
@@ -112,6 +118,9 @@ impl RuleId {
             RuleId::BooleanComparison => "boolean_comparison",
             RuleId::RedundantBooleanLiteral => "redundant_boolean_literal",
             RuleId::UnnecessaryInterpolation => "unnecessary_interpolation",
+            RuleId::UnusedParameter => "unused_parameter",
+            RuleId::ConstantStringConcat => "constant_string_concat",
+            RuleId::NegatedCondition => "negated_condition",
         }
     }
 }
@@ -225,6 +234,11 @@ pub enum LintMessage {
         then_val: String,
     },
     UnnecessaryInterpolation,
+    UnusedParameter {
+        name: String,
+    },
+    ConstantStringConcat,
+    NegatedCondition,
 }
 
 impl LintMessage {
@@ -261,6 +275,9 @@ impl LintMessage {
             LintMessage::BooleanComparison { .. } => RuleId::BooleanComparison,
             LintMessage::RedundantBooleanLiteral { .. } => RuleId::RedundantBooleanLiteral,
             LintMessage::UnnecessaryInterpolation => RuleId::UnnecessaryInterpolation,
+            LintMessage::UnusedParameter { .. } => RuleId::UnusedParameter,
+            LintMessage::ConstantStringConcat => RuleId::ConstantStringConcat,
+            LintMessage::NegatedCondition => RuleId::NegatedCondition,
         }
     }
 
@@ -355,6 +372,13 @@ impl LintMessage {
             ),
             LintMessage::UnnecessaryInterpolation => {
                 Some("replace `s\"${x}\"` with just `x` (no interpolation needed)".to_string())
+            }
+            LintMessage::UnusedParameter { name } => {
+                Some(format!("if this is intentional, prefix with `_`: `_{name}`"))
+            }
+            LintMessage::ConstantStringConcat => Some("combine the string literals into a single string".to_string()),
+            LintMessage::NegatedCondition => {
+                Some("invert the condition and swap the `then` and `else` branches".to_string())
             }
         }
     }
@@ -456,6 +480,16 @@ impl fmt::Display for LintMessage {
                 write!(
                     f,
                     "unnecessary string interpolation: the expression can be used directly"
+                )
+            }
+            LintMessage::UnusedParameter { name } => write!(f, "unused parameter `{name}`"),
+            LintMessage::ConstantStringConcat => {
+                write!(f, "concatenating string literals can be written as a single string")
+            }
+            LintMessage::NegatedCondition => {
+                write!(
+                    f,
+                    "negated condition in `if`/`else` — consider swapping the branches and inverting the condition"
                 )
             }
         }

--- a/crates/mq-lint/src/rules/complexity/complex_interpolation.rs
+++ b/crates/mq-lint/src/rules/complexity/complex_interpolation.rs
@@ -45,6 +45,7 @@ impl LintRule for ComplexInterpolation {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -58,16 +59,21 @@ mod tests {
         ComplexInterpolation.check(&ctx)
     }
 
-    #[test]
-    fn detects_too_many_interpolations() {
-        // 4 interpolated expressions, limit 3
-        let diags = check_with_max(r#"s"${.h1} ${.h2} ${.h3} ${.h4}""#, 3);
+    #[rstest]
+    #[case(r#"s"${.h1} ${.h2} ${.h3} ${.h4}""#, 3)]
+    #[case(r#"s"${.h1} ${.h2} ${.h3} ${.h4} ${.h5}""#, 3)]
+    #[case(r#"s"${.h1} ${.h2}""#, 1)]
+    fn detects_too_many_interpolations(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_within_limit() {
-        let diags = check_with_max(r#"s"${.h1} ${.h2}""#, 3);
+    #[rstest]
+    #[case(r#"s"${.h1} ${.h2}""#, 3)]
+    #[case(r#"s"${.h1} ${.h2} ${.h3}""#, 3)]
+    #[case(r#"s"hello world""#, 1)]
+    fn no_diagnostic_within_limit(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/complexity/deeply_nested.rs
+++ b/crates/mq-lint/src/rules/complexity/deeply_nested.rs
@@ -72,6 +72,7 @@ fn scope_depth(ctx: &LintContext<'_>, scope_id: ScopeId) -> usize {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -85,9 +86,19 @@ mod tests {
         DeeplyNested.check(&ctx)
     }
 
-    #[test]
-    fn no_diagnostic_for_shallow_code() {
-        let diags = check_with_max("def f(): .h1;", 4);
+    #[rstest]
+    #[case("def f(): if (true): if (true): 1 else: 2 else: 3;", 1)]
+    #[case("loop if (true): if (true): 1 else: 2 else: 3 end", 1)]
+    fn detects_deeply_nested(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
+        assert!(!diags.is_empty());
+    }
+
+    #[rstest]
+    #[case("def f(): .h1;", 4)]
+    #[case(".h1 | .h2", 4)]
+    fn no_diagnostic_for_shallow_code(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/complexity/function_too_long.rs
+++ b/crates/mq-lint/src/rules/complexity/function_too_long.rs
@@ -44,6 +44,7 @@ impl LintRule for FunctionTooLong {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -57,9 +58,19 @@ mod tests {
         FunctionTooLong.check(&ctx)
     }
 
-    #[test]
-    fn no_diagnostic_for_short_function() {
-        let diags = check_with_max("def f(): .h1;", 50);
+    #[rstest]
+    #[case("def f(): .h1 | .h2 | .h3;", 0)]
+    #[case("def g(): .h1;", 0)]
+    fn detects_function_too_long(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[rstest]
+    #[case("def f(): .h1;", 50)]
+    #[case("def f(): .h1 | .h2;", 10)]
+    fn no_diagnostic_for_short_function(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/complexity/too_many_match_arms.rs
+++ b/crates/mq-lint/src/rules/complexity/too_many_match_arms.rs
@@ -48,6 +48,7 @@ impl LintRule for TooManyMatchArms {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -61,15 +62,19 @@ mod tests {
         TooManyMatchArms.check(&ctx)
     }
 
-    #[test]
-    fn detects_too_many_arms() {
-        let diags = check_with_max(r#"match (1): | "a": 1 | "b": 2 | "c": 3 | _: 0 end"#, 3);
+    #[rstest]
+    #[case(r#"match (1): | "a": 1 | "b": 2 | "c": 3 | _: 0 end"#, 3)]
+    #[case(r#"match (1): | "a": 1 | "b": 2 | _: 0 end"#, 2)]
+    fn detects_too_many_arms(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_within_limit() {
-        let diags = check_with_max(r#"match (1): | "a": 1 | "b": 2 | _: 0 end"#, 3);
+    #[rstest]
+    #[case(r#"match (1): | "a": 1 | "b": 2 | _: 0 end"#, 3)]
+    #[case(r#"match (1): | "a": 1 | _: 0 end"#, 2)]
+    fn no_diagnostic_within_limit(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/complexity/too_many_params.rs
+++ b/crates/mq-lint/src/rules/complexity/too_many_params.rs
@@ -40,6 +40,7 @@ impl LintRule for TooManyParams {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -53,16 +54,21 @@ mod tests {
         TooManyParams.check(&ctx)
     }
 
-    #[test]
-    fn detects_too_many_params() {
-        let diags = check_with_max("def f(a, b, c): a", 2);
+    #[rstest]
+    #[case("def f(a, b, c): a", 2, "3 parameters")]
+    #[case("def f(a, b, c, d): a", 3, "4 parameters")]
+    fn detects_too_many_params(#[case] code: &str, #[case] max: usize, #[case] msg: &str) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("3 parameters"));
+        assert!(diags[0].message().contains(msg));
     }
 
-    #[test]
-    fn no_diagnostic_within_limit() {
-        let diags = check_with_max("def f(a, b): a", 2);
+    #[rstest]
+    #[case("def f(a, b): a", 2)]
+    #[case("def f(a): a", 2)]
+    #[case("def f(): .h1", 0)]
+    fn no_diagnostic_within_limit(#[case] code: &str, #[case] max: usize) {
+        let diags = check_with_max(code, max);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness.rs
+++ b/crates/mq-lint/src/rules/correctness.rs
@@ -8,6 +8,7 @@ pub mod shadow_variable;
 pub mod unreachable_code;
 pub mod unused_function;
 pub mod unused_import;
+pub mod unused_parameter;
 pub mod unused_variable;
 
 use crate::LintRule;
@@ -17,6 +18,7 @@ pub fn all() -> Vec<Box<dyn LintRule>> {
         Box::new(unused_variable::UnusedVariable),
         Box::new(unused_function::UnusedFunction),
         Box::new(unused_import::UnusedImport),
+        Box::new(unused_parameter::UnusedParameter),
         Box::new(unreachable_code::UnreachableCode),
         Box::new(infinite_loop::InfiniteLoop),
         Box::new(deprecated_function_call::DeprecatedFunctionCall),

--- a/crates/mq-lint/src/rules/correctness/always_true_condition.rs
+++ b/crates/mq-lint/src/rules/correctness/always_true_condition.rs
@@ -63,6 +63,7 @@ impl LintRule for AlwaysTrueCondition {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -75,23 +76,22 @@ mod tests {
         AlwaysTrueCondition.check(&ctx)
     }
 
-    #[test]
-    fn detects_literal_true_condition() {
-        let diags = check("if (true): 1 else: 2;");
+    #[rstest]
+    #[case("if (true): 1 else: 2;", "always `true`")]
+    #[case("if (false): 1 else: 2;", "always `false`")]
+    #[case("if (true): 1;", "always `true`")]
+    fn detects_constant_boolean_condition(#[case] code: &str, #[case] expected_msg: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("always `true`"));
+        assert!(diags[0].message().contains(expected_msg));
     }
 
-    #[test]
-    fn detects_literal_false_condition() {
-        let diags = check("if (false): 1 else: 2;");
-        assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("always `false`"));
-    }
-
-    #[test]
-    fn no_diagnostic_for_dynamic_condition() {
-        let diags = check("if (.h1): 1 else: 2;");
+    #[rstest]
+    #[case("if (.h1): 1 else: 2;")]
+    #[case("if (x): 1 else: 2;")]
+    #[case("if (.checked == true): 1 else: 2;")]
+    fn no_diagnostic_for_dynamic_condition(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/deprecated_function_call.rs
+++ b/crates/mq-lint/src/rules/correctness/deprecated_function_call.rs
@@ -49,6 +49,7 @@ impl LintRule for DeprecatedFunctionCall {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -61,24 +62,17 @@ mod tests {
         DeprecatedFunctionCall.check(&ctx)
     }
 
-    #[test]
-    fn detects_call_to_deprecated_function() {
-        let diags = check("# deprecated\ndef old(): 1; | old()");
-        assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("old"));
-        assert_eq!(diags[0].severity, Severity::Warn);
-    }
-
-    #[test]
-    fn no_diagnostic_for_non_deprecated_function() {
-        let diags = check("def current(): 1; | current()");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_when_deprecated_function_not_called() {
-        let diags = check("# deprecated\ndef old(): 1;");
-        assert_eq!(diags.len(), 0);
+    #[rstest]
+    #[case("# deprecated\ndef old(): 1; | old()", 1, "old")]
+    #[case("# Deprecated\ndef old(): 1; | old()", 1, "old")]
+    #[case("# DEPRECATED\ndef old(): 1; | old()", 1, "old")]
+    #[case("# deprecated: use new_fn instead\ndef old(): 1; | old()", 1, "old")]
+    #[case("# deprecated\ndef my_old_func(): 1; | my_old_func()", 1, "my_old_func")]
+    #[case("# deprecated\ndef old(): 1;\ndef wrapper(): old();", 1, "old")]
+    fn detects_deprecated_call(#[case] code: &str, #[case] expected: usize, #[case] fn_name: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), expected);
+        assert!(diags[0].message().contains(fn_name));
     }
 
     #[test]
@@ -97,47 +91,13 @@ mod tests {
         assert!(messages.iter().any(|m| m.contains("old_b")));
     }
 
-    #[test]
-    fn detects_deprecated_with_uppercase_marker() {
-        let diags = check("# Deprecated\ndef old(): 1; | old()");
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn detects_deprecated_with_all_caps_marker() {
-        let diags = check("# DEPRECATED\ndef old(): 1; | old()");
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn no_diagnostic_when_different_function_called() {
-        let diags = check("# deprecated\ndef old(): 1;\ndef current(): 2; | current()");
+    #[rstest]
+    #[case("def current(): 1; | current()")]
+    #[case("# deprecated\ndef old(): 1;")]
+    #[case("# deprecated\ndef old(): 1;\ndef current(): 2; | current()")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn detects_deprecated_call_inside_function_body() {
-        let diags = check("# deprecated\ndef old(): 1;\ndef wrapper(): old();");
-        assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("old"));
-    }
-
-    #[test]
-    fn detects_deprecated_call_with_message_suffix() {
-        let diags = check("# deprecated: use new_fn instead\ndef old(): 1; | old()");
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn diagnostic_message_contains_function_name() {
-        let diags = check("# deprecated\ndef my_old_func(): 1; | my_old_func()");
-        assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("my_old_func"));
-    }
-
-    #[test]
-    fn rule_id_is_deprecated_function_call() {
-        assert_eq!(DeprecatedFunctionCall.id(), RuleId::DeprecatedFunctionCall);
     }
 
     #[test]

--- a/crates/mq-lint/src/rules/correctness/duplicate_import.rs
+++ b/crates/mq-lint/src/rules/correctness/duplicate_import.rs
@@ -49,6 +49,7 @@ impl LintRule for DuplicateImport {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -61,21 +62,20 @@ mod tests {
         DuplicateImport.check(&ctx)
     }
 
-    #[test]
-    fn detects_duplicate_import() {
-        let diags = check("import \"a\" | import \"a\" | a");
+    #[rstest]
+    #[case("import \"a\" | import \"a\" | a")]
+    #[case("import \"b\" | import \"b\" | import \"b\" | b")]
+    fn detects_duplicate_import(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_duplicate_import_with_other_module() {
-        let diags = check("import \"a\" | import \"b\" | a");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_duplicate_import() {
-        let diags = check("import \"a\" | a");
+    #[rstest]
+    #[case("import \"a\" | import \"b\" | a")]
+    #[case("import \"a\" | a")]
+    #[case(".h1")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/duplicate_match_arm.rs
+++ b/crates/mq-lint/src/rules/correctness/duplicate_match_arm.rs
@@ -68,6 +68,7 @@ impl LintRule for DuplicateMatchArm {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -80,15 +81,20 @@ mod tests {
         DuplicateMatchArm.check(&ctx)
     }
 
-    #[test]
-    fn detects_duplicate_arm() {
-        let diags = check(r#"match (1): | "a": "h" | "a": "hh" | _: "other" end"#);
+    #[rstest]
+    #[case(r#"match (1): | "a": "h" | "a": "hh" | _: "other" end"#)]
+    #[case(r#"match (1): | "x": 1 | "x": 2 | _: 0 end"#)]
+    fn detects_duplicate_arm(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_duplicate_arms() {
-        let diags = check(r#"match (1): | "a": "h" | "b": "t" | _: "other" end"#);
+    #[rstest]
+    #[case(r#"match (1): | "a": "h" | "b": "t" | _: "other" end"#)]
+    #[case(r#"match (1): | "a": 1 | _: 0 end"#)]
+    #[case(r#"match (1): | _: 0 | _: 1 end"#)]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/infinite_loop.rs
+++ b/crates/mq-lint/src/rules/correctness/infinite_loop.rs
@@ -61,6 +61,7 @@ fn is_descendant_of(ctx: &LintContext<'_>, maybe_parent: Option<SymbolId>, targe
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -73,15 +74,20 @@ mod tests {
         InfiniteLoop.check(&ctx)
     }
 
-    #[test]
-    fn detects_loop_without_break() {
-        let diags = check("loop .h1 end");
+    #[rstest]
+    #[case("loop .h1 end")]
+    #[case("loop .h1 | .h2 end")]
+    fn detects_loop_without_break(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_when_break_present() {
-        let diags = check("loop break end");
+    #[rstest]
+    #[case("loop break end")]
+    #[case("loop if (true): break else: .h1 end")]
+    #[case("while (.h1): .h1 end")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/missing_else_in_expr.rs
+++ b/crates/mq-lint/src/rules/correctness/missing_else_in_expr.rs
@@ -39,6 +39,7 @@ impl LintRule for MissingElseInExpr {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -51,29 +52,22 @@ mod tests {
         MissingElseInExpr.check(&ctx)
     }
 
-    #[test]
-    fn detects_if_without_else() {
-        let diags = check("if (true): 1;");
+    #[rstest]
+    #[case("if (true): 1;")]
+    #[case("if (.h1): 2;")]
+    #[case("if (true): 1 elif (false): 2;")]
+    fn detects_missing_else(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message().contains("missing an `else` branch"));
     }
 
-    #[test]
-    fn no_diagnostic_with_else() {
-        let diags = check("if (true): 1 else: 2;");
+    #[rstest]
+    #[case("if (true): 1 else: 2;")]
+    #[case("if (true): 1 elif (false): 2 else: 3;")]
+    #[case(".h1")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_with_elif_else() {
-        let diags = check("if (true): 1 elif (false): 2 else: 3;");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn detects_if_with_only_elif() {
-        // elif but no else is still missing an else
-        let diags = check("if (true): 1 elif (false): 2;");
-        assert_eq!(diags.len(), 1);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/shadow_variable.rs
+++ b/crates/mq-lint/src/rules/correctness/shadow_variable.rs
@@ -63,6 +63,7 @@ fn shadows_outer_variable(ctx: &LintContext<'_>, current_scope: ScopeId, name: &
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -75,16 +76,19 @@ mod tests {
         ShadowVariable.check(&ctx)
     }
 
-    #[test]
-    fn detects_shadow() {
-        // Outer `x`, then inner `x` in function body
-        let diags = check("let x = 1 | def f(): let x = 2; x; end");
+    #[rstest]
+    #[case("let x = 1 | def f(): let x = 2; x; end")]
+    #[case("let y = 1 | def g(): let y = 2; y; end")]
+    fn detects_shadow(#[case] code: &str) {
+        let diags = check(code);
         assert!(!diags.is_empty());
     }
 
-    #[test]
-    fn no_shadow_different_names() {
-        let diags = check("let x = 1 | def f(): let y = 2; y; end");
+    #[rstest]
+    #[case("let x = 1 | def f(): let y = 2; y; end")]
+    #[case("let x = 1 | x")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/unreachable_code.rs
+++ b/crates/mq-lint/src/rules/correctness/unreachable_code.rs
@@ -64,6 +64,7 @@ impl LintRule for UnreachableCode {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -76,9 +77,18 @@ mod tests {
         UnreachableCode.check(&ctx)
     }
 
-    #[test]
-    fn no_diagnostic_without_break() {
-        let diags = check(".h1 | .value");
+    #[rstest]
+    #[case("loop break | .h1 end")]
+    fn detects_unreachable_after_break(#[case] code: &str) {
+        let diags = check(code);
+        assert!(!diags.is_empty());
+    }
+
+    #[rstest]
+    #[case(".h1 | .value")]
+    #[case("loop break end")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/unused_function.rs
+++ b/crates/mq-lint/src/rules/correctness/unused_function.rs
@@ -44,6 +44,7 @@ impl LintRule for UnusedFunction {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -56,22 +57,20 @@ mod tests {
         UnusedFunction.check(&ctx)
     }
 
-    #[test]
-    fn detects_unused_function() {
-        let diags = check("def foo(): .h1;");
+    #[rstest]
+    #[case("def foo(): .h1;", "unused function `foo`")]
+    #[case("def bar(): .h2;", "unused function `bar`")]
+    fn detects_unused_function(#[case] code: &str, #[case] msg: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("unused function `foo`"));
+        assert!(diags[0].message().contains(msg));
     }
 
-    #[test]
-    fn no_diagnostic_when_function_called() {
-        let diags = check("def foo(): .h1; | foo");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_when_function_called_with_parens() {
-        let diags = check("def foo(): .h1; | foo()");
+    #[rstest]
+    #[case("def foo(): .h1; | foo")]
+    #[case("def foo(): .h1; | foo()")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/unused_import.rs
+++ b/crates/mq-lint/src/rules/correctness/unused_import.rs
@@ -43,6 +43,7 @@ impl LintRule for UnusedImport {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -57,9 +58,11 @@ mod tests {
         UnusedImport.check(&ctx)
     }
 
-    #[test]
-    fn no_imports_no_diagnostic() {
-        let diags = check(".h1");
+    #[rstest]
+    #[case(".h1")]
+    #[case(".h1 | .value")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/correctness/unused_parameter.rs
+++ b/crates/mq-lint/src/rules/correctness/unused_parameter.rs
@@ -1,0 +1,119 @@
+use rustc_hash::FxHashSet;
+
+use crate::{Diagnostic, LintContext, LintMessage, LintRule, RuleId, Severity};
+use mq_hir::{ScopeId, ScopeKind, SymbolId, SymbolKind};
+
+pub struct UnusedParameter;
+
+fn is_in_scope_subtree(ctx: &LintContext<'_>, scope_id: ScopeId, target_scope_id: ScopeId) -> bool {
+    let mut current = Some(scope_id);
+    while let Some(sid) = current {
+        if sid == target_scope_id {
+            return true;
+        }
+        current = ctx.hir.scope(sid).and_then(|s| s.parent_id);
+    }
+    false
+}
+
+impl LintRule for UnusedParameter {
+    fn id(&self) -> RuleId {
+        RuleId::UnusedParameter
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Warn
+    }
+
+    fn check(&self, ctx: &LintContext<'_>) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        let functions: Vec<(SymbolId, _)> = ctx.all_symbols().filter(|(_, s)| s.is_function()).collect();
+
+        for (fn_id, _) in functions {
+            let Some((fn_scope_id, _)) = ctx
+                .hir
+                .scopes()
+                .find(|(_, scope)| matches!(&scope.kind, ScopeKind::Function(id) if *id == fn_id))
+            else {
+                continue;
+            };
+
+            let used_names: FxHashSet<&str> = ctx
+                .all_symbols()
+                .filter(|(_, s)| matches!(s.kind, SymbolKind::Ref | SymbolKind::Ident | SymbolKind::Call))
+                .filter(|(_, s)| is_in_scope_subtree(ctx, s.scope, fn_scope_id))
+                .filter_map(|(_, s)| s.value.as_deref())
+                .collect();
+
+            for (_, param_sym) in ctx
+                .all_symbols()
+                .filter(|(_, s)| s.parent == Some(fn_id) && matches!(s.kind, SymbolKind::Parameter))
+            {
+                let name = match param_sym.value.as_deref() {
+                    Some(n) => n,
+                    None => continue,
+                };
+
+                if name.starts_with('_') || used_names.contains(name) {
+                    continue;
+                }
+
+                let mut d = Diagnostic::new(LintMessage::UnusedParameter { name: name.to_string() }, self.severity());
+                if let Some(range) = param_sym.source.text_range {
+                    d = d.with_range(range);
+                }
+                diagnostics.push(d);
+            }
+        }
+
+        diagnostics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mq_hir::Hir;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{LintConfig, LintContext};
+
+    fn check(code: &str) -> Vec<Diagnostic> {
+        let mut hir = Hir::default();
+        let (source_id, _) = hir.add_code(None, code);
+        let config = LintConfig::default();
+        let ctx = LintContext::new(&hir, source_id, &config);
+        UnusedParameter.check(&ctx)
+    }
+
+    #[rstest]
+    #[case("def f(a, b): a", 1, "b")]
+    #[case("def f(a, b, c): a + b", 1, "c")]
+    fn detects_unused_parameter(#[case] code: &str, #[case] expected_count: usize, #[case] expected_name: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), expected_count);
+        assert!(diags[0].message().contains(expected_name));
+    }
+
+    #[rstest]
+    #[case("def f(a, b): a + b")]
+    #[case("def f(a): a")]
+    #[case("def f(): .h1")]
+    fn no_diagnostic_when_all_params_used(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn underscore_prefix_suppresses_warning() {
+        let diags = check("def f(_unused, b): b");
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn detects_multiple_unused_parameters() {
+        let diags = check("def f(a, b, c): .h1");
+        assert_eq!(diags.len(), 3);
+    }
+}

--- a/crates/mq-lint/src/rules/correctness/unused_variable.rs
+++ b/crates/mq-lint/src/rules/correctness/unused_variable.rs
@@ -46,6 +46,7 @@ impl LintRule for UnusedVariable {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -58,22 +59,21 @@ mod tests {
         UnusedVariable.check(&ctx)
     }
 
-    #[test]
-    fn detects_unused_variable() {
-        let diags = check("let x = .h1");
+    #[rstest]
+    #[case("let x = .h1", "unused variable `x`")]
+    #[case("let my_var = .h2", "unused variable `my_var`")]
+    fn detects_unused_variable(#[case] code: &str, #[case] msg: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("unused variable `x`"));
+        assert!(diags[0].message().contains(msg));
     }
 
-    #[test]
-    fn no_diagnostic_when_variable_used() {
-        let diags = check("let x = .h1 | x");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn underscore_prefix_suppresses_warning() {
-        let diags = check("let _x = .h1");
+    #[rstest]
+    #[case("let x = .h1 | x")]
+    #[case("let _x = .h1")]
+    #[case("let _ignored = .h1")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/module/ambiguous_qualified_access.rs
+++ b/crates/mq-lint/src/rules/module/ambiguous_qualified_access.rs
@@ -71,6 +71,7 @@ impl LintRule for AmbiguousQualifiedAccess {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -83,22 +84,21 @@ mod tests {
         AmbiguousQualifiedAccess.check(&ctx)
     }
 
-    #[test]
-    fn detects_same_function_name_in_two_modules() {
-        let diags = check("module a: def foo(): 1; end | module b: def foo(): 2; end");
+    #[rstest]
+    #[case("module a: def foo(): 1; end | module b: def foo(): 2; end", "foo")]
+    #[case("module x: def bar(): 1; end | module y: def bar(): 2; end", "bar")]
+    fn detects_same_function_name_in_two_modules(#[case] code: &str, #[case] fn_name: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 2);
-        assert!(diags.iter().all(|d| d.message().contains("foo")));
+        assert!(diags.iter().all(|d| d.message().contains(fn_name)));
     }
 
-    #[test]
-    fn no_diagnostic_for_distinct_function_names() {
-        let diags = check("module a: def foo(): 1; end | module b: def bar(): 2; end");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_function_outside_module() {
-        let diags = check("def foo(): 1; | foo()");
+    #[rstest]
+    #[case("module a: def foo(): 1; end | module b: def bar(): 2; end")]
+    #[case("def foo(): 1; | foo()")]
+    #[case("module a: def foo(): 1; end")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/module/missing_module_doc.rs
+++ b/crates/mq-lint/src/rules/module/missing_module_doc.rs
@@ -31,6 +31,7 @@ impl LintRule for MissingModuleDoc {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -43,16 +44,20 @@ mod tests {
         MissingModuleDoc.check(&ctx)
     }
 
-    #[test]
-    fn detects_module_without_doc() {
-        let diags = check("module a: def b(): 1; end");
+    #[rstest]
+    #[case("module a: def b(): 1; end", "module `a`")]
+    #[case("module my_mod: .h1 end", "module `my_mod`")]
+    fn detects_module_without_doc(#[case] code: &str, #[case] msg: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("module `a`"));
+        assert!(diags[0].message().contains(msg));
     }
 
-    #[test]
-    fn no_diagnostic_when_module_has_doc() {
-        let diags = check("# A module that does something.\nmodule a: def b(): 1; end");
+    #[rstest]
+    #[case("# A module that does something.\nmodule a: def b(): 1; end")]
+    #[case("# Docs.\nmodule my_mod: .h1 end")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/selector/inefficient_selector.rs
+++ b/crates/mq-lint/src/rules/selector/inefficient_selector.rs
@@ -63,6 +63,7 @@ impl LintRule for InefficientSelector {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -75,23 +76,21 @@ mod tests {
         InefficientSelector.check(&ctx)
     }
 
-    #[test]
-    fn no_diagnostic_for_direct_selector() {
-        let diags = check(".h1");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_recursive_alone() {
-        let diags = check("..");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn detects_recursive_followed_by_specific_selector() {
-        // `.. | .h1` — the `..` is redundant because `.h1` already selects h1 nodes directly.
-        let diags = check(".. | .h1");
+    #[rstest]
+    #[case(".. | .h1")]
+    #[case(".. | .h2")]
+    fn detects_recursive_followed_by_specific_selector(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message().contains("inefficient selector"));
+    }
+
+    #[rstest]
+    #[case(".h1")]
+    #[case("..")]
+    #[case(".h1 | .h2")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/selector/missing_depth_guard.rs
+++ b/crates/mq-lint/src/rules/selector/missing_depth_guard.rs
@@ -44,6 +44,7 @@ impl LintRule for MissingDepthGuard {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -56,23 +57,20 @@ mod tests {
         MissingDepthGuard.check(&ctx)
     }
 
-    #[test]
-    fn detects_bare_recursive_selector() {
-        let diags = check("..");
+    #[rstest]
+    #[case("..")]
+    fn detects_bare_recursive_selector(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message().contains("depth guard"));
     }
 
-    #[test]
-    fn no_diagnostic_when_depth_attr_present() {
-        // When .depth is used somewhere, we consider depth guarding in place.
-        let diags = check(".. | .depth");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_non_recursive_selector() {
-        let diags = check(".h1");
+    #[rstest]
+    #[case(".. | .depth")]
+    #[case(".h1")]
+    #[case(".h1 | .value")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/selector/selector_always_empty.rs
+++ b/crates/mq-lint/src/rules/selector/selector_always_empty.rs
@@ -69,6 +69,7 @@ impl LintRule for SelectorAlwaysEmpty {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -81,33 +82,20 @@ mod tests {
         SelectorAlwaysEmpty.check(&ctx)
     }
 
-    #[test]
-    fn detects_conflicting_heading_levels() {
-        let diags = check(".h1 | .h2");
+    #[rstest]
+    #[case(".h1 | .h2")]
+    #[case(".todo | .done")]
+    fn detects_conflicting_selectors(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn detects_todo_then_done() {
-        let diags = check(".todo | .done");
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn no_diagnostic_for_same_selector_repeated() {
-        let diags = check(".h1 | .h1");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_generic_then_specific_heading() {
-        let diags = check(".heading | .h1");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_when_unrelated_step_is_between() {
-        let diags = check(".h1 | to_text() | .h2");
+    #[rstest]
+    #[case(".h1 | .h1")]
+    #[case(".heading | .h1")]
+    #[case(".h1 | to_text() | .h2")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style.rs
+++ b/crates/mq-lint/src/rules/style.rs
@@ -1,5 +1,7 @@
 pub mod boolean_comparison;
+pub mod constant_string_concat;
 pub mod naming_convention;
+pub mod negated_condition;
 pub mod prefer_coalesce;
 pub mod prefer_let_over_var;
 pub mod prefer_pipe_style;
@@ -21,5 +23,7 @@ pub fn all() -> Vec<Box<dyn LintRule>> {
         Box::new(boolean_comparison::BooleanComparison),
         Box::new(redundant_boolean_literal::RedundantBooleanLiteral),
         Box::new(unnecessary_interpolation::UnnecessaryInterpolation),
+        Box::new(constant_string_concat::ConstantStringConcat),
+        Box::new(negated_condition::NegatedCondition),
     ]
 }

--- a/crates/mq-lint/src/rules/style/boolean_comparison.rs
+++ b/crates/mq-lint/src/rules/style/boolean_comparison.rs
@@ -56,6 +56,7 @@ impl LintRule for BooleanComparison {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -68,9 +69,21 @@ mod tests {
         BooleanComparison.check(&ctx)
     }
 
-    #[test]
-    fn no_diagnostic_for_non_boolean_comparison() {
-        let diags = check(r#".type == "heading""#);
+    #[rstest]
+    #[case(".checked == true")]
+    #[case(".checked == false")]
+    #[case(".checked != true")]
+    #[case(".checked != false")]
+    fn detects_boolean_comparison(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[rstest]
+    #[case(r#".type == "heading""#)]
+    #[case(".h1 | .checked")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/constant_string_concat.rs
+++ b/crates/mq-lint/src/rules/style/constant_string_concat.rs
@@ -1,0 +1,67 @@
+use crate::{Diagnostic, LintContext, LintMessage, LintRule, RuleId, Severity};
+use mq_hir::SymbolKind;
+
+pub struct ConstantStringConcat;
+
+impl LintRule for ConstantStringConcat {
+    fn id(&self) -> RuleId {
+        RuleId::ConstantStringConcat
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Style
+    }
+
+    fn check(&self, ctx: &LintContext<'_>) -> Vec<Diagnostic> {
+        ctx.all_symbols()
+            .filter(|(_, sym)| matches!(sym.kind, SymbolKind::BinaryOp) && sym.value.as_deref() == Some("+"))
+            .filter_map(|(op_id, op_sym)| {
+                let children: Vec<_> = ctx.all_symbols().filter(|(_, s)| s.parent == Some(op_id)).collect();
+
+                if children.len() < 2 || !children.iter().all(|(_, s)| matches!(s.kind, SymbolKind::String)) {
+                    return None;
+                }
+
+                let mut d = Diagnostic::new(LintMessage::ConstantStringConcat, self.severity());
+                if let Some(range) = op_sym.source.text_range {
+                    d = d.with_range(range);
+                }
+                Some(d)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mq_hir::Hir;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{LintConfig, LintContext};
+
+    fn check(code: &str) -> Vec<Diagnostic> {
+        let mut hir = Hir::default();
+        let (source_id, _) = hir.add_code(None, code);
+        let config = LintConfig::default();
+        let ctx = LintContext::new(&hir, source_id, &config);
+        ConstantStringConcat.check(&ctx)
+    }
+
+    #[rstest]
+    #[case(r#""hello" + " world""#)]
+    #[case(r#""foo" + "bar""#)]
+    fn detects_string_literal_concat(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[rstest]
+    #[case(r#""hello" + to_text()"#)]
+    #[case(r#"x + "world""#)]
+    #[case(r#"1 + 2"#)]
+    fn no_diagnostic_for_non_literal_concat(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 0);
+    }
+}

--- a/crates/mq-lint/src/rules/style/naming_convention.rs
+++ b/crates/mq-lint/src/rules/style/naming_convention.rs
@@ -67,6 +67,7 @@ fn to_snake_case(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -79,28 +80,29 @@ mod tests {
         NamingConvention.check(&ctx)
     }
 
-    #[test]
-    fn detects_camel_case_function() {
-        let diags = check("def myFunc(): .h1;");
+    #[rstest]
+    #[case("def myFunc(): .h1;", "myFunc")]
+    #[case("def camelCaseFn(): .h1;", "camelCaseFn")]
+    fn detects_camel_case_function(#[case] code: &str, #[case] name: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("myFunc"));
+        assert!(diags[0].message().contains(name));
     }
 
-    #[test]
-    fn no_diagnostic_for_snake_case() {
-        let diags = check("def my_func(): .h1;");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn detects_camel_case_variable() {
-        let diags = check("let myVar = .h1");
+    #[rstest]
+    #[case("let myVar = .h1")]
+    #[case("let camelCase = .h1")]
+    fn detects_camel_case_variable(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn underscore_prefix_is_ok() {
-        let diags = check("def _myHelper(): .h1;");
+    #[rstest]
+    #[case("def my_func(): .h1;")]
+    #[case("def _myHelper(): .h1;")]
+    #[case("let my_var = .h1")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/negated_condition.rs
+++ b/crates/mq-lint/src/rules/style/negated_condition.rs
@@ -1,0 +1,95 @@
+use std::collections::HashSet;
+
+use crate::{Diagnostic, LintContext, LintMessage, LintRule, RuleId, Severity};
+use mq_hir::{SymbolId, SymbolKind};
+
+pub struct NegatedCondition;
+
+impl LintRule for NegatedCondition {
+    fn id(&self) -> RuleId {
+        RuleId::NegatedCondition
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Style
+    }
+
+    fn check(&self, ctx: &LintContext<'_>) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        let if_ids_with_else: HashSet<SymbolId> = ctx
+            .hir
+            .symbols_for_source(ctx.source_id)
+            .filter(|(_, s)| matches!(s.kind, SymbolKind::Else))
+            .filter_map(|(_, s)| s.parent)
+            .collect();
+
+        for (if_id, if_sym) in ctx
+            .hir
+            .symbols_for_source(ctx.source_id)
+            .filter(|(id, s)| matches!(s.kind, SymbolKind::If) && if_ids_with_else.contains(id))
+        {
+            let mut children: Vec<_> = ctx
+                .all_symbols()
+                .filter(|(_, s)| s.parent == Some(if_id))
+                .filter_map(|(_, s)| s.source.text_range.map(|r| (r, s)))
+                .collect();
+            children.sort_by_key(|(r, _)| (r.start.line, r.start.column));
+
+            let Some((_, cond_sym)) = children.first() else {
+                continue;
+            };
+
+            if !matches!(cond_sym.kind, SymbolKind::UnaryOp) || cond_sym.value.as_deref() != Some("!") {
+                continue;
+            }
+
+            let mut d = Diagnostic::new(LintMessage::NegatedCondition, self.severity());
+            if let Some(range) = if_sym.source.text_range {
+                d = d.with_range(range);
+            }
+            diagnostics.push(d);
+        }
+
+        diagnostics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mq_hir::Hir;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{LintConfig, LintContext};
+
+    fn check(code: &str) -> Vec<Diagnostic> {
+        let mut hir = Hir::default();
+        let (source_id, _) = hir.add_code(None, code);
+        let config = LintConfig::default();
+        let ctx = LintContext::new(&hir, source_id, &config);
+        NegatedCondition.check(&ctx)
+    }
+
+    #[rstest]
+    #[case("if (!.checked): 1 else: 2")]
+    #[case("if (!x): \"yes\" else: \"no\"")]
+    fn detects_negated_condition(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[rstest]
+    #[case("if (.checked): 1 else: 2")]
+    #[case("if (.value == none): 1 else: 2")]
+    fn no_diagnostic_for_non_negated_condition(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn no_diagnostic_without_else_branch() {
+        let diags = check("if (!.checked): 1");
+        assert_eq!(diags.len(), 0);
+    }
+}

--- a/crates/mq-lint/src/rules/style/prefer_coalesce.rs
+++ b/crates/mq-lint/src/rules/style/prefer_coalesce.rs
@@ -99,6 +99,7 @@ impl LintRule for PreferCoalesce {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -111,27 +112,19 @@ mod tests {
         PreferCoalesce.check(&ctx)
     }
 
-    #[test]
-    fn detects_eq_none_pattern() {
-        let diags = check(r#"if (.value == none): "default" else: .value"#);
+    #[rstest]
+    #[case(r#"if (.value == none): "default" else: .value"#)]
+    #[case(r#"if (x != none): x else: "default""#)]
+    fn detects_null_check_pattern(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn detects_ne_none_pattern() {
-        let diags = check(r#"if (x != none): x else: "default""#);
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn no_diagnostic_when_branches_differ() {
-        let diags = check(r#"if (.value == none): "default" else: .other"#);
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_unrelated_condition() {
-        let diags = check(r#"if (.checked == true): "yes" else: "no""#);
+    #[rstest]
+    #[case(r#"if (.value == none): "default" else: .other"#)]
+    #[case(r#"if (.checked == true): "yes" else: "no""#)]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/prefer_let_over_var.rs
+++ b/crates/mq-lint/src/rules/style/prefer_let_over_var.rs
@@ -79,6 +79,7 @@ impl LintRule for PreferLetOverVar {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -91,16 +92,20 @@ mod tests {
         PreferLetOverVar.check(&ctx)
     }
 
-    #[test]
-    fn detects_var_never_reassigned() {
-        let diags = check("var x = .h1 | x");
+    #[rstest]
+    #[case("var x = .h1 | x")]
+    #[case("var my_val = .h2 | my_val")]
+    fn detects_var_never_reassigned(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message().contains("prefer `let` over `var`"));
     }
 
-    #[test]
-    fn no_diagnostic_for_let() {
-        let diags = check("let x = .h1 | x");
+    #[rstest]
+    #[case("let x = .h1 | x")]
+    #[case(".h1 | .value")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/prefer_pipe_style.rs
+++ b/crates/mq-lint/src/rules/style/prefer_pipe_style.rs
@@ -43,6 +43,7 @@ impl LintRule for PreferPipeStyle {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -55,29 +56,20 @@ mod tests {
         PreferPipeStyle.check(&ctx)
     }
 
-    #[test]
-    fn detects_nested_unary_calls() {
-        let diags = check("to_text(to_upper(x))");
+    #[rstest]
+    #[case("to_text(to_upper(x))")]
+    #[case("trim(to_text(x))")]
+    fn detects_nested_unary_calls(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message().contains("to_text"));
-        assert!(diags[0].message().contains("to_upper"));
     }
 
-    #[test]
-    fn no_diagnostic_for_multi_arg_outer_call() {
-        let diags = check("add(foo(x), y)");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_non_call_argument() {
-        let diags = check("to_text(x)");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_already_piped_style() {
-        let diags = check("x | to_upper() | to_text()");
+    #[rstest]
+    #[case("add(foo(x), y)")]
+    #[case("to_text(x)")]
+    #[case("x | to_upper() | to_text()")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/prefer_specific_heading.rs
+++ b/crates/mq-lint/src/rules/style/prefer_specific_heading.rs
@@ -30,6 +30,7 @@ impl LintRule for PreferSpecificHeading {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -42,17 +43,20 @@ mod tests {
         PreferSpecificHeading.check(&ctx)
     }
 
-    #[test]
-    fn detects_generic_heading_selector() {
-        let diags = check(".h");
+    #[rstest]
+    #[case(".h")]
+    fn detects_generic_heading_selector(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_for_specific_heading() {
-        let diags = check(".h1");
+    #[rstest]
+    #[case(".h1")]
+    #[case(".h2")]
+    #[case(".h6")]
+    #[case(".h1 | .value")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
-        let diags2 = check(".h6");
-        assert_eq!(diags2.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/redundant_boolean_literal.rs
+++ b/crates/mq-lint/src/rules/style/redundant_boolean_literal.rs
@@ -105,6 +105,7 @@ fn first_child_boolean<'a>(ctx: &'a LintContext<'_>, parent_id: SymbolId) -> Opt
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -117,28 +118,21 @@ mod tests {
         RedundantBooleanLiteral.check(&ctx)
     }
 
-    #[test]
-    fn detects_true_false_pattern() {
-        let diags = check("if (.h1): true else: false;");
+    #[rstest]
+    #[case("if (.h1): true else: false;")]
+    #[case("if (.h1): false else: true;")]
+    fn detects_redundant_boolean_branches(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message().contains("redundant boolean literal"));
     }
 
-    #[test]
-    fn detects_false_true_pattern() {
-        let diags = check("if (.h1): false else: true;");
-        assert_eq!(diags.len(), 1);
-    }
-
-    #[test]
-    fn no_diagnostic_for_non_boolean_branches() {
-        let diags = check("if (.h1): 1 else: 2;");
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_mixed_branches() {
-        let diags = check("if (.h1): true else: 2;");
+    #[rstest]
+    #[case("if (.h1): 1 else: 2;")]
+    #[case("if (.h1): true else: 2;")]
+    #[case("if (.h1): 1 else: false;")]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/redundant_try.rs
+++ b/crates/mq-lint/src/rules/style/redundant_try.rs
@@ -44,6 +44,7 @@ impl LintRule for RedundantTry {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -56,15 +57,18 @@ mod tests {
         RedundantTry.check(&ctx)
     }
 
-    #[test]
-    fn detects_catch_none() {
-        let diags = check(r#"try: get("x") catch: none"#);
+    #[rstest]
+    #[case(r#"try: get("x") catch: none"#)]
+    fn detects_catch_none(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_for_catch_with_fallback() {
-        let diags = check(r#"try: get("x") catch: "default""#);
+    #[rstest]
+    #[case(r#"try: get("x") catch: "default""#)]
+    #[case(r#"try: get("x") catch: 0"#)]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }

--- a/crates/mq-lint/src/rules/style/unnecessary_interpolation.rs
+++ b/crates/mq-lint/src/rules/style/unnecessary_interpolation.rs
@@ -41,6 +41,7 @@ impl LintRule for UnnecessaryInterpolation {
 #[cfg(test)]
 mod tests {
     use mq_hir::Hir;
+    use rstest::rstest;
 
     use super::*;
     use crate::{LintConfig, LintContext};
@@ -53,21 +54,20 @@ mod tests {
         UnnecessaryInterpolation.check(&ctx)
     }
 
-    #[test]
-    fn detects_unnecessary_interpolation() {
-        let diags = check(r#"s"${x}""#);
+    #[rstest]
+    #[case(r#"s"${x}""#)]
+    #[case(r#"s"${.h1}""#)]
+    fn detects_unnecessary_interpolation(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 1);
     }
 
-    #[test]
-    fn no_diagnostic_for_multiple_expressions() {
-        let diags = check(r#"s"${x}${y}""#);
-        assert_eq!(diags.len(), 0);
-    }
-
-    #[test]
-    fn no_diagnostic_for_text_with_expression() {
-        let diags = check(r#"s"prefix ${x}""#);
+    #[rstest]
+    #[case(r#"s"${x}${y}""#)]
+    #[case(r#"s"prefix ${x}""#)]
+    #[case(r#"s"${x} suffix""#)]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
         assert_eq!(diags.len(), 0);
     }
 }


### PR DESCRIPTION
- Add UnusedParameter correctness rule to warn on function parameters that are never referenced (prefix with `_` to suppress)
- Add ConstantStringConcat style rule to detect string literal concatenation that can be collapsed into a single string
- Add NegatedCondition style rule to flag `if !cond { ... } else { ... }` patterns and suggest swapping branches
- Refactor tests across all existing rules to use rstest parameterized cases for consistency