### PR TITLE
✨ feat(mq-test): add @parametrize annotation for parameterized tests

### DIFF
--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -7,9 +7,10 @@ Standalone test runner for mq — auto-discovers and executes test functions in 
 `mq-test` discovers test functions in `.mq` files and runs them using the mq engine. A function is treated as a test if:
 
 - Its name starts with `test_`, **OR**
-- It is immediately preceded by a `# @test` or `#[test]` annotation comment.
+- It is immediately preceded by a `# @test` or `# [test]` annotation comment, **OR**
+- It is immediately preceded by a `# @parametrize(...)` annotation comment.
 
-Test discovery uses the CST so both conventions are resolved accurately without any line-scanning heuristics.
+Test discovery uses the CST so all conventions are resolved accurately without any line-scanning heuristics.
 
 ## Installation
 
@@ -64,6 +65,25 @@ def check_string_upcase():
 end
 ```
 
+### Parameterized Tests
+
+Use `# @parametrize(expr)` to run a function once per element in an array.
+Each element is spread as positional arguments to the function.
+Generated test case names use the pattern `name[0]`, `name[1]`, etc.
+
+```mq
+include "test"
+|
+
+# @parametrize([["hello", 5], ["world", 5], ["", 0]])
+def test_len(input, expected):
+  assert_eq(len(input), expected)
+end
+```
+
+This produces three test cases — `len[0]`, `len[1]`, `len[2]` — each called
+with the corresponding `[input, expected]` pair.
+
 ### Test Helpers
 
 Tests use the built-in `assert_eq` and related helpers from the `test` module:
@@ -75,7 +95,8 @@ Tests use the built-in `assert_eq` and related helpers from the `test` module:
 | `test_case(name, fn)`       | Registers a named test case    |
 | `run_tests(cases)`          | Runs all registered test cases |
 
-The runner automatically generates a `run_tests([...])` call from all discovered test functions — test files do not need to maintain a manual list.
+The runner automatically generates a `run_tests(flatten([...]))` call from all
+discovered test functions — test files do not need to maintain a manual list.
 
 ## Example
 

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -208,21 +208,60 @@ mod tests {
 
     #[rstest]
     #[case("@test", Some(TestAnnotation::Test))]
+    #[case("  @test  ", Some(TestAnnotation::Test))]
     #[case("[test]", Some(TestAnnotation::Test))]
+    #[case("  [test]  ", Some(TestAnnotation::Test))]
     #[case(
         "@parametrize([[1, 2], [3, 4]])",
         Some(TestAnnotation::Parametrize { params_expr: "[[1, 2], [3, 4]]".to_string() })
     )]
+    #[case(
+        "  @parametrize(  [[1, 2]]  )  ",
+        Some(TestAnnotation::Parametrize { params_expr: "[[1, 2]]".to_string() })
+    )]
+    #[case(
+        "@parametrize(range(0, 5))",
+        Some(TestAnnotation::Parametrize { params_expr: "range(0, 5)".to_string() })
+    )]
+    #[case(
+        "@parametrize([])",
+        Some(TestAnnotation::Parametrize { params_expr: "[]".to_string() })
+    )]
     #[case("@unknown(foo)", None)]
+    #[case("@skip", None)]
     #[case("not an annotation", None)]
+    #[case("@", None)]
+    #[case("@parametrize", None)]
     fn test_parse_annotation(#[case] input: &str, #[case] expected: Option<TestAnnotation>) {
         assert_eq!(TestRunner::parse_annotation(input), expected);
+    }
+
+    fn first_def(content: &str) -> mq_lang::Shared<mq_lang::CstNode> {
+        let (nodes, _) = mq_lang::parse_recovery(content);
+        nodes
+            .into_iter()
+            .find(|n| n.kind == mq_lang::CstNodeKind::Def)
+            .expect("no def node found")
+    }
+
+    #[rstest]
+    #[case("def foo():\n  None\nend\n", 0)]
+    #[case("def foo(x):\n  None\nend\n", 1)]
+    #[case("def foo(x, y):\n  None\nend\n", 2)]
+    #[case("def foo(x, y, z):\n  None\nend\n", 3)]
+    #[case("def foo(a, b, c, d):\n  None\nend\n", 4)]
+    fn test_get_arity(#[case] content: &str, #[case] expected: usize) {
+        let node = first_def(content);
+        assert_eq!(TestRunner::get_arity(&node), expected);
     }
 
     #[rstest]
     #[case(
         "def test_foo():\n  None\nend\n\ndef helper():\n  None\nend\n\ndef test_bar():\n  None\nend\n",
-        vec![DiscoveredTest::Simple("test_foo".to_string()), DiscoveredTest::Simple("test_bar".to_string())]
+        vec![
+            DiscoveredTest::Simple("test_foo".to_string()),
+            DiscoveredTest::Simple("test_bar".to_string()),
+        ]
     )]
     #[case(
         "# @test\ndef my_check():\n  None\nend\n\ndef not_a_test():\n  None\nend\n",
@@ -234,20 +273,54 @@ mod tests {
     )]
     #[case(
         "def test_first():\n  None\nend\n\n# @test\ndef annotated():\n  None\nend\n",
-        vec![DiscoveredTest::Simple("test_first".to_string()), DiscoveredTest::Simple("annotated".to_string())]
+        vec![
+            DiscoveredTest::Simple("test_first".to_string()),
+            DiscoveredTest::Simple("annotated".to_string()),
+        ]
     )]
     #[case("def helper():\n  None\nend\n", vec![])]
     #[case(
         "module a:\n  def test_first():\n  None\nend\n\n# @test\ndef annotated():\n  None\nend\nend\n",
-        vec![DiscoveredTest::Simple("test_first".to_string()), DiscoveredTest::Simple("annotated".to_string())]
+        vec![
+            DiscoveredTest::Simple("test_first".to_string()),
+            DiscoveredTest::Simple("annotated".to_string()),
+        ]
     )]
     fn test_discover_tests_simple(#[case] content: &str, #[case] expected: Vec<DiscoveredTest>) {
         assert_eq!(TestRunner::discover_tests(content), expected);
     }
 
-    #[test]
-    fn test_discover_tests_parametrized() {
-        let content = "# @parametrize([[\"hello\", 5], [\"world\", 5]])\ndef test_len(input, expected):\n  None\nend\n";
+    #[rstest]
+    #[case(
+        "# @parametrize([[\"hello\", 5], [\"world\", 5]])\ndef test_len(input, expected):\n  None\nend\n",
+        "test_len",
+        "[[\"hello\", 5], [\"world\", 5]]",
+        2
+    )]
+    #[case(
+        "# @parametrize([[1], [2], [3]])\ndef test_double(x):\n  None\nend\n",
+        "test_double",
+        "[[1], [2], [3]]",
+        1
+    )]
+    #[case(
+        "# @parametrize([[\"a\", \"b\", \"ab\"], [\"x\", \"y\", \"xy\"]])\ndef test_concat(a, b, expected):\n  None\nend\n",
+        "test_concat",
+        "[[\"a\", \"b\", \"ab\"], [\"x\", \"y\", \"xy\"]]",
+        3
+    )]
+    #[case(
+        "# @parametrize([[\"ignored\"]])\ndef test_no_args():\n  None\nend\n",
+        "test_no_args",
+        "[[\"ignored\"]]",
+        0
+    )]
+    fn test_discover_tests_parametrized(
+        #[case] content: &str,
+        #[case] expected_name: &str,
+        #[case] expected_params_expr: &str,
+        #[case] expected_arity: usize,
+    ) {
         let tests = TestRunner::discover_tests(content);
         assert_eq!(tests.len(), 1);
         match &tests[0] {
@@ -256,56 +329,130 @@ mod tests {
                 params_expr,
                 arity,
             } => {
-                assert_eq!(name, "test_len");
-                assert_eq!(params_expr, "[[\"hello\", 5], [\"world\", 5]]");
-                assert_eq!(*arity, 2);
+                assert_eq!(name, expected_name);
+                assert_eq!(params_expr, expected_params_expr);
+                assert_eq!(*arity, expected_arity);
             }
             other => panic!("expected Parametrized, got {other:?}"),
         }
     }
 
-    #[rstest]
-    #[case(
-        "include \"test\"\n|",
-        vec![DiscoveredTest::Simple("test_foo".to_string()), DiscoveredTest::Simple("test_bar".to_string())],
-        vec![("[test_case(\"foo\", test_foo)]", true), ("[test_case(\"bar\", test_bar)]", true)]
-    )]
-    #[case(
-        "include \"test\"\n|",
-        vec![DiscoveredTest::Simple("my_check".to_string())],
-        vec![("[test_case(\"my_check\", my_check)]", true)]
-    )]
-    fn test_build_test_query_simple(
-        #[case] content: &str,
-        #[case] tests: Vec<DiscoveredTest>,
-        #[case] expected_snippets: Vec<(&str, bool)>,
-    ) {
-        let query = TestRunner::build_test_query(content, &tests);
-        assert!(query.contains("flatten(["));
-        for (snippet, should_contain) in expected_snippets {
-            assert_eq!(
-                query.contains(snippet),
-                should_contain,
-                "snippet {snippet:?} in query:\n{query}"
-            );
-        }
+    #[test]
+    fn test_discover_tests_multiple_parametrized() {
+        let content = concat!(
+            "# @parametrize([[1, 2], [3, 4]])\n",
+            "def test_add(a, b):\n  None\nend\n\n",
+            "# @parametrize([[\"hello\", 5]])\n",
+            "def test_len(s, n):\n  None\nend\n",
+        );
+        let tests = TestRunner::discover_tests(content);
+        assert_eq!(tests.len(), 2);
+        assert!(matches!(&tests[0], DiscoveredTest::Parametrized { name, .. } if name == "test_add"));
+        assert!(matches!(&tests[1], DiscoveredTest::Parametrized { name, .. } if name == "test_len"));
     }
 
     #[test]
-    fn test_build_test_query_parametrized() {
-        let tests = vec![DiscoveredTest::Parametrized {
-            name: "test_len".to_string(),
-            params_expr: "[[\"hello\", 5], [\"world\", 5]]".to_string(),
-            arity: 2,
-        }];
-        let query = TestRunner::build_test_query("include \"test\"\n|", &tests);
-        assert!(query.contains("flatten(["));
-        assert!(query.contains("map("));
-        assert!(
-            query.contains("zip(range(0, len([[\"hello\", 5], [\"world\", 5]])), [[\"hello\", 5], [\"world\", 5]])")
+    fn test_discover_tests_mixed_all_kinds() {
+        let content = concat!(
+            "def test_simple():\n  None\nend\n\n",
+            "# @test\ndef annotated():\n  None\nend\n\n",
+            "# @parametrize([[1, 2]])\ndef test_param(a, b):\n  None\nend\n",
         );
-        assert!(query.contains("test_len(__ic[1][0], __ic[1][1])"));
-        assert!(query.contains("\"len[\""));
+        let tests = TestRunner::discover_tests(content);
+        assert_eq!(tests.len(), 3);
+        assert!(matches!(&tests[0], DiscoveredTest::Simple(n) if n == "test_simple"));
+        assert!(matches!(&tests[1], DiscoveredTest::Simple(n) if n == "annotated"));
+        assert!(matches!(&tests[2], DiscoveredTest::Parametrized { name, .. } if name == "test_param"));
+    }
+
+    #[test]
+    fn test_discover_tests_parametrized_in_module() {
+        let content = concat!(
+            "module m:\n",
+            "  # @parametrize([[1, 2]])\n",
+            "  def test_add(a, b):\n  None\nend\n",
+            "end\n",
+        );
+        let tests = TestRunner::discover_tests(content);
+        assert_eq!(tests.len(), 1);
+        assert!(
+            matches!(&tests[0], DiscoveredTest::Parametrized { name, arity, .. } if name == "test_add" && *arity == 2)
+        );
+    }
+
+    #[test]
+    fn test_discover_tests_ignores_unknown_annotation() {
+        let content = "# @skip\ndef my_check():\n  None\nend\n";
+        let tests = TestRunner::discover_tests(content);
+        assert!(tests.is_empty());
+    }
+
+    #[rstest]
+    #[case(vec![DiscoveredTest::Simple("test_foo".to_string())], "[test_case(\"foo\", test_foo)]")]
+    #[case(vec![DiscoveredTest::Simple("test_is_array".to_string())], "[test_case(\"is_array\", test_is_array)]")]
+    #[case(vec![DiscoveredTest::Simple("my_check".to_string())], "[test_case(\"my_check\", my_check)]")]
+    fn test_build_test_query_simple_cases(#[case] tests: Vec<DiscoveredTest>, #[case] expected: &str) {
+        let query = TestRunner::build_test_query("content", &tests);
+        assert!(query.starts_with("content\n"), "query must start with original content");
+        assert!(query.contains("flatten(["), "must use flatten");
+        assert!(query.contains(expected), "expected {expected:?} in:\n{query}");
+    }
+
+    #[rstest]
+    #[case(
+        DiscoveredTest::Parametrized { name: "test_no_args".to_string(), params_expr: "[[]]".to_string(), arity: 0 },
+        "test_no_args()",
+        "\"no_args[\""
+    )]
+    #[case(
+        DiscoveredTest::Parametrized { name: "test_double".to_string(), params_expr: "[[1], [2]]".to_string(), arity: 1 },
+        "test_double(__ic[1][0])",
+        "\"double[\""
+    )]
+    #[case(
+        DiscoveredTest::Parametrized { name: "test_len".to_string(), params_expr: "[[\"a\", 1]]".to_string(), arity: 2 },
+        "test_len(__ic[1][0], __ic[1][1])",
+        "\"len[\""
+    )]
+    #[case(
+        DiscoveredTest::Parametrized { name: "test_concat".to_string(), params_expr: "[[\"a\", \"b\", \"ab\"]]".to_string(), arity: 3 },
+        "test_concat(__ic[1][0], __ic[1][1], __ic[1][2])",
+        "\"concat[\""
+    )]
+    #[case(
+        DiscoveredTest::Parametrized { name: "check_len".to_string(), params_expr: "[[1]]".to_string(), arity: 1 },
+        "check_len(__ic[1][0])",
+        "\"check_len[\""
+    )]
+    fn test_build_test_query_parametrized_cases(
+        #[case] test: DiscoveredTest,
+        #[case] expected_call: &str,
+        #[case] expected_label: &str,
+    ) {
+        let query = TestRunner::build_test_query("content", &[test]);
+        assert!(query.contains("flatten(["), "must use flatten");
+        assert!(query.contains("map("), "must use map");
+        assert!(query.contains("zip(range("), "must use zip+range");
+        assert!(
+            query.contains(expected_call),
+            "expected call {expected_call:?} in:\n{query}"
+        );
+        assert!(
+            query.contains(expected_label),
+            "expected label {expected_label:?} in:\n{query}"
+        );
+    }
+
+    #[test]
+    fn test_build_test_query_multiple_simple() {
+        let tests = vec![
+            DiscoveredTest::Simple("test_foo".to_string()),
+            DiscoveredTest::Simple("test_bar".to_string()),
+        ];
+        let query = TestRunner::build_test_query("content", &tests);
+        assert!(query.contains("[test_case(\"foo\", test_foo)]"));
+        assert!(query.contains("[test_case(\"bar\", test_bar)]"));
+        assert!(query.contains("flatten(["));
     }
 
     #[test]
@@ -318,9 +465,18 @@ mod tests {
                 arity: 2,
             },
         ];
-        let query = TestRunner::build_test_query("include \"test\"\n|", &tests);
+        let query = TestRunner::build_test_query("content", &tests);
         assert!(query.contains("[test_case(\"foo\", test_foo)]"));
         assert!(query.contains("map("));
+        assert!(query.contains("test_len(__ic[1][0], __ic[1][1])"));
         assert!(query.contains("flatten(["));
+    }
+
+    #[test]
+    fn test_build_test_query_preserves_content() {
+        let content = "include \"test\"\n|\ndef helper(): None end";
+        let tests = vec![DiscoveredTest::Simple("test_foo".to_string())];
+        let query = TestRunner::build_test_query(content, &tests);
+        assert!(query.starts_with(content));
     }
 }

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -3,35 +3,42 @@ use miette::IntoDiagnostic;
 use mq_lang::{CstNodeKind, CstTrivia};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+/// Parsed test annotation from a leading comment.
+#[derive(Debug, PartialEq)]
+enum TestAnnotation {
+    Test,
+    Parametrize { params_expr: String },
+}
+
+/// A test function discovered in a `.mq` file.
+#[derive(Debug, PartialEq)]
+enum DiscoveredTest {
+    Simple(String),
+    Parametrized {
+        name: String,
+        params_expr: String,
+        arity: usize,
+    },
+}
+
 /// Discovers and runs mq test functions from `.mq` files.
 ///
-/// A function is treated as a test if:
-/// - Its name starts with `test_`, OR
-/// - It is immediately preceded by a `# @test` annotation comment.
-///
-/// Test discovery uses the CST so that both conditions are resolved accurately
-/// without any line-scanning heuristics.
-///
-/// The runner auto-generates the `run_tests([...])` call so test files do not
-/// need to maintain a manual list of test cases.
+/// A function is treated as a test if its name starts with `test_`, it is
+/// preceded by `# @test` / `# [test]`, or preceded by `# @parametrize(expr)`.
+/// The runner auto-generates the `run_tests(...)` call from discovered tests.
 pub struct TestRunner {
     files: Vec<PathBuf>,
 }
 
 impl TestRunner {
-    /// Create a new `TestRunner` for the given files.
-    ///
-    /// If `files` is empty the runner will glob `**/*.mq` in the current
-    /// working directory.
+    /// Creates a `TestRunner` for the given files.
+    /// If `files` is empty, globs `**/*.mq` in the current directory.
     pub fn new(files: Vec<PathBuf>) -> Self {
         Self { files }
     }
 
-    /// Discover and execute all test functions.
-    ///
-    /// Files that contain no test functions are skipped silently.
-    /// Returns an error (and stops) if any test fails or if a file cannot be
-    /// read / executed.
+    /// Discovers and executes all test functions.
     pub fn run(self) -> miette::Result<()> {
         let test_files: Vec<PathBuf> = if self.files.is_empty() {
             glob("./**/*.mq")
@@ -44,18 +51,17 @@ impl TestRunner {
 
         for file in &test_files {
             let content = fs::read_to_string(file).into_diagnostic()?;
-            let test_names = Self::discover_test_functions(&content);
-            if test_names.is_empty() {
+            let tests = Self::discover_tests(&content);
+            if tests.is_empty() {
                 continue;
             }
 
-            let query = Self::build_test_query(&content, &test_names);
+            let query = Self::build_test_query(&content, &tests);
             let mut engine = mq_lang::DefaultEngine::default();
             engine.load_builtin_module();
             engine.define_string_value("TEST_FILE", file.to_string_lossy().as_ref());
 
-            // Add the file's directory to the search path so relative `include`
-            // statements in the test file resolve correctly.
+            // Resolve relative `include` statements in the test file.
             if let Some(parent) = file.parent()
                 && parent != Path::new("")
             {
@@ -69,22 +75,17 @@ impl TestRunner {
         Ok(())
     }
 
-    /// Parse `content` via the CST and return the names of all test functions.
-    ///
-    /// A top-level `def` node is included when:
-    /// - Its name starts with `test_`, OR
-    /// - Its `leading_trivia` contains a comment whose text (trimmed) is `@test`.
-    fn discover_test_functions(content: &str) -> Vec<String> {
+    fn discover_tests(content: &str) -> Vec<DiscoveredTest> {
         let (nodes, _) = mq_lang::parse_recovery(content);
-        Self::discover_test_functions_in(&nodes)
+        Self::discover_tests_in(&nodes)
     }
 
-    fn discover_test_functions_in(nodes: &[mq_lang::Shared<mq_lang::CstNode>]) -> Vec<String> {
-        let mut names = Vec::new();
+    fn discover_tests_in(nodes: &[mq_lang::Shared<mq_lang::CstNode>]) -> Vec<DiscoveredTest> {
+        let mut tests = Vec::new();
 
         for node in nodes {
             if node.kind == CstNodeKind::Module {
-                names.extend(Self::discover_test_functions_in(&node.children));
+                tests.extend(Self::discover_tests_in(&node.children));
                 continue;
             }
 
@@ -92,7 +93,6 @@ impl TestRunner {
                 continue;
             }
 
-            // The function name is children[0] — same convention as the formatter.
             let func_name = match node.children.first() {
                 Some(child) => child.to_string(),
                 None => continue,
@@ -102,36 +102,102 @@ impl TestRunner {
                 continue;
             }
 
-            if func_name.starts_with("test_") || Self::has_test_annotation(&node.leading_trivia) {
-                names.push(func_name);
+            match Self::find_test_annotation(&node.leading_trivia) {
+                Some(TestAnnotation::Test) => {
+                    tests.push(DiscoveredTest::Simple(func_name));
+                }
+                Some(TestAnnotation::Parametrize { params_expr }) => {
+                    let arity = Self::get_arity(node);
+                    tests.push(DiscoveredTest::Parametrized {
+                        name: func_name,
+                        params_expr,
+                        arity,
+                    });
+                }
+                None if func_name.starts_with("test_") => {
+                    tests.push(DiscoveredTest::Simple(func_name));
+                }
+                None => {}
             }
         }
 
-        names
+        tests
     }
 
-    /// Returns `true` if `trivia` contains a `# @test` annotation comment.
-    fn has_test_annotation(trivia: &[CstTrivia]) -> bool {
-        trivia
-            .iter()
-            .any(|t| t.comment().is_some_and(|c| c.trim() == "@test" || c.trim() == "[test]"))
-    }
-
-    /// Append an auto-generated `run_tests([…])` call to the file content.
+    /// Parses a comment into a `TestAnnotation`.
     ///
-    /// Display names strip the `test_` prefix to match the existing manual
-    /// convention (e.g. `test_is_array` → `"is_array"`).
-    fn build_test_query(content: &str, test_names: &[String]) -> String {
-        let cases = test_names
+    /// Supported forms: `@test`, `[test]`, `@parametrize(expr)`.
+    /// Unknown `@name(...)` annotations are silently ignored.
+    fn parse_annotation(comment: &str) -> Option<TestAnnotation> {
+        let s = comment.trim();
+
+        if s == "[test]" {
+            return Some(TestAnnotation::Test);
+        }
+
+        let s = s.strip_prefix('@')?;
+
+        if s == "test" {
+            return Some(TestAnnotation::Test);
+        }
+
+        // Parse `name(args)` — split at the first '(' only so args may contain '('.
+        let paren = s.find('(')?;
+        let name = s[..paren].trim();
+        let rest = s[paren + 1..].trim();
+        let args = rest.strip_suffix(')')?.trim().to_string();
+
+        match name {
+            "parametrize" => Some(TestAnnotation::Parametrize { params_expr: args }),
+            _ => None,
+        }
+    }
+
+    fn find_test_annotation(trivia: &[CstTrivia]) -> Option<TestAnnotation> {
+        trivia.iter().find_map(|t| t.comment().and_then(Self::parse_annotation))
+    }
+
+    /// Returns the number of positional parameters of a `def` node.
+    fn get_arity(node: &mq_lang::Shared<mq_lang::CstNode>) -> usize {
+        let (sig, _) = node.split_cond_and_program();
+        // sig[0] is the function name; the rest are parameter idents.
+        sig.len().saturating_sub(1)
+    }
+
+    /// Builds the `run_tests(flatten([...]))` call appended to the file content.
+    ///
+    /// Simple tests are `[test_case(...)]`; parametrized tests expand via
+    /// `map(zip(range(...), params), fn(...))`. `flatten` merges both into one list.
+    fn build_test_query(content: &str, tests: &[DiscoveredTest]) -> String {
+        let cases = tests
             .iter()
-            .map(|name| {
-                let display = name.strip_prefix("test_").unwrap_or(name);
-                format!("  test_case(\"{display}\", {name})")
+            .map(|test| match test {
+                DiscoveredTest::Simple(name) => {
+                    let display = name.strip_prefix("test_").unwrap_or(name);
+                    format!("  [test_case(\"{display}\", {name})]")
+                }
+                DiscoveredTest::Parametrized {
+                    name,
+                    params_expr,
+                    arity,
+                } => {
+                    let display = name.strip_prefix("test_").unwrap_or(name);
+                    let arg_list = (0..*arity)
+                        .map(|i| format!("__ic[1][{i}]"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(
+                        "  map(\
+                            zip(range(0, len({params_expr})), {params_expr}), \
+                            fn(__ic): test_case(\"{display}[\" + to_string(__ic[0]) + \"]\", \
+                            fn(): {name}({arg_list}) ;) ;)"
+                    )
+                }
             })
             .collect::<Vec<_>>()
             .join(",\n");
 
-        format!("{content}\n| run_tests([\n{cases}\n])")
+        format!("{content}\n| run_tests(flatten([\n{cases}\n]))")
     }
 }
 
@@ -141,54 +207,120 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case("@test", Some(TestAnnotation::Test))]
+    #[case("[test]", Some(TestAnnotation::Test))]
+    #[case(
+        "@parametrize([[1, 2], [3, 4]])",
+        Some(TestAnnotation::Parametrize { params_expr: "[[1, 2], [3, 4]]".to_string() })
+    )]
+    #[case("@unknown(foo)", None)]
+    #[case("not an annotation", None)]
+    fn test_parse_annotation(#[case] input: &str, #[case] expected: Option<TestAnnotation>) {
+        assert_eq!(TestRunner::parse_annotation(input), expected);
+    }
+
+    #[rstest]
     #[case(
         "def test_foo():\n  None\nend\n\ndef helper():\n  None\nend\n\ndef test_bar():\n  None\nend\n",
-        vec!["test_foo", "test_bar"]
+        vec![DiscoveredTest::Simple("test_foo".to_string()), DiscoveredTest::Simple("test_bar".to_string())]
     )]
     #[case(
         "# @test\ndef my_check():\n  None\nend\n\ndef not_a_test():\n  None\nend\n",
-        vec!["my_check"]
+        vec![DiscoveredTest::Simple("my_check".to_string())]
     )]
     #[case(
         "# [test]\ndef another_check():\n  None\nend\n",
-        vec!["another_check"]
+        vec![DiscoveredTest::Simple("another_check".to_string())]
     )]
     #[case(
         "def test_first():\n  None\nend\n\n# @test\ndef annotated():\n  None\nend\n",
-        vec!["test_first", "annotated"]
+        vec![DiscoveredTest::Simple("test_first".to_string()), DiscoveredTest::Simple("annotated".to_string())]
     )]
     #[case("def helper():\n  None\nend\n", vec![])]
     #[case(
         "module a:\n  def test_first():\n  None\nend\n\n# @test\ndef annotated():\n  None\nend\nend\n",
-        vec!["test_first", "annotated"]
+        vec![DiscoveredTest::Simple("test_first".to_string()), DiscoveredTest::Simple("annotated".to_string())]
     )]
-    fn test_discover_test_functions(#[case] content: &str, #[case] expected: Vec<&str>) {
-        let names = TestRunner::discover_test_functions(content);
-        assert_eq!(names, expected);
+    fn test_discover_tests_simple(#[case] content: &str, #[case] expected: Vec<DiscoveredTest>) {
+        assert_eq!(TestRunner::discover_tests(content), expected);
+    }
+
+    #[test]
+    fn test_discover_tests_parametrized() {
+        let content = "# @parametrize([[\"hello\", 5], [\"world\", 5]])\ndef test_len(input, expected):\n  None\nend\n";
+        let tests = TestRunner::discover_tests(content);
+        assert_eq!(tests.len(), 1);
+        match &tests[0] {
+            DiscoveredTest::Parametrized {
+                name,
+                params_expr,
+                arity,
+            } => {
+                assert_eq!(name, "test_len");
+                assert_eq!(params_expr, "[[\"hello\", 5], [\"world\", 5]]");
+                assert_eq!(*arity, 2);
+            }
+            other => panic!("expected Parametrized, got {other:?}"),
+        }
     }
 
     #[rstest]
     #[case(
         "include \"test\"\n|",
-        vec!["test_foo".to_string(), "test_bar".to_string()],
-        vec![("foo", "test_foo"), ("bar", "test_bar")]
+        vec![DiscoveredTest::Simple("test_foo".to_string()), DiscoveredTest::Simple("test_bar".to_string())],
+        vec![("[test_case(\"foo\", test_foo)]", true), ("[test_case(\"bar\", test_bar)]", true)]
     )]
     #[case(
         "include \"test\"\n|",
-        vec!["my_check".to_string()],
-        vec![("my_check", "my_check")]
+        vec![DiscoveredTest::Simple("my_check".to_string())],
+        vec![("[test_case(\"my_check\", my_check)]", true)]
     )]
-    fn test_build_test_query(
+    fn test_build_test_query_simple(
         #[case] content: &str,
-        #[case] names: Vec<String>,
-        #[case] expected_cases: Vec<(&str, &str)>,
+        #[case] tests: Vec<DiscoveredTest>,
+        #[case] expected_snippets: Vec<(&str, bool)>,
     ) {
-        let query = TestRunner::build_test_query(content, &names);
-        for (display, func) in expected_cases {
-            assert!(
-                query.contains(&format!("test_case(\"{display}\", {func})")),
-                "expected test_case(\"{display}\", {func}) in query:\n{query}"
+        let query = TestRunner::build_test_query(content, &tests);
+        assert!(query.contains("flatten(["));
+        for (snippet, should_contain) in expected_snippets {
+            assert_eq!(
+                query.contains(snippet),
+                should_contain,
+                "snippet {snippet:?} in query:\n{query}"
             );
         }
+    }
+
+    #[test]
+    fn test_build_test_query_parametrized() {
+        let tests = vec![DiscoveredTest::Parametrized {
+            name: "test_len".to_string(),
+            params_expr: "[[\"hello\", 5], [\"world\", 5]]".to_string(),
+            arity: 2,
+        }];
+        let query = TestRunner::build_test_query("include \"test\"\n|", &tests);
+        assert!(query.contains("flatten(["));
+        assert!(query.contains("map("));
+        assert!(
+            query.contains("zip(range(0, len([[\"hello\", 5], [\"world\", 5]])), [[\"hello\", 5], [\"world\", 5]])")
+        );
+        assert!(query.contains("test_len(__ic[1][0], __ic[1][1])"));
+        assert!(query.contains("\"len[\""));
+    }
+
+    #[test]
+    fn test_build_test_query_mixed() {
+        let tests = vec![
+            DiscoveredTest::Simple("test_foo".to_string()),
+            DiscoveredTest::Parametrized {
+                name: "test_len".to_string(),
+                params_expr: "[[\"a\", 1]]".to_string(),
+                arity: 2,
+            },
+        ];
+        let query = TestRunner::build_test_query("include \"test\"\n|", &tests);
+        assert!(query.contains("[test_case(\"foo\", test_foo)]"));
+        assert!(query.contains("map("));
+        assert!(query.contains("flatten(["));
     }
 }


### PR DESCRIPTION
Introduce structured annotation parsing so test functions can be run once per element in a parameter array.

Usage:

```jq
# @parametrize([["hello", 5], ["world", 5], ["", 0]])
def test_len(input, expected):
  assert_eq(len(input), expected)
end
```