### PR TITLE
✨ feat(cli): add --count / -c flag to output match counts

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -391,6 +391,11 @@ struct OutputArgs {
     /// is empty. Mirrors jq's --exit-status / -e flag.
     #[arg(short = 'e', long = "exit-status", default_value_t = false)]
     exit_status: bool,
+
+    /// Output only the count of matching (non-None) results. Mirrors grep -c.
+    /// With multiple files, prints "filename: N" per file and "total: N" at the end.
+    #[arg(short = 'c', long = "count", default_value_t = false)]
+    count: bool,
 }
 
 impl OutputArgs {
@@ -658,6 +663,14 @@ impl Cli {
             return Err(miette!(
                 "--before-context, --after-context, and --context are only valid with -F grep"
             ));
+        }
+
+        if self.output.count && self.output.update {
+            return Err(miette!("--count and --update cannot be used together"));
+        }
+
+        if self.output.count && self.input.stream {
+            return Err(miette!("--count is not supported with --stream"));
         }
 
         // Check if query is actually an external subcommand
@@ -995,6 +1008,10 @@ impl Cli {
         let query = self.get_query()?;
         let files = self.read_contents()?;
 
+        if self.output.count {
+            return self.process_batch_count(&query, &files);
+        }
+
         if files.len() > self.parallel_threshold {
             files.par_iter().try_for_each(|(file, content)| {
                 let mut engine = self.create_engine()?;
@@ -1045,6 +1062,72 @@ impl Cli {
         };
 
         self.emit_results(runtime_values, grep_input, file)
+    }
+
+    fn count_file(
+        &self,
+        engine: &mut mq_lang::DefaultEngine,
+        query: &str,
+        file: &Option<PathBuf>,
+        content: &ContentData,
+    ) -> miette::Result<usize> {
+        let effective_query;
+        let query = match self.auto_query_prefix(file) {
+            Some(prefix) => {
+                effective_query = format!("{} | {}", prefix, query);
+                effective_query.as_str()
+            }
+            None => query,
+        };
+        if let Some(f) = file {
+            self.set_file_vars(engine, f);
+        }
+        let input = self.resolve_input(file, content)?;
+        let runtime_values = engine.eval(query, input.into_iter()).map_err(|e| *e)?;
+        Ok(runtime_values.compact().len())
+    }
+
+    fn process_batch_count(&self, query: &str, files: &[(Option<PathBuf>, ContentData)]) -> miette::Result<()> {
+        let multiple_files = files.len() > 1;
+        let mut total = 0usize;
+        let mut engine = self.create_engine()?;
+
+        let stdout = io::stdout();
+        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
+            let file = fs::File::create(output_file).into_diagnostic()?;
+            Box::new(BufWriter::new(file))
+        } else if self.output.unbuffered {
+            Box::new(stdout.lock())
+        } else {
+            Box::new(BufWriter::new(stdout.lock()))
+        };
+
+        for (file, content) in files {
+            let count = self.count_file(&mut engine, query, file, content)?;
+            total += count;
+            if multiple_files {
+                let name = file
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "(stdin)".to_string());
+                Self::write_ignore_pipe(&mut handle, format!("{}: {}\n", name, count).as_bytes())?;
+            }
+        }
+
+        if multiple_files {
+            Self::write_ignore_pipe(&mut handle, format!("total: {}\n", total).as_bytes())?;
+        } else {
+            Self::write_ignore_pipe(&mut handle, format!("{}\n", total).as_bytes())?;
+        }
+
+        if !self.output.unbuffered
+            && let Err(e) = handle.flush()
+            && e.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(miette!(e));
+        }
+
+        Ok(())
     }
 
     fn process_streaming(&self) -> miette::Result<()> {

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -394,7 +394,7 @@ struct OutputArgs {
 
     /// Output only the count of matching (non-None) results. Mirrors grep -c.
     /// With multiple files, prints "filename: N" per file and "total: N" at the end.
-    #[arg(short = 'c', long = "count", default_value_t = false)]
+    #[arg(short = 'c', long = "count", default_value_t = false, conflicts_with_all = ["update", "stream"])]
     count: bool,
 }
 
@@ -663,14 +663,6 @@ impl Cli {
             return Err(miette!(
                 "--before-context, --after-context, and --context are only valid with -F grep"
             ));
-        }
-
-        if self.output.count && self.output.update {
-            return Err(miette!("--count and --update cannot be used together"));
-        }
-
-        if self.output.count && self.input.stream {
-            return Err(miette!("--count is not supported with --stream"));
         }
 
         // Check if query is actually an external subcommand

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -841,6 +841,89 @@ fn test_exit_status_parallel_batch(
 }
 
 #[rstest]
+#[case::two_matches("# h1\n\n## h2a\n\n## h2b\n", ".h2", "2\n")]
+#[case::no_matches("# h1\n\nbody\n", ".h2", "0\n")]
+#[case::all_match("# h1\n\n# h2\n", ".h", "2\n")]
+fn test_count_stdin(
+    #[case] input: &str,
+    #[case] query: &str,
+    #[case] expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--unbuffered")
+        .arg("--count")
+        .arg(query)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(expected.to_owned());
+    Ok(())
+}
+
+#[test]
+fn test_count_short_flag() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--unbuffered")
+        .arg("-c")
+        .arg(".h2")
+        .write_stdin("# h1\n\n## h2\n\n## h2b\n")
+        .assert()
+        .success()
+        .stdout("2\n");
+    Ok(())
+}
+
+#[test]
+fn test_count_multiple_files() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, file_a) = create_file("test_count_a.md", "# h1\n\n## h2\n\n## h2b\n");
+    let (_, file_b) = create_file("test_count_b.md", "# h1\n\n## h2\n\n## h2b\n\n## h2c\n");
+    let file_a_clone = file_a.clone();
+    let file_b_clone = file_b.clone();
+
+    defer! {
+        if file_a_clone.exists() { std::fs::remove_file(&file_a_clone).ok(); }
+        if file_b_clone.exists() { std::fs::remove_file(&file_b_clone).ok(); }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let output = cmd
+        .arg("--unbuffered")
+        .arg("--count")
+        .arg(".h2")
+        .arg(&file_a)
+        .arg(&file_b)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8(output)?;
+    assert!(
+        output_str.contains("test_count_a.md: 2"),
+        "missing per-file count for a: {output_str}"
+    );
+    assert!(
+        output_str.contains("test_count_b.md: 3"),
+        "missing per-file count for b: {output_str}"
+    );
+    assert!(output_str.contains("total: 5"), "missing total: {output_str}");
+    Ok(())
+}
+
+#[test]
+fn test_count_update_error() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--count")
+        .arg("--update")
+        .arg(".h")
+        .write_stdin("# title\n")
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[rstest]
 #[case::bash("bash", "_mq()")]
 #[case::elvish("elvish", "edit:completion:arg-completer[mq]")]
 #[case::fish("fish", "complete -c mq")]


### PR DESCRIPTION
Count non-None results instead of printing them, mirroring grep -c. Single file or stdin prints only the number; multiple files print "filename: N" per file followed by "total: N".

- Add OutputArgs::count field with --count / -c
- Add count_file() helper using RuntimeValues::compact()
- Add process_batch_count() for the count output path
- Validate incompatible flag combinations (--count + --update/--stream)
- Add integration tests for stdin, short flag, multi-file, and error cases

Close #1942 