### PR TITLE
✨ feat(mq-check): match patterns against markdown node kinds

### DIFF
--- a/crates/mq-check/src/narrowing.rs
+++ b/crates/mq-check/src/narrowing.rs
@@ -172,7 +172,10 @@ pub(crate) fn type_name_to_type(name: &str, ctx: &mut InferenceContext) -> Optio
             let v = ctx.fresh_var();
             Some(Type::dict(Type::Var(k), Type::Var(v)))
         }
-        _ => None,
+        // Node-kind pattern (`:h1`, `:code`, `:list`) narrows to Markdown.
+        _ => mq_lang::Selector::from_selector_str(&format!(".{name}"))
+            .filter(|selector| !selector.is_attribute_selector())
+            .map(|_| Type::Markdown),
     }
 }
 

--- a/crates/mq-check/tests/integration_test.rs
+++ b/crates/mq-check/tests/integration_test.rs
@@ -118,6 +118,32 @@ fn test_match_different_types_creates_union() {
     );
 }
 
+#[test]
+fn test_pattern_matching_markdown_node_kind() {
+    let result = check_types(
+        r#"
+        def describe(node):
+          match (node):
+            | :h1: "top-level heading"
+            | :h2: "section heading"
+            | :h if (.depth > 2): "deep heading"
+            | :code if (.lang == "rust"): upcase(.value)
+            | :code: .value
+            | :list if (.ordered): "ordered list"
+            | :list: "unordered list"
+            | :text: .value
+            | _: "other node"
+          end
+        ;
+        "#,
+    );
+    assert!(
+        result.is_empty(),
+        "node-kind patterns with attribute guards should type-check: {:?}",
+        result
+    );
+}
+
 #[rstest]
 #[case::wildcard_only(r#"match (42): | _: 0 end"#, true, "wildcard-only arm covers everything")]
 #[case::wildcard_after_literal(

--- a/crates/mq-check/tests/type_errors_test.rs
+++ b/crates/mq-check/tests/type_errors_test.rs
@@ -627,6 +627,18 @@ fn test_dict_destructuring_type_check(#[case] code: &str, #[case] should_succeed
     true,
     "multiple whole-type arms before wildcard should not cause errors"
 )]
+// Markdown node-kind labels (`:h1`, `:code`, ...) should type-check like other type labels
+#[case::node_kind_label_then_wildcard_valid(
+    r#"def f(x): match (x): | :h1:: "top" | _: x end"#,
+    true,
+    "wildcard arm after :h1: label arm should succeed"
+)]
+// Attribute selectors (`.lang`, `.depth`, ...) in a guard/body read the matched node
+#[case::node_kind_guard_attribute_access_valid(
+    r#"def f(x): match (x): | :code if (.lang == "rust"): upcase(.value) | :code: .value | _: x end"#,
+    true,
+    "guard/body reading attributes of a node-kind pattern should not error"
+)]
 fn test_cross_arm_narrowing(#[case] code: &str, #[case] should_succeed: bool, #[case] description: &str) {
     let result = check_types(code);
     assert_eq!(result.is_empty(), should_succeed, "{}: {result:?}", description);

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1442,7 +1442,8 @@ impl<T: ModuleResolver> Evaluator<T> {
                         define(&guard_env, *name, value.clone());
                     }
 
-                    let guard_result = self.eval_expr(runtime_value, guard_node, &guard_env)?;
+                    // Guard sees the matched value as `.`, so `.depth`/`.lang` work unbound.
+                    let guard_result = self.eval_expr(&match_value, guard_node, &guard_env)?;
                     if !guard_result.is_truthy() {
                         // Guard failed, try next arm
                         continue;
@@ -1455,7 +1456,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     define(&body_env, name, value);
                 }
 
-                return self.eval_expr(runtime_value, &arm.body, &body_env);
+                return self.eval_expr(&match_value, &arm.body, &body_env);
             }
         }
 
@@ -1587,7 +1588,13 @@ impl<T: ModuleResolver> Evaluator<T> {
                     "function" => matches!(value, RuntimeValue::Function(_, _, _)),
                     "symbol" => matches!(value, RuntimeValue::Symbol(_)),
                     "none" => matches!(value, RuntimeValue::None),
-                    _ => false,
+                    // Node-kind pattern (`:h1`, `:code`, `:list`), backed by the selector table.
+                    _ => match value {
+                        RuntimeValue::Markdown(node, _) => Selector::from_selector_str(&format!(".{type_str}"))
+                            .filter(|selector| !selector.is_attribute_selector())
+                            .is_some_and(|selector| builtin::eval_selector(node, &selector) != RuntimeValue::NONE),
+                        _ => false,
+                    },
                 };
 
                 if matches { Ok(Some(Vec::new())) } else { Ok(None) }
@@ -6708,6 +6715,158 @@ mod tests {
                     pattern: Pattern::Type(crate::Ident::new("bytes")),
                     guard: None,
                     body: ast_node(ast::Expr::Literal(ast::Literal::String("bytes".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::String("other".to_string())])
+    )]
+    #[case::match_type_node_kind_heading_matches(
+        vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+            values: vec![],
+            position: None,
+            depth: 1,
+        }))],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    pattern: Pattern::Type(crate::Ident::new("h1")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("h1".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+            value: "h1".to_string(),
+            position: None,
+        }))])
+    )]
+    #[case::match_type_node_kind_heading_depth_mismatch_falls_to_wildcard(
+        vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+            values: vec![],
+            position: None,
+            depth: 2,
+        }))],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    pattern: Pattern::Type(crate::Ident::new("h1")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("h1".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+            value: "other".to_string(),
+            position: None,
+        }))])
+    )]
+    #[case::match_type_node_kind_generic_heading_matches_any_depth(
+        vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+            values: vec![],
+            position: None,
+            depth: 5,
+        }))],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    pattern: Pattern::Type(crate::Ident::new("h")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("heading".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+            value: "heading".to_string(),
+            position: None,
+        }))])
+    )]
+    #[case::match_type_node_kind_unknown_name_no_match(
+        vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+            values: vec![],
+            position: None,
+            depth: 1,
+        }))],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    pattern: Pattern::Type(crate::Ident::new("not_a_real_node_kind")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("matched".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+            value: "other".to_string(),
+            position: None,
+        }))])
+    )]
+    #[case::match_type_node_kind_attribute_name_does_not_match(
+        vec![RuntimeValue::new_markdown(mq_markdown::Node::Code(mq_markdown::Code {
+            value: "fn main() {}".to_string(),
+            lang: Some("rust".to_string()),
+            position: None,
+            meta: None,
+            fence: true,
+        }))],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    // `:lang` is an attribute selector, not a node-kind selector, so it must not match.
+                    pattern: Pattern::Type(crate::Ident::new("lang")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("matched".to_string()))),
+                },
+                MatchArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("other".to_string()))),
+                },
+            ]
+        ))],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+            value: "other".to_string(),
+            position: None,
+        }))])
+    )]
+    #[case::match_type_node_kind_no_match_on_non_markdown(
+        vec![RuntimeValue::Number(42.into())],
+        vec![ast_node(ast::Expr::Match(
+            ast_node(ast::Expr::Self_),
+            smallvec![
+                MatchArm {
+                    pattern: Pattern::Type(crate::Ident::new("code")),
+                    guard: None,
+                    body: ast_node(ast::Expr::Literal(ast::Literal::String("matched".to_string()))),
                 },
                 MatchArm {
                     pattern: Pattern::Wildcard,

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -177,6 +177,216 @@ fn engine() -> DefaultEngine {
     ",
       vec![RuntimeValue::Number(0.into())],
       Ok(vec![RuntimeValue::String("is_array".to_string())].into()))]
+#[case::match_node_kind_h1("
+    match(.) do
+      | :h1: \"h1\"
+      | :h2: \"h2\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+          values: vec![],
+          position: None,
+          depth: 1,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "h1".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_heading_guard_depth("
+    match(.) do
+      | :h1: \"h1\"
+      | :h2: \"h2\"
+      | :h if (.depth > 2): \"deep\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+          values: vec![],
+          position: None,
+          depth: 3,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "deep".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_code_lang_guard("
+    match(.) do
+      | :code if (.lang == \"rust\"): \"rust code\"
+      | :code: \"other code\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Code(mq_markdown::Code {
+          value: "fn main() {}".to_string(),
+          lang: Some("rust".to_string()),
+          position: None,
+          meta: None,
+          fence: true,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "rust code".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_code_lang_guard_no_match("
+    match(.) do
+      | :code if (.lang == \"rust\"): \"rust code\"
+      | :code: \"other code\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Code(mq_markdown::Code {
+          value: "print(\"hi\")".to_string(),
+          lang: Some("python".to_string()),
+          position: None,
+          meta: None,
+          fence: true,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "other code".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_list_ordered_guard("
+    match(.) do
+      | :list if (.ordered): \"ordered\"
+      | :list: \"unordered\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::List(mq_markdown::List {
+          values: vec![],
+          index: 0,
+          level: 1,
+          ordered: true,
+          checked: None,
+          position: None,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "ordered".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_list_unordered("
+    match(.) do
+      | :list if (.ordered): \"ordered\"
+      | :list: \"unordered\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::List(mq_markdown::List {
+          values: vec![],
+          index: 0,
+          level: 1,
+          ordered: false,
+          checked: None,
+          position: None,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "unordered".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_no_match_on_non_markdown("
+    match(.) do
+      | :code: \"code\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::Number(1.into())],
+      Ok(vec![RuntimeValue::String("other".to_string())].into()))]
+#[case::match_node_kind_or_pattern("
+    match(.) do
+      | :h1 || :h2: \"top-level\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+          values: vec![],
+          position: None,
+          depth: 2,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "top-level".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_alias_paragraph("
+    match(.) do
+      | :p: \"paragraph\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "hello".to_string(),
+          position: None,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "paragraph".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_task_checked_guard("
+    match(.) do
+      | :list if (.checked == true): \"done\"
+      | :list if (.checked == false): \"todo\"
+      | :list: \"plain list\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::List(mq_markdown::List {
+          values: vec![],
+          index: 0,
+          level: 1,
+          ordered: false,
+          checked: Some(true),
+          position: None,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "done".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_strong_matches("
+    match(.) do
+      | :strong: \"bold\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Strong(mq_markdown::Strong {
+          values: vec![],
+          position: None,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "bold".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_unknown_name_falls_to_wildcard("
+    match(.) do
+      | :not_a_real_kind: \"matched\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading {
+          values: vec![],
+          position: None,
+          depth: 1,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "other".to_string(),
+          position: None,
+      }))].into()))]
+#[case::match_node_kind_attribute_name_pattern_does_not_match("
+    match(.) do
+      | :lang: \"matched\"
+      | _: \"other\"
+    end
+    ",
+      vec![RuntimeValue::new_markdown(mq_markdown::Node::Code(mq_markdown::Code {
+          value: "fn main() {}".to_string(),
+          lang: Some("rust".to_string()),
+          position: None,
+          meta: None,
+          fence: true,
+      }))],
+      Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text {
+          value: "other".to_string(),
+          position: None,
+      }))].into()))]
 #[case::if_("
     def fibonacci(x):
       if(eq(x, 0)):

--- a/docs/books/src/reference/pattern_matching.md
+++ b/docs/books/src/reference/pattern_matching.md
@@ -55,6 +55,42 @@ Available type patterns:
 - `:markdown` - Matches markdown values
 - `:none` - Matches none value
 
+## Markdown Node-Kind Patterns
+
+Match a `:markdown` value against a specific node kind using the same names as
+[selectors](./selectors.md) (without the leading `.`):
+
+```mq
+match (node):
+  | :h1: "top-level heading"
+  | :h2: "section heading"
+  | :code: "code block"
+  | :list: "list"
+  | :text: "text"
+  | _: "other node"
+end
+```
+
+Any node-kind name accepted by a selector (`h1`..`h6`, `h`, `code`, `list`,
+`text`, `strong`, `emphasis`, `link`, `table`, and so on) can be used. A
+pattern matches only when the value is a markdown node of that kind; other
+values fall through to the next arm.
+
+Inside a matched arm, `.` refers to the matched node itself, so attribute
+selectors like `.depth`, `.lang`, or `.ordered` can be used directly in the
+guard or body without binding a variable:
+
+```mq
+match (node):
+  | :h if (.depth > 2): "deep heading"
+  | :code if (.lang == "rust"): upcase(.value)
+  | :code: .value
+  | :list if (.ordered): "ordered list"
+  | :list: "unordered list"
+  | _: "other node"
+end
+```
+
 ## Array Patterns
 
 Destructure arrays and bind elements to variables:
@@ -321,6 +357,24 @@ def classify_status(code):
     | 404: "not found"
     | 500 || 502 || 503: "server error"
     | _: "unknown"
+  end
+end
+```
+
+### Dispatching on Markdown Node Kinds
+
+```mq
+def describe_node(node):
+  match (node):
+    | :h1: "top-level heading"
+    | :h2: "section heading"
+    | :h if (.depth > 2): "deep heading"
+    | :code if (.lang == "rust"): upcase(.value)
+    | :code: .value
+    | :list if (.ordered): "ordered list"
+    | :list: "unordered list"
+    | :text: .value
+    | _: "other node"
   end
 end
 ```


### PR DESCRIPTION
Extend `match` type patterns so an arm like `:h1` or `:code` matches a markdown value against a node-kind selector (same names as selectors, without the leading `.`), in addition to the existing type names (`:string`, `:number`, etc.). Attribute selectors (e.g. `:lang`) are rejected since they don't identify a node kind.

Also fix match guard/body evaluation to run against the matched value instead of the pipeline's `.`, so attribute selectors like `.depth` or `.lang` resolve correctly inside a guard or arm body without binding a variable first.

Close #1946 