### PR TITLE
📝 docs(mq-web-api): add Dockerfile.vercel and update README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ dependencies = [
  "mq-formatter",
  "mq-hir",
  "mq-lang",
+ "mq-lint",
  "mq-markdown",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -7,7 +7,6 @@ homepage = "https://mqlang.org/"
 keywords = ["markdown", "jq", "query"]
 license = "MIT"
 name = "mq-web-api"
-publish = false
 readme = "README.md"
 repository = "https://github.com/harehare/mq"
 version = "0.6.3"
@@ -44,3 +43,4 @@ utoipa-swagger-ui = {workspace = true}
 [[bin]]
 name = "mq-web-api"
 path = "src/main.rs"
+

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -28,6 +28,7 @@ mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["cst"]}
+mq-lint = {workspace = true}
 mq-markdown = {workspace = true, features = ["json"]}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}

--- a/crates/mq-web-api/Dockerfile.vercel
+++ b/crates/mq-web-api/Dockerfile.vercel
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM rust:1.96.0-slim@sha256:c37af730be4fd8104cbf9aedbd6ab259e51ca2d5437817a0f8680edf66ac6c28 AS builder
+
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+RUN cargo build -p mq-web-api --bin mq-web-api --release
+
+FROM gcr.io/distroless/cc:nonroot
+
+COPY --from=builder --chown=nonroot:nonroot /usr/src/app/target/release/mq-web-api /usr/local/bin/mq-web-api
+
+ENV HOST=0.0.0.0
+ENV PORT=8080
+
+
+ENTRYPOINT ["/usr/local/bin/mq-web-api"]

--- a/crates/mq-web-api/Dockerfile.vercel
+++ b/crates/mq-web-api/Dockerfile.vercel
@@ -10,8 +10,4 @@ FROM gcr.io/distroless/cc:nonroot
 
 COPY --from=builder --chown=nonroot:nonroot /usr/src/app/target/release/mq-web-api /usr/local/bin/mq-web-api
 
-ENV HOST=0.0.0.0
-ENV PORT=8080
-
-
 ENTRYPOINT ["/usr/local/bin/mq-web-api"]

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -11,6 +11,9 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
 | `POST` | `/api/v1/check` | Type-check a query |
 | `POST` | `/api/v1/format` | Format a query |
+| `GET` | `/api/v1/functions` | List builtin mq functions |
+| `GET` | `/api/v1/selectors` | List builtin mq selectors |
+| `POST` | `/api/v1/lint` | Lint a query |
 | `GET` | `/api/v1/openapi.json` | OpenAPI specification |
 | `GET` | `/docs` | Swagger UI |
 
@@ -55,6 +58,22 @@ Legacy paths (`/api/query`, `/api/check`, `/api/format`, `/openapi.json`) redire
 ```
 
 Returns an array of errors (empty means no issues). Always returns HTTP 200.
+
+### `GET /api/v1/functions`
+
+Returns all builtin mq functions with their descriptions and parameters.
+
+### `GET /api/v1/selectors`
+
+Returns all builtin mq selectors with their descriptions and parameters.
+
+### `POST /api/v1/lint`
+
+```json
+{ "query": "let x = .h1 | .text" }
+```
+
+Returns an array of style/correctness diagnostics (empty means no issues). Always returns HTTP 200.
 
 ### `POST /api/v1/format`
 
@@ -171,6 +190,26 @@ curl -X POST http://localhost:8080/api/v1/check \
 curl -X POST http://localhost:8080/api/v1/format \
   -H "Content-Type: application/json" \
   -d '{"query": "if(a):1 elif(b):2 else:3"}'
+```
+
+### List builtin functions
+
+```bash
+curl http://localhost:8080/api/v1/functions
+```
+
+### List builtin selectors
+
+```bash
+curl http://localhost:8080/api/v1/selectors
+```
+
+### Lint a query
+
+```bash
+curl -X POST http://localhost:8080/api/v1/lint \
+  -H "Content-Type: application/json" \
+  -d '{"query": "let x = .h1 | .text"}'
 ```
 
 ## Features

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -1,92 +1,154 @@
 <h1 align="center">mq-web-api</h1>
 
-Web API server for the mq markdown query language.
-
-## Configuration
-
-The server can be configured using environment variables:
-
-### Basic Configuration
-
-| Environment Variable | Description                  | Default Value                       |
-| -------------------- | ---------------------------- | ----------------------------------- |
-| `HOST`               | Host to bind to              | `0.0.0.0`                           |
-| `PORT`               | Port to bind to              | `8080`                              |
-| `RUST_LOG`           | Log level                    | `mq_web_api=debug,tower_http=debug` |
-| `LOG_FORMAT`         | Log format: `json` or `text` | `json`                              |
-| `CORS_ORIGINS`       | Comma-separated CORS origins | `*`                                 |
-
-### Rate Limiting Configuration
-
-| Environment Variable                  | Description                                    | Default Value |
-| ------------------------------------- | ---------------------------------------------- | ------------- |
-| `DATABASE_URL`                        | Database URL for rate limiting (libsql format) | `:memory:`    |
-| `DATABASE_TOKEN`                      | Database authentication token (for remote DB)  | None          |
-| `RATE_LIMIT_REQUESTS_PER_WINDOW`      | Maximum requests per time window               | `100`         |
-| `RATE_LIMIT_WINDOW_SIZE_SECONDS`      | Time window size in seconds                    | `3600`        |
-| `RATE_LIMIT_CLEANUP_INTERVAL_SECONDS` | Cleanup interval for expired records           | `3600`        |
-| `RATE_LIMIT_POOL_MAX_SIZE`            | Maximum database connection pool size          | `10`          |
-| `RATE_LIMIT_POOL_TIMEOUT_SECONDS`     | Database connection timeout in seconds         | `30`          |
-
-## Usage
-
-### Running with default settings
-
-```bash
-cargo run --bin mq-web-api
-```
-
-### Running with custom configuration
-
-```bash
-HOST=localhost PORT=3000 RUST_LOG=info cargo run --bin mq-web-api
-```
-
-### Running with specific CORS origins
-
-```bash
-CORS_ORIGINS="https://example.com,https://app.example.com" cargo run --bin mq-web-api
-```
-
-### Running with text-format logs
-
-```bash
-LOG_FORMAT=text cargo run --bin mq-web-api
-```
-
-### Running with JSON logs (default)
-
-```bash
-LOG_FORMAT=json cargo run --bin mq-web-api
-```
-
-### Running with rate limiting using Turso database
-
-```bash
-DATABASE_URL="libsql://your-database.turso.io" \
-DATABASE_TOKEN="your-auth-token" \
-RATE_LIMIT_REQUESTS_PER_WINDOW=50 \
-RATE_LIMIT_WINDOW_SIZE_SECONDS=3600 \
-cargo run --bin mq-web-api
-```
+HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query language over the network.
 
 ## API Endpoints
 
-- `GET /api/query?query=<mq-query>&input=<content>&input_format=<format>` - Execute query via GET
-- `POST /api/query` - Execute query via POST with JSON body
-- `GET /api/query/diagnostics?query=<mq-query>` - Get query diagnostics
-- `GET /openapi.json` - OpenAPI specification
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check |
+| `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
+| `POST` | `/api/v1/query` | Execute a query (JSON body) |
+| `POST` | `/api/v1/check` | Type-check a query |
+| `POST` | `/api/v1/format` | Format a query |
+| `GET` | `/api/v1/openapi.json` | OpenAPI specification |
+| `GET` | `/docs` | Swagger UI |
+
+Legacy paths (`/api/query`, `/api/check`, `/api/format`, `/openapi.json`) redirect permanently to the `/api/v1/` equivalents.
+
+### `GET /api/v1/query`
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | Yes | mq query string |
+| `input` | No | Input content |
+| `input_format` | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+
+### `POST /api/v1/query`
+
+```json
+{
+  "query": ".h",
+  "input": "## Markdown Content\n\nBody text.",
+  "input_format": "markdown",
+  "output_format": "markdown",
+  "modules": ["json"],
+  "args": { "key": "value" },
+  "aggregate": false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query` | `string` | mq query string |
+| `input` | `string?` | Input content |
+| `input_format` | `string?` | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+| `output_format` | `string?` | `markdown` (default), `html`, `text`, `json`, `none` |
+| `modules` | `string[]?` | Builtin module names to load (e.g. `"json"`, `"csv"`) |
+| `args` | `object?` | String variables passed to the engine |
+| `aggregate` | `bool?` | Aggregate all input nodes before querying (equivalent to CLI `-A`) |
+
+### `POST /api/v1/check`
+
+```json
+{ "query": "upcase() | downcase()" }
+```
+
+Returns an array of errors (empty means no issues). Always returns HTTP 200.
+
+### `POST /api/v1/format`
+
+```json
+{
+  "query": "if(a):1 elif(b):2 else:3",
+  "indent_width": 2,
+  "sort_imports": false,
+  "sort_functions": false,
+  "sort_fields": false
+}
+```
+
+## Configuration
+
+All settings are controlled through environment variables.
+
+### Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HOST` | `0.0.0.0` | Bind address |
+| `PORT` | `8080` | Bind port |
+| `RUST_LOG` | `mq_web_api=debug,tower_http=debug` | Log level filter |
+| `LOG_FORMAT` | `json` | Log format: `json` or `text` |
+| `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
+
+### Rate Limiting
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RATE_LIMIT_REQUESTS_PER_WINDOW` | `100` | Maximum requests per window |
+| `RATE_LIMIT_WINDOW_SIZE_SECONDS` | `3600` | Window size in seconds |
+| `RATE_LIMIT_CLEANUP_INTERVAL_SECONDS` | `3600` | Expired-entry cleanup interval |
+
+### OpenTelemetry (requires `otel` feature)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP exporter endpoint (e.g. `http://localhost:4317`) |
+| `OTEL_SERVICE_NAME` | `mq-web-api` | Service name reported to the collector |
+
+## Usage
+
+### Running locally
+
+```bash
+# Default settings
+cargo run --bin mq-web-api
+
+# Custom host and port
+HOST=localhost PORT=3000 cargo run --bin mq-web-api
+
+# Text-format logs
+LOG_FORMAT=text cargo run --bin mq-web-api
+
+# Restrict CORS origins
+CORS_ORIGINS="https://example.com,https://app.example.com" cargo run --bin mq-web-api
+
+# Enable OpenTelemetry
+cargo run --features otel --bin mq-web-api
+```
+
+### Docker
+
+Build and run from the workspace root:
+
+```bash
+docker build -f crates/mq-web-api/Dockerfile.vercel -t mq-web-api .
+docker run -p 8080:8080 mq-web-api
+```
+
+With custom configuration:
+
+```bash
+docker run -p 3000:3000 \
+  -e PORT=3000 \
+  -e LOG_FORMAT=text \
+  -e CORS_ORIGINS="https://example.com" \
+  mq-web-api
+```
 
 ## Examples
 
-### Query via GET
+### Execute a query (GET)
+
 ```bash
-curl "http://localhost:8080/api/query?query=.h&input=%23%20Title%0A%0AContent&input_format=markdown"
+curl "http://localhost:8080/api/v1/query?query=.h&input=%23%20Title%0A%0AContent&input_format=markdown"
 ```
 
-### Query via POST
+### Execute a query (POST)
+
 ```bash
-curl -X POST http://localhost:8080/api/query \
+curl -X POST http://localhost:8080/api/v1/query \
   -H "Content-Type: application/json" \
   -d '{
     "query": ".h",
@@ -95,24 +157,34 @@ curl -X POST http://localhost:8080/api/query \
   }'
 ```
 
-### Get diagnostics
+### Type-check a query
+
 ```bash
-curl "http://localhost:8080/api/query/diagnostics?query=invalid%20query"
+curl -X POST http://localhost:8080/api/v1/check \
+  -H "Content-Type: application/json" \
+  -d '{"query": "upcase() | downcase()"}'
+```
+
+### Format a query
+
+```bash
+curl -X POST http://localhost:8080/api/v1/format \
+  -H "Content-Type: application/json" \
+  -d '{"query": "if(a):1 elif(b):2 else:3"}'
 ```
 
 ## Features
 
-- **Axum-based HTTP server** - Fast and reliable web framework
-- **Rate limiting** - Built-in rate limiting with libsql/SQLite backend support
-- **CORS support** - Configurable CORS origins for web applications
-- **Structured logging** - JSON and text format logging with tracing
-- **OpenAPI documentation** - Auto-generated API documentation
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `use_mimalloc` | enabled | Use mimalloc as the global allocator |
+| `otel` | disabled | Enable OpenTelemetry tracing via OTLP |
 
 ## Support
 
-- 🐛 [Report bugs](https://github.com/harehare/mq/issues)
-- 💡 [Request features](https://github.com/harehare/mq/issues)
-- 📖 [Read the documentation](https://mqlang.org/book/)
+- [Report bugs](https://github.com/harehare/mq/issues)
+- [Request features](https://github.com/harehare/mq/issues)
+- [Read the documentation](https://mqlang.org/book/)
 
 ## License
 

--- a/crates/mq-web-api/src/api.rs
+++ b/crates/mq-web-api/src/api.rs
@@ -109,6 +109,62 @@ pub struct FormatApiResponse {
     pub formatted: String,
 }
 
+/// Documentation for a single builtin function.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct FunctionDoc {
+    pub name: String,
+    pub description: String,
+    pub params: Vec<String>,
+}
+
+/// Response body for `GET /api/functions`.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct FunctionsApiResponse {
+    pub functions: Vec<FunctionDoc>,
+}
+
+/// Documentation for a single builtin selector.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SelectorDoc {
+    pub name: String,
+    pub description: String,
+    pub params: Vec<String>,
+}
+
+/// Response body for `GET /api/selectors`.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SelectorsApiResponse {
+    pub selectors: Vec<SelectorDoc>,
+}
+
+/// Request body for `POST /api/lint`.
+#[derive(Deserialize, Serialize, ToSchema, Clone, Debug)]
+pub struct LintApiRequest {
+    #[schema(example = "def f(x): let y = 1; x;")]
+    pub query: String,
+}
+
+/// A single lint diagnostic.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LintDiagnostic {
+    /// Identifier of the lint rule that produced this diagnostic (e.g. `"unused_variable"`).
+    pub rule_id: String,
+    pub message: String,
+    /// Severity: `"style"`, `"perf"`, `"warn"`, or `"error"`.
+    pub severity: String,
+    pub help: Option<String>,
+    pub start_line: Option<u32>,
+    pub start_column: Option<u32>,
+    pub end_line: Option<u32>,
+    pub end_column: Option<u32>,
+}
+
+/// Response body for `POST /api/lint`.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LintApiResponse {
+    pub diagnostics: Vec<LintDiagnostic>,
+}
+
 pub fn query(request: ApiRequest) -> miette::Result<QueryApiResponse> {
     execute_query(request)
 }
@@ -169,6 +225,62 @@ pub fn format_query(request: FormatApiRequest) -> miette::Result<FormatApiRespon
         .format(&request.query)
         .map_err(|e| miette!("Format error: {}", e))?;
     Ok(FormatApiResponse { formatted })
+}
+
+/// Lists all builtin mq functions with their documentation.
+pub fn list_functions() -> FunctionsApiResponse {
+    let mut functions: Vec<FunctionDoc> = mq_lang::BUILTIN_FUNCTION_DOC
+        .iter()
+        .map(|(name, doc)| FunctionDoc {
+            name: name.to_string(),
+            description: doc.description.to_string(),
+            params: doc.params.iter().map(|p| p.to_string()).collect(),
+        })
+        .collect();
+    functions.sort_by(|a, b| a.name.cmp(&b.name));
+    FunctionsApiResponse { functions }
+}
+
+/// Lists all builtin mq selectors with their documentation.
+pub fn list_selectors() -> SelectorsApiResponse {
+    let mut selectors: Vec<SelectorDoc> = mq_lang::BUILTIN_SELECTOR_DOC
+        .iter()
+        .map(|(name, doc)| SelectorDoc {
+            name: name.to_string(),
+            description: doc.description.to_string(),
+            params: doc.params.iter().map(|p| p.to_string()).collect(),
+        })
+        .collect();
+    selectors.sort_by(|a, b| a.name.cmp(&b.name));
+    SelectorsApiResponse { selectors }
+}
+
+/// Lints the given query and returns any diagnostics found.
+pub fn lint(request: LintApiRequest) -> LintApiResponse {
+    let mut hir = mq_hir::Hir::default();
+    let (source_id, _) = hir.add_code(None, &request.query);
+
+    let config = mq_lint::LintConfig::default();
+    let ctx = mq_lint::LintContext::new(&hir, source_id, &config);
+    let diagnostics = mq_lint::Linter::with_default_rules()
+        .run(&ctx)
+        .into_iter()
+        .map(|d| {
+            let range = d.range;
+            LintDiagnostic {
+                rule_id: d.rule_id().as_str().to_string(),
+                message: d.message(),
+                severity: d.severity.to_string(),
+                help: d.help(),
+                start_line: range.as_ref().map(|r| r.start.line),
+                start_column: range.as_ref().map(|r| r.start.column as u32),
+                end_line: range.as_ref().map(|r| r.end.line),
+                end_column: range.as_ref().map(|r| r.end.column as u32),
+            }
+        })
+        .collect();
+
+    LintApiResponse { diagnostics }
 }
 
 fn type_error_kind(e: &mq_check::TypeError) -> String {
@@ -511,5 +623,37 @@ mod tests {
         };
         let result = format_query(req);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_list_functions() {
+        let resp = list_functions();
+        assert!(!resp.functions.is_empty());
+        assert!(resp.functions.iter().any(|f| f.name == "halt"));
+    }
+
+    #[test]
+    fn test_list_selectors() {
+        let resp = list_selectors();
+        assert!(!resp.selectors.is_empty());
+        assert!(resp.selectors.iter().any(|s| s.name == ".h"));
+    }
+
+    #[test]
+    fn test_lint_unused_variable() {
+        let req = LintApiRequest {
+            query: "let x = .h1 | .text".to_string(),
+        };
+        let resp = lint(req);
+        assert!(resp.diagnostics.iter().any(|d| d.rule_id == "unused_variable"));
+    }
+
+    #[test]
+    fn test_lint_clean_query_has_no_diagnostics() {
+        let req = LintApiRequest {
+            query: ".h1".to_string(),
+        };
+        let resp = lint(req);
+        assert!(resp.diagnostics.is_empty());
     }
 }

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -60,13 +60,6 @@ pub struct HealthResponse {
 }
 
 /// Returns 200 OK when the server is healthy.
-#[utoipa::path(
-    get,
-    path = "/health",
-    responses(
-        (status = 200, description = "Server is healthy", body = HealthResponse),
-    )
-)]
 pub async fn health_check() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
@@ -74,7 +67,6 @@ pub async fn health_check() -> Json<HealthResponse> {
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        health_check,
         get_query_api,
         post_query_api,
         post_check_api,
@@ -85,7 +77,6 @@ pub async fn health_check() -> Json<HealthResponse> {
         openapi_json
     ),
     components(
-        schemas(HealthResponse),
         schemas(ApiRequest),
         schemas(InputFormat),
         schemas(OutputFormat),

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -11,8 +11,9 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::{
-        ApiRequest, CheckApiRequest, CheckApiResponse, CheckError, FormatApiRequest, FormatApiResponse, InputFormat,
-        OutputFormat, QueryApiResponse,
+        ApiRequest, CheckApiRequest, CheckApiResponse, CheckError, FormatApiRequest, FormatApiResponse, FunctionDoc,
+        FunctionsApiResponse, InputFormat, LintApiRequest, LintApiResponse, LintDiagnostic, OutputFormat,
+        QueryApiResponse, SelectorDoc, SelectorsApiResponse,
     },
     problem::ProblemDetails,
 };
@@ -72,7 +73,17 @@ pub async fn health_check() -> Json<HealthResponse> {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(health_check, get_query_api, post_query_api, post_check_api, post_format_api, openapi_json),
+    paths(
+        health_check,
+        get_query_api,
+        post_query_api,
+        post_check_api,
+        post_format_api,
+        get_functions_api,
+        get_selectors_api,
+        post_lint_api,
+        openapi_json
+    ),
     components(
         schemas(HealthResponse),
         schemas(ApiRequest),
@@ -84,6 +95,13 @@ pub async fn health_check() -> Json<HealthResponse> {
         schemas(CheckError),
         schemas(FormatApiRequest),
         schemas(FormatApiResponse),
+        schemas(FunctionDoc),
+        schemas(FunctionsApiResponse),
+        schemas(SelectorDoc),
+        schemas(SelectorsApiResponse),
+        schemas(LintApiRequest),
+        schemas(LintApiResponse),
+        schemas(LintDiagnostic),
     ),
     tags(
         (name = "mq-api", description = "Markdown Query API")
@@ -258,6 +276,60 @@ pub async fn post_format_api(
                 .with_detail("error", &e.to_string()))
         }
     }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/functions",
+    responses(
+        (status = 200, description = "List of builtin mq functions", body = FunctionsApiResponse),
+    )
+)]
+pub async fn get_functions_api(State(_state): State<AppState>) -> Json<FunctionsApiResponse> {
+    debug!("GET /functions called");
+    Json(crate::api::list_functions())
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/selectors",
+    responses(
+        (status = 200, description = "List of builtin mq selectors", body = SelectorsApiResponse),
+    )
+)]
+pub async fn get_selectors_api(State(_state): State<AppState>) -> Json<SelectorsApiResponse> {
+    debug!("GET /selectors called");
+    Json(crate::api::list_selectors())
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/lint",
+    responses(
+        (status = 200, description = "Lint completed", body = LintApiResponse),
+    ),
+    request_body = LintApiRequest
+)]
+pub async fn post_lint_api(
+    State(_state): State<AppState>,
+    Json(request): Json<LintApiRequest>,
+) -> Json<LintApiResponse> {
+    debug!("POST /lint called with query: {}", request.query);
+
+    let query_str = request.query.clone();
+    let response = tokio::task::spawn_blocking(move || crate::api::lint(request))
+        .await
+        .unwrap_or_else(|e| {
+            error!("Lint task panicked: {}", e);
+            crate::api::LintApiResponse { diagnostics: vec![] }
+        });
+    info!(
+        "Lint for query '{}': {} diagnostics found",
+        query_str,
+        response.diagnostics.len()
+    );
+
+    Json(response)
 }
 
 static OPENAPI_SPEC: OnceLock<utoipa::openapi::OpenApi> = OnceLock::new();

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -17,7 +17,10 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::{
     config::Config,
-    handlers::{ApiDoc, AppState, get_query_api, health_check, post_check_api, post_format_api, post_query_api},
+    handlers::{
+        ApiDoc, AppState, get_functions_api, get_query_api, get_selectors_api, health_check, post_check_api,
+        post_format_api, post_lint_api, post_query_api,
+    },
     middleware::rate_limit_middleware,
     rate_limiter::RateLimiter,
 };
@@ -51,7 +54,10 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
     let v1_routes = Router::new()
         .route("/query", get(get_query_api).post(post_query_api))
         .route("/check", post(post_check_api))
-        .route("/format", post(post_format_api));
+        .route("/format", post(post_format_api))
+        .route("/functions", get(get_functions_api))
+        .route("/selectors", get(get_selectors_api))
+        .route("/lint", post(post_lint_api));
 
     Router::new()
         .merge(SwaggerUi::new("/docs").url("/api/v1/openapi.json", ApiDoc::openapi()))

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-        "revCount": 1017464,
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "revCount": 1024265,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1017464%2Brev-567a49d1913ce81ac6e9582e3553dd90a955875f/019ed27e-44b2-7462-b1ef-3564aa6c28ee/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1024265%2Brev-b5aa0fbd538984f6e3d201be0005b4463d8b09f8/019f16f0-35af-7183-be09-e5210929bf03/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781925477,
-        "narHash": "sha256-QT9/mwEXqfrB9v7E2YGPeYTowXZP8c34behjJ9HuQKA=",
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e8e2021ee8cf3b58b000953ed3bee0d16b5e98e0",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Add Dockerfile.vercel using rust:1.96.0-slim builder and distroless/cc:nonroot runtime; PORT env var controls the bind port
- Rewrite README with accurate endpoint table (v1 paths), full request schemas, Docker usage, and Cargo feature descriptions; remove stale DATABASE_URL / pool config entries