### PR TITLE
✨ feat(mq-lang): add url_decode builtin function

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -343,7 +343,14 @@ fn register_string(ctx: &mut InferenceContext) {
     // Encoding functions
     register_many(
         ctx,
-        &["base64", "base64d", "base64url", "base64urld", "url_encode"],
+        &[
+            "base64",
+            "base64d",
+            "base64url",
+            "base64urld",
+            "url_encode",
+            "url_decode",
+        ],
         vec![Type::String],
         Type::String,
     );
@@ -381,6 +388,7 @@ fn register_string(ctx: &mut InferenceContext) {
             "base64url",
             "base64urld",
             "url_encode",
+            "url_decode",
             "utf8bytelen",
         ],
     );
@@ -1574,6 +1582,7 @@ mod tests {
     #[case::base64("base64(\"hello\")", true)]
     #[case::base64d("base64d(\"aGVsbG8=\")", true)]
     #[case::url_encode("url_encode(\"hello world\")", true)]
+    #[case::url_decode("url_decode(\"hello%20world\")", true)]
     fn test_string_encoding_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -4190,6 +4190,26 @@ mod tests {
              ast_call("url_encode", SmallVec::new())
         ],
         Ok(vec![RuntimeValue::String("1".to_string())]))]
+    #[case::url_decode(vec![RuntimeValue::String("test%20string%20with%20spaces".to_string())],
+        vec![
+             ast_call("url_decode", SmallVec::new())
+        ],
+        Ok(vec![RuntimeValue::String("test string with spaces".to_string())]))]
+    #[case::url_decode(vec![RuntimeValue::String("test%21%40%23%24%25%5E%26%2A%28%29".to_string())],
+        vec![
+             ast_call("url_decode", SmallVec::new())
+        ],
+        Ok(vec![RuntimeValue::String("test!@#$%^&*()".to_string())]))]
+    #[case::url_decode(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test%20string".to_string(), position: None}))],
+        vec![
+             ast_call("url_decode", SmallVec::new())
+        ],
+        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test string".to_string(), position: None}))]))]
+    #[case::url_decode(vec![RuntimeValue::Number(1.into())],
+        vec![
+             ast_call("url_decode", SmallVec::new())
+        ],
+        Ok(vec![RuntimeValue::String("1".to_string())]))]
     #[case::update(vec!["".to_string().into()],
         vec![
              ast_call("update", smallvec![

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -789,6 +789,24 @@ fn url_encode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
     }
 }
 
+#[mq_macros::mq_fn(name = "url_decode", params = Fixed(1))]
+fn url_decode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => convert::url_decode(s),
+        [node @ RuntimeValue::Markdown(_, _)] => node
+            .markdown_node()
+            .map(|md| {
+                convert::url_decode(md.value().as_str()).and_then(|o| match o {
+                    RuntimeValue::String(s) => Ok(node.update_markdown_value(&s)),
+                    a => Err(Error::InvalidTypes(ident.to_string(), vec![a.clone()])),
+                })
+            })
+            .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
+        [a] => convert::url_decode(&a.to_string()),
+        _ => unreachable!("url_decode should always receive exactly one argument"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "to_text", params = Fixed(1))]
 fn to_text_impl(_: &Ident, _: &RuntimeValue, args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.first() {
@@ -3915,6 +3933,7 @@ mq_macros::builtin_dispatch! {
     PACK,
     UNPACK,
     URL_ENCODE,
+    URL_DECODE,
     TO_TEXT,
     ENDS_WITH,
     STARTS_WITH,
@@ -4872,6 +4891,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         SmolStr::new("url_encode"),
         BuiltinFunctionDoc {
             description: "URL-encodes the given string.",
+            params: &["input"],
+        },
+    );
+    map.insert(
+        SmolStr::new("url_decode"),
+        BuiltinFunctionDoc {
+            description: "URL-decodes the given string.",
             params: &["input"],
         },
     );


### PR DESCRIPTION
Adds a named url_decode(s) counterpart to url_encode(s). The underlying percent-decoding already existed for the `@ :urid` conversion operator; this exposes it as a directly callable function for symmetry.