### PR TITLE
✨ feat(mq-test): add --coverage flag for line coverage reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,6 +2754,7 @@ dependencies = [
  "miette",
  "mq-lang",
  "rstest",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "mq-lang",
  "rstest",
  "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -938,18 +938,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -957,27 +957,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1541,11 +1541,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2211,11 +2209,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2383,15 +2381,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -2622,7 +2620,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "similar 3.1.1",
  "smallvec",
  "smol_str",
@@ -3429,15 +3427,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3451,16 +3450,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3539,6 +3538,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3622,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3634,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3768,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3779,10 +3787,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
@@ -3792,19 +3801,19 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "walkdir",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -3913,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -4167,20 +4176,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4529,12 +4527,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -4615,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -4673,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6115,18 +6112,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6231,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1015,7 +1015,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         env: &Shared<SharedCell<Env>>,
     ) -> EvalResult {
         #[cfg(feature = "debugger")]
-        {
+        if self.debugger.read().unwrap().is_active() {
             let token = &get_token(Shared::clone(&self.token_arena), node.token_id);
             let call_stack = self.debugger.read().unwrap().current_call_stack();
             let debug_context = DebugContext {

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -15,6 +15,7 @@ clap = {workspace = true, features = ["derive"]}
 glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mq-lang = {workspace = true, features = ["cst", "debugger", "file-io"]}
+rustc-hash = {workspace = true}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -16,6 +16,7 @@ glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mq-lang = {workspace = true, features = ["cst", "debugger", "file-io"]}
 rustc-hash = {workspace = true}
+serde_json = {workspace = true}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.6.4"
 clap = {workspace = true, features = ["derive"]}
 glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
-mq-lang = {workspace = true, features = ["cst", "file-io"]}
+mq-lang = {workspace = true, features = ["cst", "debugger", "file-io"]}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -35,6 +35,21 @@ mq-test --coverage
 
 # Write an lcov tracefile for CI (e.g. codecov, genhtml)
 mq-test --coverage --coverage-format lcov --coverage-output lcov.info
+
+# Write a self-contained HTML report with per-line source highlighting
+mq-test --coverage --coverage-format html --coverage-output coverage.html
+
+# Write an HTML report and open it in the browser
+mq-test --coverage --coverage-format html --coverage-output coverage.html --open
+
+# Write a Markdown report (e.g. to paste into a PR description)
+mq-test --coverage --coverage-format markdown --coverage-output coverage.md
+
+# Write a JSON report
+mq-test --coverage --coverage-format json --coverage-output coverage.json
+
+# Write a Cobertura XML report (e.g. Jenkins, GitLab CI)
+mq-test --coverage --coverage-format cobertura --coverage-output cobertura.xml
 ```
 
 ## Coverage
@@ -50,10 +65,25 @@ Coverage report:
   Total: 66.7% (2/3)
 ```
 
-- `--coverage-format <text|lcov>` selects the report format (default: `text`).
-  `lcov` produces an [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php)
-  suitable for `genhtml` or CI coverage integrations.
+- `--coverage-format <text|lcov|html|markdown|json|cobertura>` selects the report format (default: `text`).
+  - `lcov` produces an [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php)
+    suitable for `genhtml` or CI coverage integrations.
+  - `html` produces a self-contained HTML report: a summary table plus a
+    collapsible, line-by-line source view per file, with covered lines
+    highlighted green and uncovered lines red. Follows the viewer's
+    light/dark theme.
+  - `markdown` produces the same summary table plus a per-file source listing
+    in a ` ```diff ` block, so GitHub (and other diff-aware Markdown
+    renderers) colors covered/uncovered lines green/red — handy for pasting
+    into a PR description or CI job summary.
+  - `json` produces a machine-readable report with per-file and total stats,
+    plus a `lines` array per file giving each line's content and
+    `covered`/`uncovered`/`plain` status.
+  - `cobertura` produces a [Cobertura](https://cobertura.github.io/cobertura/) XML report
+    suitable for Jenkins/GitLab CI coverage integrations.
 - `--coverage-output <path>` writes the report to a file instead of stdout.
+- `--open` opens the written report in the OS default application (`open` on
+  macOS, `xdg-open` on Linux, `start` on Windows). Requires `--coverage-output`.
 - Coverage is line-based: a line counts as covered if the evaluator executed
   any expression on it. `def`/`include`/`import` declaration lines themselves
   aren't counted (only their bodies are), and coverage of `include`d/imported

--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -29,7 +29,37 @@ mq-test tests.mq
 
 # Run multiple test files
 mq-test tests.mq other_tests.mq
+
+# Run with a line-coverage report
+mq-test --coverage
+
+# Write an lcov tracefile for CI (e.g. codecov, genhtml)
+mq-test --coverage --coverage-format lcov --coverage-output lcov.info
 ```
+
+## Coverage
+
+Pass `--coverage` to report which lines of each executed test file were run
+by the evaluator:
+
+```
+Coverage report:
+  tests.mq                                              66.7% (2/3)
+      uncovered lines: 9
+
+  Total: 66.7% (2/3)
+```
+
+- `--coverage-format <text|lcov>` selects the report format (default: `text`).
+  `lcov` produces an [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php)
+  suitable for `genhtml` or CI coverage integrations.
+- `--coverage-output <path>` writes the report to a file instead of stdout.
+- Coverage is line-based: a line counts as covered if the evaluator executed
+  any expression on it. `def`/`include`/`import` declaration lines themselves
+  aren't counted (only their bodies are), and coverage of `include`d/imported
+  modules is not tracked — only the file passed to `mq-test` is measured.
+- Coverage tracking is only active when `--coverage` is passed, so normal
+  `mq-test` runs have no added overhead.
 
 ## Writing Tests
 

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -1,8 +1,9 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Shared};
+use rustc_hash::FxHashSet;
 
 /// Output format for a coverage report.
 #[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -17,14 +18,14 @@ pub enum CoverageFormat {
 
 /// Shared, thread-safe accumulator of source lines visited during a single test-file run.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct CoverageData(Arc<Mutex<HashSet<usize>>>);
+pub(crate) struct CoverageData(Arc<Mutex<FxHashSet<usize>>>);
 
 impl CoverageData {
     fn record(&self, line: usize) {
         self.0.lock().unwrap().insert(line);
     }
 
-    pub(crate) fn snapshot(&self) -> HashSet<usize> {
+    pub(crate) fn snapshot(&self) -> FxHashSet<usize> {
         self.0.lock().unwrap().clone()
     }
 }
@@ -51,11 +52,11 @@ impl DebuggerHandler for CoverageHandler {
 pub struct FileCoverage {
     pub file: PathBuf,
     executable_lines: BTreeSet<usize>,
-    visited_lines: HashSet<usize>,
+    visited_lines: FxHashSet<usize>,
 }
 
 impl FileCoverage {
-    pub(crate) fn new(file: PathBuf, executable_lines: BTreeSet<usize>, visited_lines: HashSet<usize>) -> Self {
+    pub(crate) fn new(file: PathBuf, executable_lines: BTreeSet<usize>, visited_lines: FxHashSet<usize>) -> Self {
         Self {
             file,
             executable_lines,
@@ -245,7 +246,7 @@ mod tests {
         let cov = FileCoverage::new(
             PathBuf::from("test.mq"),
             BTreeSet::from([1, 2, 3, 4]),
-            HashSet::from([1, 2]),
+            [1, 2].into_iter().collect(),
         );
         assert_eq!(cov.total_lines(), 4);
         assert_eq!(cov.covered_lines(), 2);
@@ -255,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_file_coverage_percent_no_executable_lines() {
-        let cov = FileCoverage::new(PathBuf::from("empty.mq"), BTreeSet::new(), HashSet::new());
+        let cov = FileCoverage::new(PathBuf::from("empty.mq"), BTreeSet::new(), FxHashSet::default());
         assert_eq!(cov.percent(), 100.0);
     }
 
@@ -264,7 +265,7 @@ mod tests {
         let cov = FileCoverage::new(
             PathBuf::from("test.mq"),
             BTreeSet::from([1, 2, 3, 4]),
-            HashSet::from([1, 2]),
+            [1, 2].into_iter().collect(),
         );
         let report = format_text_report(&[cov]);
         assert!(report.contains("test.mq"));
@@ -275,7 +276,11 @@ mod tests {
 
     #[test]
     fn test_format_lcov_report_structure() {
-        let cov = FileCoverage::new(PathBuf::from("test.mq"), BTreeSet::from([1, 2]), HashSet::from([1]));
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2]),
+            [1].into_iter().collect(),
+        );
         let report = format_lcov_report(&[cov]);
         assert!(report.contains("SF:test.mq\n"));
         assert!(report.contains("DA:1,1\n"));

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -11,7 +11,6 @@ pub enum CoverageFormat {
     /// Human-readable summary printed to the terminal.
     #[default]
     Text,
-    /// [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) format,
     /// suitable for `genhtml` or CI coverage integrations.
     Lcov,
     /// Self-contained HTML report.
@@ -20,7 +19,6 @@ pub enum CoverageFormat {
     Json,
     /// Markdown report, suitable for pasting into a PR description or GitHub summary.
     Markdown,
-    /// [Cobertura](https://cobertura.github.io/cobertura/) XML format,
     /// suitable for Jenkins/GitLab CI coverage integrations.
     Cobertura,
 }

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -1,0 +1,287 @@
+use std::collections::{BTreeSet, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Shared};
+
+/// Output format for a coverage report.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CoverageFormat {
+    /// Human-readable summary printed to the terminal.
+    #[default]
+    Text,
+    /// [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) format,
+    /// suitable for `genhtml` or CI coverage integrations.
+    Lcov,
+}
+
+/// Shared, thread-safe accumulator of source lines visited during a single test-file run.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct CoverageData(Arc<Mutex<HashSet<usize>>>);
+
+impl CoverageData {
+    fn record(&self, line: usize) {
+        self.0.lock().unwrap().insert(line);
+    }
+
+    pub(crate) fn snapshot(&self) -> HashSet<usize> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+/// Records the line of every top-level-module expression visited by the evaluator.
+///
+/// Lines belonging to `include`d/imported modules are intentionally ignored;
+/// only the coverage of the test file itself is tracked.
+#[derive(Debug)]
+pub(crate) struct CoverageHandler(pub(crate) CoverageData);
+
+impl DebuggerHandler for CoverageHandler {
+    fn on_step(&self, context: &DebugContext) -> DebuggerAction {
+        if context.source.name.is_none() {
+            self.0.record(context.token.range.start.line as usize);
+        }
+        // Keep single-stepping through every expression in the program.
+        DebuggerAction::StepInto
+    }
+}
+
+/// Coverage result for a single test file.
+#[derive(Debug, Clone)]
+pub struct FileCoverage {
+    pub file: PathBuf,
+    executable_lines: BTreeSet<usize>,
+    visited_lines: HashSet<usize>,
+}
+
+impl FileCoverage {
+    pub(crate) fn new(file: PathBuf, executable_lines: BTreeSet<usize>, visited_lines: HashSet<usize>) -> Self {
+        Self {
+            file,
+            executable_lines,
+            visited_lines,
+        }
+    }
+
+    /// Number of lines considered executable (the coverage denominator).
+    pub fn total_lines(&self) -> usize {
+        self.executable_lines.len()
+    }
+
+    /// Number of executable lines that were visited at least once.
+    pub fn covered_lines(&self) -> usize {
+        self.executable_lines
+            .iter()
+            .filter(|line| self.visited_lines.contains(line))
+            .count()
+    }
+
+    /// Executable lines that were never visited, in ascending order.
+    pub fn uncovered_lines(&self) -> Vec<usize> {
+        self.executable_lines
+            .iter()
+            .filter(|line| !self.visited_lines.contains(line))
+            .copied()
+            .collect()
+    }
+
+    /// Percentage of executable lines covered, in `[0.0, 100.0]`.
+    /// A file with no executable lines is reported as fully covered.
+    pub fn percent(&self) -> f64 {
+        let total = self.total_lines();
+        if total == 0 {
+            100.0
+        } else {
+            (self.covered_lines() as f64 / total as f64) * 100.0
+        }
+    }
+
+    fn is_hit(&self, line: usize) -> bool {
+        self.visited_lines.contains(&line)
+    }
+}
+
+/// CST node kinds that are excluded from the set of "executable" lines used
+/// as the coverage denominator: either purely structural wrappers/delimiters,
+/// or declaration statements (`def`, `include`, `import`) whose own line is
+/// registered without going through the evaluator's per-expression debugger
+/// hook, so it would otherwise be permanently reported as uncovered. Their
+/// bodies/children are still collected independently.
+fn is_structural(kind: &CstNodeKind) -> bool {
+    matches!(
+        kind,
+        CstNodeKind::Module
+            | CstNodeKind::Nodes
+            | CstNodeKind::Block
+            | CstNodeKind::End
+            | CstNodeKind::Pattern
+            | CstNodeKind::OrPattern
+            | CstNodeKind::Token
+            | CstNodeKind::Eof
+            | CstNodeKind::Def
+            | CstNodeKind::Include
+            | CstNodeKind::Import
+    )
+}
+
+fn collect_executable_lines(nodes: &[Shared<CstNode>], max_line: usize, lines: &mut BTreeSet<usize>) {
+    for node in nodes {
+        if !is_structural(&node.kind)
+            && let Some(token) = &node.token
+        {
+            let line = token.range.start.line as usize;
+            if line >= 1 && line <= max_line {
+                lines.insert(line);
+            }
+        }
+
+        match node.kind {
+            // Only the function body counts toward coverage — the signature
+            // (name + params) is declaration syntax, not a per-step execution.
+            CstNodeKind::Def => {
+                let (_, program) = node.split_cond_and_program();
+                collect_executable_lines(&program, max_line, lines);
+            }
+            // Single-statement declarations have no body worth descending into.
+            CstNodeKind::Include | CstNodeKind::Import => {}
+            _ => collect_executable_lines(&node.children, max_line, lines),
+        }
+    }
+}
+
+/// Determines the set of "executable" lines in `content` (bounded to the file's
+/// own line count, since `content` may have a generated test harness appended).
+pub(crate) fn executable_lines(content: &str) -> BTreeSet<usize> {
+    let max_line = content.lines().count().max(1);
+    let (nodes, _) = mq_lang::parse_recovery(content);
+    let mut lines = BTreeSet::new();
+    collect_executable_lines(&nodes, max_line, &mut lines);
+    lines
+}
+
+/// Renders a human-readable coverage summary.
+pub(crate) fn format_text_report(coverages: &[FileCoverage]) -> String {
+    let mut out = String::from("\nCoverage report:\n");
+    let (mut total_covered, mut total_lines) = (0, 0);
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        out.push_str(&format!(
+            "  {:<50} {:>6.1}% ({}/{})\n",
+            cov.file.display(),
+            cov.percent(),
+            cov.covered_lines(),
+            cov.total_lines()
+        ));
+
+        let uncovered = cov.uncovered_lines();
+        if !uncovered.is_empty() {
+            let lines = uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ");
+            out.push_str(&format!("      uncovered lines: {lines}\n"));
+        }
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    out.push_str(&format!("\n  Total: {overall:.1}% ({total_covered}/{total_lines})\n"));
+    out
+}
+
+/// Renders an lcov tracefile.
+pub(crate) fn format_lcov_report(coverages: &[FileCoverage]) -> String {
+    let mut out = String::new();
+
+    for cov in coverages {
+        out.push_str(&format!("SF:{}\n", cov.file.display()));
+        for line in &cov.executable_lines {
+            let hit = if cov.is_hit(*line) { 1 } else { 0 };
+            out.push_str(&format!("DA:{line},{hit}\n"));
+        }
+        out.push_str(&format!("LF:{}\n", cov.total_lines()));
+        out.push_str(&format!("LH:{}\n", cov.covered_lines()));
+        out.push_str("end_of_record\n");
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_executable_lines_excludes_structural_nodes() {
+        let content = "def foo():\n  1 + 1\nend\n";
+        let lines = executable_lines(content);
+        // Line 1 (`def foo():`) is a declaration, not a per-step execution.
+        // Line 2 (`1 + 1`) is the body. Line 3 (`end`) is structural.
+        assert!(!lines.contains(&1), "def line should not be executable: {lines:?}");
+        assert!(lines.contains(&2), "body line should be executable: {lines:?}");
+        assert!(!lines.contains(&3), "end line should not be executable: {lines:?}");
+    }
+
+    #[test]
+    fn test_executable_lines_bounded_by_content_line_count() {
+        // Callers must pass the original file content — not the query with the
+        // generated `run_tests(...)` harness appended — so that lines beyond
+        // the file's own line count are never reported.
+        let content = "def foo():\n  1 + 1\nend\n";
+        let lines = executable_lines(content);
+        let max_line = content.lines().count();
+        assert!(
+            lines.iter().all(|&l| l <= max_line),
+            "lines must be bounded by content's own line count: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn test_file_coverage_percent() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            HashSet::from([1, 2]),
+        );
+        assert_eq!(cov.total_lines(), 4);
+        assert_eq!(cov.covered_lines(), 2);
+        assert_eq!(cov.uncovered_lines(), vec![3, 4]);
+        assert_eq!(cov.percent(), 50.0);
+    }
+
+    #[test]
+    fn test_file_coverage_percent_no_executable_lines() {
+        let cov = FileCoverage::new(PathBuf::from("empty.mq"), BTreeSet::new(), HashSet::new());
+        assert_eq!(cov.percent(), 100.0);
+    }
+
+    #[test]
+    fn test_format_text_report_contains_summary() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            HashSet::from([1, 2]),
+        );
+        let report = format_text_report(&[cov]);
+        assert!(report.contains("test.mq"));
+        assert!(report.contains("50.0%"));
+        assert!(report.contains("uncovered lines: 3, 4"));
+        assert!(report.contains("Total: 50.0% (2/4)"));
+    }
+
+    #[test]
+    fn test_format_lcov_report_structure() {
+        let cov = FileCoverage::new(PathBuf::from("test.mq"), BTreeSet::from([1, 2]), HashSet::from([1]));
+        let report = format_lcov_report(&[cov]);
+        assert!(report.contains("SF:test.mq\n"));
+        assert!(report.contains("DA:1,1\n"));
+        assert!(report.contains("DA:2,0\n"));
+        assert!(report.contains("LF:2\n"));
+        assert!(report.contains("LH:1\n"));
+        assert!(report.contains("end_of_record\n"));
+    }
+}

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -14,6 +14,15 @@ pub enum CoverageFormat {
     /// [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) format,
     /// suitable for `genhtml` or CI coverage integrations.
     Lcov,
+    /// Self-contained HTML report.
+    Html,
+    /// Machine-readable JSON report.
+    Json,
+    /// Markdown report, suitable for pasting into a PR description or GitHub summary.
+    Markdown,
+    /// [Cobertura](https://cobertura.github.io/cobertura/) XML format,
+    /// suitable for Jenkins/GitLab CI coverage integrations.
+    Cobertura,
 }
 
 /// Shared, thread-safe accumulator of source lines visited during a single test-file run.
@@ -53,14 +62,22 @@ pub struct FileCoverage {
     pub file: PathBuf,
     executable_lines: BTreeSet<usize>,
     visited_lines: FxHashSet<usize>,
+    /// The file's own source text, used to render per-line source in the HTML report.
+    content: String,
 }
 
 impl FileCoverage {
-    pub(crate) fn new(file: PathBuf, executable_lines: BTreeSet<usize>, visited_lines: FxHashSet<usize>) -> Self {
+    pub(crate) fn new(
+        file: PathBuf,
+        executable_lines: BTreeSet<usize>,
+        visited_lines: FxHashSet<usize>,
+        content: String,
+    ) -> Self {
         Self {
             file,
             executable_lines,
             visited_lines,
+            content,
         }
     }
 
@@ -99,6 +116,47 @@ impl FileCoverage {
 
     fn is_hit(&self, line: usize) -> bool {
         self.visited_lines.contains(&line)
+    }
+
+    fn line_status(&self, line: usize) -> LineStatus {
+        if !self.executable_lines.contains(&line) {
+            LineStatus::Plain
+        } else if self.is_hit(line) {
+            LineStatus::Covered
+        } else {
+            LineStatus::Uncovered
+        }
+    }
+}
+
+/// Coverage classification of a single source line, shared by the HTML,
+/// Markdown, and JSON renderers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineStatus {
+    /// Not considered executable (declarations, structural syntax, blank lines).
+    Plain,
+    /// Executable and visited by the evaluator.
+    Covered,
+    /// Executable but never visited.
+    Uncovered,
+}
+
+impl LineStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            LineStatus::Plain => "plain",
+            LineStatus::Covered => "covered",
+            LineStatus::Uncovered => "uncovered",
+        }
+    }
+
+    /// Diff-style prefix: GitHub colors `+`/`-` lines in ` ```diff ` blocks green/red.
+    fn diff_prefix(self) -> char {
+        match self {
+            LineStatus::Plain => ' ',
+            LineStatus::Covered => '+',
+            LineStatus::Uncovered => '-',
+        }
     }
 }
 
@@ -212,9 +270,370 @@ pub(crate) fn format_lcov_report(coverages: &[FileCoverage]) -> String {
     out
 }
 
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Classifies a coverage percentage into a badge color tier.
+fn badge_class(pct: f64) -> &'static str {
+    if pct >= 80.0 {
+        "high"
+    } else if pct >= 50.0 {
+        "mid"
+    } else {
+        "low"
+    }
+}
+
+const HTML_STYLE: &str = r#"
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --row-alt: #f9fafb;
+  --covered-bg: #d9f7e3;
+  --covered-fg: #1a7f37;
+  --uncovered-bg: #ffe3e3;
+  --uncovered-fg: #c53030;
+  --badge-high-bg: #d9f7e3;
+  --badge-high-fg: #1a7f37;
+  --badge-mid-bg: #fff3cd;
+  --badge-mid-fg: #8a6100;
+  --badge-low-bg: #ffe3e3;
+  --badge-low-fg: #c53030;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #16181d;
+    --fg: #e6e6e6;
+    --muted: #9aa0a6;
+    --border: #30333a;
+    --row-alt: #1d2026;
+    --covered-bg: #123822;
+    --covered-fg: #4ada91;
+    --uncovered-bg: #3a1618;
+    --uncovered-fg: #ff8080;
+    --badge-high-bg: #123822;
+    --badge-high-fg: #4ada91;
+    --badge-mid-bg: #3a2f00;
+    --badge-mid-fg: #ffd766;
+    --badge-low-bg: #3a1618;
+    --badge-low-fg: #ff8080;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 2rem auto;
+  max-width: 960px;
+  color: var(--fg);
+  background: var(--bg);
+}
+h1 { font-size: 1.4rem; }
+table { border-collapse: collapse; width: 100%; }
+th, td { text-align: left; padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--border); }
+th { background: var(--row-alt); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--muted); }
+tbody tr:hover { background: var(--row-alt); }
+td.uncovered { color: var(--uncovered-fg); font-family: ui-monospace, monospace; font-size: 0.85rem; }
+tfoot td { font-weight: 700; border-top: 2px solid var(--border); border-bottom: none; }
+a { color: inherit; }
+.badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-weight: 600; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+.badge.high { background: var(--badge-high-bg); color: var(--badge-high-fg); }
+.badge.mid { background: var(--badge-mid-bg); color: var(--badge-mid-fg); }
+.badge.low { background: var(--badge-low-bg); color: var(--badge-low-fg); }
+details { margin-top: 1rem; border: 1px solid var(--border); border-radius: 8px; padding: 0.6rem 1rem; }
+summary { cursor: pointer; font-weight: 600; }
+summary:hover { color: var(--muted); }
+table.source { margin-top: 0.6rem; border: none; font-family: ui-monospace, monospace; font-size: 0.85rem; }
+table.source td { padding: 0.1rem 0.6rem; border-bottom: none; white-space: pre; }
+table.source td.lineno { color: var(--muted); text-align: right; user-select: none; width: 1%; }
+table.source tr.covered td.code { background: var(--covered-bg); color: var(--covered-fg); }
+table.source tr.uncovered td.code { background: var(--uncovered-bg); color: var(--uncovered-fg); }
+"#;
+
+/// Renders the per-line source table for a single file, with executable lines
+/// highlighted green (covered) or red (uncovered).
+fn format_html_source(cov: &FileCoverage, anchor: &str) -> String {
+    let mut lines_html = String::new();
+
+    for (i, line) in cov.content.lines().enumerate() {
+        let line_no = i + 1;
+        let status = cov.line_status(line_no);
+
+        lines_html.push_str(&format!(
+            "          <tr class=\"{class}\"><td class=\"lineno\">{line_no}</td><td class=\"code\">{code}</td></tr>\n",
+            class = status.as_str(),
+            code = html_escape(line),
+        ));
+    }
+
+    format!(
+        "      <details id=\"{anchor}\">\n\
+        \x20       <summary>{file} — {pct:.1}% ({covered}/{total})</summary>\n\
+        \x20       <table class=\"source\">\n\
+        \x20         <tbody>\n\
+        {lines_html}\
+        \x20         </tbody>\n\
+        \x20       </table>\n\
+        \x20     </details>\n",
+        anchor = anchor,
+        file = html_escape(&cov.file.display().to_string()),
+        pct = cov.percent(),
+        covered = cov.covered_lines(),
+        total = cov.total_lines(),
+    )
+}
+
+/// Renders a self-contained HTML coverage report: a summary table plus a
+/// collapsible, green/red line-highlighted source view per file.
+pub(crate) fn format_html_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let mut rows = String::new();
+    let mut sources = String::new();
+
+    for (i, cov) in coverages.iter().enumerate() {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let uncovered = cov.uncovered_lines();
+        let uncovered_text = if uncovered.is_empty() {
+            "-".to_string()
+        } else {
+            uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+        };
+
+        let anchor = format!("file-{i}");
+
+        rows.push_str(&format!(
+            "      <tr>\n\
+            \x20       <td><a href=\"#{anchor}\">{file}</a></td>\n\
+            \x20       <td><span class=\"badge {badge}\">{pct:.1}%</span></td>\n\
+            \x20       <td>{covered}/{total}</td>\n\
+            \x20       <td class=\"uncovered\">{uncovered_text}</td>\n\
+            \x20     </tr>\n",
+            file = html_escape(&cov.file.display().to_string()),
+            badge = badge_class(cov.percent()),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+
+        sources.push_str(&format_html_source(cov, &anchor));
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    format!(
+        "<!doctype html>\n\
+        <html lang=\"en\">\n\
+        <head>\n\
+        \x20 <meta charset=\"utf-8\">\n\
+        \x20 <title>mq-test coverage report</title>\n\
+        \x20 <style>{HTML_STYLE}</style>\n\
+        </head>\n\
+        <body>\n\
+        \x20 <h1>Coverage report</h1>\n\
+        \x20 <table>\n\
+        \x20   <thead>\n\
+        \x20     <tr><th>File</th><th>Coverage</th><th>Lines</th><th>Uncovered lines</th></tr>\n\
+        \x20   </thead>\n\
+        \x20   <tbody>\n\
+        {rows}\
+        \x20   </tbody>\n\
+        \x20   <tfoot>\n\
+        \x20     <tr><td>Total</td><td><span class=\"badge {overall_badge}\">{overall:.1}%</span></td><td>{total_covered}/{total_lines}</td><td></td></tr>\n\
+        \x20   </tfoot>\n\
+        \x20 </table>\n\
+        {sources}\
+        </body>\n\
+        </html>\n",
+        overall_badge = badge_class(overall),
+    )
+}
+
+/// Renders a Markdown coverage report: a summary table followed by each
+/// file's source in a ` ```diff ` block, so GitHub and other diff-aware
+/// Markdown renderers color covered/uncovered lines green/red.
+pub(crate) fn format_markdown_report(coverages: &[FileCoverage]) -> String {
+    let mut out =
+        String::from("# Coverage report\n\n| File | Coverage | Lines | Uncovered lines |\n| --- | --- | --- | --- |\n");
+    let (mut total_covered, mut total_lines) = (0, 0);
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let uncovered = cov.uncovered_lines();
+        let uncovered_text = if uncovered.is_empty() {
+            "-".to_string()
+        } else {
+            uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+        };
+
+        out.push_str(&format!(
+            "| `{file}` | {pct:.1}% | {covered}/{total} | {uncovered_text} |\n",
+            file = cov.file.display(),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+    out.push_str(&format!("\n**Total: {overall:.1}% ({total_covered}/{total_lines})**\n"));
+
+    for cov in coverages {
+        out.push_str(&format!(
+            "\n## {file} — {pct:.1}% ({covered}/{total})\n\n```diff\n",
+            file = cov.file.display(),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+
+        for (i, line) in cov.content.lines().enumerate() {
+            out.push(cov.line_status(i + 1).diff_prefix());
+            out.push_str(line);
+            out.push('\n');
+        }
+
+        out.push_str("```\n");
+    }
+
+    out
+}
+
+/// Renders a machine-readable JSON coverage report.
+pub(crate) fn format_json_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let files: Vec<serde_json::Value> = coverages
+        .iter()
+        .map(|cov| {
+            total_covered += cov.covered_lines();
+            total_lines += cov.total_lines();
+
+            let lines: Vec<serde_json::Value> = cov
+                .content
+                .lines()
+                .enumerate()
+                .map(|(i, line)| {
+                    let line_no = i + 1;
+                    serde_json::json!({
+                        "line": line_no,
+                        "content": line,
+                        "status": cov.line_status(line_no).as_str(),
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "file": cov.file.display().to_string(),
+                "totalLines": cov.total_lines(),
+                "coveredLines": cov.covered_lines(),
+                "percent": cov.percent(),
+                "uncoveredLines": cov.uncovered_lines(),
+                "lines": lines,
+            })
+        })
+        .collect();
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    let report = serde_json::json!({
+        "files": files,
+        "total": {
+            "totalLines": total_lines,
+            "coveredLines": total_covered,
+            "percent": overall,
+        },
+    });
+
+    serde_json::to_string_pretty(&report).expect("coverage report is always serializable")
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Renders a [Cobertura](https://cobertura.github.io/cobertura/) XML coverage report.
+///
+/// Since `mq` has no notion of packages/classes, each file is reported as a
+/// single class within a single package.
+pub(crate) fn format_cobertura_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let mut packages = String::new();
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let file = xml_escape(&cov.file.display().to_string());
+        let mut lines = String::new();
+        for line in &cov.executable_lines {
+            let hits = if cov.is_hit(*line) { 1 } else { 0 };
+            lines.push_str(&format!("          <line number=\"{line}\" hits=\"{hits}\"/>\n"));
+        }
+
+        packages.push_str(&format!(
+            "  <package name=\"{file}\" line-rate=\"{rate:.4}\" branch-rate=\"1.0\">\n\
+            \x20   <classes>\n\
+            \x20     <class name=\"{file}\" filename=\"{file}\" line-rate=\"{rate:.4}\" branch-rate=\"1.0\">\n\
+            \x20       <lines>\n\
+            {lines}\
+            \x20       </lines>\n\
+            \x20     </class>\n\
+            \x20   </classes>\n\
+            \x20 </package>\n",
+            rate = if cov.total_lines() == 0 {
+                1.0
+            } else {
+                cov.covered_lines() as f64 / cov.total_lines() as f64
+            },
+        ));
+    }
+
+    let overall_rate = if total_lines == 0 {
+        1.0
+    } else {
+        total_covered as f64 / total_lines as f64
+    };
+
+    format!(
+        "<?xml version=\"1.0\"?>\n\
+        <coverage line-rate=\"{overall_rate:.4}\" branch-rate=\"1.0\" lines-covered=\"{total_covered}\" \
+        lines-valid=\"{total_lines}\" version=\"mq-test\">\n\
+        \x20 <packages>\n\
+        {packages}\
+        \x20 </packages>\n\
+        </coverage>\n"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_executable_lines_excludes_structural_nodes() {
@@ -247,6 +666,7 @@ mod tests {
             PathBuf::from("test.mq"),
             BTreeSet::from([1, 2, 3, 4]),
             [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
         );
         assert_eq!(cov.total_lines(), 4);
         assert_eq!(cov.covered_lines(), 2);
@@ -256,7 +676,12 @@ mod tests {
 
     #[test]
     fn test_file_coverage_percent_no_executable_lines() {
-        let cov = FileCoverage::new(PathBuf::from("empty.mq"), BTreeSet::new(), FxHashSet::default());
+        let cov = FileCoverage::new(
+            PathBuf::from("empty.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
         assert_eq!(cov.percent(), 100.0);
     }
 
@@ -266,6 +691,7 @@ mod tests {
             PathBuf::from("test.mq"),
             BTreeSet::from([1, 2, 3, 4]),
             [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
         );
         let report = format_text_report(&[cov]);
         assert!(report.contains("test.mq"));
@@ -280,6 +706,7 @@ mod tests {
             PathBuf::from("test.mq"),
             BTreeSet::from([1, 2]),
             [1].into_iter().collect(),
+            "a\nb\n".to_string(),
         );
         let report = format_lcov_report(&[cov]);
         assert!(report.contains("SF:test.mq\n"));
@@ -288,5 +715,213 @@ mod tests {
         assert!(report.contains("LF:2\n"));
         assert!(report.contains("LH:1\n"));
         assert!(report.contains("end_of_record\n"));
+    }
+
+    #[test]
+    fn test_format_html_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+        assert!(report.starts_with("<!doctype html>"));
+        assert!(report.contains("test.mq"));
+        assert!(report.contains("50.0%"));
+        assert!(report.contains("2/4"));
+        assert!(report.contains("3, 4"));
+        assert!(report.contains("Total"));
+    }
+
+    #[test]
+    fn test_format_html_report_escapes_file_path() {
+        let cov = FileCoverage::new(
+            PathBuf::from("<a & b>.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
+        let report = format_html_report(&[cov]);
+        assert!(report.contains("&lt;a &amp; b&gt;.mq"));
+        assert!(!report.contains("<a & b>.mq"));
+    }
+
+    #[test]
+    fn test_format_html_report_highlights_covered_and_uncovered_lines() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+
+        // Line 1 and 3 were visited -> covered (green); line 2 was not -> uncovered (red).
+        assert!(
+            report
+                .contains("<tr class=\"covered\"><td class=\"lineno\">1</td><td class=\"code\">covered one</td></tr>")
+        );
+        assert!(
+            report
+                .contains("<tr class=\"uncovered\"><td class=\"lineno\">2</td><td class=\"code\">uncovered</td></tr>")
+        );
+        assert!(
+            report
+                .contains("<tr class=\"covered\"><td class=\"lineno\">3</td><td class=\"code\">covered two</td></tr>")
+        );
+        assert!(report.contains("tr.covered td.code { background: var(--covered-bg)"));
+        assert!(report.contains("tr.uncovered td.code { background: var(--uncovered-bg)"));
+        assert!(report.contains("prefers-color-scheme: dark"));
+        assert!(report.contains("<span class=\"badge mid\">66.7%</span>"));
+    }
+
+    #[test]
+    fn test_format_html_report_marks_non_executable_lines_plain() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([2]),
+            [2].into_iter().collect(),
+            "def foo():\n  1 + 1\nend\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+
+        assert!(
+            report.contains("<tr class=\"plain\"><td class=\"lineno\">1</td><td class=\"code\">def foo():</td></tr>")
+        );
+        assert!(report.contains("<tr class=\"covered\"><td class=\"lineno\">2</td>"));
+        assert!(report.contains("<tr class=\"plain\"><td class=\"lineno\">3</td><td class=\"code\">end</td></tr>"));
+    }
+
+    #[rstest]
+    #[case(100.0, "high")]
+    #[case(80.0, "high")]
+    #[case(79.9, "mid")]
+    #[case(50.0, "mid")]
+    #[case(49.9, "low")]
+    #[case(0.0, "low")]
+    fn test_badge_class(#[case] pct: f64, #[case] expected: &str) {
+        assert_eq!(badge_class(pct), expected);
+    }
+
+    #[test]
+    fn test_format_markdown_report_summary_and_totals() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+        assert!(report.starts_with("# Coverage report"));
+        assert!(report.contains("| `test.mq` | 50.0% | 2/4 | 3, 4 |"));
+        assert!(report.contains("**Total: 50.0% (2/4)**"));
+    }
+
+    #[test]
+    fn test_format_markdown_report_diff_highlights_covered_and_uncovered_lines() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+
+        assert!(report.contains("```diff\n"));
+        assert!(report.contains("+covered one\n"));
+        assert!(report.contains("-uncovered\n"));
+        assert!(report.contains("+covered two\n"));
+    }
+
+    #[test]
+    fn test_format_markdown_report_marks_non_executable_lines_plain() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([2]),
+            [2].into_iter().collect(),
+            "def foo():\n  1 + 1\nend\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+
+        assert!(report.contains(" def foo():\n"));
+        assert!(report.contains("+  1 + 1\n"));
+        assert!(report.contains(" end\n"));
+    }
+
+    #[test]
+    fn test_format_json_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_json_report(&[cov]);
+        let parsed: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+        assert_eq!(parsed["files"][0]["file"], "test.mq");
+        assert_eq!(parsed["files"][0]["totalLines"], 4);
+        assert_eq!(parsed["files"][0]["coveredLines"], 2);
+        assert_eq!(parsed["files"][0]["percent"], 50.0);
+        assert_eq!(parsed["files"][0]["uncoveredLines"], serde_json::json!([3, 4]));
+        assert_eq!(parsed["total"]["totalLines"], 4);
+        assert_eq!(parsed["total"]["coveredLines"], 2);
+        assert_eq!(parsed["total"]["percent"], 50.0);
+    }
+
+    #[test]
+    fn test_format_json_report_includes_per_line_status() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_json_report(&[cov]);
+        let parsed: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+        let lines = &parsed["files"][0]["lines"];
+        assert_eq!(
+            lines[0],
+            serde_json::json!({"line": 1, "content": "covered one", "status": "covered"})
+        );
+        assert_eq!(
+            lines[1],
+            serde_json::json!({"line": 2, "content": "uncovered", "status": "uncovered"})
+        );
+        assert_eq!(
+            lines[2],
+            serde_json::json!({"line": 3, "content": "covered two", "status": "covered"})
+        );
+    }
+
+    #[test]
+    fn test_format_cobertura_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2]),
+            [1].into_iter().collect(),
+            "a\nb\n".to_string(),
+        );
+        let report = format_cobertura_report(&[cov]);
+        assert!(report.starts_with("<?xml version=\"1.0\"?>"));
+        assert!(
+            report.contains("<coverage line-rate=\"0.5000\" branch-rate=\"1.0\" lines-covered=\"1\" lines-valid=\"2\"")
+        );
+        assert!(report.contains("filename=\"test.mq\""));
+        assert!(report.contains("<line number=\"1\" hits=\"1\"/>"));
+        assert!(report.contains("<line number=\"2\" hits=\"0\"/>"));
+    }
+
+    #[test]
+    fn test_format_cobertura_report_escapes_file_path() {
+        let cov = FileCoverage::new(
+            PathBuf::from("<a & b>.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
+        let report = format_cobertura_report(&[cov]);
+        assert!(report.contains("&lt;a &amp; b&gt;.mq"));
+        assert!(!report.contains("<a & b>.mq"));
     }
 }

--- a/crates/mq-test/src/lib.rs
+++ b/crates/mq-test/src/lib.rs
@@ -1,2 +1,5 @@
+mod coverage;
 mod runner;
+
+pub use coverage::{CoverageFormat, FileCoverage};
 pub use runner::TestRunner;

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -19,7 +19,13 @@ use std::{path::PathBuf, process::ExitCode};
     ## Run with a line-coverage report:\n\
     mq-test --coverage\n\n\
     ## Write an lcov tracefile for CI:\n\
-    mq-test --coverage --coverage-format lcov --coverage-output lcov.info")]
+    mq-test --coverage --coverage-format lcov --coverage-output lcov.info\n\n\
+    ## Write an HTML coverage report (green/red per-line highlighting):\n\
+    mq-test --coverage --coverage-format html --coverage-output coverage.html\n\n\
+    ## Write a Markdown coverage report:\n\
+    mq-test --coverage --coverage-format markdown --coverage-output coverage.md\n\n\
+    ## Write an HTML coverage report and open it in the browser:\n\
+    mq-test --coverage --coverage-format html --coverage-output coverage.html --open")]
 struct Cli {
     /// Path(s) to mq test files.
     /// Defaults to **/*.mq in the current directory when omitted.
@@ -37,6 +43,11 @@ struct Cli {
     /// Write the coverage report to a file instead of stdout.
     #[arg(long, requires = "coverage")]
     coverage_output: Option<PathBuf>,
+
+    /// Open the written coverage report in the OS default application.
+    /// Requires `--coverage-output`.
+    #[arg(long, requires_all = ["coverage", "coverage_output"])]
+    open: bool,
 }
 
 fn main() -> ExitCode {
@@ -46,6 +57,7 @@ fn main() -> ExitCode {
         .with_coverage(cli.coverage)
         .with_coverage_format(cli.coverage_format)
         .with_coverage_output(cli.coverage_output)
+        .with_open(cli.open)
         .run()
     {
         eprintln!("{e:?}");

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -1,6 +1,8 @@
+mod coverage;
 mod runner;
 
 use clap::Parser;
+use coverage::CoverageFormat;
 use std::{path::PathBuf, process::ExitCode};
 
 #[derive(Parser, Debug)]
@@ -13,17 +15,39 @@ use std::{path::PathBuf, process::ExitCode};
     ## Run tests across multiple files:\n\
     mq-test tests.mq other_tests.mq\n\n\
     ## Discover and run all *.mq files in the current directory:\n\
-    mq-test")]
+    mq-test\n\n\
+    ## Run with a line-coverage report:\n\
+    mq-test --coverage\n\n\
+    ## Write an lcov tracefile for CI:\n\
+    mq-test --coverage --coverage-format lcov --coverage-output lcov.info")]
 struct Cli {
     /// Path(s) to mq test files.
     /// Defaults to **/*.mq in the current directory when omitted.
     files: Vec<PathBuf>,
+
+    /// Collect and report line coverage for the executed test files.
+    /// Coverage of `include`d/imported modules is not tracked.
+    #[arg(long)]
+    coverage: bool,
+
+    /// Report format used when `--coverage` is enabled.
+    #[arg(long, value_enum, default_value = "text", requires = "coverage")]
+    coverage_format: CoverageFormat,
+
+    /// Write the coverage report to a file instead of stdout.
+    #[arg(long, requires = "coverage")]
+    coverage_output: Option<PathBuf>,
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    if let Err(e) = runner::TestRunner::new(cli.files).run() {
+    if let Err(e) = runner::TestRunner::new(cli.files)
+        .with_coverage(cli.coverage)
+        .with_coverage_format(cli.coverage_format)
+        .with_coverage_output(cli.coverage_output)
+        .run()
+    {
         eprintln!("{e:?}");
         ExitCode::FAILURE
     } else {

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -4,6 +4,8 @@ use mq_lang::{CstNodeKind, CstTrivia};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::coverage::{self, CoverageData, CoverageFormat, CoverageHandler, FileCoverage};
+
 /// Parsed test annotation from a leading comment.
 #[derive(Debug, PartialEq)]
 enum TestAnnotation {
@@ -29,13 +31,41 @@ enum DiscoveredTest {
 /// The runner auto-generates the `run_tests(...)` call from discovered tests.
 pub struct TestRunner {
     files: Vec<PathBuf>,
+    coverage: bool,
+    coverage_format: CoverageFormat,
+    coverage_output: Option<PathBuf>,
 }
 
 impl TestRunner {
     /// Creates a `TestRunner` for the given files.
     /// If `files` is empty, globs `**/*.mq` in the current directory.
     pub fn new(files: Vec<PathBuf>) -> Self {
-        Self { files }
+        Self {
+            files,
+            coverage: false,
+            coverage_format: CoverageFormat::default(),
+            coverage_output: None,
+        }
+    }
+
+    /// Enables line-coverage tracking. Coverage of `include`d/imported modules
+    /// is not tracked — only the test file being executed.
+    pub fn with_coverage(mut self, coverage: bool) -> Self {
+        self.coverage = coverage;
+        self
+    }
+
+    /// Sets the report format used when coverage is enabled.
+    pub fn with_coverage_format(mut self, format: CoverageFormat) -> Self {
+        self.coverage_format = format;
+        self
+    }
+
+    /// Sets an output file for the coverage report. When `None`, the report
+    /// is printed to stdout.
+    pub fn with_coverage_output(mut self, output: Option<PathBuf>) -> Self {
+        self.coverage_output = output;
+        self
     }
 
     /// Discovers and executes all test functions.
@@ -46,8 +76,9 @@ impl TestRunner {
                 .collect::<Result<Vec<_>, _>>()
                 .into_diagnostic()?
         } else {
-            self.files
+            self.files.clone()
         };
+        let mut file_coverages = Vec::new();
 
         for file in &test_files {
             let content = fs::read_to_string(file).into_diagnostic()?;
@@ -68,8 +99,40 @@ impl TestRunner {
                 engine.set_search_paths(vec![parent.to_path_buf()]);
             }
 
+            let coverage_data = if self.coverage {
+                let data = CoverageData::default();
+                engine.set_debugger_handler(Box::new(CoverageHandler(data.clone())));
+                let debugger = engine.debugger();
+                debugger.write().unwrap().activate();
+                debugger
+                    .write()
+                    .unwrap()
+                    .set_command(mq_lang::DebuggerCommand::StepInto);
+                Some(data)
+            } else {
+                None
+            };
+
             let input = mq_lang::null_input();
             engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
+
+            if let Some(data) = coverage_data {
+                let visited = data.snapshot();
+                let executable = coverage::executable_lines(&content);
+                file_coverages.push(FileCoverage::new(file.clone(), executable, visited));
+            }
+        }
+
+        if self.coverage {
+            let report = match self.coverage_format {
+                CoverageFormat::Text => coverage::format_text_report(&file_coverages),
+                CoverageFormat::Lcov => coverage::format_lcov_report(&file_coverages),
+            };
+
+            match &self.coverage_output {
+                Some(path) => fs::write(path, report).into_diagnostic()?,
+                None => print!("{report}"),
+            }
         }
 
         Ok(())

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -34,6 +34,7 @@ pub struct TestRunner {
     coverage: bool,
     coverage_format: CoverageFormat,
     coverage_output: Option<PathBuf>,
+    open: bool,
 }
 
 impl TestRunner {
@@ -45,6 +46,7 @@ impl TestRunner {
             coverage: false,
             coverage_format: CoverageFormat::default(),
             coverage_output: None,
+            open: false,
         }
     }
 
@@ -65,6 +67,12 @@ impl TestRunner {
     /// is printed to stdout.
     pub fn with_coverage_output(mut self, output: Option<PathBuf>) -> Self {
         self.coverage_output = output;
+        self
+    }
+
+    /// Opens the written coverage report in the OS default application after `run()`.
+    pub fn with_open(mut self, open: bool) -> Self {
+        self.open = open;
         self
     }
 
@@ -119,7 +127,7 @@ impl TestRunner {
             if let Some(data) = coverage_data {
                 let visited = data.snapshot();
                 let executable = coverage::executable_lines(&content);
-                file_coverages.push(FileCoverage::new(file.clone(), executable, visited));
+                file_coverages.push(FileCoverage::new(file.clone(), executable, visited, content));
             }
         }
 
@@ -127,10 +135,19 @@ impl TestRunner {
             let report = match self.coverage_format {
                 CoverageFormat::Text => coverage::format_text_report(&file_coverages),
                 CoverageFormat::Lcov => coverage::format_lcov_report(&file_coverages),
+                CoverageFormat::Html => coverage::format_html_report(&file_coverages),
+                CoverageFormat::Markdown => coverage::format_markdown_report(&file_coverages),
+                CoverageFormat::Json => coverage::format_json_report(&file_coverages),
+                CoverageFormat::Cobertura => coverage::format_cobertura_report(&file_coverages),
             };
 
             match &self.coverage_output {
-                Some(path) => fs::write(path, report).into_diagnostic()?,
+                Some(path) => {
+                    fs::write(path, report).into_diagnostic()?;
+                    if self.open {
+                        open_in_default_app(path)?;
+                    }
+                }
                 None => print!("{report}"),
             }
         }
@@ -262,6 +279,31 @@ impl TestRunner {
 
         format!("{content}\n| run_tests(flatten([\n{cases}\n]))")
     }
+}
+
+/// Builds the command that opens `path` in the OS default application for
+/// `target_os` (as in `std::env::consts::OS`): `open` on macOS, `start` on
+/// Windows, `xdg-open` elsewhere.
+fn build_open_command(path: &Path, target_os: &str) -> std::process::Command {
+    let mut cmd = if target_os == "macos" {
+        std::process::Command::new("open")
+    } else if target_os == "windows" {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/C", "start", ""]);
+        cmd
+    } else {
+        std::process::Command::new("xdg-open")
+    };
+    cmd.arg(path);
+    cmd
+}
+
+/// Launches `path` in the OS default application.
+fn open_in_default_app(path: &Path) -> miette::Result<()> {
+    build_open_command(path, std::env::consts::OS)
+        .status()
+        .into_diagnostic()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -541,5 +583,26 @@ mod tests {
         let tests = vec![DiscoveredTest::Simple("test_foo".to_string())];
         let query = TestRunner::build_test_query(content, &tests);
         assert!(query.starts_with(content));
+    }
+
+    #[rstest]
+    #[case("macos", "open", Vec::<&str>::new())]
+    #[case("windows", "cmd", vec!["/C", "start", ""])]
+    #[case("linux", "xdg-open", Vec::<&str>::new())]
+    #[case("freebsd", "xdg-open", Vec::<&str>::new())]
+    fn test_build_open_command(
+        #[case] target_os: &str,
+        #[case] expected_program: &str,
+        #[case] expected_args: Vec<&str>,
+    ) {
+        let path = PathBuf::from("coverage.html");
+        let cmd = build_open_command(&path, target_os);
+
+        assert_eq!(cmd.get_program(), expected_program);
+
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        let mut expected: Vec<String> = expected_args.into_iter().map(String::from).collect();
+        expected.push("coverage.html".to_string());
+        assert_eq!(args, expected);
     }
 }


### PR DESCRIPTION
## Summary

Adds line coverage tracking to mq-test via mq-lang's existing debugger hooks, gated behind the --coverage flag so normal test runs pay no overhead. Supports text and lcov (--coverage-format) report output, optionally written to a file with --coverage-output.

Also moves the debugger's is_active() check ahead of DebugContext construction in mq-lang's eval_expr, so consumers that compile in the debugger feature (like mq-test) only pay its cost when the debugger is actually activated at runtime.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [x] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
