### PR TITLE
✨ feat(mq-test): add --coverage flag for line coverage reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,6 +2752,8 @@ dependencies = [
  "miette",
  "mq-lang",
  "rstest",
+ "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -353,6 +353,17 @@ impl<T: ModuleResolver> Engine<T> {
         })
     }
 
+    /// Resolves `module_name` to the path its resolver loaded it from.
+    pub fn get_module_path(&self, module_name: &str) -> Result<String, Box<error::Error>> {
+        self.evaluator.module_loader.get_module_path(module_name).map_err(|e| {
+            Box::new(error::Error::from_error(
+                "",
+                e.into(),
+                self.evaluator.module_loader.clone(),
+            ))
+        })
+    }
+
     pub const fn version() -> &'static str {
         env!("CARGO_PKG_VERSION")
     }

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1015,7 +1015,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         env: &Shared<SharedCell<Env>>,
     ) -> EvalResult {
         #[cfg(feature = "debugger")]
-        {
+        if self.debugger.read().unwrap().is_active() {
             let token = &get_token(Shared::clone(&self.token_arena), node.token_id);
             let call_stack = self.debugger.read().unwrap().current_call_stack();
             let debug_context = DebugContext {

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -14,7 +14,9 @@ version = "0.6.4"
 clap = {workspace = true, features = ["derive"]}
 glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
-mq-lang = {workspace = true, features = ["cst", "file-io"]}
+mq-lang = {workspace = true, features = ["cst", "debugger", "file-io"]}
+rustc-hash = {workspace = true}
+serde_json = {workspace = true}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -54,17 +54,24 @@ mq-test --coverage --coverage-format cobertura --coverage-output cobertura.xml
 
 ## Coverage
 
-Pass `--coverage` to report which lines of each executed test file were run
-by the evaluator:
+Pass `--coverage` to report how much of the code your tests `include`/`import`
+was actually exercised while the tests ran — i.e. is the library code under
+test covered, not just the test file itself:
 
 ```
 Coverage report:
-  tests.mq                                              66.7% (2/3)
+  lib/string_utils.mq                                   66.7% (2/3)
       uncovered lines: 9
 
   Total: 66.7% (2/3)
 ```
 
+- Only `include`d/imported modules are measured. The test file's own lines
+  (test bodies, assertions, `include`/`import` statements) are not counted —
+  they're the thing doing the exercising, not the thing being measured. A
+  test file with no `include`/`import` produces no coverage output.
+- A module is reported once with combined coverage across every test file
+  that imports it, even if several test files share it.
 - `--coverage-format <text|lcov|html|markdown|json|cobertura>` selects the report format (default: `text`).
   - `lcov` produces an [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php)
     suitable for `genhtml` or CI coverage integrations.
@@ -85,9 +92,8 @@ Coverage report:
 - `--open` opens the written report in the OS default application (`open` on
   macOS, `xdg-open` on Linux, `start` on Windows). Requires `--coverage-output`.
 - Coverage is line-based: a line counts as covered if the evaluator executed
-  any expression on it. `def`/`include`/`import` declaration lines themselves
-  aren't counted (only their bodies are), and coverage of `include`d/imported
-  modules is not tracked — only the file passed to `mq-test` is measured.
+  any expression on it while running the tests. `def`/`include`/`import`
+  declaration lines themselves aren't counted (only their bodies are).
 - Coverage tracking is only active when `--coverage` is passed, so normal
   `mq-test` runs have no added overhead.
 

--- a/crates/mq-test/README.md
+++ b/crates/mq-test/README.md
@@ -29,7 +29,67 @@ mq-test tests.mq
 
 # Run multiple test files
 mq-test tests.mq other_tests.mq
+
+# Run with a line-coverage report
+mq-test --coverage
+
+# Write an lcov tracefile for CI (e.g. codecov, genhtml)
+mq-test --coverage --coverage-format lcov --coverage-output lcov.info
+
+# Write a self-contained HTML report with per-line source highlighting
+mq-test --coverage --coverage-format html --coverage-output coverage.html
+
+# Write an HTML report and open it in the browser
+mq-test --coverage --coverage-format html --coverage-output coverage.html --open
+
+# Write a Markdown report (e.g. to paste into a PR description)
+mq-test --coverage --coverage-format markdown --coverage-output coverage.md
+
+# Write a JSON report
+mq-test --coverage --coverage-format json --coverage-output coverage.json
+
+# Write a Cobertura XML report (e.g. Jenkins, GitLab CI)
+mq-test --coverage --coverage-format cobertura --coverage-output cobertura.xml
 ```
+
+## Coverage
+
+Pass `--coverage` to report which lines of each executed test file were run
+by the evaluator:
+
+```
+Coverage report:
+  tests.mq                                              66.7% (2/3)
+      uncovered lines: 9
+
+  Total: 66.7% (2/3)
+```
+
+- `--coverage-format <text|lcov|html|markdown|json|cobertura>` selects the report format (default: `text`).
+  - `lcov` produces an [lcov tracefile](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php)
+    suitable for `genhtml` or CI coverage integrations.
+  - `html` produces a self-contained HTML report: a summary table plus a
+    collapsible, line-by-line source view per file, with covered lines
+    highlighted green and uncovered lines red. Follows the viewer's
+    light/dark theme.
+  - `markdown` produces the same summary table plus a per-file source listing
+    in a ` ```diff ` block, so GitHub (and other diff-aware Markdown
+    renderers) colors covered/uncovered lines green/red — handy for pasting
+    into a PR description or CI job summary.
+  - `json` produces a machine-readable report with per-file and total stats,
+    plus a `lines` array per file giving each line's content and
+    `covered`/`uncovered`/`plain` status.
+  - `cobertura` produces a [Cobertura](https://cobertura.github.io/cobertura/) XML report
+    suitable for Jenkins/GitLab CI coverage integrations.
+- `--coverage-output <path>` writes the report to a file instead of stdout.
+- `--open` opens the written report in the OS default application (`open` on
+  macOS, `xdg-open` on Linux, `start` on Windows). Requires `--coverage-output`.
+- Coverage is line-based: a line counts as covered if the evaluator executed
+  any expression on it. `def`/`include`/`import` declaration lines themselves
+  aren't counted (only their bodies are), and coverage of `include`d/imported
+  modules is not tracked — only the file passed to `mq-test` is measured.
+- Coverage tracking is only active when `--coverage` is passed, so normal
+  `mq-test` runs have no added overhead.
 
 ## Writing Tests
 

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Module, STANDARD_MODULES, Shared};
+use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Module, Shared};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Output format for a coverage report.
@@ -49,13 +49,17 @@ impl CoverageData {
     }
 }
 
-/// Records lines visited inside `include`d/imported modules; the test file's own lines and
-/// the `builtin`/standard-library modules (always loaded, never the code under test) are ignored.
+/// The `test` module (`assert_eq` and friends) — boilerplate every test file
+/// includes for the assertion framework itself, never the code under test.
+const TEST_ASSERTION_MODULE: &str = "test";
+
+/// Records lines visited inside `include`d/imported modules; the test file's own lines,
+/// the implicitly-loaded `builtin` module, and the `test` assertion module are ignored.
 #[derive(Debug)]
 pub(crate) struct CoverageHandler(pub(crate) CoverageData);
 
 fn is_trackable_module(module_name: &str) -> bool {
-    module_name != Module::BUILTIN_MODULE && !STANDARD_MODULES.contains_key(module_name)
+    module_name != Module::BUILTIN_MODULE && module_name != TEST_ASSERTION_MODULE
 }
 
 impl DebuggerHandler for CoverageHandler {
@@ -656,10 +660,10 @@ mod tests {
     #[rstest]
     #[case("lib", true)]
     #[case("my_module", true)]
+    #[case("csv", true)] // a std module can itself be the code under test (e.g. csv_test.mq)
+    #[case("json", true)]
     #[case("builtin", false)]
     #[case("test", false)]
-    #[case("csv", false)]
-    #[case("json", false)]
     fn test_is_trackable_module(#[case] module_name: &str, #[case] expected: bool) {
         assert_eq!(is_trackable_module(module_name), expected);
     }

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Shared};
-use rustc_hash::FxHashSet;
+use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Module, STANDARD_MODULES, Shared};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Output format for a coverage report.
 #[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -23,31 +23,51 @@ pub enum CoverageFormat {
     Cobertura,
 }
 
-/// Shared, thread-safe accumulator of source lines visited during a single test-file run.
+/// Source and visited lines for one `include`d/imported module.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct CoverageData(Arc<Mutex<FxHashSet<usize>>>);
+pub(crate) struct ModuleHits {
+    pub(crate) code: String,
+    pub(crate) lines: FxHashSet<usize>,
+}
+
+/// Visited lines per imported module, keyed by module name, merged across all test files.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct CoverageData(Arc<Mutex<FxHashMap<String, ModuleHits>>>);
 
 impl CoverageData {
-    fn record(&self, line: usize) {
-        self.0.lock().unwrap().insert(line);
+    fn record(&self, module_name: &str, code: &str, line: usize) {
+        let mut data = self.0.lock().unwrap();
+        let hits = data.entry(module_name.to_string()).or_insert_with(|| ModuleHits {
+            code: code.to_string(),
+            lines: FxHashSet::default(),
+        });
+        hits.lines.insert(line);
     }
 
-    pub(crate) fn snapshot(&self) -> FxHashSet<usize> {
+    pub(crate) fn snapshot(&self) -> FxHashMap<String, ModuleHits> {
         self.0.lock().unwrap().clone()
     }
 }
 
-/// Records the line of every top-level-module expression visited by the evaluator.
-///
-/// Lines belonging to `include`d/imported modules are intentionally ignored;
-/// only the coverage of the test file itself is tracked.
+/// Records lines visited inside `include`d/imported modules; the test file's own lines and
+/// the `builtin`/standard-library modules (always loaded, never the code under test) are ignored.
 #[derive(Debug)]
 pub(crate) struct CoverageHandler(pub(crate) CoverageData);
 
+fn is_trackable_module(module_name: &str) -> bool {
+    module_name != Module::BUILTIN_MODULE && !STANDARD_MODULES.contains_key(module_name)
+}
+
 impl DebuggerHandler for CoverageHandler {
     fn on_step(&self, context: &DebugContext) -> DebuggerAction {
-        if context.source.name.is_none() {
-            self.0.record(context.token.range.start.line as usize);
+        if let Some(module_name) = &context.source.name
+            && is_trackable_module(module_name)
+        {
+            self.0.record(
+                module_name,
+                &context.source.code,
+                context.token.range.start.line as usize,
+            );
         }
         // Keep single-stepping through every expression in the program.
         DebuggerAction::StepInto
@@ -632,6 +652,30 @@ pub(crate) fn format_cobertura_report(coverages: &[FileCoverage]) -> String {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[rstest]
+    #[case("lib", true)]
+    #[case("my_module", true)]
+    #[case("builtin", false)]
+    #[case("test", false)]
+    #[case("csv", false)]
+    #[case("json", false)]
+    fn test_is_trackable_module(#[case] module_name: &str, #[case] expected: bool) {
+        assert_eq!(is_trackable_module(module_name), expected);
+    }
+
+    #[test]
+    fn test_coverage_data_records_per_module_and_merges_across_runs() {
+        let data = CoverageData::default();
+        data.record("lib", "def foo():\n  1\nend\n", 2);
+        data.record("lib", "def foo():\n  1\nend\n", 2); // same test file re-visiting the same line
+        data.record("other", "def bar():\n  2\nend\n", 2);
+
+        let snapshot = data.snapshot();
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot["lib"].lines, FxHashSet::from_iter([2]));
+        assert_eq!(snapshot["other"].lines, FxHashSet::from_iter([2]));
+    }
 
     #[test]
     fn test_executable_lines_excludes_structural_nodes() {

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -5,6 +5,8 @@ use std::sync::{Arc, Mutex};
 use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Module, Shared};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::highlight;
+
 /// Output format for a coverage report.
 #[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CoverageFormat {
@@ -292,7 +294,7 @@ pub(crate) fn format_lcov_report(coverages: &[FileCoverage]) -> String {
     out
 }
 
-fn html_escape(s: &str) -> String {
+pub(crate) fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
@@ -318,16 +320,31 @@ const HTML_STYLE: &str = r#"
   --muted: #6b7280;
   --border: #e5e7eb;
   --row-alt: #f9fafb;
-  --covered-bg: #d9f7e3;
-  --covered-fg: #1a7f37;
-  --uncovered-bg: #ffe3e3;
-  --uncovered-fg: #c53030;
+  --covered-bg: #d9f7e380;
+  --uncovered-bg: #ffe3e380;
   --badge-high-bg: #d9f7e3;
   --badge-high-fg: #1a7f37;
   --badge-mid-bg: #fff3cd;
   --badge-mid-fg: #8a6100;
   --badge-low-bg: #ffe3e3;
   --badge-low-fg: #c53030;
+
+  /* mq source highlighting, from the Tarn Light theme
+     (https://github.com/harehare/tarn-theme). */
+  --code-bg: #f8fafc;
+  --code-fg: #0f172a;
+  --tok-comment: #64748b;
+  --tok-keyword: #7c3aed;
+  --tok-operator: #475569;
+  --tok-function: #0891b2;
+  --tok-module: #0284c7;
+  --tok-property: #0e7490;
+  --tok-string: #059669;
+  --tok-number: #c2410c;
+  --tok-boolean: #0369a1;
+  --tok-builtin: #0369a1;
+  --tok-variable: #1e40af;
+  --tok-punctuation: #475569;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -336,16 +353,30 @@ const HTML_STYLE: &str = r#"
     --muted: #9aa0a6;
     --border: #30333a;
     --row-alt: #1d2026;
-    --covered-bg: #123822;
-    --covered-fg: #4ada91;
-    --uncovered-bg: #3a1618;
-    --uncovered-fg: #ff8080;
+    --covered-bg: #12382280;
+    --uncovered-bg: #3a161880;
     --badge-high-bg: #123822;
     --badge-high-fg: #4ada91;
     --badge-mid-bg: #3a2f00;
     --badge-mid-fg: #ffd766;
     --badge-low-bg: #3a1618;
     --badge-low-fg: #ff8080;
+
+    /* mq source highlighting, from the Tarn (dark) theme. */
+    --code-bg: #1e293b;
+    --code-fg: #e2e8f0;
+    --tok-comment: #6b7a90;
+    --tok-keyword: #bb9af7;
+    --tok-operator: #94a3b8;
+    --tok-function: #56d4d4;
+    --tok-module: #67b8e3;
+    --tok-property: #67e8f9;
+    --tok-string: #89ddff;
+    --tok-number: #de935f;
+    --tok-boolean: #85d4ff;
+    --tok-builtin: #85d4ff;
+    --tok-variable: #9cdcfe;
+    --tok-punctuation: #94a3b8;
   }
 }
 * { box-sizing: border-box; }
@@ -361,7 +392,7 @@ table { border-collapse: collapse; width: 100%; }
 th, td { text-align: left; padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--border); }
 th { background: var(--row-alt); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--muted); }
 tbody tr:hover { background: var(--row-alt); }
-td.uncovered { color: var(--uncovered-fg); font-family: ui-monospace, monospace; font-size: 0.85rem; }
+td.uncovered { color: var(--badge-low-fg); font-family: ui-monospace, monospace; font-size: 0.85rem; }
 tfoot td { font-weight: 700; border-top: 2px solid var(--border); border-bottom: none; }
 a { color: inherit; }
 .badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-weight: 600; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
@@ -371,26 +402,39 @@ a { color: inherit; }
 details { margin-top: 1rem; border: 1px solid var(--border); border-radius: 8px; padding: 0.6rem 1rem; }
 summary { cursor: pointer; font-weight: 600; }
 summary:hover { color: var(--muted); }
-table.source { margin-top: 0.6rem; border: none; font-family: ui-monospace, monospace; font-size: 0.85rem; }
+table.source { margin-top: 0.6rem; border: none; border-radius: 6px; overflow: hidden; background: var(--code-bg); font-family: ui-monospace, monospace; font-size: 0.85rem; }
 table.source td { padding: 0.1rem 0.6rem; border-bottom: none; white-space: pre; }
+table.source td.code { color: var(--code-fg); }
 table.source td.lineno { color: var(--muted); text-align: right; user-select: none; width: 1%; }
-table.source tr.covered td.code { background: var(--covered-bg); color: var(--covered-fg); }
-table.source tr.uncovered td.code { background: var(--uncovered-bg); color: var(--uncovered-fg); }
+table.source tr.covered td.code { background: var(--covered-bg); }
+table.source tr.uncovered td.code { background: var(--uncovered-bg); }
+.tok-comment { color: var(--tok-comment); font-style: italic; }
+.tok-keyword { color: var(--tok-keyword); font-weight: 600; }
+.tok-operator { color: var(--tok-operator); }
+.tok-punctuation { color: var(--tok-punctuation); }
+.tok-function { color: var(--tok-function); }
+.tok-module { color: var(--tok-module); }
+.tok-property { color: var(--tok-property); }
+.tok-string { color: var(--tok-string); }
+.tok-number { color: var(--tok-number); }
+.tok-boolean { color: var(--tok-boolean); }
+.tok-builtin { color: var(--tok-builtin); }
+.tok-variable { color: var(--tok-variable); }
 "#;
 
 /// Renders the per-line source table for a single file, with executable lines
 /// highlighted green (covered) or red (uncovered).
 fn format_html_source(cov: &FileCoverage, anchor: &str) -> String {
     let mut lines_html = String::new();
+    let highlighted_lines = highlight::highlight_lines(&cov.content);
 
-    for (i, line) in cov.content.lines().enumerate() {
+    for (i, code) in highlighted_lines.into_iter().enumerate() {
         let line_no = i + 1;
         let status = cov.line_status(line_no);
 
         lines_html.push_str(&format!(
             "          <tr class=\"{class}\"><td class=\"lineno\">{line_no}</td><td class=\"code\">{code}</td></tr>\n",
             class = status.as_str(),
-            code = html_escape(line),
         ));
     }
 
@@ -797,29 +841,23 @@ mod tests {
     fn test_format_html_report_highlights_covered_and_uncovered_lines() {
         let cov = FileCoverage::new(
             PathBuf::from("test.mq"),
-            BTreeSet::from([1, 2, 3]),
-            [1, 3].into_iter().collect(),
-            "covered one\nuncovered\ncovered two\n".to_string(),
+            BTreeSet::from([2, 3]),
+            [2].into_iter().collect(),
+            "def foo():\n  1\n  | 2\nend\n".to_string(),
         );
         let report = format_html_report(&[cov]);
 
-        // Line 1 and 3 were visited -> covered (green); line 2 was not -> uncovered (red).
-        assert!(
-            report
-                .contains("<tr class=\"covered\"><td class=\"lineno\">1</td><td class=\"code\">covered one</td></tr>")
-        );
-        assert!(
-            report
-                .contains("<tr class=\"uncovered\"><td class=\"lineno\">2</td><td class=\"code\">uncovered</td></tr>")
-        );
-        assert!(
-            report
-                .contains("<tr class=\"covered\"><td class=\"lineno\">3</td><td class=\"code\">covered two</td></tr>")
-        );
+        // Line 2 was visited -> covered (green); line 3 was not -> uncovered (red).
+        assert!(report.contains(
+            "<tr class=\"covered\"><td class=\"lineno\">2</td><td class=\"code\">  <span class=\"tok-number\">1</span></td></tr>"
+        ));
+        assert!(report.contains(
+            "<tr class=\"uncovered\"><td class=\"lineno\">3</td><td class=\"code\">  <span class=\"tok-operator\">|</span> <span class=\"tok-number\">2</span></td></tr>"
+        ));
         assert!(report.contains("tr.covered td.code { background: var(--covered-bg)"));
         assert!(report.contains("tr.uncovered td.code { background: var(--uncovered-bg)"));
         assert!(report.contains("prefers-color-scheme: dark"));
-        assert!(report.contains("<span class=\"badge mid\">66.7%</span>"));
+        assert!(report.contains("<span class=\"badge mid\">50.0%</span>"));
     }
 
     #[test]
@@ -832,11 +870,16 @@ mod tests {
         );
         let report = format_html_report(&[cov]);
 
-        assert!(
-            report.contains("<tr class=\"plain\"><td class=\"lineno\">1</td><td class=\"code\">def foo():</td></tr>")
-        );
+        assert!(report.contains(
+            "<tr class=\"plain\"><td class=\"lineno\">1</td><td class=\"code\">\
+             <span class=\"tok-keyword\">def</span> <span class=\"tok-function\">foo</span>\
+             <span class=\"tok-punctuation\">(</span><span class=\"tok-punctuation\">)</span>\
+             <span class=\"tok-punctuation\">:</span></td></tr>"
+        ));
         assert!(report.contains("<tr class=\"covered\"><td class=\"lineno\">2</td>"));
-        assert!(report.contains("<tr class=\"plain\"><td class=\"lineno\">3</td><td class=\"code\">end</td></tr>"));
+        assert!(report.contains(
+            "<tr class=\"plain\"><td class=\"lineno\">3</td><td class=\"code\"><span class=\"tok-keyword\">end</span></td></tr>"
+        ));
     }
 
     #[rstest]

--- a/crates/mq-test/src/coverage.rs
+++ b/crates/mq-test/src/coverage.rs
@@ -1,0 +1,925 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use mq_lang::{CstNode, CstNodeKind, DebugContext, DebuggerAction, DebuggerHandler, Shared};
+use rustc_hash::FxHashSet;
+
+/// Output format for a coverage report.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CoverageFormat {
+    /// Human-readable summary printed to the terminal.
+    #[default]
+    Text,
+    /// suitable for `genhtml` or CI coverage integrations.
+    Lcov,
+    /// Self-contained HTML report.
+    Html,
+    /// Machine-readable JSON report.
+    Json,
+    /// Markdown report, suitable for pasting into a PR description or GitHub summary.
+    Markdown,
+    /// suitable for Jenkins/GitLab CI coverage integrations.
+    Cobertura,
+}
+
+/// Shared, thread-safe accumulator of source lines visited during a single test-file run.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct CoverageData(Arc<Mutex<FxHashSet<usize>>>);
+
+impl CoverageData {
+    fn record(&self, line: usize) {
+        self.0.lock().unwrap().insert(line);
+    }
+
+    pub(crate) fn snapshot(&self) -> FxHashSet<usize> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+/// Records the line of every top-level-module expression visited by the evaluator.
+///
+/// Lines belonging to `include`d/imported modules are intentionally ignored;
+/// only the coverage of the test file itself is tracked.
+#[derive(Debug)]
+pub(crate) struct CoverageHandler(pub(crate) CoverageData);
+
+impl DebuggerHandler for CoverageHandler {
+    fn on_step(&self, context: &DebugContext) -> DebuggerAction {
+        if context.source.name.is_none() {
+            self.0.record(context.token.range.start.line as usize);
+        }
+        // Keep single-stepping through every expression in the program.
+        DebuggerAction::StepInto
+    }
+}
+
+/// Coverage result for a single test file.
+#[derive(Debug, Clone)]
+pub struct FileCoverage {
+    pub file: PathBuf,
+    executable_lines: BTreeSet<usize>,
+    visited_lines: FxHashSet<usize>,
+    /// The file's own source text, used to render per-line source in the HTML report.
+    content: String,
+}
+
+impl FileCoverage {
+    pub(crate) fn new(
+        file: PathBuf,
+        executable_lines: BTreeSet<usize>,
+        visited_lines: FxHashSet<usize>,
+        content: String,
+    ) -> Self {
+        Self {
+            file,
+            executable_lines,
+            visited_lines,
+            content,
+        }
+    }
+
+    /// Number of lines considered executable (the coverage denominator).
+    pub fn total_lines(&self) -> usize {
+        self.executable_lines.len()
+    }
+
+    /// Number of executable lines that were visited at least once.
+    pub fn covered_lines(&self) -> usize {
+        self.executable_lines
+            .iter()
+            .filter(|line| self.visited_lines.contains(line))
+            .count()
+    }
+
+    /// Executable lines that were never visited, in ascending order.
+    pub fn uncovered_lines(&self) -> Vec<usize> {
+        self.executable_lines
+            .iter()
+            .filter(|line| !self.visited_lines.contains(line))
+            .copied()
+            .collect()
+    }
+
+    /// Percentage of executable lines covered, in `[0.0, 100.0]`.
+    /// A file with no executable lines is reported as fully covered.
+    pub fn percent(&self) -> f64 {
+        let total = self.total_lines();
+        if total == 0 {
+            100.0
+        } else {
+            (self.covered_lines() as f64 / total as f64) * 100.0
+        }
+    }
+
+    fn is_hit(&self, line: usize) -> bool {
+        self.visited_lines.contains(&line)
+    }
+
+    fn line_status(&self, line: usize) -> LineStatus {
+        if !self.executable_lines.contains(&line) {
+            LineStatus::Plain
+        } else if self.is_hit(line) {
+            LineStatus::Covered
+        } else {
+            LineStatus::Uncovered
+        }
+    }
+}
+
+/// Coverage classification of a single source line, shared by the HTML,
+/// Markdown, and JSON renderers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineStatus {
+    /// Not considered executable (declarations, structural syntax, blank lines).
+    Plain,
+    /// Executable and visited by the evaluator.
+    Covered,
+    /// Executable but never visited.
+    Uncovered,
+}
+
+impl LineStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            LineStatus::Plain => "plain",
+            LineStatus::Covered => "covered",
+            LineStatus::Uncovered => "uncovered",
+        }
+    }
+
+    /// Diff-style prefix: GitHub colors `+`/`-` lines in ` ```diff ` blocks green/red.
+    fn diff_prefix(self) -> char {
+        match self {
+            LineStatus::Plain => ' ',
+            LineStatus::Covered => '+',
+            LineStatus::Uncovered => '-',
+        }
+    }
+}
+
+/// CST node kinds that are excluded from the set of "executable" lines used
+/// as the coverage denominator: either purely structural wrappers/delimiters,
+/// or declaration statements (`def`, `include`, `import`) whose own line is
+/// registered without going through the evaluator's per-expression debugger
+/// hook, so it would otherwise be permanently reported as uncovered. Their
+/// bodies/children are still collected independently.
+fn is_structural(kind: &CstNodeKind) -> bool {
+    matches!(
+        kind,
+        CstNodeKind::Module
+            | CstNodeKind::Nodes
+            | CstNodeKind::Block
+            | CstNodeKind::End
+            | CstNodeKind::Pattern
+            | CstNodeKind::OrPattern
+            | CstNodeKind::Token
+            | CstNodeKind::Eof
+            | CstNodeKind::Def
+            | CstNodeKind::Include
+            | CstNodeKind::Import
+    )
+}
+
+fn collect_executable_lines(nodes: &[Shared<CstNode>], max_line: usize, lines: &mut BTreeSet<usize>) {
+    for node in nodes {
+        if !is_structural(&node.kind)
+            && let Some(token) = &node.token
+        {
+            let line = token.range.start.line as usize;
+            if line >= 1 && line <= max_line {
+                lines.insert(line);
+            }
+        }
+
+        match node.kind {
+            // Only the function body counts toward coverage — the signature
+            // (name + params) is declaration syntax, not a per-step execution.
+            CstNodeKind::Def => {
+                let (_, program) = node.split_cond_and_program();
+                collect_executable_lines(&program, max_line, lines);
+            }
+            // Single-statement declarations have no body worth descending into.
+            CstNodeKind::Include | CstNodeKind::Import => {}
+            _ => collect_executable_lines(&node.children, max_line, lines),
+        }
+    }
+}
+
+/// Determines the set of "executable" lines in `content` (bounded to the file's
+/// own line count, since `content` may have a generated test harness appended).
+pub(crate) fn executable_lines(content: &str) -> BTreeSet<usize> {
+    let max_line = content.lines().count().max(1);
+    let (nodes, _) = mq_lang::parse_recovery(content);
+    let mut lines = BTreeSet::new();
+    collect_executable_lines(&nodes, max_line, &mut lines);
+    lines
+}
+
+/// Renders a human-readable coverage summary.
+pub(crate) fn format_text_report(coverages: &[FileCoverage]) -> String {
+    let mut out = String::from("\nCoverage report:\n");
+    let (mut total_covered, mut total_lines) = (0, 0);
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        out.push_str(&format!(
+            "  {:<50} {:>6.1}% ({}/{})\n",
+            cov.file.display(),
+            cov.percent(),
+            cov.covered_lines(),
+            cov.total_lines()
+        ));
+
+        let uncovered = cov.uncovered_lines();
+        if !uncovered.is_empty() {
+            let lines = uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ");
+            out.push_str(&format!("      uncovered lines: {lines}\n"));
+        }
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    out.push_str(&format!("\n  Total: {overall:.1}% ({total_covered}/{total_lines})\n"));
+    out
+}
+
+/// Renders an lcov tracefile.
+pub(crate) fn format_lcov_report(coverages: &[FileCoverage]) -> String {
+    let mut out = String::new();
+
+    for cov in coverages {
+        out.push_str(&format!("SF:{}\n", cov.file.display()));
+        for line in &cov.executable_lines {
+            let hit = if cov.is_hit(*line) { 1 } else { 0 };
+            out.push_str(&format!("DA:{line},{hit}\n"));
+        }
+        out.push_str(&format!("LF:{}\n", cov.total_lines()));
+        out.push_str(&format!("LH:{}\n", cov.covered_lines()));
+        out.push_str("end_of_record\n");
+    }
+
+    out
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Classifies a coverage percentage into a badge color tier.
+fn badge_class(pct: f64) -> &'static str {
+    if pct >= 80.0 {
+        "high"
+    } else if pct >= 50.0 {
+        "mid"
+    } else {
+        "low"
+    }
+}
+
+const HTML_STYLE: &str = r#"
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --row-alt: #f9fafb;
+  --covered-bg: #d9f7e3;
+  --covered-fg: #1a7f37;
+  --uncovered-bg: #ffe3e3;
+  --uncovered-fg: #c53030;
+  --badge-high-bg: #d9f7e3;
+  --badge-high-fg: #1a7f37;
+  --badge-mid-bg: #fff3cd;
+  --badge-mid-fg: #8a6100;
+  --badge-low-bg: #ffe3e3;
+  --badge-low-fg: #c53030;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #16181d;
+    --fg: #e6e6e6;
+    --muted: #9aa0a6;
+    --border: #30333a;
+    --row-alt: #1d2026;
+    --covered-bg: #123822;
+    --covered-fg: #4ada91;
+    --uncovered-bg: #3a1618;
+    --uncovered-fg: #ff8080;
+    --badge-high-bg: #123822;
+    --badge-high-fg: #4ada91;
+    --badge-mid-bg: #3a2f00;
+    --badge-mid-fg: #ffd766;
+    --badge-low-bg: #3a1618;
+    --badge-low-fg: #ff8080;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 2rem auto;
+  max-width: 960px;
+  color: var(--fg);
+  background: var(--bg);
+}
+h1 { font-size: 1.4rem; }
+table { border-collapse: collapse; width: 100%; }
+th, td { text-align: left; padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--border); }
+th { background: var(--row-alt); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--muted); }
+tbody tr:hover { background: var(--row-alt); }
+td.uncovered { color: var(--uncovered-fg); font-family: ui-monospace, monospace; font-size: 0.85rem; }
+tfoot td { font-weight: 700; border-top: 2px solid var(--border); border-bottom: none; }
+a { color: inherit; }
+.badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-weight: 600; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+.badge.high { background: var(--badge-high-bg); color: var(--badge-high-fg); }
+.badge.mid { background: var(--badge-mid-bg); color: var(--badge-mid-fg); }
+.badge.low { background: var(--badge-low-bg); color: var(--badge-low-fg); }
+details { margin-top: 1rem; border: 1px solid var(--border); border-radius: 8px; padding: 0.6rem 1rem; }
+summary { cursor: pointer; font-weight: 600; }
+summary:hover { color: var(--muted); }
+table.source { margin-top: 0.6rem; border: none; font-family: ui-monospace, monospace; font-size: 0.85rem; }
+table.source td { padding: 0.1rem 0.6rem; border-bottom: none; white-space: pre; }
+table.source td.lineno { color: var(--muted); text-align: right; user-select: none; width: 1%; }
+table.source tr.covered td.code { background: var(--covered-bg); color: var(--covered-fg); }
+table.source tr.uncovered td.code { background: var(--uncovered-bg); color: var(--uncovered-fg); }
+"#;
+
+/// Renders the per-line source table for a single file, with executable lines
+/// highlighted green (covered) or red (uncovered).
+fn format_html_source(cov: &FileCoverage, anchor: &str) -> String {
+    let mut lines_html = String::new();
+
+    for (i, line) in cov.content.lines().enumerate() {
+        let line_no = i + 1;
+        let status = cov.line_status(line_no);
+
+        lines_html.push_str(&format!(
+            "          <tr class=\"{class}\"><td class=\"lineno\">{line_no}</td><td class=\"code\">{code}</td></tr>\n",
+            class = status.as_str(),
+            code = html_escape(line),
+        ));
+    }
+
+    format!(
+        "      <details id=\"{anchor}\">\n\
+        \x20       <summary>{file} — {pct:.1}% ({covered}/{total})</summary>\n\
+        \x20       <table class=\"source\">\n\
+        \x20         <tbody>\n\
+        {lines_html}\
+        \x20         </tbody>\n\
+        \x20       </table>\n\
+        \x20     </details>\n",
+        anchor = anchor,
+        file = html_escape(&cov.file.display().to_string()),
+        pct = cov.percent(),
+        covered = cov.covered_lines(),
+        total = cov.total_lines(),
+    )
+}
+
+/// Renders a self-contained HTML coverage report: a summary table plus a
+/// collapsible, green/red line-highlighted source view per file.
+pub(crate) fn format_html_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let mut rows = String::new();
+    let mut sources = String::new();
+
+    for (i, cov) in coverages.iter().enumerate() {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let uncovered = cov.uncovered_lines();
+        let uncovered_text = if uncovered.is_empty() {
+            "-".to_string()
+        } else {
+            uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+        };
+
+        let anchor = format!("file-{i}");
+
+        rows.push_str(&format!(
+            "      <tr>\n\
+            \x20       <td><a href=\"#{anchor}\">{file}</a></td>\n\
+            \x20       <td><span class=\"badge {badge}\">{pct:.1}%</span></td>\n\
+            \x20       <td>{covered}/{total}</td>\n\
+            \x20       <td class=\"uncovered\">{uncovered_text}</td>\n\
+            \x20     </tr>\n",
+            file = html_escape(&cov.file.display().to_string()),
+            badge = badge_class(cov.percent()),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+
+        sources.push_str(&format_html_source(cov, &anchor));
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    format!(
+        "<!doctype html>\n\
+        <html lang=\"en\">\n\
+        <head>\n\
+        \x20 <meta charset=\"utf-8\">\n\
+        \x20 <title>mq-test coverage report</title>\n\
+        \x20 <style>{HTML_STYLE}</style>\n\
+        </head>\n\
+        <body>\n\
+        \x20 <h1>Coverage report</h1>\n\
+        \x20 <table>\n\
+        \x20   <thead>\n\
+        \x20     <tr><th>File</th><th>Coverage</th><th>Lines</th><th>Uncovered lines</th></tr>\n\
+        \x20   </thead>\n\
+        \x20   <tbody>\n\
+        {rows}\
+        \x20   </tbody>\n\
+        \x20   <tfoot>\n\
+        \x20     <tr><td>Total</td><td><span class=\"badge {overall_badge}\">{overall:.1}%</span></td><td>{total_covered}/{total_lines}</td><td></td></tr>\n\
+        \x20   </tfoot>\n\
+        \x20 </table>\n\
+        {sources}\
+        </body>\n\
+        </html>\n",
+        overall_badge = badge_class(overall),
+    )
+}
+
+/// Renders a Markdown coverage report: a summary table followed by each
+/// file's source in a ` ```diff ` block, so GitHub and other diff-aware
+/// Markdown renderers color covered/uncovered lines green/red.
+pub(crate) fn format_markdown_report(coverages: &[FileCoverage]) -> String {
+    let mut out =
+        String::from("# Coverage report\n\n| File | Coverage | Lines | Uncovered lines |\n| --- | --- | --- | --- |\n");
+    let (mut total_covered, mut total_lines) = (0, 0);
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let uncovered = cov.uncovered_lines();
+        let uncovered_text = if uncovered.is_empty() {
+            "-".to_string()
+        } else {
+            uncovered.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+        };
+
+        out.push_str(&format!(
+            "| `{file}` | {pct:.1}% | {covered}/{total} | {uncovered_text} |\n",
+            file = cov.file.display(),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+    }
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+    out.push_str(&format!("\n**Total: {overall:.1}% ({total_covered}/{total_lines})**\n"));
+
+    for cov in coverages {
+        out.push_str(&format!(
+            "\n## {file} — {pct:.1}% ({covered}/{total})\n\n```diff\n",
+            file = cov.file.display(),
+            pct = cov.percent(),
+            covered = cov.covered_lines(),
+            total = cov.total_lines(),
+        ));
+
+        for (i, line) in cov.content.lines().enumerate() {
+            out.push(cov.line_status(i + 1).diff_prefix());
+            out.push_str(line);
+            out.push('\n');
+        }
+
+        out.push_str("```\n");
+    }
+
+    out
+}
+
+/// Renders a machine-readable JSON coverage report.
+pub(crate) fn format_json_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let files: Vec<serde_json::Value> = coverages
+        .iter()
+        .map(|cov| {
+            total_covered += cov.covered_lines();
+            total_lines += cov.total_lines();
+
+            let lines: Vec<serde_json::Value> = cov
+                .content
+                .lines()
+                .enumerate()
+                .map(|(i, line)| {
+                    let line_no = i + 1;
+                    serde_json::json!({
+                        "line": line_no,
+                        "content": line,
+                        "status": cov.line_status(line_no).as_str(),
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "file": cov.file.display().to_string(),
+                "totalLines": cov.total_lines(),
+                "coveredLines": cov.covered_lines(),
+                "percent": cov.percent(),
+                "uncoveredLines": cov.uncovered_lines(),
+                "lines": lines,
+            })
+        })
+        .collect();
+
+    let overall = if total_lines == 0 {
+        100.0
+    } else {
+        (total_covered as f64 / total_lines as f64) * 100.0
+    };
+
+    let report = serde_json::json!({
+        "files": files,
+        "total": {
+            "totalLines": total_lines,
+            "coveredLines": total_covered,
+            "percent": overall,
+        },
+    });
+
+    serde_json::to_string_pretty(&report).expect("coverage report is always serializable")
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Renders a [Cobertura](https://cobertura.github.io/cobertura/) XML coverage report.
+///
+/// Since `mq` has no notion of packages/classes, each file is reported as a
+/// single class within a single package.
+pub(crate) fn format_cobertura_report(coverages: &[FileCoverage]) -> String {
+    let (mut total_covered, mut total_lines) = (0, 0);
+    let mut packages = String::new();
+
+    for cov in coverages {
+        total_covered += cov.covered_lines();
+        total_lines += cov.total_lines();
+
+        let file = xml_escape(&cov.file.display().to_string());
+        let mut lines = String::new();
+        for line in &cov.executable_lines {
+            let hits = if cov.is_hit(*line) { 1 } else { 0 };
+            lines.push_str(&format!("          <line number=\"{line}\" hits=\"{hits}\"/>\n"));
+        }
+
+        packages.push_str(&format!(
+            "  <package name=\"{file}\" line-rate=\"{rate:.4}\" branch-rate=\"1.0\">\n\
+            \x20   <classes>\n\
+            \x20     <class name=\"{file}\" filename=\"{file}\" line-rate=\"{rate:.4}\" branch-rate=\"1.0\">\n\
+            \x20       <lines>\n\
+            {lines}\
+            \x20       </lines>\n\
+            \x20     </class>\n\
+            \x20   </classes>\n\
+            \x20 </package>\n",
+            rate = if cov.total_lines() == 0 {
+                1.0
+            } else {
+                cov.covered_lines() as f64 / cov.total_lines() as f64
+            },
+        ));
+    }
+
+    let overall_rate = if total_lines == 0 {
+        1.0
+    } else {
+        total_covered as f64 / total_lines as f64
+    };
+
+    format!(
+        "<?xml version=\"1.0\"?>\n\
+        <coverage line-rate=\"{overall_rate:.4}\" branch-rate=\"1.0\" lines-covered=\"{total_covered}\" \
+        lines-valid=\"{total_lines}\" version=\"mq-test\">\n\
+        \x20 <packages>\n\
+        {packages}\
+        \x20 </packages>\n\
+        </coverage>\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn test_executable_lines_excludes_structural_nodes() {
+        let content = "def foo():\n  1 + 1\nend\n";
+        let lines = executable_lines(content);
+        // Line 1 (`def foo():`) is a declaration, not a per-step execution.
+        // Line 2 (`1 + 1`) is the body. Line 3 (`end`) is structural.
+        assert!(!lines.contains(&1), "def line should not be executable: {lines:?}");
+        assert!(lines.contains(&2), "body line should be executable: {lines:?}");
+        assert!(!lines.contains(&3), "end line should not be executable: {lines:?}");
+    }
+
+    #[test]
+    fn test_executable_lines_bounded_by_content_line_count() {
+        // Callers must pass the original file content — not the query with the
+        // generated `run_tests(...)` harness appended — so that lines beyond
+        // the file's own line count are never reported.
+        let content = "def foo():\n  1 + 1\nend\n";
+        let lines = executable_lines(content);
+        let max_line = content.lines().count();
+        assert!(
+            lines.iter().all(|&l| l <= max_line),
+            "lines must be bounded by content's own line count: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn test_file_coverage_percent() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        assert_eq!(cov.total_lines(), 4);
+        assert_eq!(cov.covered_lines(), 2);
+        assert_eq!(cov.uncovered_lines(), vec![3, 4]);
+        assert_eq!(cov.percent(), 50.0);
+    }
+
+    #[test]
+    fn test_file_coverage_percent_no_executable_lines() {
+        let cov = FileCoverage::new(
+            PathBuf::from("empty.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
+        assert_eq!(cov.percent(), 100.0);
+    }
+
+    #[test]
+    fn test_format_text_report_contains_summary() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_text_report(&[cov]);
+        assert!(report.contains("test.mq"));
+        assert!(report.contains("50.0%"));
+        assert!(report.contains("uncovered lines: 3, 4"));
+        assert!(report.contains("Total: 50.0% (2/4)"));
+    }
+
+    #[test]
+    fn test_format_lcov_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2]),
+            [1].into_iter().collect(),
+            "a\nb\n".to_string(),
+        );
+        let report = format_lcov_report(&[cov]);
+        assert!(report.contains("SF:test.mq\n"));
+        assert!(report.contains("DA:1,1\n"));
+        assert!(report.contains("DA:2,0\n"));
+        assert!(report.contains("LF:2\n"));
+        assert!(report.contains("LH:1\n"));
+        assert!(report.contains("end_of_record\n"));
+    }
+
+    #[test]
+    fn test_format_html_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+        assert!(report.starts_with("<!doctype html>"));
+        assert!(report.contains("test.mq"));
+        assert!(report.contains("50.0%"));
+        assert!(report.contains("2/4"));
+        assert!(report.contains("3, 4"));
+        assert!(report.contains("Total"));
+    }
+
+    #[test]
+    fn test_format_html_report_escapes_file_path() {
+        let cov = FileCoverage::new(
+            PathBuf::from("<a & b>.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
+        let report = format_html_report(&[cov]);
+        assert!(report.contains("&lt;a &amp; b&gt;.mq"));
+        assert!(!report.contains("<a & b>.mq"));
+    }
+
+    #[test]
+    fn test_format_html_report_highlights_covered_and_uncovered_lines() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+
+        // Line 1 and 3 were visited -> covered (green); line 2 was not -> uncovered (red).
+        assert!(
+            report
+                .contains("<tr class=\"covered\"><td class=\"lineno\">1</td><td class=\"code\">covered one</td></tr>")
+        );
+        assert!(
+            report
+                .contains("<tr class=\"uncovered\"><td class=\"lineno\">2</td><td class=\"code\">uncovered</td></tr>")
+        );
+        assert!(
+            report
+                .contains("<tr class=\"covered\"><td class=\"lineno\">3</td><td class=\"code\">covered two</td></tr>")
+        );
+        assert!(report.contains("tr.covered td.code { background: var(--covered-bg)"));
+        assert!(report.contains("tr.uncovered td.code { background: var(--uncovered-bg)"));
+        assert!(report.contains("prefers-color-scheme: dark"));
+        assert!(report.contains("<span class=\"badge mid\">66.7%</span>"));
+    }
+
+    #[test]
+    fn test_format_html_report_marks_non_executable_lines_plain() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([2]),
+            [2].into_iter().collect(),
+            "def foo():\n  1 + 1\nend\n".to_string(),
+        );
+        let report = format_html_report(&[cov]);
+
+        assert!(
+            report.contains("<tr class=\"plain\"><td class=\"lineno\">1</td><td class=\"code\">def foo():</td></tr>")
+        );
+        assert!(report.contains("<tr class=\"covered\"><td class=\"lineno\">2</td>"));
+        assert!(report.contains("<tr class=\"plain\"><td class=\"lineno\">3</td><td class=\"code\">end</td></tr>"));
+    }
+
+    #[rstest]
+    #[case(100.0, "high")]
+    #[case(80.0, "high")]
+    #[case(79.9, "mid")]
+    #[case(50.0, "mid")]
+    #[case(49.9, "low")]
+    #[case(0.0, "low")]
+    fn test_badge_class(#[case] pct: f64, #[case] expected: &str) {
+        assert_eq!(badge_class(pct), expected);
+    }
+
+    #[test]
+    fn test_format_markdown_report_summary_and_totals() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+        assert!(report.starts_with("# Coverage report"));
+        assert!(report.contains("| `test.mq` | 50.0% | 2/4 | 3, 4 |"));
+        assert!(report.contains("**Total: 50.0% (2/4)**"));
+    }
+
+    #[test]
+    fn test_format_markdown_report_diff_highlights_covered_and_uncovered_lines() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+
+        assert!(report.contains("```diff\n"));
+        assert!(report.contains("+covered one\n"));
+        assert!(report.contains("-uncovered\n"));
+        assert!(report.contains("+covered two\n"));
+    }
+
+    #[test]
+    fn test_format_markdown_report_marks_non_executable_lines_plain() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([2]),
+            [2].into_iter().collect(),
+            "def foo():\n  1 + 1\nend\n".to_string(),
+        );
+        let report = format_markdown_report(&[cov]);
+
+        assert!(report.contains(" def foo():\n"));
+        assert!(report.contains("+  1 + 1\n"));
+        assert!(report.contains(" end\n"));
+    }
+
+    #[test]
+    fn test_format_json_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3, 4]),
+            [1, 2].into_iter().collect(),
+            "a\nb\nc\nd\n".to_string(),
+        );
+        let report = format_json_report(&[cov]);
+        let parsed: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+        assert_eq!(parsed["files"][0]["file"], "test.mq");
+        assert_eq!(parsed["files"][0]["totalLines"], 4);
+        assert_eq!(parsed["files"][0]["coveredLines"], 2);
+        assert_eq!(parsed["files"][0]["percent"], 50.0);
+        assert_eq!(parsed["files"][0]["uncoveredLines"], serde_json::json!([3, 4]));
+        assert_eq!(parsed["total"]["totalLines"], 4);
+        assert_eq!(parsed["total"]["coveredLines"], 2);
+        assert_eq!(parsed["total"]["percent"], 50.0);
+    }
+
+    #[test]
+    fn test_format_json_report_includes_per_line_status() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2, 3]),
+            [1, 3].into_iter().collect(),
+            "covered one\nuncovered\ncovered two\n".to_string(),
+        );
+        let report = format_json_report(&[cov]);
+        let parsed: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+        let lines = &parsed["files"][0]["lines"];
+        assert_eq!(
+            lines[0],
+            serde_json::json!({"line": 1, "content": "covered one", "status": "covered"})
+        );
+        assert_eq!(
+            lines[1],
+            serde_json::json!({"line": 2, "content": "uncovered", "status": "uncovered"})
+        );
+        assert_eq!(
+            lines[2],
+            serde_json::json!({"line": 3, "content": "covered two", "status": "covered"})
+        );
+    }
+
+    #[test]
+    fn test_format_cobertura_report_structure() {
+        let cov = FileCoverage::new(
+            PathBuf::from("test.mq"),
+            BTreeSet::from([1, 2]),
+            [1].into_iter().collect(),
+            "a\nb\n".to_string(),
+        );
+        let report = format_cobertura_report(&[cov]);
+        assert!(report.starts_with("<?xml version=\"1.0\"?>"));
+        assert!(
+            report.contains("<coverage line-rate=\"0.5000\" branch-rate=\"1.0\" lines-covered=\"1\" lines-valid=\"2\"")
+        );
+        assert!(report.contains("filename=\"test.mq\""));
+        assert!(report.contains("<line number=\"1\" hits=\"1\"/>"));
+        assert!(report.contains("<line number=\"2\" hits=\"0\"/>"));
+    }
+
+    #[test]
+    fn test_format_cobertura_report_escapes_file_path() {
+        let cov = FileCoverage::new(
+            PathBuf::from("<a & b>.mq"),
+            BTreeSet::new(),
+            FxHashSet::default(),
+            String::new(),
+        );
+        let report = format_cobertura_report(&[cov]);
+        assert!(report.contains("&lt;a &amp; b&gt;.mq"));
+        assert!(!report.contains("<a & b>.mq"));
+    }
+}

--- a/crates/mq-test/src/highlight.rs
+++ b/crates/mq-test/src/highlight.rs
@@ -1,0 +1,251 @@
+//! Syntax highlighting for mq source embedded in the HTML coverage report.
+//!
+//! Classifies tokens by walking the CST returned by [`mq_lang::parse_recovery`]
+//! and renders each source line as HTML with `<span class="tok-*">` wrappers,
+//! colored via the `tok-*` CSS classes defined in `coverage::HTML_STYLE`
+//! (palette taken from the [Tarn](https://github.com/harehare/tarn-theme) theme).
+
+use mq_lang::{CstNode, CstNodeKind, CstTrivia, Shared, TokenKind};
+use rustc_hash::FxHashMap;
+
+use crate::coverage::html_escape;
+
+/// Coarse lexical category used to pick a `tok-*` CSS class for a token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenClass {
+    Comment,
+    Keyword,
+    Operator,
+    Punctuation,
+    Function,
+    Module,
+    Property,
+    String,
+    Number,
+    Boolean,
+    Builtin,
+    Variable,
+}
+
+impl TokenClass {
+    fn css_class(self) -> &'static str {
+        match self {
+            TokenClass::Comment => "tok-comment",
+            TokenClass::Keyword => "tok-keyword",
+            TokenClass::Operator => "tok-operator",
+            TokenClass::Punctuation => "tok-punctuation",
+            TokenClass::Function => "tok-function",
+            TokenClass::Module => "tok-module",
+            TokenClass::Property => "tok-property",
+            TokenClass::String => "tok-string",
+            TokenClass::Number => "tok-number",
+            TokenClass::Boolean => "tok-boolean",
+            TokenClass::Builtin => "tok-builtin",
+            TokenClass::Variable => "tok-variable",
+        }
+    }
+}
+
+/// A classified token span within one source line, in 1-based UTF-8 columns
+/// (matching `mq_lang::Range`), end-exclusive.
+struct Span {
+    line: u32,
+    start_col: usize,
+    end_col: usize,
+    class: TokenClass,
+}
+
+/// The CST reuses the identifier's own node/token for `Call`/`MacroCall`/
+/// `QualifiedAccess` (its `kind` changes but the token stays the identifier),
+/// while `def`/`import`/dict-key names are separate child `Ident` nodes of a
+/// keyword-bearing parent — so classification needs both the node's own kind
+/// and its parent context.
+fn classify_ident(node_kind: &CstNodeKind, parent: Option<&CstNodeKind>, index_in_parent: usize) -> TokenClass {
+    match node_kind {
+        CstNodeKind::Call | CstNodeKind::CallDynamic | CstNodeKind::MacroCall => TokenClass::Function,
+        CstNodeKind::QualifiedAccess => TokenClass::Module,
+        _ => match parent {
+            Some(CstNodeKind::Def) | Some(CstNodeKind::Macro) if index_in_parent == 0 => TokenClass::Function,
+            Some(CstNodeKind::Import) | Some(CstNodeKind::Include) | Some(CstNodeKind::Module) => TokenClass::Module,
+            Some(CstNodeKind::DictEntry) if index_in_parent == 0 => TokenClass::Property,
+            Some(CstNodeKind::QualifiedAccess) => TokenClass::Function,
+            _ => TokenClass::Variable,
+        },
+    }
+}
+
+fn classify_token(
+    token_kind: &TokenKind,
+    node_kind: &CstNodeKind,
+    parent: Option<&CstNodeKind>,
+    index_in_parent: usize,
+) -> Option<TokenClass> {
+    use TokenKind::*;
+
+    Some(match token_kind {
+        Def | Let | If | Elif | Else | End | While | Loop | Foreach | Include | Import | Module | Match | Fn | Do
+        | Var | Macro | Try | Catch | As | Break | Continue | Quote | Unquote => TokenClass::Keyword,
+        Self_ | Nodes | None => TokenClass::Builtin,
+        BoolLiteral(_) => TokenClass::Boolean,
+        NumberLiteral(_) => TokenClass::Number,
+        StringLiteral(_) | InterpolatedString(_) | BytesLiteral(_) | Env(_) | Selector(_) => TokenClass::String,
+        Comment(_) => TokenClass::Comment,
+        Ident(_) => classify_ident(node_kind, parent, index_in_parent),
+        And | Or | Not | Coalesce | Plus | Minus | Asterisk | Slash | Percent | Equal | EqEq | NeEq | Lt | Lte | Gt
+        | Gte | Arrow | Pipe | TildeEqual | NotTildeEqual | LeftShift | RightShift | Convert | DoubleDot
+        | DotDotDot | PlusEqual | MinusEqual | StarEqual | SlashEqual | PercentEqual | DoubleSlashEqual | PipeEqual => {
+            TokenClass::Operator
+        }
+        LParen | RParen | LBrace | RBrace | LBracket | RBracket | Colon | DoubleColon | SemiColon | Comma
+        | Question => TokenClass::Punctuation,
+        Whitespace(_) | Tab(_) | NewLine | Eof => return Option::None,
+    })
+}
+
+fn collect_spans(nodes: &[Shared<CstNode>], parent: Option<&CstNodeKind>, out: &mut Vec<Span>) {
+    for (index, node) in nodes.iter().enumerate() {
+        for trivia in node.leading_trivia.iter().chain(node.trailing_trivia.iter()) {
+            if let CstTrivia::Comment(token) = trivia {
+                out.push(Span {
+                    line: token.range.start.line,
+                    // The lexer's comment token starts after the `#` delimiter;
+                    // pull the span back one column so `#` is highlighted too.
+                    start_col: token.range.start.column.saturating_sub(1),
+                    end_col: token.range.end.column,
+                    class: TokenClass::Comment,
+                });
+            }
+        }
+
+        if let Some(token) = &node.token
+            && let Some(class) = classify_token(&token.kind, &node.kind, parent, index)
+        {
+            out.push(Span {
+                line: token.range.start.line,
+                start_col: token.range.start.column,
+                end_col: token.range.end.column,
+                class,
+            });
+        }
+
+        collect_spans(&node.children, Some(&node.kind), out);
+    }
+}
+
+fn render_line(line: &str, spans: &[Span]) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let escape_range = |start: usize, end: usize| -> String {
+        let start = start.min(chars.len());
+        let end = end.min(chars.len());
+        html_escape(&chars[start..end].iter().collect::<String>())
+    };
+
+    let mut html = String::new();
+    let mut cursor = 0usize;
+
+    for span in spans {
+        let start = span.start_col.saturating_sub(1);
+        let end = span.end_col.saturating_sub(1);
+        // Defensively skip spans that are out of order/overlapping/out-of-bounds
+        // (e.g. a token whose range spans multiple lines) rather than panicking.
+        if start < cursor || start >= chars.len() || end <= start {
+            continue;
+        }
+
+        if start > cursor {
+            html.push_str(&escape_range(cursor, start));
+        }
+        html.push_str(&format!(
+            "<span class=\"{}\">{}</span>",
+            span.class.css_class(),
+            escape_range(start, end)
+        ));
+        cursor = end.min(chars.len());
+    }
+
+    if cursor < chars.len() {
+        html.push_str(&escape_range(cursor, chars.len()));
+    }
+
+    html
+}
+
+/// Renders every line of `content` as syntax-highlighted, HTML-escaped markup
+/// suitable for a `<td class="code">` cell, in source line order.
+pub(crate) fn highlight_lines(content: &str) -> Vec<String> {
+    let (nodes, _) = mq_lang::parse_recovery(content);
+    let mut spans = Vec::new();
+    collect_spans(&nodes, None, &mut spans);
+
+    let mut by_line: FxHashMap<u32, Vec<Span>> = FxHashMap::default();
+    for span in spans {
+        by_line.entry(span.line).or_default().push(span);
+    }
+
+    content
+        .lines()
+        .enumerate()
+        .map(|(i, line)| {
+            let line_no = (i + 1) as u32;
+            let mut line_spans = by_line.remove(&line_no).unwrap_or_default();
+            line_spans.sort_by_key(|s| s.start_col);
+            render_line(line, &line_spans)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "def foo(x):\n  x + 1\nend\n",
+        0,
+        "<span class=\"tok-keyword\">def</span> <span class=\"tok-function\">foo</span><span class=\"tok-punctuation\">(</span><span class=\"tok-variable\">x</span><span class=\"tok-punctuation\">)</span><span class=\"tok-punctuation\">:</span>"
+    )]
+    #[case(
+        "upcase()\n",
+        0,
+        "<span class=\"tok-function\">upcase</span><span class=\"tok-punctuation\">(</span><span class=\"tok-punctuation\">)</span>"
+    )]
+    #[case("# leading comment\n1\n", 0, "<span class=\"tok-comment\">")]
+    #[case("\"hi\"\n", 0, "<span class=\"tok-string\">")]
+    #[case(
+        "1 + 2\n",
+        0,
+        "<span class=\"tok-number\">1</span> <span class=\"tok-operator\">+</span> <span class=\"tok-number\">2</span>"
+    )]
+    fn test_highlight_lines_classifies_tokens(#[case] code: &str, #[case] line_index: usize, #[case] expected: &str) {
+        let lines = highlight_lines(code);
+        assert!(
+            lines[line_index].contains(expected),
+            "expected {:?} to contain {:?}",
+            lines[line_index],
+            expected
+        );
+    }
+
+    #[test]
+    fn test_highlight_lines_import_and_module_names_are_module_class() {
+        let lines = highlight_lines("import \"foo\" as bar\n");
+        assert!(lines[0].contains("<span class=\"tok-keyword\">import</span>"));
+    }
+
+    #[test]
+    fn test_highlight_lines_preserves_line_count_and_plain_whitespace() {
+        let code = "1\n\n  2\n";
+        let lines = highlight_lines(code);
+        assert_eq!(lines.len(), 3);
+        assert!(lines[1].is_empty());
+        assert!(lines[2].starts_with("  "));
+    }
+
+    #[test]
+    fn test_highlight_lines_escapes_html_in_strings_and_comments() {
+        let lines = highlight_lines("\"<a>\"\n");
+        assert!(lines[0].contains("&lt;a&gt;"));
+        assert!(!lines[0].contains("<a>"));
+    }
+}

--- a/crates/mq-test/src/lib.rs
+++ b/crates/mq-test/src/lib.rs
@@ -1,4 +1,5 @@
 mod coverage;
+mod highlight;
 mod runner;
 
 pub use coverage::{CoverageFormat, FileCoverage};

--- a/crates/mq-test/src/lib.rs
+++ b/crates/mq-test/src/lib.rs
@@ -1,2 +1,5 @@
+mod coverage;
 mod runner;
+
+pub use coverage::{CoverageFormat, FileCoverage};
 pub use runner::TestRunner;

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -1,4 +1,5 @@
 mod coverage;
+mod highlight;
 mod runner;
 
 use clap::Parser;

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -31,8 +31,9 @@ struct Cli {
     /// Defaults to **/*.mq in the current directory when omitted.
     files: Vec<PathBuf>,
 
-    /// Collect and report line coverage for the executed test files.
-    /// Coverage of `include`d/imported modules is not tracked.
+    /// Collect and report line coverage of the `include`d/imported modules
+    /// exercised while running the tests. Coverage of the test files'
+    /// own lines is not tracked.
     #[arg(long)]
     coverage: bool,
 

--- a/crates/mq-test/src/main.rs
+++ b/crates/mq-test/src/main.rs
@@ -1,6 +1,8 @@
+mod coverage;
 mod runner;
 
 use clap::Parser;
+use coverage::CoverageFormat;
 use std::{path::PathBuf, process::ExitCode};
 
 #[derive(Parser, Debug)]
@@ -13,17 +15,51 @@ use std::{path::PathBuf, process::ExitCode};
     ## Run tests across multiple files:\n\
     mq-test tests.mq other_tests.mq\n\n\
     ## Discover and run all *.mq files in the current directory:\n\
-    mq-test")]
+    mq-test\n\n\
+    ## Run with a line-coverage report:\n\
+    mq-test --coverage\n\n\
+    ## Write an lcov tracefile for CI:\n\
+    mq-test --coverage --coverage-format lcov --coverage-output lcov.info\n\n\
+    ## Write an HTML coverage report (green/red per-line highlighting):\n\
+    mq-test --coverage --coverage-format html --coverage-output coverage.html\n\n\
+    ## Write a Markdown coverage report:\n\
+    mq-test --coverage --coverage-format markdown --coverage-output coverage.md\n\n\
+    ## Write an HTML coverage report and open it in the browser:\n\
+    mq-test --coverage --coverage-format html --coverage-output coverage.html --open")]
 struct Cli {
     /// Path(s) to mq test files.
     /// Defaults to **/*.mq in the current directory when omitted.
     files: Vec<PathBuf>,
+
+    /// Collect and report line coverage for the executed test files.
+    /// Coverage of `include`d/imported modules is not tracked.
+    #[arg(long)]
+    coverage: bool,
+
+    /// Report format used when `--coverage` is enabled.
+    #[arg(long, value_enum, default_value = "text", requires = "coverage")]
+    coverage_format: CoverageFormat,
+
+    /// Write the coverage report to a file instead of stdout.
+    #[arg(long, requires = "coverage")]
+    coverage_output: Option<PathBuf>,
+
+    /// Open the written coverage report in the OS default application.
+    /// Requires `--coverage-output`.
+    #[arg(long, requires_all = ["coverage", "coverage_output"])]
+    open: bool,
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    if let Err(e) = runner::TestRunner::new(cli.files).run() {
+    if let Err(e) = runner::TestRunner::new(cli.files)
+        .with_coverage(cli.coverage)
+        .with_coverage_format(cli.coverage_format)
+        .with_coverage_output(cli.coverage_output)
+        .with_open(cli.open)
+        .run()
+    {
         eprintln!("{e:?}");
         ExitCode::FAILURE
     } else {

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -1,6 +1,7 @@
 use glob::glob;
 use miette::IntoDiagnostic;
 use mq_lang::{CstNodeKind, CstTrivia};
+use rustc_hash::FxHashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -50,8 +51,8 @@ impl TestRunner {
         }
     }
 
-    /// Enables line-coverage tracking. Coverage of `include`d/imported modules
-    /// is not tracked — only the test file being executed.
+    /// Enables line-coverage tracking of `include`d/imported modules.
+    /// The test files' own lines are not tracked.
     pub fn with_coverage(mut self, coverage: bool) -> Self {
         self.coverage = coverage;
         self
@@ -86,7 +87,10 @@ impl TestRunner {
         } else {
             self.files.clone()
         };
-        let mut file_coverages = Vec::new();
+        // Merged across all test files, so a shared module gets combined coverage.
+        let coverage_data = CoverageData::default();
+        // Resolved module-name -> file path, filled in as each engine resolves imports.
+        let mut module_paths: FxHashMap<String, PathBuf> = FxHashMap::default();
 
         for file in &test_files {
             let content = fs::read_to_string(file).into_diagnostic()?;
@@ -107,31 +111,46 @@ impl TestRunner {
                 engine.set_search_paths(vec![parent.to_path_buf()]);
             }
 
-            let coverage_data = if self.coverage {
-                let data = CoverageData::default();
-                engine.set_debugger_handler(Box::new(CoverageHandler(data.clone())));
+            if self.coverage {
+                engine.set_debugger_handler(Box::new(CoverageHandler(coverage_data.clone())));
                 let debugger = engine.debugger();
                 debugger.write().unwrap().activate();
                 debugger
                     .write()
                     .unwrap()
                     .set_command(mq_lang::DebuggerCommand::StepInto);
-                Some(data)
-            } else {
-                None
-            };
+            }
 
             let input = mq_lang::null_input();
             engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
 
-            if let Some(data) = coverage_data {
-                let visited = data.snapshot();
-                let executable = coverage::executable_lines(&content);
-                file_coverages.push(FileCoverage::new(file.clone(), executable, visited, content));
+            if self.coverage {
+                for module_name in coverage_data.snapshot().keys() {
+                    module_paths.entry(module_name.clone()).or_insert_with(|| {
+                        engine
+                            .get_module_path(module_name)
+                            .map(PathBuf::from)
+                            .unwrap_or_else(|_| PathBuf::from(module_name))
+                    });
+                }
             }
         }
 
         if self.coverage {
+            let mut file_coverages: Vec<FileCoverage> = coverage_data
+                .snapshot()
+                .into_iter()
+                .map(|(module_name, hits)| {
+                    let executable = coverage::executable_lines(&hits.code);
+                    let file = module_paths
+                        .get(&module_name)
+                        .cloned()
+                        .unwrap_or_else(|| PathBuf::from(&module_name));
+                    FileCoverage::new(file, executable, hits.lines, hits.code)
+                })
+                .collect();
+            file_coverages.sort_by(|a, b| a.file.cmp(&b.file));
+
             let report = match self.coverage_format {
                 CoverageFormat::Text => coverage::format_text_report(&file_coverages),
                 CoverageFormat::Lcov => coverage::format_lcov_report(&file_coverages),
@@ -604,5 +623,88 @@ mod tests {
         let mut expected: Vec<String> = expected_args.into_iter().map(String::from).collect();
         expected.push("coverage.html".to_string());
         assert_eq!(args, expected);
+    }
+
+    fn temp_project_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mq_test_{name}_{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_coverage_reports_only_the_imported_module() {
+        let dir = temp_project_dir("coverage_only_imported");
+        fs::write(
+            dir.join("lib.mq"),
+            "def add(a, b):\n  a + b\nend\n\ndef unused(a):\n  a * 100\nend\n",
+        )
+        .unwrap();
+        let test_file = dir.join("tests.mq");
+        fs::write(
+            &test_file,
+            "include \"test\" | include \"lib\"\n|\n\ndef test_add():\n  assert_eq(add(1, 2), 3)\nend\n",
+        )
+        .unwrap();
+        let output = dir.join("coverage.json");
+
+        TestRunner::new(vec![test_file])
+            .with_coverage(true)
+            .with_coverage_format(CoverageFormat::Json)
+            .with_coverage_output(Some(output.clone()))
+            .run()
+            .unwrap();
+
+        let report = fs::read_to_string(&output).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let files = parsed["files"].as_array().unwrap();
+
+        // Only "lib" is reported — the test file itself and the "test"/"builtin"
+        // modules it also pulls in are not the code under test.
+        assert_eq!(files.len(), 1, "expected only lib.mq in report: {files:?}");
+        assert!(files[0]["file"].as_str().unwrap().ends_with("lib.mq"));
+        assert_eq!(files[0]["totalLines"], 2);
+        assert_eq!(files[0]["coveredLines"], 1);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_coverage_merges_across_test_files_sharing_a_module() {
+        let dir = temp_project_dir("coverage_merge");
+        fs::write(
+            dir.join("lib.mq"),
+            "def add(a, b):\n  a + b\nend\n\ndef sub(a, b):\n  a - b\nend\n",
+        )
+        .unwrap();
+        let test_add = dir.join("test_add.mq");
+        fs::write(
+            &test_add,
+            "include \"test\" | include \"lib\"\n|\n\ndef test_add():\n  assert_eq(add(1, 2), 3)\nend\n",
+        )
+        .unwrap();
+        let test_sub = dir.join("test_sub.mq");
+        fs::write(
+            &test_sub,
+            "include \"test\" | include \"lib\"\n|\n\ndef test_sub():\n  assert_eq(sub(5, 2), 3)\nend\n",
+        )
+        .unwrap();
+        let output = dir.join("coverage.json");
+
+        TestRunner::new(vec![test_add, test_sub])
+            .with_coverage(true)
+            .with_coverage_format(CoverageFormat::Json)
+            .with_coverage_output(Some(output.clone()))
+            .run()
+            .unwrap();
+
+        let report = fs::read_to_string(&output).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let files = parsed["files"].as_array().unwrap();
+
+        assert_eq!(files.len(), 1, "lib.mq must be reported once, merged: {files:?}");
+        assert_eq!(files[0]["totalLines"], 2);
+        assert_eq!(files[0]["coveredLines"], 2);
+
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -4,6 +4,8 @@ use mq_lang::{CstNodeKind, CstTrivia};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::coverage::{self, CoverageData, CoverageFormat, CoverageHandler, FileCoverage};
+
 /// Parsed test annotation from a leading comment.
 #[derive(Debug, PartialEq)]
 enum TestAnnotation {
@@ -29,13 +31,49 @@ enum DiscoveredTest {
 /// The runner auto-generates the `run_tests(...)` call from discovered tests.
 pub struct TestRunner {
     files: Vec<PathBuf>,
+    coverage: bool,
+    coverage_format: CoverageFormat,
+    coverage_output: Option<PathBuf>,
+    open: bool,
 }
 
 impl TestRunner {
     /// Creates a `TestRunner` for the given files.
     /// If `files` is empty, globs `**/*.mq` in the current directory.
     pub fn new(files: Vec<PathBuf>) -> Self {
-        Self { files }
+        Self {
+            files,
+            coverage: false,
+            coverage_format: CoverageFormat::default(),
+            coverage_output: None,
+            open: false,
+        }
+    }
+
+    /// Enables line-coverage tracking. Coverage of `include`d/imported modules
+    /// is not tracked — only the test file being executed.
+    pub fn with_coverage(mut self, coverage: bool) -> Self {
+        self.coverage = coverage;
+        self
+    }
+
+    /// Sets the report format used when coverage is enabled.
+    pub fn with_coverage_format(mut self, format: CoverageFormat) -> Self {
+        self.coverage_format = format;
+        self
+    }
+
+    /// Sets an output file for the coverage report. When `None`, the report
+    /// is printed to stdout.
+    pub fn with_coverage_output(mut self, output: Option<PathBuf>) -> Self {
+        self.coverage_output = output;
+        self
+    }
+
+    /// Opens the written coverage report in the OS default application after `run()`.
+    pub fn with_open(mut self, open: bool) -> Self {
+        self.open = open;
+        self
     }
 
     /// Discovers and executes all test functions.
@@ -46,8 +84,9 @@ impl TestRunner {
                 .collect::<Result<Vec<_>, _>>()
                 .into_diagnostic()?
         } else {
-            self.files
+            self.files.clone()
         };
+        let mut file_coverages = Vec::new();
 
         for file in &test_files {
             let content = fs::read_to_string(file).into_diagnostic()?;
@@ -68,8 +107,49 @@ impl TestRunner {
                 engine.set_search_paths(vec![parent.to_path_buf()]);
             }
 
+            let coverage_data = if self.coverage {
+                let data = CoverageData::default();
+                engine.set_debugger_handler(Box::new(CoverageHandler(data.clone())));
+                let debugger = engine.debugger();
+                debugger.write().unwrap().activate();
+                debugger
+                    .write()
+                    .unwrap()
+                    .set_command(mq_lang::DebuggerCommand::StepInto);
+                Some(data)
+            } else {
+                None
+            };
+
             let input = mq_lang::null_input();
             engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
+
+            if let Some(data) = coverage_data {
+                let visited = data.snapshot();
+                let executable = coverage::executable_lines(&content);
+                file_coverages.push(FileCoverage::new(file.clone(), executable, visited, content));
+            }
+        }
+
+        if self.coverage {
+            let report = match self.coverage_format {
+                CoverageFormat::Text => coverage::format_text_report(&file_coverages),
+                CoverageFormat::Lcov => coverage::format_lcov_report(&file_coverages),
+                CoverageFormat::Html => coverage::format_html_report(&file_coverages),
+                CoverageFormat::Markdown => coverage::format_markdown_report(&file_coverages),
+                CoverageFormat::Json => coverage::format_json_report(&file_coverages),
+                CoverageFormat::Cobertura => coverage::format_cobertura_report(&file_coverages),
+            };
+
+            match &self.coverage_output {
+                Some(path) => {
+                    fs::write(path, report).into_diagnostic()?;
+                    if self.open {
+                        open_in_default_app(path)?;
+                    }
+                }
+                None => print!("{report}"),
+            }
         }
 
         Ok(())
@@ -199,6 +279,31 @@ impl TestRunner {
 
         format!("{content}\n| run_tests(flatten([\n{cases}\n]))")
     }
+}
+
+/// Builds the command that opens `path` in the OS default application for
+/// `target_os` (as in `std::env::consts::OS`): `open` on macOS, `start` on
+/// Windows, `xdg-open` elsewhere.
+fn build_open_command(path: &Path, target_os: &str) -> std::process::Command {
+    let mut cmd = if target_os == "macos" {
+        std::process::Command::new("open")
+    } else if target_os == "windows" {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/C", "start", ""]);
+        cmd
+    } else {
+        std::process::Command::new("xdg-open")
+    };
+    cmd.arg(path);
+    cmd
+}
+
+/// Launches `path` in the OS default application.
+fn open_in_default_app(path: &Path) -> miette::Result<()> {
+    build_open_command(path, std::env::consts::OS)
+        .status()
+        .into_diagnostic()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -478,5 +583,26 @@ mod tests {
         let tests = vec![DiscoveredTest::Simple("test_foo".to_string())];
         let query = TestRunner::build_test_query(content, &tests);
         assert!(query.starts_with(content));
+    }
+
+    #[rstest]
+    #[case("macos", "open", Vec::<&str>::new())]
+    #[case("windows", "cmd", vec!["/C", "start", ""])]
+    #[case("linux", "xdg-open", Vec::<&str>::new())]
+    #[case("freebsd", "xdg-open", Vec::<&str>::new())]
+    fn test_build_open_command(
+        #[case] target_os: &str,
+        #[case] expected_program: &str,
+        #[case] expected_args: Vec<&str>,
+    ) {
+        let path = PathBuf::from("coverage.html");
+        let cmd = build_open_command(&path, target_os);
+
+        assert_eq!(cmd.get_program(), expected_program);
+
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        let mut expected: Vec<String> = expected_args.into_iter().map(String::from).collect();
+        expected.push("coverage.html".to_string());
+        assert_eq!(args, expected);
     }
 }


### PR DESCRIPTION
## Summary

Adds line coverage tracking to mq-test via mq-lang's existing debugger hooks, gated behind the --coverage flag so normal test runs pay no overhead. Supports text and lcov (--coverage-format) report output, optionally written to a file with --coverage-output.

Also moves the debugger's is_active() check ahead of DebugContext construction in mq-lang's eval_expr, so consumers that compile in the debugger feature (like mq-test) only pay its cost when the debugger is actually activated at runtime.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [x] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
