### PR TITLE
✨ feat(mq-web-api): add curl-friendly POST /{query} shortcut endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -41,6 +41,9 @@ tracing-subscriber = {workspace = true, features = ["env-filter", "json"]}
 utoipa = {workspace = true, features = ["preserve_order"]}
 utoipa-swagger-ui = {workspace = true}
 
+[dev-dependencies]
+rstest = {workspace = true}
+
 [[bin]]
 name = "mq-web-api"
 path = "src/main.rs"

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -7,6 +7,7 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Health check |
+| `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw Markdown body |
 | `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
 | `POST` | `/api/v1/check` | Type-check a query |
@@ -18,6 +19,25 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | `GET` | `/docs` | Swagger UI |
 
 Legacy paths (`/api/query`, `/api/check`, `/api/format`, `/openapi.json`) redirect permanently to the `/api/v1/` equivalents.
+
+### `POST /{query}`
+
+Curl-friendly shortcut for one-off queries: the mq query goes in the URL path, the input content is the raw request body.
+
+```bash
+curl --data-binary @doc.md https://api.mqlang.org/.h1
+```
+
+| Parameter | Location | Required | Description |
+|-----------|----------|----------|--------------|
+| `query` | Path | Yes | mq query expression. Reserved characters (`\|`, `?`, `#`) must be percent-encoded, e.g. `.h1 \| .text` → `.h1%20%7C%20.text` |
+| (body) | Body | No | Raw input content |
+| `input_format` | Query | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+| `output_format` | Query | No | `markdown` (default), `html`, `text`, `json`, `none` |
+
+> **Use `--data-binary`, not `-d`/`--data`.** `curl -d @file` strips newlines from the file, which breaks Markdown parsing (blank lines separate paragraphs and headings). `--data-binary` sends the file exactly as-is.
+
+For queries that need modules, args, or aggregation, use `POST /api/v1/query` instead.
 
 ### `GET /api/v1/query`
 
@@ -157,6 +177,12 @@ docker run -p 3000:3000 \
 ```
 
 ## Examples
+
+### Curl-friendly shortcut
+
+```bash
+curl --data-binary @doc.md https://api.mqlang.org/.h1
+```
 
 ### Execute a query (GET)
 

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -7,7 +7,7 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Health check |
-| `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw Markdown/HTML body (HTML auto-detected) |
+| `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw body (Markdown/HTML/XML/JSON/CSV/...) |
 | `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
 | `POST` | `/api/v1/check` | Type-check a query |
@@ -32,20 +32,27 @@ curl --data-binary @doc.md https://api.mqlang.org/.h1
 |-----------|----------|----------|--------------|
 | `query` | Path | Yes | mq query expression. Reserved characters (`\|`, `?`, `#`) must be percent-encoded, e.g. `.h1 \| .text` → `.h1%20%7C%20.text` |
 | (body) | Body | No | Raw input content |
-| `input_format` | Query | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null`. Auto-detected as `html` if omitted and the body starts with `<!doctype html>` or `<html>`. |
+| `input_format` | Query | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null`, `csv`, `tsv`, `psv`, `json`, `yaml`, `toml`, `xml`, `hcl`, `toon`. See auto-detection below. |
 | `output_format` | Query | No | `markdown` (default), `html`, `text`, `json`, `none` |
 
+`html`, `xml`, and `json` are auto-detected from the body's leading bytes when `input_format` is omitted (`<!doctype html>`/`<html`, `<?xml`, and `{`/`[` respectively). `csv`, `tsv`, `psv`, `yaml`, `toml`, `hcl`, and `toon` have no reliable content signature and always need an explicit `input_format`.
+
 ```bash
-# HTML is auto-detected — no ?input_format=html needed
+# HTML/XML/JSON are auto-detected — no ?input_format= needed
 curl --data-binary @page.html https://api.mqlang.org/.h1
+curl --data-binary @data.json 'https://api.mqlang.org/json::json_to_markdown_table()'
+
+# CSV (and tsv/psv/yaml/toml/hcl/toon) need an explicit input_format,
+# then use the matching builtin module inside the query
+curl --data-binary @data.csv 'https://api.mqlang.org/csv::csv_to_markdown_table()?input_format=csv'
 
 # Force a format explicitly if auto-detection isn't what you want
 curl --data-binary @page.html "https://api.mqlang.org/.h1?input_format=text"
 ```
 
-> **Use `--data-binary`, not `-d`/`--data`.** `curl -d @file` strips newlines from the file, which breaks Markdown/HTML parsing (blank lines separate paragraphs and headings). `--data-binary` sends the file exactly as-is.
+> **Use `--data-binary`, not `-d`/`--data`.** `curl -d @file` strips newlines from the file, which breaks Markdown/HTML/XML parsing (blank lines/whitespace are often significant). `--data-binary` sends the file exactly as-is.
 
-For queries that need modules, args, or aggregation, use `POST /api/v1/query` instead.
+For queries that need `modules`, `args`, or `aggregate`, use `POST /api/v1/query` instead.
 
 ### `GET /api/v1/query`
 
@@ -53,7 +60,7 @@ For queries that need modules, args, or aggregation, use `POST /api/v1/query` in
 |-----------|----------|-------------|
 | `query` | Yes | mq query string |
 | `input` | No | Input content |
-| `input_format` | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+| `input_format` | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null`, `csv`, `tsv`, `psv`, `json`, `yaml`, `toml`, `xml`, `hcl`, `toon` |
 
 ### `POST /api/v1/query`
 
@@ -73,7 +80,7 @@ For queries that need modules, args, or aggregation, use `POST /api/v1/query` in
 |-------|------|-------------|
 | `query` | `string` | mq query string |
 | `input` | `string?` | Input content |
-| `input_format` | `string?` | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+| `input_format` | `string?` | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null`, `csv`, `tsv`, `psv`, `json`, `yaml`, `toml`, `xml`, `hcl`, `toon` |
 | `output_format` | `string?` | `markdown` (default), `html`, `text`, `json`, `none` |
 | `modules` | `string[]?` | Builtin module names to load (e.g. `"json"`, `"csv"`) |
 | `args` | `object?` | String variables passed to the engine |
@@ -196,6 +203,18 @@ curl --data-binary @doc.md https://api.mqlang.org/.h1
 
 ```bash
 curl --data-binary @page.html https://api.mqlang.org/.h1
+```
+
+### Curl-friendly shortcut with CSV input
+
+```bash
+curl --data-binary @data.csv 'https://api.mqlang.org/csv::csv_to_markdown_table()?input_format=csv'
+```
+
+### Curl-friendly shortcut with JSON input (auto-detected)
+
+```bash
+curl --data-binary @data.json 'https://api.mqlang.org/json::json_to_markdown_table()'
 ```
 
 ### Execute a query (GET)

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -7,7 +7,7 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Health check |
-| `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw Markdown body |
+| `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw Markdown/HTML body (HTML auto-detected) |
 | `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
 | `POST` | `/api/v1/check` | Type-check a query |
@@ -32,10 +32,18 @@ curl --data-binary @doc.md https://api.mqlang.org/.h1
 |-----------|----------|----------|--------------|
 | `query` | Path | Yes | mq query expression. Reserved characters (`\|`, `?`, `#`) must be percent-encoded, e.g. `.h1 \| .text` → `.h1%20%7C%20.text` |
 | (body) | Body | No | Raw input content |
-| `input_format` | Query | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null` |
+| `input_format` | Query | No | `markdown` (default), `mdx`, `text`, `html`, `raw`, `null`. Auto-detected as `html` if omitted and the body starts with `<!doctype html>` or `<html>`. |
 | `output_format` | Query | No | `markdown` (default), `html`, `text`, `json`, `none` |
 
-> **Use `--data-binary`, not `-d`/`--data`.** `curl -d @file` strips newlines from the file, which breaks Markdown parsing (blank lines separate paragraphs and headings). `--data-binary` sends the file exactly as-is.
+```bash
+# HTML is auto-detected — no ?input_format=html needed
+curl --data-binary @page.html https://api.mqlang.org/.h1
+
+# Force a format explicitly if auto-detection isn't what you want
+curl --data-binary @page.html "https://api.mqlang.org/.h1?input_format=text"
+```
+
+> **Use `--data-binary`, not `-d`/`--data`.** `curl -d @file` strips newlines from the file, which breaks Markdown/HTML parsing (blank lines separate paragraphs and headings). `--data-binary` sends the file exactly as-is.
 
 For queries that need modules, args, or aggregation, use `POST /api/v1/query` instead.
 
@@ -182,6 +190,12 @@ docker run -p 3000:3000 \
 
 ```bash
 curl --data-binary @doc.md https://api.mqlang.org/.h1
+```
+
+### Curl-friendly shortcut with HTML input (auto-detected)
+
+```bash
+curl --data-binary @page.html https://api.mqlang.org/.h1
 ```
 
 ### Execute a query (GET)

--- a/crates/mq-web-api/src/api.rs
+++ b/crates/mq-web-api/src/api.rs
@@ -28,7 +28,7 @@ pub struct QueryApiResponse {
     pub results: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum InputFormat {
     #[default]
@@ -44,6 +44,46 @@ pub enum InputFormat {
     Raw,
     #[serde(rename = "null")]
     Null,
+    /// Module-backed formats: fed as raw text and parsed by the corresponding
+    /// builtin mq module (same mechanism as the CLI's `-I` flag).
+    #[serde(rename = "csv")]
+    Csv,
+    #[serde(rename = "tsv")]
+    Tsv,
+    #[serde(rename = "psv")]
+    Psv,
+    #[serde(rename = "json")]
+    Json,
+    #[serde(rename = "yaml")]
+    Yaml,
+    #[serde(rename = "toml")]
+    Toml,
+    #[serde(rename = "xml")]
+    Xml,
+    #[serde(rename = "hcl")]
+    Hcl,
+    #[serde(rename = "toon")]
+    Toon,
+}
+
+impl InputFormat {
+    /// Returns the mq query prefix that parses raw text of this format into
+    /// structured data, for module-backed formats. `None` for formats that
+    /// are ingested natively (markdown, html, ...) without an `import`.
+    pub fn module_query_prefix(&self) -> Option<&'static str> {
+        match self {
+            Self::Csv => Some(r#"import "csv" | csv::csv_parse(true)"#),
+            Self::Tsv => Some(r#"import "csv" | csv::tsv_parse(true)"#),
+            Self::Psv => Some(r#"import "csv" | csv::psv_parse(true)"#),
+            Self::Json => Some(r#"import "json" | json::json_parse()"#),
+            Self::Yaml => Some(r#"import "yaml" | yaml::yaml_parse()"#),
+            Self::Toml => Some(r#"import "toml" | toml::toml_parse()"#),
+            Self::Xml => Some(r#"import "xml" | xml::xml_parse()"#),
+            Self::Hcl => Some(r#"import "hcl" | hcl::hcl_parse()"#),
+            Self::Toon => Some(r#"import "toon" | toon::toon_parse()"#),
+            Self::Markdown | Self::Mdx | Self::Text | Self::Html | Self::Raw | Self::Null => None,
+        }
+    }
 }
 
 /// Output format for query results.
@@ -319,19 +359,37 @@ fn execute_query(request: ApiRequest) -> miette::Result<QueryApiResponse> {
         }
     }
 
-    let query = if request.aggregate.unwrap_or(false) {
-        format!(r#"nodes | import "section" | {}"#, request.query)
-    } else {
-        request.query.clone()
+    let input_format = request.input_format.clone().unwrap_or(InputFormat::Markdown);
+
+    let query = {
+        let base = if request.aggregate.unwrap_or(false) {
+            format!(r#"nodes | import "section" | {}"#, request.query)
+        } else {
+            request.query.clone()
+        };
+        match input_format.module_query_prefix() {
+            Some(prefix) => format!("{} | {}", prefix, base),
+            None => base,
+        }
     };
 
-    let input = match request.input_format.unwrap_or(InputFormat::Markdown) {
+    let input = match input_format {
         InputFormat::Markdown => mq_lang::parse_markdown_input(&request.input.unwrap_or_default())?,
         InputFormat::Mdx => mq_lang::parse_mdx_input(&request.input.unwrap_or_default())?,
         InputFormat::Text => mq_lang::parse_text_input(&request.input.unwrap_or_default())?,
         InputFormat::Html => mq_lang::parse_html_input(&request.input.unwrap_or_default())?,
         InputFormat::Raw => mq_lang::raw_input(&request.input.unwrap_or_default()),
         InputFormat::Null => mq_lang::null_input(),
+        // Module-backed formats: pass raw text through; the `import`ed module parses it.
+        InputFormat::Csv
+        | InputFormat::Tsv
+        | InputFormat::Psv
+        | InputFormat::Json
+        | InputFormat::Yaml
+        | InputFormat::Toml
+        | InputFormat::Xml
+        | InputFormat::Hcl
+        | InputFormat::Toon => mq_lang::raw_input(&request.input.unwrap_or_default()),
     };
 
     let runtime_values = engine
@@ -446,6 +504,46 @@ fn runtime_value_to_nodes(runtime_value: &mq_lang::RuntimeValue) -> Vec<mq_markd
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(InputFormat::Csv, "name,age\nAlice,30\nBob,25")]
+    #[case(InputFormat::Tsv, "name\tage\nAlice\t30")]
+    #[case(InputFormat::Psv, "name|age\nAlice|30")]
+    #[case(InputFormat::Json, r#"{"name": "Alice", "age": 30}"#)]
+    #[case(InputFormat::Yaml, "name: Alice\nage: 30")]
+    #[case(InputFormat::Toml, "name = \"Alice\"\nage = 30")]
+    #[case(InputFormat::Xml, "<person><name>Alice</name></person>")]
+    #[case(InputFormat::Hcl, r#"resource "aws_instance" "example" { ami = "abc-123" }"#)]
+    #[case(InputFormat::Toon, "name: Alice\nage: 30")]
+    fn test_execute_module_backed_formats(#[case] input_format: InputFormat, #[case] input: &str) {
+        let req = ApiRequest {
+            query: "identity()".to_string(),
+            input: Some(input.to_string()),
+            input_format: Some(input_format),
+            modules: None,
+            args: None,
+            output_format: None,
+            aggregate: None,
+        };
+        let result = query(req);
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(!result.unwrap().results.is_empty());
+    }
+
+    #[test]
+    fn test_module_query_prefix_native_formats_are_none() {
+        for fmt in [
+            InputFormat::Markdown,
+            InputFormat::Mdx,
+            InputFormat::Text,
+            InputFormat::Html,
+            InputFormat::Raw,
+            InputFormat::Null,
+        ] {
+            assert_eq!(fmt.module_query_prefix(), None);
+        }
+    }
 
     #[test]
     fn test_execute_markdown() {

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::rejection::QueryRejection,
-    extract::{FromRequestParts, Query, State},
+    extract::{FromRequestParts, Path, Query, State},
     http::{StatusCode, request::Parts},
     response::Json,
 };
@@ -31,6 +31,12 @@ pub struct QueryParams {
 #[derive(Deserialize)]
 pub struct DiagnosticsParams {
     pub query: String,
+}
+
+#[derive(Deserialize)]
+pub struct ShorthandQueryParams {
+    pub input_format: Option<String>,
+    pub output_format: Option<String>,
 }
 
 pub struct ValidatedQuery<T>(pub T);
@@ -69,6 +75,7 @@ pub async fn health_check() -> Json<HealthResponse> {
     paths(
         get_query_api,
         post_query_api,
+        post_shorthand_query_api,
         post_check_api,
         post_format_api,
         get_functions_api,
@@ -196,6 +203,73 @@ pub async fn post_query_api(
         }
         Err(e) => {
             error!("Failed to process query '{}': {}", query_str, e);
+            Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid query")
+                .with_detail("error", &e.to_string()))
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/{query}",
+    tag = "mq-api",
+    summary = "Run an mq query against raw Markdown (curl-friendly shortcut)",
+    description = "Curl-friendly shortcut that reads the mq query from the URL path and the input content from the raw request body, e.g. `curl -d @doc.md https://api.mqlang.org/.h1`. Reserved characters in the query (`|`, `?`, `#`) must be percent-encoded.",
+    params(
+        ("query" = String, Path, description = "mq query expression", example = ".h1"),
+        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, or null"),
+        ("output_format" = Option<String>, Query, description = "Output format: markdown, html, text, json, or none"),
+    ),
+    request_body(content = String, content_type = "text/markdown", description = "Raw Markdown/MDX/HTML/text content to query"),
+    responses(
+        (status = 200, description = "Query executed successfully", body = QueryApiResponse),
+        (status = 400, description = "Invalid query or request"),
+    )
+)]
+pub async fn post_shorthand_query_api(
+    State(_state): State<AppState>,
+    Path(query): Path<String>,
+    ValidatedQuery(params): ValidatedQuery<ShorthandQueryParams>,
+    body: String,
+) -> Result<Json<QueryApiResponse>, ProblemDetails> {
+    debug!("POST /{{query}} called with query: {}", query);
+
+    let input_format = params
+        .input_format
+        .and_then(|v| serde_json::from_str::<InputFormat>(&format!("\"{}\"", v)).ok());
+    let output_format = params
+        .output_format
+        .and_then(|v| serde_json::from_str::<OutputFormat>(&format!("\"{}\"", v)).ok());
+
+    let request = ApiRequest {
+        query: query.clone(),
+        input: Some(body),
+        input_format,
+        modules: None,
+        args: None,
+        output_format,
+        aggregate: None,
+    };
+
+    match tokio::task::spawn_blocking(move || crate::api::query(request))
+        .await
+        .map_err(|e| {
+            error!("Shorthand query task panicked: {}", e);
+            ProblemDetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Internal error")
+                .with_detail("error", &e.to_string())
+        })? {
+        Ok(response) => {
+            info!(
+                "Successfully processed shorthand query: {}, results count: {}",
+                query,
+                response.results.len()
+            );
+            Ok(Json(response))
+        }
+        Err(e) => {
+            error!("Failed to process shorthand query '{}': {}", query, e);
             Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
                 .with_title("Invalid query")
                 .with_detail("error", &e.to_string()))

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -210,6 +210,15 @@ pub async fn post_query_api(
     }
 }
 
+/// Detects whether `body` looks like a full HTML document, ignoring leading
+/// whitespace and a UTF-8 BOM. Used by the shorthand endpoint to auto-select
+/// `InputFormat::Html` when the caller doesn't pass `?input_format=`.
+fn looks_like_html(body: &str) -> bool {
+    let trimmed = body.trim_start_matches('\u{feff}').trim_start();
+    let prefix: String = trimmed.chars().take(14).collect::<String>().to_ascii_lowercase();
+    prefix.starts_with("<!doctype html") || prefix.starts_with("<html")
+}
+
 #[utoipa::path(
     post,
     path = "/{query}",
@@ -218,7 +227,7 @@ pub async fn post_query_api(
     description = "Curl-friendly shortcut that reads the mq query from the URL path and the input content from the raw request body, e.g. `curl -d @doc.md https://api.mqlang.org/.h1`. Reserved characters in the query (`|`, `?`, `#`) must be percent-encoded.",
     params(
         ("query" = String, Path, description = "mq query expression", example = ".h1"),
-        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, or null"),
+        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, or null. If omitted, HTML is auto-detected when the body starts with `<!doctype html>` or `<html>`."),
         ("output_format" = Option<String>, Query, description = "Output format: markdown, html, text, json, or none"),
     ),
     request_body(content = String, content_type = "text/markdown", description = "Raw Markdown/MDX/HTML/text content to query"),
@@ -237,7 +246,8 @@ pub async fn post_shorthand_query_api(
 
     let input_format = params
         .input_format
-        .and_then(|v| serde_json::from_str::<InputFormat>(&format!("\"{}\"", v)).ok());
+        .and_then(|v| serde_json::from_str::<InputFormat>(&format!("\"{}\"", v)).ok())
+        .or_else(|| looks_like_html(&body).then_some(InputFormat::Html));
     let output_format = params
         .output_format
         .and_then(|v| serde_json::from_str::<OutputFormat>(&format!("\"{}\"", v)).ok());
@@ -409,4 +419,23 @@ static OPENAPI_SPEC: OnceLock<utoipa::openapi::OpenApi> = OnceLock::new();
 pub async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
     debug!("GET /openapi.json called");
     Json(OPENAPI_SPEC.get_or_init(ApiDoc::openapi).clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("<html><body>Hi</body></html>", true)]
+    #[case("<HTML><body>Hi</body></html>", true)]
+    #[case("<!DOCTYPE html><html></html>", true)]
+    #[case("  \n<!doctype html>\n<html></html>", true)]
+    #[case("\u{feff}<html></html>", true)]
+    #[case("# Title\n\nBody text.", false)]
+    #[case("<div>fragment</div>", false)]
+    #[case("", false)]
+    fn test_looks_like_html(#[case] body: &str, #[case] expected: bool) {
+        assert_eq!(looks_like_html(body), expected, "body: {:?}", body);
+    }
 }

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -117,7 +117,7 @@ pub struct ApiDoc;
     params(
         ("query" = String, Query, description = "mq query string to execute"),
         ("input" = String, Query, description = "Input content to process"),
-        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, or null")
+        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, null, csv, tsv, psv, json, yaml, toml, xml, hcl, or toon")
     )
 )]
 pub async fn get_query_api(
@@ -210,27 +210,42 @@ pub async fn post_query_api(
     }
 }
 
-/// Detects whether `body` looks like a full HTML document, ignoring leading
+/// Guesses `body`'s format from its leading bytes, ignoring leading
 /// whitespace and a UTF-8 BOM. Used by the shorthand endpoint to auto-select
-/// `InputFormat::Html` when the caller doesn't pass `?input_format=`.
-fn looks_like_html(body: &str) -> bool {
+/// `input_format` when the caller doesn't pass `?input_format=`.
+///
+/// Only formats with an unambiguous leading marker are detected here
+/// (HTML, XML, JSON). Formats like CSV/TSV/PSV/YAML/TOML/HCL/TOON have no
+/// reliable content signature and are indistinguishable from plain
+/// Markdown/text without an explicit `?input_format=`.
+fn sniff_input_format(body: &str) -> Option<InputFormat> {
     let trimmed = body.trim_start_matches('\u{feff}').trim_start();
-    let prefix: String = trimmed.chars().take(14).collect::<String>().to_ascii_lowercase();
-    prefix.starts_with("<!doctype html") || prefix.starts_with("<html")
+    let lower_prefix: String = trimmed.chars().take(14).collect::<String>().to_ascii_lowercase();
+
+    if lower_prefix.starts_with("<!doctype html") || lower_prefix.starts_with("<html") {
+        return Some(InputFormat::Html);
+    }
+    if lower_prefix.starts_with("<?xml") {
+        return Some(InputFormat::Xml);
+    }
+    match trimmed.chars().next() {
+        Some('{') | Some('[') => Some(InputFormat::Json),
+        _ => None,
+    }
 }
 
 #[utoipa::path(
     post,
     path = "/{query}",
     tag = "mq-api",
-    summary = "Run an mq query against raw Markdown (curl-friendly shortcut)",
-    description = "Curl-friendly shortcut that reads the mq query from the URL path and the input content from the raw request body, e.g. `curl -d @doc.md https://api.mqlang.org/.h1`. Reserved characters in the query (`|`, `?`, `#`) must be percent-encoded.",
+    summary = "Run an mq query against raw Markdown/HTML/XML/JSON/CSV/... (curl-friendly shortcut)",
+    description = "Curl-friendly shortcut that reads the mq query from the URL path and the input content from the raw request body, e.g. `curl --data-binary @doc.md https://api.mqlang.org/.h1`. Reserved characters in the query (`|`, `?`, `#`) must be percent-encoded.",
     params(
         ("query" = String, Path, description = "mq query expression", example = ".h1"),
-        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, or null. If omitted, HTML is auto-detected when the body starts with `<!doctype html>` or `<html>`."),
+        ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, null, csv, tsv, psv, json, yaml, toml, xml, hcl, or toon. If omitted, html/xml/json are auto-detected from the body's leading bytes; csv/tsv/psv/yaml/toml/hcl/toon have no reliable signature and require this parameter."),
         ("output_format" = Option<String>, Query, description = "Output format: markdown, html, text, json, or none"),
     ),
-    request_body(content = String, content_type = "text/markdown", description = "Raw Markdown/MDX/HTML/text content to query"),
+    request_body(content = String, content_type = "text/markdown", description = "Raw content to query: Markdown/MDX/HTML/text natively, or CSV/TSV/PSV/JSON/YAML/TOML/XML/HCL/TOON via the matching `input_format`"),
     responses(
         (status = 200, description = "Query executed successfully", body = QueryApiResponse),
         (status = 400, description = "Invalid query or request"),
@@ -247,7 +262,7 @@ pub async fn post_shorthand_query_api(
     let input_format = params
         .input_format
         .and_then(|v| serde_json::from_str::<InputFormat>(&format!("\"{}\"", v)).ok())
-        .or_else(|| looks_like_html(&body).then_some(InputFormat::Html));
+        .or_else(|| sniff_input_format(&body));
     let output_format = params
         .output_format
         .and_then(|v| serde_json::from_str::<OutputFormat>(&format!("\"{}\"", v)).ok());
@@ -427,15 +442,20 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case("<html><body>Hi</body></html>", true)]
-    #[case("<HTML><body>Hi</body></html>", true)]
-    #[case("<!DOCTYPE html><html></html>", true)]
-    #[case("  \n<!doctype html>\n<html></html>", true)]
-    #[case("\u{feff}<html></html>", true)]
-    #[case("# Title\n\nBody text.", false)]
-    #[case("<div>fragment</div>", false)]
-    #[case("", false)]
-    fn test_looks_like_html(#[case] body: &str, #[case] expected: bool) {
-        assert_eq!(looks_like_html(body), expected, "body: {:?}", body);
+    #[case("<html><body>Hi</body></html>", Some(InputFormat::Html))]
+    #[case("<HTML><body>Hi</body></html>", Some(InputFormat::Html))]
+    #[case("<!DOCTYPE html><html></html>", Some(InputFormat::Html))]
+    #[case("  \n<!doctype html>\n<html></html>", Some(InputFormat::Html))]
+    #[case("\u{feff}<html></html>", Some(InputFormat::Html))]
+    #[case(r#"<?xml version="1.0"?><root/>"#, Some(InputFormat::Xml))]
+    #[case(r#"{"a": 1}"#, Some(InputFormat::Json))]
+    #[case("[1, 2, 3]", Some(InputFormat::Json))]
+    #[case("  \n[1, 2, 3]", Some(InputFormat::Json))]
+    #[case("# Title\n\nBody text.", None)]
+    #[case("<div>fragment</div>", None)]
+    #[case("a,b,c\n1,2,3", None)]
+    #[case("", None)]
+    fn test_sniff_input_format(#[case] body: &str, #[case] expected: Option<InputFormat>) {
+        assert_eq!(sniff_input_format(body), expected, "body: {:?}", body);
     }
 }

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -19,7 +19,7 @@ use crate::{
     config::Config,
     handlers::{
         ApiDoc, AppState, get_functions_api, get_query_api, get_selectors_api, health_check, post_check_api,
-        post_format_api, post_lint_api, post_query_api,
+        post_format_api, post_lint_api, post_query_api, post_shorthand_query_api,
     },
     middleware::rate_limit_middleware,
     rate_limiter::RateLimiter,
@@ -75,6 +75,9 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
             "/openapi.json",
             get(|| async { Redirect::permanent("/api/v1/openapi.json") }),
         )
+        // Curl-friendly shortcut: query in the path, raw Markdown body.
+        // Static routes above (e.g. /health, /docs, /api/v1/*) take precedence.
+        .route("/{query}", post(post_shorthand_query_api))
         .layer(
             ServiceBuilder::new()
                 .layer(CompressionLayer::new())


### PR DESCRIPTION
## Summary

Lets users run one-off queries without JSON, e.g.
`curl --data-binary @doc.md https://api.mqlang.org/.h1`. The query comes from the URL path and the input is the raw request body.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
