### PR TITLE
✨ feat(mq-lang): decouple http builtin from http-import feature

### DIFF
--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -60,7 +60,8 @@ file-io = []
 std = []
 sync = []
 http-import = []
-http-import-ureq = ["http-import", "dep:ureq"]
+http = ["dep:ureq"]
+http-import-ureq = ["http-import", "http"]
 
 [dev-dependencies]
 divan = {workspace = true}

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -2,7 +2,7 @@ pub(super) mod bytes;
 pub(crate) mod capability;
 pub(super) mod convert;
 pub(super) mod date;
-#[cfg(feature = "http-import-ureq")]
+#[cfg(feature = "http")]
 mod http;
 pub(super) mod path;
 mod random;
@@ -3878,7 +3878,7 @@ fn write_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
 /// returns the response body as a string. `body`, when given, is sent regardless of method.
 /// `headers`, a dict of string to string, is applied to the request when given.
 /// Requires the `--allow-net` CLI flag (see [`capability`]).
-#[cfg(feature = "http-import-ureq")]
+#[cfg(feature = "http")]
 #[mq_macros::mq_fn(name = "http", params = Range(2, 4))]
 fn http_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4221,7 +4221,7 @@ mq_macros::builtin_dispatch! {
     COLLECTION,
     #[cfg(feature = "file-io")]
     WRITE_FILE,
-    #[cfg(feature = "http-import-ureq")]
+    #[cfg(feature = "http")]
     HTTP,
 }
 
@@ -5775,7 +5775,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
             params: &["path", "content"],
         },
     );
-    #[cfg(feature = "http-import-ureq")]
+    #[cfg(feature = "http")]
     map.insert(
         SmolStr::new("http"),
         BuiltinFunctionDoc {

--- a/crates/mq-lang/src/eval/builtin/capability.rs
+++ b/crates/mq-lang/src/eval/builtin/capability.rs
@@ -25,7 +25,7 @@ pub fn set_allow_write(allow: bool) {
     WRITE_ALLOWED.store(allow, Ordering::Relaxed);
 }
 
-#[cfg(feature = "http-import-ureq")]
+#[cfg(feature = "http")]
 pub(crate) fn is_net_allowed() -> bool {
     NET_ALLOWED.load(Ordering::Relaxed)
 }

--- a/crates/mq-lang/src/eval/builtin/http.rs
+++ b/crates/mq-lang/src/eval/builtin/http.rs
@@ -1,8 +1,8 @@
 //! `http` builtin: issues an HTTPS request using any method (`get`, `post`, `put`, `delete`,
 //! `patch`, `head`, ...) and returns the response body as a string.
 //!
-//! Gated at compile time by the `http-import-ureq` feature and at runtime by the
-//! `--allow-net` CLI flag (see [`super::capability`]) — both must be satisfied before a
+//! Gated at compile time by the `http` feature (implied by `http-import-ureq`) and at
+//! runtime by the `--allow-net` CLI flag (see [`super::capability`]) — both must be satisfied before a
 //! request is made. Requests go through the same SSRF-hardened agent used for HTTP module
 //! imports (see [`crate::module::resolver::ssrf`]): HTTPS only, no automatic redirects, and
 //! DNS resolution filtered to publicly routable addresses so a hostname can't be rebound to

--- a/crates/mq-lang/src/module/resolver.rs
+++ b/crates/mq-lang/src/module/resolver.rs
@@ -5,7 +5,7 @@ pub mod http_resolver;
 pub(crate) mod local_fs_resolver;
 #[cfg(feature = "http-import")]
 pub mod lockfile;
-#[cfg(feature = "http-import")]
+#[cfg(any(feature = "http-import", feature = "http"))]
 pub mod ssrf;
 pub(crate) mod std_resolver;
 

--- a/crates/mq-lang/src/module/resolver/ssrf.rs
+++ b/crates/mq-lang/src/module/resolver/ssrf.rs
@@ -3,7 +3,8 @@
 //! (`eval/builtin/http.rs`).
 //!
 //! [`is_global_ip`] has no I/O dependencies. [`SsrfSafeResolver`]/[`ssrf_safe_agent`] additionally
-//! require a concrete `ureq` transport, so they're gated behind `http-import-ureq`.
+//! require a concrete `ureq` transport, so they're gated behind `http-import-ureq` (HTTP module
+//! imports) or `http` (the `http` builtin) — either one pulls in `ureq`.
 
 /// Returns `true` if `url` uses the `https://` scheme.
 pub fn is_https(url: &str) -> bool {
@@ -48,11 +49,11 @@ pub fn is_global_ip(ip: std::net::IpAddr) -> bool {
 /// services. Filtering at the resolver level pins the connection to the
 /// addresses validated here, so a later re-resolution can't smuggle in an
 /// internal address.
-#[cfg(feature = "http-import-ureq")]
+#[cfg(any(feature = "http-import-ureq", feature = "http"))]
 #[derive(Debug, Default)]
 pub(crate) struct SsrfSafeResolver(ureq::unversioned::resolver::DefaultResolver);
 
-#[cfg(feature = "http-import-ureq")]
+#[cfg(any(feature = "http-import-ureq", feature = "http"))]
 impl ureq::unversioned::resolver::Resolver for SsrfSafeResolver {
     fn resolve(
         &self,
@@ -83,7 +84,7 @@ impl ureq::unversioned::resolver::Resolver for SsrfSafeResolver {
 /// [`SsrfSafeResolver`] so only publicly routable addresses are ever connected to.
 ///
 /// Shared by the HTTP module-import fetcher and the `http` builtin.
-#[cfg(feature = "http-import-ureq")]
+#[cfg(any(feature = "http-import-ureq", feature = "http"))]
 pub(crate) fn ssrf_safe_agent(timeout: std::time::Duration, https_only: bool) -> ureq::Agent {
     let config = ureq::Agent::config_builder()
         .timeout_global(Some(timeout))

--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -19,7 +19,7 @@ itertools = {workspace = true}
 mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}
-mq-lang = {workspace = true, features = ["ast-json", "sync", "file-io"]}
+mq-lang = {workspace = true, features = ["ast-json", "sync", "file-io", "http"]}
 mq-lint = {workspace = true}
 mq-markdown = {workspace = true}
 serde_json = {workspace = true}


### PR DESCRIPTION
Adds a standalone `http` Cargo feature that gates only the `http()` builtin (and the SSRF helpers it needs), separate from `http-import` which controls HTTP-based module imports. `http-import-ureq` now composes both for backward compatibility.

mq-lsp enables `http` (not `http-import`), so completion/hover can reference the `http` function without enabling remote module imports. Runtime calls remain gated behind the existing --allow-net capability.

## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
