### PR TITLE
✨ feat(mq-lint): add SARIF and GitHub Actions annotation output formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,7 @@ dependencies = [
  "mq-lang",
  "rstest",
  "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/mq-lint/Cargo.toml
+++ b/crates/mq-lint/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/harehare/mq"
 version = "0.6.5"
 
 [features]
-cli = ["dep:clap", "dep:colored"]
+cli = ["dep:clap", "dep:colored", "dep:serde_json"]
 
 [[bin]]
 name = "mq-lint"
@@ -30,6 +30,7 @@ colored = {workspace = true, optional = true}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true}
 rustc-hash = {workspace = true}
+serde_json = {workspace = true, optional = true}
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/crates/mq-lint/README.md
+++ b/crates/mq-lint/README.md
@@ -64,11 +64,35 @@ mq-lint --min-severity warn script.mq # only show warn/error diagnostics
 mq-lint --list-rules                  # print all rule IDs and their severity
 mq-lint --fix script.mq               # rewrite the file, applying every fixable diagnostic
 echo "let x = .h1" | mq-lint --fix     # write the fixed code to stdout
+mq-lint --format sarif script.mq      # SARIF 2.1.0 JSON, e.g. for github/codeql-action/upload-sarif
+mq-lint --format github script.mq     # GitHub Actions ::error/::warning/::notice annotations
 ```
 
 Exits with a non-zero status if any diagnostic (at or above `--min-severity`) was reported. `--fix` only
 rewrites diagnostics that have a machine-applicable fix (see "Fixable" in the rules tables below); it then
 reports any remaining diagnostics as usual.
+
+### CI Integration
+
+`--format` controls how diagnostics are rendered, independent of the rules and severities selected above:
+
+- `text` (default) — human-readable Credo-style report.
+- `sarif` — a single SARIF 2.1.0 log covering every linted file, suitable for
+  [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif) or any other
+  SARIF-consuming tool.
+- `github` — one `::error file=...,line=...,col=...,title=...::message` (or `::warning`/`::notice`, depending on
+  severity) workflow-command line per diagnostic, which GitHub Actions renders as inline PR annotations.
+
+```yaml
+# .github/workflows/lint.yml
+- run: mq-lint --format sarif $(git ls-files '*.mq') > mq-lint.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: mq-lint.sarif
+
+# or, for inline annotations without a SARIF upload:
+- run: mq-lint --format github $(git ls-files '*.mq')
+```
 
 ### Disabling Rules
 

--- a/crates/mq-lint/src/format.rs
+++ b/crates/mq-lint/src/format.rs
@@ -1,0 +1,39 @@
+//! Diagnostic output formats for the `mq-lint` CLI.
+
+mod github;
+mod sarif;
+mod text;
+
+use std::io::{self, Write};
+
+use mq_lint::Diagnostic;
+
+/// Diagnostic output format.
+#[derive(Clone, Copy, Debug, Default, PartialEq, clap::ValueEnum)]
+pub(crate) enum OutputFormat {
+    /// Credo-style human-readable report (default)
+    #[default]
+    Text,
+    /// SARIF 2.1.0 JSON
+    Sarif,
+    /// GitHub Actions workflow-command annotations
+    Github,
+}
+
+/// Dispatches to the writer for the requested output format.
+pub(crate) fn write_report(
+    w: &mut impl Write,
+    format: OutputFormat,
+    results: &[(String, Vec<Diagnostic>)],
+) -> io::Result<()> {
+    match format {
+        OutputFormat::Text => {
+            for (file_label, diagnostics) in results {
+                text::write_text_report(w, file_label, diagnostics)?;
+            }
+            Ok(())
+        }
+        OutputFormat::Sarif => sarif::write_sarif_report(w, results),
+        OutputFormat::Github => github::write_github_report(w, results),
+    }
+}

--- a/crates/mq-lint/src/format/github.rs
+++ b/crates/mq-lint/src/format/github.rs
@@ -1,0 +1,102 @@
+use std::io::{self, Write};
+
+use mq_lint::{Diagnostic, Severity};
+
+/// Writes one GitHub Actions workflow-command annotation
+/// (`::error`/`::warning`/`::notice`) per diagnostic.
+///
+/// See <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>.
+pub(super) fn write_github_report(w: &mut impl Write, results: &[(String, Vec<Diagnostic>)]) -> io::Result<()> {
+    for (file_label, diagnostics) in results {
+        for diagnostic in diagnostics {
+            let level = match diagnostic.severity {
+                Severity::Error => "error",
+                Severity::Warn => "warning",
+                Severity::Perf | Severity::Style => "notice",
+            };
+
+            let mut props = format!("file={}", gha_escape_property(file_label));
+            if let Some(range) = &diagnostic.range {
+                props.push_str(&format!(",line={},col={}", range.start.line, range.start.column));
+            }
+            props.push_str(&format!(
+                ",title={}",
+                gha_escape_property(&format!("mq-lint/{}", diagnostic.rule_id().as_str()))
+            ));
+
+            writeln!(w, "::{level} {props}::{}", gha_escape_data(&diagnostic.message()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Escapes a GitHub Actions workflow-command data value (the part after the final `::`).
+fn gha_escape_data(s: &str) -> String {
+    s.replace('%', "%25").replace('\r', "%0D").replace('\n', "%0A")
+}
+
+/// Escapes a GitHub Actions workflow-command property value (e.g. `file=`, `title=`).
+fn gha_escape_property(s: &str) -> String {
+    gha_escape_data(s).replace(':', "%3A").replace(',', "%2C")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lint::{Diagnostic, LintConfig, Linter};
+    use rstest::rstest;
+
+    fn sample_diagnostics() -> Vec<Diagnostic> {
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        crate::collect_diagnostics(r#".checked == true"#, &linter, &config, Severity::Style)
+    }
+
+    #[test]
+    fn test_write_github_report_emits_workflow_command_annotations() {
+        let diagnostics = sample_diagnostics();
+        let results = vec![("test.mq".to_string(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_github_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.starts_with("::notice file=test.mq,line=1,col=1,title=mq-lint/boolean_comparison::"));
+    }
+
+    #[rstest]
+    #[case(Severity::Error, "error")]
+    #[case(Severity::Warn, "warning")]
+    #[case(Severity::Perf, "notice")]
+    #[case(Severity::Style, "notice")]
+    fn test_write_github_report_severity_to_level(#[case] severity: Severity, #[case] expected_level: &str) {
+        let kind = mq_lint::LintMessage::BooleanComparison {
+            op: "==".to_string(),
+            bool_val: "true".to_string(),
+        };
+        let diagnostic = Diagnostic::new(kind, severity);
+        let results = vec![("test.mq".to_string(), vec![diagnostic])];
+
+        let mut buf = Vec::new();
+        write_github_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.starts_with(&format!("::{expected_level} ")));
+    }
+
+    #[rstest]
+    #[case("100%", "100%25")]
+    #[case("line1\nline2", "line1%0Aline2")]
+    #[case("a\rb", "a%0Db")]
+    fn test_gha_escape_data(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(gha_escape_data(input), expected);
+    }
+
+    #[rstest]
+    #[case("a,b", "a%2Cb")]
+    #[case("a:b", "a%3Ab")]
+    #[case("100%,x", "100%25%2Cx")]
+    fn test_gha_escape_property(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(gha_escape_property(input), expected);
+    }
+}

--- a/crates/mq-lint/src/format/sarif.rs
+++ b/crates/mq-lint/src/format/sarif.rs
@@ -1,0 +1,104 @@
+use std::io::{self, Write};
+
+use mq_lint::{Diagnostic, Severity};
+
+/// Writes a single SARIF 2.1.0 log document covering every linted file.
+///
+/// See <https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html>.
+pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, Vec<Diagnostic>)]) -> io::Result<()> {
+    let sarif_results: Vec<serde_json::Value> = results
+        .iter()
+        .flat_map(|(file_label, diagnostics)| {
+            diagnostics.iter().map(move |diagnostic| {
+                let mut physical_location = serde_json::json!({
+                    "artifactLocation": {"uri": file_label},
+                });
+                if let Some(range) = &diagnostic.range {
+                    physical_location["region"] = serde_json::json!({
+                        "startLine": range.start.line,
+                        "startColumn": range.start.column,
+                        "endLine": range.end.line,
+                        "endColumn": range.end.column,
+                    });
+                }
+
+                serde_json::json!({
+                    "ruleId": diagnostic.rule_id().as_str(),
+                    "level": sarif_level(diagnostic.severity),
+                    "message": {"text": diagnostic.message()},
+                    "locations": [{"physicalLocation": physical_location}],
+                })
+            })
+        })
+        .collect();
+
+    let sarif = serde_json::json!({
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "mq-lint",
+                    "informationUri": "https://github.com/harehare/mq",
+                    "version": env!("CARGO_PKG_VERSION"),
+                }
+            },
+            "results": sarif_results,
+        }],
+    });
+
+    writeln!(w, "{}", serde_json::to_string_pretty(&sarif).map_err(io::Error::other)?)
+}
+
+/// Maps a lint [`Severity`] to a SARIF result `level` (`error`, `warning`, or `note`).
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warn => "warning",
+        Severity::Perf | Severity::Style => "note",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lint::{LintConfig, Linter};
+
+    fn sample_diagnostics() -> Vec<Diagnostic> {
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        crate::collect_diagnostics(r#".checked == true"#, &linter, &config, Severity::Style)
+    }
+
+    #[test]
+    fn test_write_sarif_report_produces_valid_sarif_shape() {
+        let diagnostics = sample_diagnostics();
+        assert!(!diagnostics.is_empty());
+        let results = vec![("test.mq".to_string(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_sarif_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(json["version"], "2.1.0");
+        assert_eq!(json["runs"][0]["tool"]["driver"]["name"], "mq-lint");
+        let result = &json["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "boolean_comparison");
+        assert_eq!(result["level"], "note");
+        assert_eq!(
+            result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            "test.mq"
+        );
+        assert_eq!(result["locations"][0]["physicalLocation"]["region"]["startLine"], 1);
+    }
+
+    #[test]
+    fn test_write_sarif_report_empty_diagnostics() {
+        let results = vec![("test.mq".to_string(), Vec::new())];
+        let mut buf = Vec::new();
+        write_sarif_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(json["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/mq-lint/src/format/text.rs
+++ b/crates/mq-lint/src/format/text.rs
@@ -1,0 +1,162 @@
+use std::io::{self, Write};
+
+use colored::Colorize;
+use mq_lint::{Diagnostic, Severity};
+
+/// Severities in the order categories are displayed, most severe first.
+const SEVERITY_ORDER: [Severity; 4] = [Severity::Error, Severity::Warn, Severity::Perf, Severity::Style];
+
+/// Writes `diagnostics` grouped by severity in a Credo-style report and returns `true` if any
+/// were reported.
+pub(super) fn write_text_report(w: &mut impl Write, file_label: &str, diagnostics: &[Diagnostic]) -> io::Result<bool> {
+    let mut printed_category = false;
+    for severity in SEVERITY_ORDER {
+        let group: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.severity == severity).collect();
+        if group.is_empty() {
+            continue;
+        }
+        if printed_category {
+            writeln!(w)?;
+        }
+        printed_category = true;
+        write_category(w, severity, &group, file_label)?;
+    }
+
+    if diagnostics.is_empty() {
+        writeln!(
+            w,
+            "{}  {}",
+            "✓".bright_green().bold(),
+            "No lint issues found.".bright_green()
+        )?;
+    } else {
+        writeln!(w)?;
+        write_summary(w, diagnostics)?;
+    }
+
+    Ok(!diagnostics.is_empty())
+}
+
+/// Maps a severity to its Credo-style category title and one-letter marker.
+fn severity_category(severity: Severity) -> (colored::ColoredString, colored::ColoredString) {
+    match severity {
+        Severity::Error => ("## Errors".bright_red().bold(), "[E]".bright_red().bold()),
+        Severity::Warn => ("## Warnings".bright_yellow().bold(), "[W]".bright_yellow().bold()),
+        Severity::Perf => ("## Performance".blue().bold(), "[P]".blue().bold()),
+        Severity::Style => ("## Style".cyan().bold(), "[S]".cyan().bold()),
+    }
+}
+
+/// Uses mq's own pipe operator `|` as the gutter bar.
+fn severity_bar(severity: Severity) -> colored::ColoredString {
+    match severity {
+        Severity::Error => "|".bright_red(),
+        Severity::Warn => "|".bright_yellow(),
+        Severity::Perf => "|".blue(),
+        Severity::Style => "|".cyan(),
+    }
+}
+
+/// Writes one severity category: a heading followed by its diagnostics, each as a
+/// `[X] message` line with the `file:line:col .rule_id` location on the line below
+/// (the rule id rendered as an mq selector, e.g. `.unused_variable`).
+fn write_category(
+    w: &mut impl Write,
+    severity: Severity,
+    diagnostics: &[&Diagnostic],
+    file_label: &str,
+) -> io::Result<()> {
+    let (title, letter) = severity_category(severity);
+    let bar = severity_bar(severity);
+
+    writeln!(w, "{}\n", title)?;
+
+    for (i, diagnostic) in diagnostics.iter().enumerate() {
+        match diagnostic.severity {
+            Severity::Error => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_red().bold())?,
+            Severity::Warn => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_yellow().bold())?,
+            Severity::Perf => writeln!(w, "{bar} {} {}", letter, diagnostic.message().blue().bold())?,
+            Severity::Style => writeln!(w, "{bar} {} {}", letter, diagnostic.message().cyan().bold())?,
+        }
+
+        let loc = match &diagnostic.range {
+            Some(range) => format!("{}:{}:{}", file_label, range.start.line, range.start.column),
+            None => file_label.to_string(),
+        };
+        writeln!(
+            w,
+            "{bar}     {} {}",
+            loc.dimmed(),
+            format!(".{}", diagnostic.rule_id().as_str()).dimmed(),
+        )?;
+
+        if let Some(help) = diagnostic.help() {
+            writeln!(w, "{bar}       {}", format!("help: {help}").bright_blue())?;
+        }
+
+        if i + 1 < diagnostics.len() {
+            writeln!(w, "{bar}")?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Writes the trailing summary line, e.g. `found 3 issues (2 warnings, 1 style).`
+fn write_summary(w: &mut impl Write, diagnostics: &[Diagnostic]) -> io::Result<()> {
+    let breakdown: Vec<String> = SEVERITY_ORDER
+        .into_iter()
+        .filter_map(|severity| {
+            let count = diagnostics.iter().filter(|d| d.severity == severity).count();
+            if count == 0 {
+                return None;
+            }
+            let (singular, plural) = match severity {
+                Severity::Error => ("error".bright_red(), "errors".bright_red()),
+                Severity::Warn => ("warning".bright_yellow(), "warnings".bright_yellow()),
+                Severity::Perf => ("performance".blue(), "performance".blue()),
+                Severity::Style => ("style".cyan(), "style".cyan()),
+            };
+            Some(format!("{count} {}", if count == 1 { singular } else { plural }))
+        })
+        .collect();
+
+    writeln!(
+        w,
+        "{} {} issue{} ({}).",
+        "found".bold(),
+        diagnostics.len().to_string().bold(),
+        if diagnostics.len() == 1 { "" } else { "s" },
+        breakdown.join(", "),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lint::{LintConfig, Linter};
+
+    #[test]
+    fn test_write_text_report_no_issues() {
+        let mut buf = Vec::new();
+        let had_diagnostics = write_text_report(&mut buf, "test.mq", &[]).unwrap();
+        assert!(!had_diagnostics);
+        assert!(String::from_utf8(buf).unwrap().contains("No lint issues found."));
+    }
+
+    #[test]
+    fn test_write_text_report_with_diagnostics() {
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        let diagnostics = crate::collect_diagnostics(r#".checked == true"#, &linter, &config, Severity::Style);
+
+        let mut buf = Vec::new();
+        let had_diagnostics = write_text_report(&mut buf, "test.mq", &diagnostics).unwrap();
+        assert!(had_diagnostics);
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("## Style"));
+        assert!(output.contains("test.mq:1:1"));
+        assert!(output.contains("found 1 issue (1 style)."));
+    }
+}

--- a/crates/mq-lint/src/main.rs
+++ b/crates/mq-lint/src/main.rs
@@ -1,3 +1,5 @@
+mod format;
+
 use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -5,6 +7,7 @@ use std::str::FromStr;
 
 use clap::Parser;
 use colored::Colorize;
+use format::OutputFormat;
 use mq_hir::Hir;
 use mq_lint::{Diagnostic, LintConfig, LintContext, Linter, RuleId, Severity};
 
@@ -31,6 +34,12 @@ struct Cli {
     /// (reads stdin if no files are given, writing the fixed code to stdout)
     #[arg(long)]
     fix: bool,
+
+    /// Diagnostic output format: `text` (human-readable), `sarif` (SARIF 2.1.0 JSON, for
+    /// GitHub code scanning and other SARIF consumers), or `github` (GitHub Actions
+    /// `::error`/`::warning`/`::notice` workflow-command annotations)
+    #[arg(long, value_enum, default_value_t)]
+    format: OutputFormat,
 }
 
 #[derive(Clone, Copy)]
@@ -94,11 +103,13 @@ fn run() -> io::Result<bool> {
             return Ok(false);
         }
 
-        let had_diagnostics = lint_source(&mut w, &code, "<stdin>", &linter, &config, min_severity)?;
+        let diagnostics = collect_diagnostics(&code, &linter, &config, min_severity);
+        let had_diagnostics = !diagnostics.is_empty();
+        format::write_report(&mut w, cli.format, &[("<stdin>".to_string(), diagnostics)])?;
         return Ok(had_diagnostics);
     }
 
-    let mut had_diagnostics = false;
+    let mut results: Vec<(String, Vec<Diagnostic>)> = Vec::with_capacity(cli.files.len());
 
     for path in &cli.files {
         let code = std::fs::read_to_string(path)
@@ -111,21 +122,26 @@ fn run() -> io::Result<bool> {
                 std::fs::write(path, &fixed)
                     .map_err(|e| io::Error::other(format!("writing file {}: {}", path.display(), e)))?;
                 let issue_word = if fix_count == 1 { "issue" } else { "issues" };
-                writeln!(
-                    w,
-                    "{} {fix_count} {issue_word} in {label}",
-                    "fixed".bright_green().bold(),
-                )?;
+                if cli.format == OutputFormat::Text {
+                    writeln!(
+                        w,
+                        "{} {fix_count} {issue_word} in {label}",
+                        "fixed".bright_green().bold()
+                    )?;
+                } else {
+                    eprintln!("fixed {fix_count} {issue_word} in {label}");
+                }
             }
             fixed
         } else {
             code
         };
 
-        if lint_source(&mut w, &code, &label, &linter, &config, min_severity)? {
-            had_diagnostics = true;
-        }
+        results.push((label, collect_diagnostics(&code, &linter, &config, min_severity)));
     }
+
+    let had_diagnostics = results.iter().any(|(_, diagnostics)| !diagnostics.is_empty());
+    format::write_report(&mut w, cli.format, &results)?;
 
     Ok(had_diagnostics)
 }
@@ -156,19 +172,14 @@ fn list_rules(w: &mut impl Write) -> io::Result<()> {
     Ok(())
 }
 
-/// Severities in the order categories are displayed, most severe first.
-const SEVERITY_ORDER: [Severity; 4] = [Severity::Error, Severity::Warn, Severity::Perf, Severity::Style];
-
-/// Lints a single source, writes diagnostics grouped by severity in a Credo-style report,
-/// and returns `true` if any were reported.
-fn lint_source(
-    w: &mut impl Write,
+/// Runs the linter over a single source, returning diagnostics at or above `min_severity`
+/// sorted by source position.
+pub(crate) fn collect_diagnostics(
     code: &str,
-    file_label: &str,
     linter: &Linter,
     config: &LintConfig,
     min_severity: Severity,
-) -> io::Result<bool> {
+) -> Vec<Diagnostic> {
     let mut hir = Hir::default();
     let (source_id, _) = hir.add_code(None, code);
     let ctx = LintContext::new(&hir, source_id, config);
@@ -179,127 +190,7 @@ fn lint_source(
         .filter(|d| d.severity >= min_severity)
         .collect();
     diagnostics.sort_by_key(|d| d.range.map(|r| (r.start.line, r.start.column)));
-
-    let mut printed_category = false;
-    for severity in SEVERITY_ORDER {
-        let group: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.severity == severity).collect();
-        if group.is_empty() {
-            continue;
-        }
-        if printed_category {
-            writeln!(w)?;
-        }
-        printed_category = true;
-        write_category(w, severity, &group, file_label)?;
-    }
-
-    if diagnostics.is_empty() {
-        writeln!(
-            w,
-            "{}  {}",
-            "✓".bright_green().bold(),
-            "No lint issues found.".bright_green()
-        )?;
-    } else {
-        writeln!(w)?;
-        write_summary(w, &diagnostics)?;
-    }
-
-    Ok(!diagnostics.is_empty())
-}
-
-/// Maps a severity to its Credo-style category title and one-letter marker.
-fn severity_category(severity: Severity) -> (colored::ColoredString, colored::ColoredString) {
-    match severity {
-        Severity::Error => ("## Errors".bright_red().bold(), "[E]".bright_red().bold()),
-        Severity::Warn => ("## Warnings".bright_yellow().bold(), "[W]".bright_yellow().bold()),
-        Severity::Perf => ("## Performance".blue().bold(), "[P]".blue().bold()),
-        Severity::Style => ("## Style".cyan().bold(), "[S]".cyan().bold()),
-    }
-}
-
-/// Uses mq's own pipe operator `|` as the gutter bar.
-fn severity_bar(severity: Severity) -> colored::ColoredString {
-    match severity {
-        Severity::Error => "|".bright_red(),
-        Severity::Warn => "|".bright_yellow(),
-        Severity::Perf => "|".blue(),
-        Severity::Style => "|".cyan(),
-    }
-}
-
-/// Writes one severity category: a heading followed by its diagnostics, each as a
-/// `[X] message` line with the `file:line:col .rule_id` location on the line below
-/// (the rule id rendered as an mq selector, e.g. `.unused_variable`).
-fn write_category(
-    w: &mut impl Write,
-    severity: Severity,
-    diagnostics: &[&Diagnostic],
-    file_label: &str,
-) -> io::Result<()> {
-    let (title, letter) = severity_category(severity);
-    let bar = severity_bar(severity);
-
-    writeln!(w, "{}\n", title)?;
-
-    for (i, diagnostic) in diagnostics.iter().enumerate() {
-        match diagnostic.severity {
-            Severity::Error => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_red().bold())?,
-            Severity::Warn => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_yellow().bold())?,
-            Severity::Perf => writeln!(w, "{bar} {} {}", letter, diagnostic.message().blue().bold())?,
-            Severity::Style => writeln!(w, "{bar} {} {}", letter, diagnostic.message().cyan().bold())?,
-        }
-
-        let loc = match &diagnostic.range {
-            Some(range) => format!("{}:{}:{}", file_label, range.start.line, range.start.column),
-            None => file_label.to_string(),
-        };
-        writeln!(
-            w,
-            "{bar}     {} {}",
-            loc.dimmed(),
-            format!(".{}", diagnostic.rule_id().as_str()).dimmed(),
-        )?;
-
-        if let Some(help) = diagnostic.help() {
-            writeln!(w, "{bar}       {}", format!("help: {help}").bright_blue())?;
-        }
-
-        if i + 1 < diagnostics.len() {
-            writeln!(w, "{bar}")?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Writes the trailing summary line, e.g. `found 3 issues (2 warnings, 1 style).`
-fn write_summary(w: &mut impl Write, diagnostics: &[Diagnostic]) -> io::Result<()> {
-    let breakdown: Vec<String> = SEVERITY_ORDER
-        .into_iter()
-        .filter_map(|severity| {
-            let count = diagnostics.iter().filter(|d| d.severity == severity).count();
-            if count == 0 {
-                return None;
-            }
-            let (singular, plural) = match severity {
-                Severity::Error => ("error".bright_red(), "errors".bright_red()),
-                Severity::Warn => ("warning".bright_yellow(), "warnings".bright_yellow()),
-                Severity::Perf => ("performance".blue(), "performance".blue()),
-                Severity::Style => ("style".cyan(), "style".cyan()),
-            };
-            Some(format!("{count} {}", if count == 1 { singular } else { plural }))
-        })
-        .collect();
-
-    writeln!(
-        w,
-        "{} {} issue{} ({}).",
-        "found".bold(),
-        diagnostics.len().to_string().bold(),
-        if diagnostics.len() == 1 { "" } else { "s" },
-        breakdown.join(", "),
-    )
+    diagnostics
 }
 
 #[cfg(test)]
@@ -351,6 +242,22 @@ mod tests {
 
         let cli = Cli::try_parse_from(["mq-lint", "test.mq"]).unwrap();
         assert!(!cli.fix);
+    }
+
+    #[rstest]
+    #[case(vec!["mq-lint"], OutputFormat::Text)]
+    #[case(vec!["mq-lint", "--format", "text"], OutputFormat::Text)]
+    #[case(vec!["mq-lint", "--format", "sarif"], OutputFormat::Sarif)]
+    #[case(vec!["mq-lint", "--format", "github"], OutputFormat::Github)]
+    fn test_cli_format(#[case] args: Vec<&str>, #[case] expected: OutputFormat) {
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert_eq!(cli.format, expected);
+    }
+
+    #[test]
+    fn test_cli_format_invalid() {
+        let result = Cli::try_parse_from(["mq-lint", "--format", "bogus"]);
+        assert!(result.is_err());
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Add a --format flag (text/sarif/github) so mq-lint diagnostics can feed CI directly: sarif emits a single SARIF 2.1.0 log for tools like github/codeql-action/upload-sarif, and github emits ::error/::warning/ ::notice workflow-command annotations for inline PR comments.

Also split the per-format rendering logic out of main.rs into src/format/{text,sarif,github}.rs, mirroring the existing rules.rs module layout.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [x] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
