### PR TITLE
✨ feat(mq-lang): suggest similar builtin/selector names on typo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "string-interner",
+ "strsim",
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -38,6 +38,7 @@ toml = {workspace = true}
 smallvec = {workspace = true}
 smol_str = {workspace = true}
 string-interner = {workspace = true}
+strsim = {workspace = true}
 thiserror = {workspace = true}
 url = {workspace = true}
 toon-format = { version = "0.5", default-features = false }

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -153,6 +153,18 @@ impl Error {
     }
 }
 
+// help() text for an unresolved name (builtin call or bare reference), with a
+// "did you mean" hint when available.
+#[cold]
+fn not_defined_help(name: &str) -> Cow<'static, str> {
+    match crate::suggest::suggest_builtin(name) {
+        Some(similar) => Cow::Owned(format!(
+            "'{name}' is not defined. A function with a similar name exists: `{similar}`."
+        )),
+        None => Cow::Owned(format!("'{name}' is not defined. Did you forget to declare it?")),
+    }
+}
+
 // help() text for an unknown selector, with a "did you mean" hint when available.
 #[cold]
 fn selector_help(sel: &selector::UnknownSelector) -> Cow<'static, str> {
@@ -254,23 +266,17 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::InvalidBase64String(_, _)) => Some(Cow::Borrowed(
                 "The provided string is not valid Base64. Check your input.",
             )),
-            InnerError::Runtime(RuntimeError::NotDefined(_, name)) => {
-                Some(match crate::suggest::suggest_builtin(name) {
-                    Some(similar) => Cow::Owned(format!(
-                        "'{name}' is not defined. A function with a similar name exists: `{similar}`."
-                    )),
-                    None => Cow::Owned(format!("'{name}' is not defined. Did you forget to declare it?")),
-                })
-            }
+            InnerError::Runtime(RuntimeError::NotDefined(_, name)) => Some(not_defined_help(name)),
+            InnerError::Runtime(RuntimeError::UndefinedReference(_, name)) => Some(not_defined_help(name)),
             InnerError::Runtime(RuntimeError::DateTimeFormatError(_, _)) => Some(Cow::Borrowed(
                 "Invalid date/time format. Please check your format string.",
             )),
             InnerError::Runtime(RuntimeError::IndexOutOfBounds(_, _)) => Some(Cow::Borrowed(
                 "Index out of bounds. Check your array or string indices.",
             )),
-            InnerError::Runtime(RuntimeError::InvalidDefinition(_, _)) => Some(Cow::Borrowed(
-                "Invalid definition. Please check your function or variable declaration.",
-            )),
+            InnerError::Runtime(RuntimeError::InvalidDefinition(_, name)) => Some(Cow::Owned(format!(
+                "'{name}' exists but is not a function, so it cannot be called."
+            ))),
             InnerError::Runtime(RuntimeError::AssignToImmutable(_, name)) => Some(Cow::Owned(format!(
                 "Cannot assign to immutable variable '{name}'. Consider declaring it as mutable."
             ))),
@@ -622,6 +628,14 @@ mod test {
         }, "".to_string())),
         "source code"
     )]
+    #[case::eval_undefined_reference(
+        InnerError::Runtime(RuntimeError::UndefinedReference(Token {
+            range: Range::default(),
+            kind: TokenKind::Eof,
+            module_id: ArenaId::new(0),
+        }, "".to_string())),
+        "source code"
+    )]
     #[case::eval_invalid_number_of_arguments(
         InnerError::Runtime(RuntimeError::InvalidNumberOfArguments{token: Token {
             range: Range::default(),
@@ -831,6 +845,13 @@ mod test {
     )]
     #[case::eval_invalid_definition(
         InnerError::Runtime(RuntimeError::InvalidDefinition(Token {
+            range: Range::default(),
+            kind: TokenKind::Eof,
+            module_id: ArenaId::new(0),
+        }, "bad".into()))
+    )]
+    #[case::eval_undefined_reference(
+        InnerError::Runtime(RuntimeError::UndefinedReference(Token {
             range: Range::default(),
             kind: TokenKind::Eof,
             module_id: ArenaId::new(0),
@@ -1059,6 +1080,48 @@ mod test {
         assert_eq!(
             help,
             Some("'totally_unrelated_gibberish_zz' is not defined. Did you forget to declare it?".to_string())
+        );
+    }
+
+    #[test]
+    fn test_undefined_reference_help_suggests_similar_builtin() {
+        // A bare identifier reference (not a call) that typos a builtin name, e.g.
+        // passing it as a function value: `map(slpit)`.
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::UndefinedReference(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "slpit".to_string(),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'slpit' is not defined. A function with a similar name exists: `split`.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_invalid_definition_help_does_not_suggest_a_rename() {
+        // `x` already resolves to a real value here (just not a callable one, e.g.
+        // `let x = 42 | x(1)`), so a "did you mean" hint would be misleading.
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::InvalidDefinition(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "x".to_string(),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'x' exists but is not a function, so it cannot be called.".to_string())
         );
     }
 

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -8,6 +8,7 @@ use crate::{
     ModuleLoader, ModuleResolver, Token, TokenKind,
     error::{runtime::RuntimeError, syntax::SyntaxError},
     module::{self, error::ModuleError},
+    selector,
 };
 
 #[allow(clippy::useless_conversion)]
@@ -152,6 +153,23 @@ impl Error {
     }
 }
 
+// help() text for an unknown selector, with a "did you mean" hint when available.
+#[cold]
+fn selector_help(sel: &selector::UnknownSelector) -> Cow<'static, str> {
+    let raw = match &sel.0.kind {
+        TokenKind::Selector(s) => s.as_str(),
+        _ => "",
+    };
+    match crate::suggest::suggest_selector(raw) {
+        Some(similar) => Cow::Owned(format!(
+            "Unknown selector `{raw}`. A selector with a similar name exists: `{similar}`."
+        )),
+        None => Cow::Borrowed(
+            "Unknown selector. Valid selectors include node types (e.g. .h1, .p, .code) and bracket access (e.g. .[0], .[n][m]).",
+        ),
+    }
+}
+
 impl Diagnostic for Error {
     #[cold]
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
@@ -194,9 +212,7 @@ impl Diagnostic for Error {
             InnerError::Syntax(SyntaxError::InsufficientTokens(_)) => Some(Cow::Borrowed(
                 "Parsing could not continue here. Check for missing arguments, operators, or mismatched delimiters.",
             )),
-            InnerError::Syntax(SyntaxError::UnknownSelector(_)) => Some(Cow::Borrowed(
-                "Unknown selector. Valid selectors include node types (e.g. .h1, .p, .code) and bracket access (e.g. .[0], .[n][m]).",
-            )),
+            InnerError::Syntax(SyntaxError::UnknownSelector(sel)) => Some(selector_help(sel)),
             InnerError::Syntax(SyntaxError::ExpectedClosingParen(_, _)) => Some(Cow::Borrowed(
                 "Expected a closing parenthesis ')'. Check your parentheses for balance.",
             )),
@@ -238,9 +254,14 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::InvalidBase64String(_, _)) => Some(Cow::Borrowed(
                 "The provided string is not valid Base64. Check your input.",
             )),
-            InnerError::Runtime(RuntimeError::NotDefined(_, name)) => Some(Cow::Owned(format!(
-                "'{name}' is not defined. Did you forget to declare it?"
-            ))),
+            InnerError::Runtime(RuntimeError::NotDefined(_, name)) => {
+                Some(match crate::suggest::suggest_builtin(name) {
+                    Some(similar) => Cow::Owned(format!(
+                        "'{name}' is not defined. A function with a similar name exists: `{similar}`."
+                    )),
+                    None => Cow::Owned(format!("'{name}' is not defined. Did you forget to declare it?")),
+                })
+            }
             InnerError::Runtime(RuntimeError::DateTimeFormatError(_, _)) => Some(Cow::Borrowed(
                 "Invalid date/time format. Please check your format string.",
             )),
@@ -343,9 +364,7 @@ impl Diagnostic for Error {
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::InvalidAssignmentTarget(_))) => Some(
                 Cow::Borrowed("Invalid assignment target. Ensure you're assigning to a valid variable or property."),
             ),
-            InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnknownSelector(_))) => Some(Cow::Borrowed(
-                "Unknown selector. Valid selectors include node types (e.g. .h1, .p, .code) and bracket access (e.g. .[0], .[n][m]).",
-            )),
+            InnerError::Module(ModuleError::SyntaxError(SyntaxError::UnknownSelector(sel))) => Some(selector_help(sel)),
             InnerError::Module(ModuleError::InvalidModule) => Some(Cow::Borrowed("Invalid module format or content.")),
             InnerError::Module(ModuleError::SyntaxError(SyntaxError::ParameterWithoutDefaultAfterDefault(_))) => {
                 Some(Cow::Borrowed(
@@ -1002,6 +1021,80 @@ mod test {
         assert!(
             help.as_deref().unwrap_or("").contains("cannot convert array to string"),
             "help text should contain the conversion message, got: {help:?}"
+        );
+    }
+
+    #[test]
+    fn test_not_defined_help_suggests_similar_builtin() {
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::NotDefined(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "slpit".to_string(),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'slpit' is not defined. A function with a similar name exists: `split`.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_not_defined_help_no_suggestion_for_unrelated_name() {
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::NotDefined(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "totally_unrelated_gibberish_zz".to_string(),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'totally_unrelated_gibberish_zz' is not defined. Did you forget to declare it?".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unknown_selector_help_suggests_similar_selector() {
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let token = Token {
+            range: Range::default(),
+            kind: TokenKind::Selector(smol_str::SmolStr::new(".hedaing")),
+            module_id: ArenaId::new(0),
+        };
+        let cause = InnerError::Syntax(SyntaxError::UnknownSelector(selector::UnknownSelector::new(token)));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("Unknown selector `.hedaing`. A selector with a similar name exists: `.heading`.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unknown_selector_help_no_suggestion_falls_back_to_generic_text() {
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let token = Token {
+            range: Range::default(),
+            kind: TokenKind::Selector(smol_str::SmolStr::new(".totally_unrelated_gibberish_zz")),
+            module_id: ArenaId::new(0),
+        };
+        let cause = InnerError::Syntax(SyntaxError::UnknownSelector(selector::UnknownSelector::new(token)));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some(
+                "Unknown selector. Valid selectors include node types (e.g. .h1, .p, .code) and bracket access (e.g. .[0], .[n][m]).".to_string()
+            )
         );
     }
 }

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -154,10 +154,11 @@ impl Error {
 }
 
 // help() text for an unresolved name (builtin call or bare reference), with a
-// "did you mean" hint when available.
+// "did you mean" hint when available. `candidates` are user-defined names that were in
+// scope at the point of failure, considered alongside builtins.
 #[cold]
-fn not_defined_help(name: &str) -> Cow<'static, str> {
-    match crate::suggest::suggest_builtin(name) {
+fn not_defined_help(name: &str, candidates: &[String]) -> Cow<'static, str> {
+    match crate::suggest::suggest_name(name, candidates.iter().map(|s| s.as_str())) {
         Some(similar) => Cow::Owned(format!(
             "'{name}' is not defined. A function with a similar name exists: `{similar}`."
         )),
@@ -266,8 +267,12 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::InvalidBase64String(_, _)) => Some(Cow::Borrowed(
                 "The provided string is not valid Base64. Check your input.",
             )),
-            InnerError::Runtime(RuntimeError::NotDefined(_, name)) => Some(not_defined_help(name)),
-            InnerError::Runtime(RuntimeError::UndefinedReference(_, name)) => Some(not_defined_help(name)),
+            InnerError::Runtime(RuntimeError::NotDefined(_, name, candidates)) => {
+                Some(not_defined_help(name, candidates))
+            }
+            InnerError::Runtime(RuntimeError::UndefinedReference(_, name, candidates)) => {
+                Some(not_defined_help(name, candidates))
+            }
             InnerError::Runtime(RuntimeError::DateTimeFormatError(_, _)) => Some(Cow::Borrowed(
                 "Invalid date/time format. Please check your format string.",
             )),
@@ -609,7 +614,7 @@ mod test {
             range: Range::default(),
             kind: TokenKind::Eof,
             module_id: ArenaId::new(0),
-        }, "".to_string())),
+        }, "".to_string(), Box::new([]))),
         "source code"
     )]
     #[case::eval_index_out_of_bounds(
@@ -633,7 +638,7 @@ mod test {
             range: Range::default(),
             kind: TokenKind::Eof,
             module_id: ArenaId::new(0),
-        }, "".to_string())),
+        }, "".to_string(), Box::new([]))),
         "source code"
     )]
     #[case::eval_invalid_number_of_arguments(
@@ -827,7 +832,7 @@ mod test {
             range: Range::default(),
             kind: TokenKind::Eof,
             module_id: ArenaId::new(0),
-        }, "name".to_string()))
+        }, "name".to_string(), Box::new([])))
     )]
     #[case::eval_datetime_format_error(
         InnerError::Runtime(RuntimeError::DateTimeFormatError(Token {
@@ -855,7 +860,7 @@ mod test {
             range: Range::default(),
             kind: TokenKind::Eof,
             module_id: ArenaId::new(0),
-        }, "bad".into()))
+        }, "bad".into(), Box::new([])))
     )]
     #[case::eval_invalid_types(
         InnerError::Runtime(RuntimeError::InvalidTypes {
@@ -1055,12 +1060,33 @@ mod test {
                 module_id: ArenaId::new(0),
             },
             "slpit".to_string(),
+            Box::new([]),
         ));
         let error = Error::from_error("source code", cause, module_loader);
         let help = error.help().map(|h| h.to_string());
         assert_eq!(
             help,
             Some("'slpit' is not defined. A function with a similar name exists: `split`.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_not_defined_help_suggests_similar_user_defined_name() {
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::NotDefined(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "my_fnc".to_string(),
+            Box::new(["my_func".to_string()]),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'my_fnc' is not defined. A function with a similar name exists: `my_func`.".to_string())
         );
     }
 
@@ -1074,6 +1100,7 @@ mod test {
                 module_id: ArenaId::new(0),
             },
             "totally_unrelated_gibberish_zz".to_string(),
+            Box::new([]),
         ));
         let error = Error::from_error("source code", cause, module_loader);
         let help = error.help().map(|h| h.to_string());
@@ -1095,12 +1122,35 @@ mod test {
                 module_id: ArenaId::new(0),
             },
             "slpit".to_string(),
+            Box::new([]),
         ));
         let error = Error::from_error("source code", cause, module_loader);
         let help = error.help().map(|h| h.to_string());
         assert_eq!(
             help,
             Some("'slpit' is not defined. A function with a similar name exists: `split`.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_undefined_reference_help_suggests_similar_user_defined_name() {
+        // A bare identifier reference (not a call) that typos a user-defined name in scope,
+        // e.g. `let my_func = fn(): 1; | map(my_fnc)`.
+        let module_loader: ModuleLoader = ModuleLoader::default();
+        let cause = InnerError::Runtime(RuntimeError::UndefinedReference(
+            Token {
+                range: Range::default(),
+                kind: TokenKind::Eof,
+                module_id: ArenaId::new(0),
+            },
+            "my_fnc".to_string(),
+            Box::new(["my_func".to_string()]),
+        ));
+        let error = Error::from_error("source code", cause, module_loader);
+        let help = error.help().map(|h| h.to_string());
+        assert_eq!(
+            help,
+            Some("'my_fnc' is not defined. A function with a similar name exists: `my_func`.".to_string())
         );
     }
 

--- a/crates/mq-lang/src/error/runtime.rs
+++ b/crates/mq-lang/src/error/runtime.rs
@@ -17,6 +17,10 @@ pub enum RuntimeError {
     InvalidBase64String(ErrorToken, String),
     #[error("\"{1}\" is not defined")]
     NotDefined(ErrorToken, FunctionName),
+    // A bare identifier reference not bound in any scope. Distinct from InvalidDefinition
+    // below, which is a resolved-but-not-callable value.
+    #[error("\"{1}\" is not defined")]
+    UndefinedReference(ErrorToken, FunctionName),
     #[error("Unable to format date time, {1}")]
     DateTimeFormatError(ErrorToken, String),
     #[error("Index out of bounds {1}")]
@@ -89,6 +93,7 @@ impl RuntimeError {
             RuntimeError::UserDefined { token, .. } => Some(token),
             RuntimeError::InvalidBase64String(token, _) => Some(token),
             RuntimeError::NotDefined(token, _) => Some(token),
+            RuntimeError::UndefinedReference(token, _) => Some(token),
             RuntimeError::DateTimeFormatError(token, _) => Some(token),
             RuntimeError::IndexOutOfBounds(token, _) => Some(token),
             RuntimeError::InvalidDefinition(token, _) => Some(token),
@@ -136,6 +141,7 @@ mod tests {
     #[case(RuntimeError::UserDefined { message: "msg".to_string(), token: eof_token() }, true)]
     #[case(RuntimeError::InvalidBase64String(eof_token(), "bad".to_string()), true)]
     #[case(RuntimeError::NotDefined(eof_token(), "f".to_string()), true)]
+    #[case(RuntimeError::UndefinedReference(eof_token(), "r".to_string()), true)]
     #[case(RuntimeError::DateTimeFormatError(eof_token(), "err".to_string()), true)]
     #[case(RuntimeError::IndexOutOfBounds(eof_token(), Number::from(1.0)), true)]
     #[case(RuntimeError::InvalidDefinition(eof_token(), "d".to_string()), true)]

--- a/crates/mq-lang/src/error/runtime.rs
+++ b/crates/mq-lang/src/error/runtime.rs
@@ -15,12 +15,16 @@ pub enum RuntimeError {
     UserDefined { message: String, token: ErrorToken },
     #[error("Invalid base64 string")]
     InvalidBase64String(ErrorToken, String),
+    // The boxed slice is a snapshot of currently-defined names (builtins excluded, since those
+    // are looked up separately) used to power "did you mean" suggestions. Boxed rather than
+    // `Vec` to keep this rarely-populated field from growing every `RuntimeError` beyond
+    // clippy's `result_large_err` threshold.
     #[error("\"{1}\" is not defined")]
-    NotDefined(ErrorToken, FunctionName),
+    NotDefined(ErrorToken, FunctionName, Box<[FunctionName]>),
     // A bare identifier reference not bound in any scope. Distinct from InvalidDefinition
     // below, which is a resolved-but-not-callable value.
     #[error("\"{1}\" is not defined")]
-    UndefinedReference(ErrorToken, FunctionName),
+    UndefinedReference(ErrorToken, FunctionName, Box<[FunctionName]>),
     #[error("Unable to format date time, {1}")]
     DateTimeFormatError(ErrorToken, String),
     #[error("Index out of bounds {1}")]
@@ -92,8 +96,8 @@ impl RuntimeError {
         match self {
             RuntimeError::UserDefined { token, .. } => Some(token),
             RuntimeError::InvalidBase64String(token, _) => Some(token),
-            RuntimeError::NotDefined(token, _) => Some(token),
-            RuntimeError::UndefinedReference(token, _) => Some(token),
+            RuntimeError::NotDefined(token, _, _) => Some(token),
+            RuntimeError::UndefinedReference(token, _, _) => Some(token),
             RuntimeError::DateTimeFormatError(token, _) => Some(token),
             RuntimeError::IndexOutOfBounds(token, _) => Some(token),
             RuntimeError::InvalidDefinition(token, _) => Some(token),
@@ -140,8 +144,8 @@ mod tests {
     #[rstest]
     #[case(RuntimeError::UserDefined { message: "msg".to_string(), token: eof_token() }, true)]
     #[case(RuntimeError::InvalidBase64String(eof_token(), "bad".to_string()), true)]
-    #[case(RuntimeError::NotDefined(eof_token(), "f".to_string()), true)]
-    #[case(RuntimeError::UndefinedReference(eof_token(), "r".to_string()), true)]
+    #[case(RuntimeError::NotDefined(eof_token(), "f".to_string(), Box::new([])), true)]
+    #[case(RuntimeError::UndefinedReference(eof_token(), "r".to_string(), Box::new([])), true)]
     #[case(RuntimeError::DateTimeFormatError(eof_token(), "err".to_string()), true)]
     #[case(RuntimeError::IndexOutOfBounds(eof_token(), Number::from(1.0)), true)]
     #[case(RuntimeError::InvalidDefinition(eof_token(), "d".to_string()), true)]

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -752,7 +752,12 @@ impl<T: ModuleResolver> Evaluator<T> {
                 }
                 _ => {
                     let token = get_token(Shared::clone(&self.token_arena), token_id);
-                    return Err(RuntimeError::NotDefined((*token).clone(), module_ident.name.to_string()).into());
+                    return Err(RuntimeError::NotDefined(
+                        (*token).clone(),
+                        module_ident.name.to_string(),
+                        Box::new([]),
+                    )
+                    .into());
                 }
             }
         }
@@ -785,7 +790,17 @@ impl<T: ModuleResolver> Evaluator<T> {
                                     .as_ref()
                                     .cloned()
                                     .unwrap_or(get_token(Shared::clone(&self.token_arena), token_id));
-                                Err(RuntimeError::NotDefined((*token).clone(), func_name.name.to_string()).into())
+                                #[cfg(not(feature = "sync"))]
+                                let candidates = module_exports.borrow().defined_names();
+                                #[cfg(feature = "sync")]
+                                let candidates = module_exports.read().unwrap().defined_names();
+
+                                Err(RuntimeError::NotDefined(
+                                    (*token).clone(),
+                                    func_name.name.to_string(),
+                                    candidates.into_boxed_slice(),
+                                )
+                                .into())
                             }
                         }
                     }
@@ -808,7 +823,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     .map(|m| (m.token.clone(), m.name.to_string()))
                     .unwrap_or_default();
                 let token = token.unwrap_or(get_token(Shared::clone(&self.token_arena), token_id));
-                Err(RuntimeError::NotDefined((*token).clone(), last_module).into())
+                Err(RuntimeError::NotDefined((*token).clone(), last_module, Box::new([])).into())
             }
         }
     }

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -5942,7 +5942,7 @@ pub enum Error {
     #[error("")]
     NotDefined(FunctionName),
     #[error("")]
-    InvalidDefinition(String),
+    UndefinedReference(String),
     #[error("")]
     InvalidDateTimeFormat(String),
     #[error("")]
@@ -5968,7 +5968,7 @@ pub enum Error {
 impl From<env::EnvError> for Error {
     fn from(e: env::EnvError) -> Self {
         match e {
-            env::EnvError::InvalidDefinition(name) => Error::InvalidDefinition(name),
+            env::EnvError::UndefinedReference(name) => Error::UndefinedReference(name),
             env::EnvError::AssignToImmutable(name) => Error::AssignToImmutable(name),
             env::EnvError::UndefinedVariable(name) => Error::UndefinedVariable(name),
         }
@@ -5993,8 +5993,8 @@ impl Error {
             Error::NotDefined(name) => {
                 RuntimeError::NotDefined((*get_token(token_arena, node.token_id)).clone(), name.clone())
             }
-            Error::InvalidDefinition(a) => {
-                RuntimeError::InvalidDefinition((*get_token(token_arena, node.token_id)).clone(), a.clone())
+            Error::UndefinedReference(a) => {
+                RuntimeError::UndefinedReference((*get_token(token_arena, node.token_id)).clone(), a.clone())
             }
             Error::InvalidDateTimeFormat(msg) => {
                 RuntimeError::DateTimeFormatError((*get_token(token_arena, node.token_id)).clone(), msg.clone())

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -5940,9 +5940,9 @@ pub enum Error {
     #[error("")]
     InvalidBase64String(#[from] base64::DecodeError),
     #[error("")]
-    NotDefined(FunctionName),
+    NotDefined(FunctionName, Vec<String>),
     #[error("")]
-    UndefinedReference(String),
+    UndefinedReference(String, Vec<String>),
     #[error("")]
     InvalidDateTimeFormat(String),
     #[error("")]
@@ -5968,7 +5968,7 @@ pub enum Error {
 impl From<env::EnvError> for Error {
     fn from(e: env::EnvError) -> Self {
         match e {
-            env::EnvError::UndefinedReference(name) => Error::UndefinedReference(name),
+            env::EnvError::UndefinedReference(name, candidates) => Error::UndefinedReference(name, candidates),
             env::EnvError::AssignToImmutable(name) => Error::AssignToImmutable(name),
             env::EnvError::UndefinedVariable(name) => Error::UndefinedVariable(name),
         }
@@ -5990,12 +5990,16 @@ impl Error {
             Error::InvalidBase64String(e) => {
                 RuntimeError::InvalidBase64String((*get_token(token_arena, node.token_id)).clone(), e.to_string())
             }
-            Error::NotDefined(name) => {
-                RuntimeError::NotDefined((*get_token(token_arena, node.token_id)).clone(), name.clone())
-            }
-            Error::UndefinedReference(a) => {
-                RuntimeError::UndefinedReference((*get_token(token_arena, node.token_id)).clone(), a.clone())
-            }
+            Error::NotDefined(name, candidates) => RuntimeError::NotDefined(
+                (*get_token(token_arena, node.token_id)).clone(),
+                name.clone(),
+                candidates.clone().into(),
+            ),
+            Error::UndefinedReference(a, candidates) => RuntimeError::UndefinedReference(
+                (*get_token(token_arena, node.token_id)).clone(),
+                a.clone(),
+                candidates.clone().into(),
+            ),
             Error::InvalidDateTimeFormat(msg) => {
                 RuntimeError::DateTimeFormatError((*get_token(token_arena, node.token_id)).clone(), msg.clone())
             }
@@ -6035,7 +6039,14 @@ pub fn eval_builtin(
     env: &Shared<SharedCell<Env>>,
 ) -> Result<RuntimeValue, Error> {
     get_builtin_functions(ident).map_or_else(
-        || Err(Error::NotDefined(ident.to_string())),
+        || {
+            #[cfg(not(feature = "sync"))]
+            let candidates = env.borrow().defined_names();
+            #[cfg(feature = "sync")]
+            let candidates = env.read().unwrap().defined_names();
+
+            Err(Error::NotDefined(ident.to_string(), candidates))
+        },
         |f| {
             let args_len = args.len() as u8;
             if f.num_params.is_valid(args_len) {
@@ -6418,7 +6429,7 @@ mod tests {
 
     #[rstest]
     #[case("div", vec![RuntimeValue::Number(1.0.into()), RuntimeValue::Number(0.0.into())], Error::ZeroDivision)]
-    #[case("unknown_func", vec![RuntimeValue::Number(1.0.into())], Error::NotDefined("unknown_func".to_string()))]
+    #[case("unknown_func", vec![RuntimeValue::Number(1.0.into())], Error::NotDefined("unknown_func".to_string(), vec![]))]
     #[case("add", vec![], Error::InvalidNumberOfArguments("add".to_string(), 2, 0))]
     #[case("add", vec![RuntimeValue::Boolean(true), RuntimeValue::Number(1.0.into())],
         Error::InvalidTypes("add".to_string(), vec![RuntimeValue::Boolean(true), RuntimeValue::Number(1.0.into())]))]

--- a/crates/mq-lang/src/eval/env.rs
+++ b/crates/mq-lang/src/eval/env.rs
@@ -16,7 +16,7 @@ type Weak<T> = std::sync::Weak<T>;
 
 #[derive(Debug, PartialEq)]
 pub enum EnvError {
-    InvalidDefinition(String),
+    UndefinedReference(String),
     AssignToImmutable(String),
     UndefinedVariable(String),
 }
@@ -34,8 +34,8 @@ impl EnvError {
     #[cold]
     pub fn to_runtime_error(&self, token_id: TokenId, token_arena: TokenArena) -> RuntimeError {
         match self {
-            EnvError::InvalidDefinition(def) => {
-                RuntimeError::InvalidDefinition((*get_token(token_arena, token_id)).clone(), def.to_string())
+            EnvError::UndefinedReference(def) => {
+                RuntimeError::UndefinedReference((*get_token(token_arena, token_id)).clone(), def.to_string())
             }
             EnvError::AssignToImmutable(var) => {
                 RuntimeError::AssignToImmutable((*get_token(token_arena, token_id)).clone(), var.to_string())
@@ -50,7 +50,7 @@ impl EnvError {
     #[cold]
     pub fn to_runtime_error_with_token(&self, token: Token) -> RuntimeError {
         match self {
-            EnvError::InvalidDefinition(def) => RuntimeError::InvalidDefinition(token, def.to_string()),
+            EnvError::UndefinedReference(def) => RuntimeError::UndefinedReference(token, def.to_string()),
             EnvError::AssignToImmutable(var) => RuntimeError::AssignToImmutable(token, var.to_string()),
             EnvError::UndefinedVariable(var) => RuntimeError::UndefinedVariable(token, var.to_string()),
         }
@@ -308,7 +308,7 @@ impl Env {
 
     /// Looks up `ident` in this scope and its ancestors, falling back to built-in functions.
     ///
-    /// Returns [`EnvError::InvalidDefinition`] if the identifier is not found anywhere in
+    /// Returns [`EnvError::UndefinedReference`] if the identifier is not found anywhere in
     /// the scope chain and is not a built-in.
     #[inline(always)]
     pub fn resolve(&self, ident: Ident) -> Result<RuntimeValue, EnvError> {
@@ -330,7 +330,7 @@ impl Env {
         if ident.resolve_with(builtin::get_builtin_functions_by_str).is_some() {
             Ok(RuntimeValue::NativeFunction(ident))
         } else {
-            Err(EnvError::InvalidDefinition(ident.to_string()))
+            Err(EnvError::UndefinedReference(ident.to_string()))
         }
     }
 

--- a/crates/mq-lang/src/eval/env.rs
+++ b/crates/mq-lang/src/eval/env.rs
@@ -16,7 +16,9 @@ type Weak<T> = std::sync::Weak<T>;
 
 #[derive(Debug, PartialEq)]
 pub enum EnvError {
-    UndefinedReference(String),
+    /// Unresolved identifier, plus the currently-defined names it was compared against
+    /// (for "did you mean" suggestions).
+    UndefinedReference(String, Vec<String>),
     AssignToImmutable(String),
     UndefinedVariable(String),
 }
@@ -34,9 +36,11 @@ impl EnvError {
     #[cold]
     pub fn to_runtime_error(&self, token_id: TokenId, token_arena: TokenArena) -> RuntimeError {
         match self {
-            EnvError::UndefinedReference(def) => {
-                RuntimeError::UndefinedReference((*get_token(token_arena, token_id)).clone(), def.to_string())
-            }
+            EnvError::UndefinedReference(def, candidates) => RuntimeError::UndefinedReference(
+                (*get_token(token_arena, token_id)).clone(),
+                def.to_string(),
+                candidates.clone().into(),
+            ),
             EnvError::AssignToImmutable(var) => {
                 RuntimeError::AssignToImmutable((*get_token(token_arena, token_id)).clone(), var.to_string())
             }
@@ -50,7 +54,9 @@ impl EnvError {
     #[cold]
     pub fn to_runtime_error_with_token(&self, token: Token) -> RuntimeError {
         match self {
-            EnvError::UndefinedReference(def) => RuntimeError::UndefinedReference(token, def.to_string()),
+            EnvError::UndefinedReference(def, candidates) => {
+                RuntimeError::UndefinedReference(token, def.to_string(), candidates.clone().into())
+            }
             EnvError::AssignToImmutable(var) => RuntimeError::AssignToImmutable(token, var.to_string()),
             EnvError::UndefinedVariable(var) => RuntimeError::UndefinedVariable(token, var.to_string()),
         }
@@ -146,7 +152,6 @@ impl EnvContext {
         }
     }
 
-    #[cfg(feature = "debugger")]
     fn iter_entries(&self) -> Box<dyn Iterator<Item = (Ident, &RuntimeValue)> + '_> {
         match self {
             EnvContext::Small(v) => Box::new(v.iter().map(|(k, v)| (*k, v))),
@@ -295,6 +300,29 @@ impl Env {
         }
     }
 
+    /// Collects the names of every binding visible from this scope (this scope plus all
+    /// ancestors) so a failed lookup can suggest a "did you mean" among user-defined
+    /// functions/variables, not just builtins. Cold path only - never called on the
+    /// `resolve()` success path.
+    #[cold]
+    pub(crate) fn defined_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .context
+            .iter_entries()
+            .map(|(ident, _)| ident.to_string())
+            .collect();
+
+        let mut current_parent = self.parent.as_ref().and_then(|p| p.upgrade());
+
+        while let Some(parent_cell) = current_parent {
+            let parent_env = borrow_env!(parent_cell);
+            names.extend(parent_env.context.iter_entries().map(|(ident, _)| ident.to_string()));
+            current_parent = parent_env.parent.as_ref().and_then(|p| p.upgrade());
+        }
+
+        names
+    }
+
     /// Returns the number of bindings in the current scope, excluding parent scopes.
     pub fn len(&self) -> usize {
         self.context.len()
@@ -330,7 +358,7 @@ impl Env {
         if ident.resolve_with(builtin::get_builtin_functions_by_str).is_some() {
             Ok(RuntimeValue::NativeFunction(ident))
         } else {
-            Err(EnvError::UndefinedReference(ident.to_string()))
+            Err(EnvError::UndefinedReference(ident.to_string(), self.defined_names()))
         }
     }
 

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -54,6 +54,7 @@ mod number;
 mod optimizer;
 mod range;
 mod selector;
+mod suggest;
 
 use lexer::Lexer;
 #[cfg(not(feature = "sync"))]

--- a/crates/mq-lang/src/suggest.rs
+++ b/crates/mq-lang/src/suggest.rs
@@ -1,0 +1,118 @@
+//! "Did you mean" suggestions for unresolved builtin/selector names. Namespace-aware:
+//! builtins are only compared against builtins, selectors only against selectors.
+
+// Short queries only tolerate a single edit so a 1-2 char typo doesn't fuzzy-match
+// an unrelated long name.
+fn max_edit_distance(len: usize) -> usize {
+    match len {
+        0..=3 => 1,
+        4..=6 => 2,
+        _ => len / 3,
+    }
+}
+
+// Ties are broken alphabetically so diagnostics stay stable regardless of the
+// candidates' iteration order.
+#[cold]
+fn closest_match<'a, I>(target: &str, candidates: I) -> Option<&'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let allowed = max_edit_distance(target.chars().count());
+
+    candidates
+        .into_iter()
+        .filter(|candidate| *candidate != target)
+        .filter_map(|candidate| {
+            let dist = strsim::damerau_levenshtein(target, candidate);
+            (dist <= allowed).then_some((dist, candidate))
+        })
+        .min_by(|(dist_a, cand_a), (dist_b, cand_b)| dist_a.cmp(dist_b).then_with(|| cand_a.cmp(cand_b)))
+        .map(|(_, candidate)| candidate)
+}
+
+// Excludes purely symbolic aliases (`.**`, `.<>`, `..`) - not meaningful
+// edit-distance suggestion targets.
+fn is_word_like_selector(selector: &str) -> bool {
+    selector
+        .strip_prefix('.')
+        .and_then(|rest| rest.chars().next())
+        .is_some_and(|c| c.is_ascii_alphabetic())
+}
+
+/// Closest known builtin function name to `name`, or `None` if nothing is close enough.
+#[cold]
+pub(crate) fn suggest_builtin(name: &str) -> Option<&'static str> {
+    closest_match(name, crate::BUILTIN_FUNCTION_DOC.keys().map(|s| s.as_str()))
+}
+
+/// Closest known selector (e.g. `.h1`, `.code`) to `name`, or `None` if nothing is close enough.
+#[cold]
+pub(crate) fn suggest_selector(name: &str) -> Option<&'static str> {
+    closest_match(
+        name,
+        crate::BUILTIN_SELECTOR_DOC
+            .keys()
+            .map(|s| s.as_str())
+            .filter(|s| is_word_like_selector(s)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::transposition("slpit", &["split", "join", "map"], Some("split"))]
+    #[case::hyphen_vs_underscore("sort-desc", &["sort_desc", "sort_asc"], Some("sort_desc"))]
+    #[case::multiple_equally_close_candidates_pick_alphabetical("cat", &["bat", "cot", "car"], Some("bat"))]
+    #[case::no_suggestion_when_nothing_close("xyz123", &["split", "join", "map"], None)]
+    #[case::exact_match_is_not_suggested("split", &["split", "join"], None)]
+    fn test_closest_match(#[case] target: &str, #[case] candidates: &[&str], #[case] expected: Option<&str>) {
+        assert_eq!(closest_match(target, candidates.iter().copied()), expected);
+    }
+
+    #[test]
+    fn test_short_query_does_not_absurdly_match_long_candidate() {
+        // A single-character query only tolerates a single edit, so it must not
+        // fuzzy-match an unrelated multi-character candidate.
+        assert_eq!(closest_match("a", ["array", "abs"].into_iter()), None);
+    }
+
+    #[test]
+    fn test_suggest_builtin_finds_real_transposition_typo() {
+        assert_eq!(suggest_builtin("slpit"), Some("split"));
+    }
+
+    #[test]
+    fn test_suggest_builtin_finds_hyphen_for_underscore_typo() {
+        assert_eq!(suggest_builtin("date-add"), Some("date_add"));
+    }
+
+    #[test]
+    fn test_suggest_builtin_no_suggestion_for_unrelated_name() {
+        assert_eq!(suggest_builtin("completely_unrelated_xyz"), None);
+    }
+
+    #[test]
+    fn test_suggest_selector_finds_transposition_typo() {
+        assert_eq!(suggest_selector(".hedaing"), Some(".heading"));
+    }
+
+    #[rstest]
+    #[case::word(".heading", true)]
+    #[case::word_short(".h", true)]
+    #[case::symbolic_angle(".<>", false)]
+    #[case::symbolic_stars(".**", false)]
+    #[case::symbolic_dots("..", false)]
+    #[case::symbolic_brackets(".[]", false)]
+    fn test_is_word_like_selector(#[case] selector: &str, #[case] expected: bool) {
+        assert_eq!(is_word_like_selector(selector), expected);
+    }
+
+    #[test]
+    fn test_suggest_selector_no_suggestion_for_unrelated_name() {
+        assert_eq!(suggest_selector(".completely_unrelated_xyz"), None);
+    }
+}

--- a/crates/mq-lang/src/suggest.rs
+++ b/crates/mq-lang/src/suggest.rs
@@ -40,10 +40,18 @@ fn is_word_like_selector(selector: &str) -> bool {
         .is_some_and(|c| c.is_ascii_alphabetic())
 }
 
-/// Closest known builtin function name to `name`, or `None` if nothing is close enough.
+/// Closest name to `name` among builtin functions and the given extra candidates (e.g.
+/// user-defined functions/variables visible in scope when the lookup failed).
 #[cold]
-pub(crate) fn suggest_builtin(name: &str) -> Option<&'static str> {
-    closest_match(name, crate::BUILTIN_FUNCTION_DOC.keys().map(|s| s.as_str()))
+pub(crate) fn suggest_name<'a>(name: &str, extra_candidates: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    closest_match(
+        name,
+        crate::BUILTIN_FUNCTION_DOC
+            .keys()
+            .map(|s| s.as_str())
+            .chain(extra_candidates),
+    )
+    .map(str::to_string)
 }
 
 /// Closest known selector (e.g. `.h1`, `.code`) to `name`, or `None` if nothing is close enough.
@@ -81,18 +89,23 @@ mod tests {
     }
 
     #[test]
-    fn test_suggest_builtin_finds_real_transposition_typo() {
-        assert_eq!(suggest_builtin("slpit"), Some("split"));
+    fn test_suggest_name_finds_real_transposition_typo() {
+        assert_eq!(suggest_name("slpit", []), Some("split".to_string()));
     }
 
     #[test]
-    fn test_suggest_builtin_finds_hyphen_for_underscore_typo() {
-        assert_eq!(suggest_builtin("date-add"), Some("date_add"));
+    fn test_suggest_name_finds_hyphen_for_underscore_typo() {
+        assert_eq!(suggest_name("date-add", []), Some("date_add".to_string()));
     }
 
     #[test]
-    fn test_suggest_builtin_no_suggestion_for_unrelated_name() {
-        assert_eq!(suggest_builtin("completely_unrelated_xyz"), None);
+    fn test_suggest_name_no_suggestion_for_unrelated_name() {
+        assert_eq!(suggest_name("completely_unrelated_xyz", []), None);
+    }
+
+    #[test]
+    fn test_suggest_name_considers_extra_candidates() {
+        assert_eq!(suggest_name("my_fnc", ["my_func"]), Some("my_func".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add namespace-aware "did you mean" suggestions (rustc-style) for unresolved builtin calls and unknown selectors, using Damerau-Levenshtein distance scaled by query length with deterministic tie-breaking.

Close #1897

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
