### PR TITLE
✨ feat(mq-lang): add html_escape, html_unescape, and strip_tags string functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "html-escape"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+
+[[package]]
 name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,6 +2608,7 @@ dependencies = [
  "dirs 6.0.0",
  "getrandom 0.4.3",
  "hcl-rs",
+ "html-escape",
  "itertools 0.15.0",
  "md5",
  "miette",

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -355,6 +355,9 @@ fn register_string(ctx: &mut InferenceContext) {
             "base64urld",
             "url_encode",
             "url_decode",
+            "html_escape",
+            "html_unescape",
+            "strip_tags",
         ],
         vec![Type::String],
         Type::String,
@@ -394,6 +397,9 @@ fn register_string(ctx: &mut InferenceContext) {
             "base64urld",
             "url_encode",
             "url_decode",
+            "html_escape",
+            "html_unescape",
+            "strip_tags",
             "utf8bytelen",
         ],
     );
@@ -1550,6 +1556,12 @@ mod tests {
     #[case::base64urld("base64urld(\"aGVsbG8=\")", true)]
     #[case::ltrim_number("ltrim(42)", false)]
     #[case::rtrim_number("rtrim(42)", false)]
+    #[case::html_escape("html_escape(\"<b>hi</b>\")", true)]
+    #[case::html_escape_number("html_escape(42)", false)] // Should fail: wrong type
+    #[case::html_unescape("html_unescape(\"&lt;b&gt;hi&lt;/b&gt;\")", true)]
+    #[case::html_unescape_number("html_unescape(42)", false)] // Should fail: wrong type
+    #[case::strip_tags("strip_tags(\"<b>hi</b>\")", true)]
+    #[case::strip_tags_number("strip_tags(42)", false)] // Should fail: wrong type
     fn test_string_case_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -17,6 +17,7 @@ base64 = {workspace = true}
 ciborium = {workspace = true}
 csv = {workspace = true}
 hcl-rs = {workspace = true}
+html-escape = "0.2"
 md5 = {workspace = true}
 sha2 = {workspace = true}
 chrono = {workspace = true}

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -796,6 +796,63 @@ fn to_html_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
     }
 }
 
+#[mq_macros::mq_fn(name = "html_escape", params = Fixed(1))]
+fn html_escape_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => convert::html_escape(s),
+        [node @ RuntimeValue::Markdown(_, _)] => node
+            .markdown_node()
+            .map(|md| {
+                convert::html_escape(md.value().as_str()).and_then(|o| match o {
+                    RuntimeValue::String(s) => Ok(node.update_markdown_value(&s)),
+                    a => Err(Error::InvalidTypes(ident.to_string(), vec![a.clone()])),
+                })
+            })
+            .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
+        [RuntimeValue::None] => Ok(RuntimeValue::NONE),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("html_escape should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "html_unescape", params = Fixed(1))]
+fn html_unescape_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => convert::html_unescape(s),
+        [node @ RuntimeValue::Markdown(_, _)] => node
+            .markdown_node()
+            .map(|md| {
+                convert::html_unescape(md.value().as_str()).and_then(|o| match o {
+                    RuntimeValue::String(s) => Ok(node.update_markdown_value(&s)),
+                    a => Err(Error::InvalidTypes(ident.to_string(), vec![a.clone()])),
+                })
+            })
+            .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
+        [RuntimeValue::None] => Ok(RuntimeValue::NONE),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("html_unescape should always receive exactly one argument"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "strip_tags", params = Fixed(1))]
+fn strip_tags_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => convert::strip_tags(s),
+        [node @ RuntimeValue::Markdown(_, _)] => node
+            .markdown_node()
+            .map(|md| {
+                convert::strip_tags(md.value().as_str()).and_then(|o| match o {
+                    RuntimeValue::String(s) => Ok(node.update_markdown_value(&s)),
+                    a => Err(Error::InvalidTypes(ident.to_string(), vec![a.clone()])),
+                })
+            })
+            .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
+        [RuntimeValue::None] => Ok(RuntimeValue::NONE),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("strip_tags should always receive exactly one argument"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "to_markdown_string", params = Fixed(1))]
 fn to_markdown_string_impl(_: &Ident, _: &RuntimeValue, args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     convert::to_markdown_string(args)
@@ -4065,6 +4122,9 @@ mq_macros::builtin_dispatch! {
     MAX,
     FROM_HTML,
     TO_HTML,
+    HTML_ESCAPE,
+    HTML_UNESCAPE,
+    STRIP_TAGS,
     TO_MARKDOWN_STRING,
     TO_STRING,
     TO_NUMBER,
@@ -4911,6 +4971,27 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Converts the given markdown string to HTML.",
             params: &["markdown"],
+        },
+    );
+    map.insert(
+        SmolStr::new("html_escape"),
+        BuiltinFunctionDoc {
+            description: "Escapes `&`, `<`, `>`, `\"`, and `'` in the given string as HTML entities.",
+            params: &["string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("html_unescape"),
+        BuiltinFunctionDoc {
+            description: "Decodes named and numeric HTML entities in the given string into their corresponding characters.",
+            params: &["string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("strip_tags"),
+        BuiltinFunctionDoc {
+            description: "Removes HTML tags from the given string, keeping the surrounding text content.",
+            params: &["string"],
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -2,6 +2,7 @@ use crate::RuntimeValue;
 use crate::eval::builtin::Error;
 use crate::number::Number;
 use base64::prelude::*;
+use html_escape::decode_html_entities;
 use percent_encoding::{NON_ALPHANUMERIC, percent_decode, utf8_percent_encode};
 use sha2::Digest;
 use url::Url;
@@ -436,6 +437,57 @@ pub(super) fn url_decode(input: &str) -> Result<RuntimeValue, Error> {
     ))
 }
 
+/// Escape `&`, `<`, `>`, `"`, and `'` as HTML entities
+#[inline(always)]
+pub(super) fn html_escape(input: &str) -> Result<RuntimeValue, Error> {
+    let mut result = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '&' => result.push_str("&amp;"),
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '"' => result.push_str("&quot;"),
+            '\'' => result.push_str("&#39;"),
+            _ => result.push(c),
+        }
+    }
+    Ok(RuntimeValue::String(result))
+}
+
+/// Decode named and numeric HTML entities into their corresponding characters
+#[inline(always)]
+pub(super) fn html_unescape(input: &str) -> Result<RuntimeValue, Error> {
+    Ok(RuntimeValue::String(decode_html_entities(input).into_owned()))
+}
+
+/// Strip HTML tags from a string, keeping the surrounding text content
+#[inline(always)]
+pub(super) fn strip_tags(input: &str) -> Result<RuntimeValue, Error> {
+    let mut result = String::with_capacity(input.len());
+    let mut in_tag = false;
+    let mut quote: Option<char> = None;
+
+    for c in input.chars() {
+        if in_tag {
+            match quote {
+                Some(q) if c == q => quote = None,
+                Some(_) => {}
+                None => match c {
+                    '"' | '\'' => quote = Some(c),
+                    '>' => in_tag = false,
+                    _ => {}
+                },
+            }
+        } else if c == '<' {
+            in_tag = true;
+        } else {
+            result.push(c);
+        }
+    }
+
+    Ok(RuntimeValue::String(result))
+}
+
 /// Compute MD5 hash and return lowercase hex string.
 ///
 /// Note: MD5 is cryptographically broken and should not be used for security
@@ -686,6 +738,64 @@ mod tests {
     #[case("café", "caf%C3%A9")]
     fn test_url_encode(#[case] input: &str, #[case] expected: &str) {
         let result = url_encode(input).unwrap();
+        assert_eq!(result, RuntimeValue::String(expected.to_string()));
+    }
+
+    // Test html_escape
+    #[rstest]
+    #[case("<b>bold</b>", "&lt;b&gt;bold&lt;/b&gt;")]
+    #[case("Tom & Jerry", "Tom &amp; Jerry")]
+    #[case(r#"say "hi""#, "say &quot;hi&quot;")]
+    #[case("it's", "it&#39;s")]
+    #[case("plain text", "plain text")]
+    #[case("", "")]
+    fn test_html_escape(#[case] input: &str, #[case] expected: &str) {
+        let result = html_escape(input).unwrap();
+        assert_eq!(result, RuntimeValue::String(expected.to_string()));
+    }
+
+    // Test html_unescape
+    #[rstest]
+    #[case("&lt;b&gt;bold&lt;/b&gt;", "<b>bold</b>")]
+    #[case("Tom &amp; Jerry", "Tom & Jerry")]
+    #[case("&quot;quoted&quot;", "\"quoted\"")]
+    #[case("&#39;single&#39;", "'single'")]
+    #[case("&apos;apos&apos;", "'apos'")]
+    #[case("&#65;&#x42;", "AB")]
+    #[case("plain text", "plain text")]
+    #[case("", "")]
+    fn test_html_unescape(#[case] input: &str, #[case] expected: &str) {
+        let result = html_unescape(input).unwrap();
+        assert_eq!(result, RuntimeValue::String(expected.to_string()));
+    }
+
+    // Test html_escape/html_unescape round trip
+    #[rstest]
+    #[case("<script>alert('xss')</script>")]
+    #[case(r#"5 > 3 && 2 < 4, say "hi""#)]
+    fn test_html_escape_unescape_round_trip(#[case] input: &str) {
+        let escaped = html_escape(input).unwrap();
+        let RuntimeValue::String(escaped) = escaped else {
+            panic!("Expected String")
+        };
+        let unescaped = html_unescape(&escaped).unwrap();
+        assert_eq!(unescaped, RuntimeValue::String(input.to_string()));
+    }
+
+    // Test strip_tags
+    #[rstest]
+    #[case("<b>bold</b>", "bold")]
+    #[case("<p>Hello <em>world</em>!</p>", "Hello world!")]
+    #[case("no tags here", "no tags here")]
+    #[case(r#"<a href="http://example.com" title="a > b">link</a>"#, "link")]
+    #[case("<div class='a<b'>text</div>", "text")]
+    #[case("", "")]
+    // A stray, unterminated `<` is treated as the start of a tag through the
+    // end of the input, mirroring common strip_tags implementations.
+    #[case("a < b", "a ")]
+    #[case("a > b", "a > b")]
+    fn test_strip_tags(#[case] input: &str, #[case] expected: &str) {
+        let result = strip_tags(input).unwrap();
         assert_eq!(result, RuntimeValue::String(expected.to_string()));
     }
 

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3113,6 +3113,17 @@ fn engine() -> DefaultEngine {
 // url_encode
 #[case::url_encode_spaces(r#"url_encode("hello world")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello%20world".to_string())].into()))]
 #[case::url_encode_plain(r#"url_encode("abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("abc".to_string())].into()))]
+// html_escape
+#[case::html_escape_tags(r#"html_escape("<b>hi</b>")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("&lt;b&gt;hi&lt;/b&gt;".to_string())].into()))]
+#[case::html_escape_amp(r#"html_escape("a & b")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("a &amp; b".to_string())].into()))]
+#[case::html_escape_markdown_type(r#"to_md_text("<b>hi</b>") | html_escape | type"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("markdown".to_string())].into()))]
+#[case::html_escape_markdown_value(r#"to_md_text("<b>hi</b>") | html_escape | to_text"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("&lt;b&gt;hi&lt;/b&gt;".to_string())].into()))]
+// html_unescape
+#[case::html_unescape_tags(r#"html_unescape("&lt;b&gt;hi&lt;/b&gt;")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("<b>hi</b>".to_string())].into()))]
+#[case::html_unescape_numeric(r#"html_unescape("&#65;&#x42;")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("AB".to_string())].into()))]
+// strip_tags
+#[case::strip_tags_basic(r#"strip_tags("<p>Hello <em>world</em>!</p>")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("Hello world!".to_string())].into()))]
+#[case::strip_tags_no_tags(r#"strip_tags("plain text")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("plain text".to_string())].into()))]
 // to_number conversion
 #[case::to_number_string(r#"to_number("42")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // to_boolean conversion
@@ -3356,6 +3367,12 @@ fn engine() -> DefaultEngine {
 #[case::ascii_downcase_none("ascii_downcase(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // trim: None input → None
 #[case::trim_none("trim(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
+// html_escape: None input → None
+#[case::html_escape_none("html_escape(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
+// html_unescape: None input → None
+#[case::html_unescape_none("html_unescape(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
+// strip_tags: None input → None
+#[case::strip_tags_none("strip_tags(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // ltrim: None input → None
 #[case::ltrim_none("ltrim(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // rtrim: None input → None
@@ -3650,6 +3667,12 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 #[case::upcase_non_string("upcase(42)", vec![RuntimeValue::None],)]
 // ascii_upcase: non-string/non-markdown/non-none → type error
 #[case::ascii_upcase_non_string("ascii_upcase(42)", vec![RuntimeValue::None],)]
+// html_escape: non-string/non-markdown/non-none → type error
+#[case::html_escape_non_string("html_escape(42)", vec![RuntimeValue::None],)]
+// html_unescape: non-string/non-markdown/non-none → type error
+#[case::html_unescape_non_string("html_unescape(42)", vec![RuntimeValue::None],)]
+// strip_tags: non-string/non-markdown/non-none → type error
+#[case::strip_tags_non_string("strip_tags(42)", vec![RuntimeValue::None],)]
 // range: multi-char string with step → error
 #[case::range_multichar_with_step(r#"range("aa", "zz", 2)"#, vec![RuntimeValue::None],)]
 // range: invalid type → error


### PR DESCRIPTION
## Summary

Provide string-level HTML entity escaping/unescaping and tag-stripping, which was previously missing since to_html/from_html only convert the Markdown AST as a whole. html_unescape uses the html-escape crate to decode named and numeric character references.

Close #2002

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
