### PR TITLE
✨ feat(mq-crawler): add sitemap.xml ingestion as a seed-URL source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2520,6 +2520,7 @@ dependencies = [
  "miette",
  "mq-lang",
  "mq-markdown",
+ "quick-xml",
  "reqwest",
  "robots_txt",
  "rstest",
@@ -3076,7 +3077,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3360,7 +3361,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3506,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -5095,7 +5096,7 @@ dependencies = [
  "http 1.4.2",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -5288,9 +5289,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6245,9 +6246,9 @@ checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ opentelemetry_sdk = {version = "0.32", features = ["rt-tokio"]}
 opfs = "0.2.0"
 percent-encoding = "2.3.2"
 proptest = "1.11"
+quick-xml = "0.41.0"
 rand = "0.10.1"
 rayon = "1.11.0"
 regex-lite = "0.1.9"

--- a/crates/mq-crawler/Cargo.toml
+++ b/crates/mq-crawler/Cargo.toml
@@ -21,6 +21,7 @@ futures = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
 mq-lang = {workspace = true}
 mq-markdown = {workspace = true}
+quick-xml = {workspace = true}
 reqwest = {workspace = true, features = ["json"]}
 robots_txt = {workspace = true}
 scraper = {workspace = true}

--- a/crates/mq-crawler/README.md
+++ b/crates/mq-crawler/README.md
@@ -26,6 +26,7 @@ Make web scraping and content extraction effortless with intelligent Markdown co
 - **Headless Chrome**: Built-in headless Chrome for JavaScript-heavy sites (no external server needed)
 - **WebDriver Support**: Use Selenium WebDriver for browser-based crawling
 - **Domain Filtering**: Restrict crawling to specific domains
+- **Sitemap Ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
 
 ## Installation
 
@@ -106,6 +107,20 @@ mq-crawl -c 3 https://example.com
 
 # High-speed crawling with 10 workers
 mq-crawl -c 10 -d 0.1 https://example.com
+```
+
+### Sitemap Ingestion
+
+```bash
+# Seed the crawl frontier with every URL listed in a sitemap.xml,
+# in addition to the start URL. Sitemap index files (<sitemapindex>)
+# are followed recursively. Discovered URLs still respect robots.txt,
+# --allowed-domains, and --depth.
+mq-crawl --sitemap https://example.com/sitemap.xml https://example.com
+
+# Useful with --depth 0 to crawl exactly the pages listed in the sitemap
+# without following links at all.
+mq-crawl --depth 0 --sitemap https://example.com/sitemap.xml https://example.com
 ```
 
 ### Custom Robots.txt
@@ -223,6 +238,8 @@ Options:
           WebDriver URL for browser-based crawling (e.g., http://localhost:4444)
   -f, --format <FORMAT>
           Output format: text or json [default: text]
+      --sitemap <SITEMAP_URL>
+          URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from
       --extract-scripts-as-code-blocks
           Extract <script> tags as code blocks in Markdown
       --generate-front-matter

--- a/crates/mq-crawler/src/crawler.rs
+++ b/crates/mq-crawler/src/crawler.rs
@@ -179,6 +179,7 @@ impl Crawler {
         conversion_options: mq_markdown::ConversionOptions,
         depth_limit: Option<usize>,
         allowed_domains: Option<Vec<String>>,
+        additional_seed_urls: Vec<Url>,
     ) -> Result<Self, String> {
         let initial_domain = start_url
             .domain()
@@ -188,6 +189,9 @@ impl Crawler {
 
         let to_visit = SegQueue::new();
         to_visit.push((start_url.clone(), 0));
+        for seed_url in additional_seed_urls {
+            to_visit.push((seed_url, 0));
+        }
 
         Ok(Self {
             allowed_domains,
@@ -704,6 +708,7 @@ mod tests {
             mq_markdown::ConversionOptions::default(),
             depth_limit,
             allowed_domains,
+            Vec::new(),
         )
         .await
         .unwrap()
@@ -767,6 +772,7 @@ mod tests {
             mq_markdown::ConversionOptions::default(),
             Some(2),
             None,
+            Vec::new(),
         )
         .await
         .unwrap();
@@ -790,10 +796,48 @@ mod tests {
             mq_markdown::ConversionOptions::default(),
             None,
             None,
+            Vec::new(),
         )
         .await
         .unwrap();
 
         assert_eq!(crawler.depth_limit, None);
+    }
+
+    #[tokio::test]
+    async fn test_crawler_new_with_additional_seed_urls() {
+        let start_url = Url::parse("http://start.invalid/").unwrap();
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let seed_urls = vec![
+            Url::parse("http://start.invalid/from-sitemap-1").unwrap(),
+            Url::parse("http://start.invalid/from-sitemap-2").unwrap(),
+        ];
+        let crawler = Crawler::new(
+            http_client,
+            start_url.clone(),
+            0.0,
+            None,
+            None,
+            None,
+            1,
+            OutputFormat::Text,
+            mq_markdown::ConversionOptions::default(),
+            None,
+            None,
+            seed_urls.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut queued = Vec::new();
+        while let Some((url, depth)) = crawler.to_visit.pop() {
+            queued.push((url, depth));
+        }
+
+        assert_eq!(queued.len(), 3);
+        assert!(queued.contains(&(start_url, 0)));
+        for seed_url in seed_urls {
+            assert!(queued.contains(&(seed_url, 0)));
+        }
     }
 }

--- a/crates/mq-crawler/src/lib.rs
+++ b/crates/mq-crawler/src/lib.rs
@@ -10,6 +10,7 @@
 //! - robots.txt compliance
 //! - HTML to markdown conversion
 //! - Link discovery and following
+//! - sitemap.xml ingestion as a seed-URL source
 //! - Crawl statistics and result tracking
 //! - Support for custom HTTP headers and user agents
 //! - Rate limiting and politeness delays
@@ -43,3 +44,4 @@
 pub mod crawler;
 pub mod http_client;
 pub mod robots;
+pub mod sitemap;

--- a/crates/mq-crawler/src/main.rs
+++ b/crates/mq-crawler/src/main.rs
@@ -98,6 +98,11 @@ struct CliArgs {
     /// Output format for results and statistics
     #[clap(short = 'f', long, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
+    /// Optional URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from.
+    /// Discovered URLs are added to the crawl frontier alongside the start URL and are still
+    /// subject to robots.txt, domain filtering, and depth limits.
+    #[clap(long, value_name = "SITEMAP_URL")]
+    sitemap: Option<Url>,
     #[clap(flatten)]
     pub conversion: ConversionArgs,
 }
@@ -213,6 +218,22 @@ async fn main() {
         OutputFormat::Json => mq_crawler::crawler::OutputFormat::Json,
     };
 
+    let sitemap_seed_urls = if let Some(ref sitemap_url) = args.sitemap {
+        tracing::info!("Fetching seed URLs from sitemap: {}", sitemap_url);
+        match mq_crawler::sitemap::fetch_sitemap_urls(&client, sitemap_url).await {
+            Ok(urls) => {
+                tracing::info!("Discovered {} seed URL(s) from sitemap.", urls.len());
+                urls
+            }
+            Err(e) => {
+                tracing::error!("Failed to fetch sitemap {}: {}", sitemap_url, e);
+                return;
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
     match Crawler::new(
         client,
         args.url.clone(),
@@ -229,6 +250,7 @@ async fn main() {
         },
         args.depth,
         effective_allowed,
+        sitemap_seed_urls,
     )
     .await
     {

--- a/crates/mq-crawler/src/sitemap.rs
+++ b/crates/mq-crawler/src/sitemap.rs
@@ -1,0 +1,292 @@
+//! Support for reading `sitemap.xml` files as a seed-URL source.
+//!
+//! Sitemaps come in two flavors, both handled here:
+//! - A `<urlset>` document, whose `<url><loc>` entries are crawl targets.
+//! - A `<sitemapindex>` document, whose `<sitemap><loc>` entries point at
+//!   further sitemaps that are fetched and parsed recursively.
+
+use crate::http_client::HttpClient;
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+use std::collections::HashSet;
+use url::Url;
+
+/// Maximum depth of `<sitemapindex>` nesting to follow, guarding against
+/// pathological or maliciously deep sitemap chains.
+const MAX_SITEMAP_INDEX_DEPTH: usize = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SitemapKind {
+    UrlSet,
+    SitemapIndex,
+}
+
+/// Fetches a sitemap at `sitemap_url` and returns the flat list of page URLs
+/// it describes. `<sitemapindex>` documents are followed recursively until
+/// only `<urlset>` (page) entries remain.
+pub async fn fetch_sitemap_urls(http_client: &HttpClient, sitemap_url: &Url) -> Result<Vec<Url>, String> {
+    let mut visited_sitemaps = HashSet::new();
+    let mut urls = Vec::new();
+    fetch_sitemap_urls_recursive(http_client, sitemap_url, 0, &mut visited_sitemaps, &mut urls).await?;
+    Ok(urls)
+}
+
+fn fetch_sitemap_urls_recursive<'a>(
+    http_client: &'a HttpClient,
+    sitemap_url: &'a Url,
+    depth: usize,
+    visited_sitemaps: &'a mut HashSet<Url>,
+    urls: &'a mut Vec<Url>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
+    Box::pin(async move {
+        if depth > MAX_SITEMAP_INDEX_DEPTH {
+            return Err(format!(
+                "Sitemap index nesting exceeded max depth of {} at {}",
+                MAX_SITEMAP_INDEX_DEPTH, sitemap_url
+            ));
+        }
+
+        if !visited_sitemaps.insert(sitemap_url.clone()) {
+            tracing::warn!("Skipping already-visited sitemap URL (cycle detected): {}", sitemap_url);
+            return Ok(());
+        }
+
+        tracing::info!("Fetching sitemap: {}", sitemap_url);
+        let body = http_client
+            .fetch(sitemap_url.clone())
+            .await
+            .map_err(|e| format!("Failed to fetch sitemap {}: {}", sitemap_url, e))?;
+
+        let (kind, locs) =
+            parse_sitemap_xml(&body).map_err(|e| format!("Failed to parse sitemap {}: {}", sitemap_url, e))?;
+
+        for loc in locs {
+            match Url::parse(&loc) {
+                Ok(url) => match kind {
+                    SitemapKind::UrlSet => urls.push(url),
+                    SitemapKind::SitemapIndex => {
+                        fetch_sitemap_urls_recursive(http_client, &url, depth + 1, visited_sitemaps, urls).await?;
+                    }
+                },
+                Err(e) => tracing::warn!("Skipping invalid <loc> URL '{}' in sitemap {}: {}", loc, sitemap_url, e),
+            }
+        }
+
+        Ok(())
+    })
+}
+
+/// Parses sitemap XML, returning the document kind and the raw text of each
+/// `<loc>` element found.
+fn parse_sitemap_xml(xml: &str) -> Result<(SitemapKind, Vec<String>), String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut kind = None;
+    let mut locs = Vec::new();
+    let mut in_loc = false;
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) => match e.local_name().as_ref() {
+                b"urlset" => kind = Some(SitemapKind::UrlSet),
+                b"sitemapindex" => kind = Some(SitemapKind::SitemapIndex),
+                b"loc" => in_loc = true,
+                _ => {}
+            },
+            Ok(Event::End(e)) => {
+                if e.local_name().as_ref() == b"loc" {
+                    in_loc = false;
+                }
+            }
+            Ok(Event::Text(t)) => {
+                if in_loc {
+                    let decoded = t.decode().map_err(|e| format!("Failed to decode <loc> text: {}", e))?;
+                    let text = quick_xml::escape::unescape(&decoded)
+                        .map_err(|e| format!("Failed to unescape <loc> text: {}", e))?;
+                    let text = text.trim();
+                    if !text.is_empty() {
+                        locs.push(text.to_string());
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(format!("Invalid sitemap XML: {}", e)),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let kind = kind.ok_or_else(|| "Sitemap XML is missing a <urlset> or <sitemapindex> root element".to_string())?;
+    Ok((kind, locs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method::GET, MockServer};
+
+    #[test]
+    fn test_parse_urlset() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/page1</loc>
+    <lastmod>2024-01-01</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/page2</loc>
+  </url>
+</urlset>"#;
+
+        let (kind, locs) = parse_sitemap_xml(xml).unwrap();
+        assert_eq!(kind, SitemapKind::UrlSet);
+        assert_eq!(locs, vec!["https://example.com/page1", "https://example.com/page2"]);
+    }
+
+    #[test]
+    fn test_parse_sitemapindex() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-a.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-b.xml</loc>
+  </sitemap>
+</sitemapindex>"#;
+
+        let (kind, locs) = parse_sitemap_xml(xml).unwrap();
+        assert_eq!(kind, SitemapKind::SitemapIndex);
+        assert_eq!(
+            locs,
+            vec!["https://example.com/sitemap-a.xml", "https://example.com/sitemap-b.xml"]
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_root_element() {
+        let xml = r#"<?xml version="1.0"?><foo><bar/></foo>"#;
+        let result = parse_sitemap_xml(xml);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing a <urlset>"));
+    }
+
+    #[test]
+    fn test_parse_invalid_xml() {
+        let xml = "<urlset><url><loc>https://example.com/a</wrong></url></urlset>";
+        let result = parse_sitemap_xml(xml);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_sitemap_urls_urlset() {
+        let server = MockServer::start_async().await;
+        let body = r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/a</loc></url>
+  <url><loc>https://example.com/b</loc></url>
+</urlset>"#;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/sitemap.xml");
+                then.status(200).body(body);
+            })
+            .await;
+
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let sitemap_url = Url::parse(&format!("http://{}/sitemap.xml", server.address())).unwrap();
+        let urls = fetch_sitemap_urls(&http_client, &sitemap_url).await.unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                Url::parse("https://example.com/a").unwrap(),
+                Url::parse("https://example.com/b").unwrap(),
+            ]
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_sitemap_urls_follows_index() {
+        let server = MockServer::start_async().await;
+        let address = server.address().to_string();
+
+        let index_body = format!(
+            r#"<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://{}/sitemap-a.xml</loc></sitemap>
+</sitemapindex>"#,
+            address
+        );
+        let leaf_body = r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/leaf</loc></url>
+</urlset>"#;
+
+        let index_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/sitemap.xml");
+                then.status(200).body(index_body.clone());
+            })
+            .await;
+        let leaf_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/sitemap-a.xml");
+                then.status(200).body(leaf_body);
+            })
+            .await;
+
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let sitemap_url = Url::parse(&format!("http://{}/sitemap.xml", address)).unwrap();
+        let urls = fetch_sitemap_urls(&http_client, &sitemap_url).await.unwrap();
+
+        assert_eq!(urls, vec![Url::parse("https://example.com/leaf").unwrap()]);
+        index_mock.assert_async().await;
+        leaf_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_sitemap_urls_detects_cycle() {
+        let server = MockServer::start_async().await;
+        let address = server.address().to_string();
+
+        let cyclic_body = format!(
+            r#"<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://{}/sitemap.xml</loc></sitemap>
+</sitemapindex>"#,
+            address
+        );
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/sitemap.xml");
+                then.status(200).body(cyclic_body.clone());
+            })
+            .await;
+
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let sitemap_url = Url::parse(&format!("http://{}/sitemap.xml", address)).unwrap();
+        let urls = fetch_sitemap_urls(&http_client, &sitemap_url).await.unwrap();
+
+        assert!(urls.is_empty());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_sitemap_urls_fetch_error() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/sitemap.xml");
+                then.status(404);
+            })
+            .await;
+
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let sitemap_url = Url::parse(&format!("http://{}/sitemap.xml", server.address())).unwrap();
+        let result = fetch_sitemap_urls(&http_client, &sitemap_url).await;
+
+        assert!(result.is_err());
+        mock.assert_async().await;
+    }
+}

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -43,7 +43,7 @@ strsim = {workspace = true}
 thiserror = {workspace = true}
 url = {workspace = true}
 toon-format = { version = "0.5", default-features = false }
-quick-xml = "0.41.0"
+quick-xml = {workspace = true}
 similar = "3.0.0"
 ureq = { workspace = true, optional = true }
 uuid = {workspace = true, features = ["v4", "v7"]}

--- a/docs/books/src/start/crawler.md
+++ b/docs/books/src/start/crawler.md
@@ -12,6 +12,7 @@ mq-crawler is a web crawler that fetches HTML content from websites, converts it
 - **Headless Chrome**: Built-in headless Chrome for JavaScript-heavy sites (no external server needed)
 - **WebDriver support**: Browser-based crawling via Selenium WebDriver
 - **Domain filtering**: Restrict crawling to specific domains
+- **Sitemap ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
 
 ## Installation
 
@@ -66,6 +67,7 @@ mq-crawl [OPTIONS] <URL>
 | `-q, --mq-query <QUERY>` | mq-lang query for processing content | — |
 | `--robots-path <PATH>` | Custom robots.txt file path | — |
 | `--allowed-domains <DOMAINS>` | Comma-separated list of extra domains to crawl; the start URL's domain is always included | start domain only |
+| `--sitemap <SITEMAP_URL>` | URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from | — |
 | `--headless` | Use built-in headless Chrome (Chrome/Chromium must be installed) | — |
 | `--chrome-path <PATH>` | Path to Chrome/Chromium executable (requires `--headless`) | auto-detect |
 | `-U, --webdriver-url <URL>` | External WebDriver URL for browser-based crawling | — |
@@ -104,6 +106,18 @@ By default, only the start URL's domain is crawled. Use `--allowed-domains` to i
 # Also crawl docs.example.com and blog.example.com
 # The start URL's domain is always included automatically
 mq-crawl --allowed-domains docs.example.com,blog.example.com https://example.com
+```
+
+### Sitemap Ingestion
+
+Use `--sitemap` to seed the crawl frontier with every URL listed in a sitemap.xml, in addition to the start URL. Sitemap index files (`<sitemapindex>`) are followed recursively. Discovered URLs still respect robots.txt, `--allowed-domains`, and `--depth`:
+
+```bash
+mq-crawl --sitemap https://example.com/sitemap.xml https://example.com
+
+# Combine with --depth 0 to crawl exactly the pages listed in the sitemap
+# without following any links.
+mq-crawl --depth 0 --sitemap https://example.com/sitemap.xml https://example.com
 ```
 
 ### Headless Chrome


### PR DESCRIPTION
## Summary

Adds a --sitemap flag to mq-crawl that fetches and parses a sitemap.xml (or sitemap index, followed recursively) and enqueues its URLs as additional crawl seeds alongside the start URL. Seeded URLs still go through the existing robots.txt, domain-filtering, and depth-limit checks.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
