### PR TITLE
✨ feat(mq-lang): add http_*_json builtins to parse HTTP responses as JSON

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -593,6 +593,29 @@ def http_delete(url, headers = {}): http(:delete, url, headers);
 # string), and returns the response body as a string
 def http_head(url, headers = {}): http(:head, url, headers);
 
+# Performs an HTTPS GET request, optionally with the given headers (a dict of string to
+# string), and parses the response body as JSON, returning the resulting data structure
+def http_get_json(url, headers = {}): _json_parse(http(:get, url, headers));
+
+# Performs an HTTPS POST request with the given body, optionally with the given headers
+# (a dict of string to string), and parses the response body as JSON, returning the
+# resulting data structure
+def http_post_json(url, body, headers = {}): _json_parse(http(:post, url, body, headers));
+
+# Performs an HTTPS PUT request with the given body, optionally with the given headers
+# (a dict of string to string), and parses the response body as JSON, returning the
+# resulting data structure
+def http_put_json(url, body, headers = {}): _json_parse(http(:put, url, body, headers));
+
+# Performs an HTTPS PATCH request with the given body, optionally with the given headers
+# (a dict of string to string), and parses the response body as JSON, returning the
+# resulting data structure
+def http_patch_json(url, body, headers = {}): _json_parse(http(:patch, url, body, headers));
+
+# Performs an HTTPS DELETE request, optionally with the given headers (a dict of string to
+# string), and parses the response body as JSON, returning the resulting data structure
+def http_delete_json(url, headers = {}): _json_parse(http(:delete, url, headers));
+
 # Prints the debug information of the given value(s).
 def debug(*args):
   if (len(args) == 1):


### PR DESCRIPTION
## Summary

Add http_get_json/http_post_json/http_put_json/http_patch_json/http_delete_json to builtin.mq, composing the existing http() and _json_parse() builtins so callers can fetch a URL and get back a dict/array directly instead of a raw string.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
