### PR TITLE
✨ feat(mq-lang): support import aliasing with `as`

### DIFF
--- a/crates/mq-check/tests/integration_test.rs
+++ b/crates/mq-check/tests/integration_test.rs
@@ -586,6 +586,16 @@ fn test_module_imports() {
     println!("Module import result: {:?}", result);
 }
 
+#[test]
+fn test_import_does_not_type_error() {
+    assert!(check_types(r#"import "not_a_real_module""#).is_empty());
+}
+
+#[test]
+fn test_import_with_alias_does_not_type_error() {
+    assert!(check_types(r#"import "not_a_real_module" as m"#).is_empty());
+}
+
 // While Loop
 
 #[test]

--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -1995,6 +1995,8 @@ s"test${val1}"
 "#
     )]
     #[case::include("include  \"test.mq\"", "include \"test.mq\"")]
+    #[case::import("import  \"test.mq\"", "import \"test.mq\"")]
+    #[case::import_as("import  \"test.mq\"   as   m", "import \"test.mq\" as m")]
     #[case::nodes("nodes|nodes", "nodes | nodes")]
     #[case::fn_("fn(): program;", "fn(): program;")]
     #[case::fn_multiline(
@@ -3014,6 +3016,15 @@ end
 | import "a.mq"
 | import "b.mq""#,
         r#"import "a.mq"
+| import "b.mq"
+| import "c.mq"
+"#
+    )]
+    #[case::sort_imports_with_alias(
+        r#"import "c.mq"
+| import "a.mq" as a
+| import "b.mq""#,
+        r#"import "a.mq" as a
 | import "b.mq"
 | import "c.mq"
 "#

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -405,6 +405,8 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
     #[case::pattern_match("match (v): | [1,2,3]: 1 end", "match", SymbolKind::Match)]
     #[case::pattern_match_arm("match (v): | 1: \"one\" end", "1", SymbolKind::Pattern { is_dict: false })]
     #[case::import("import \"foo\"", "foo", SymbolKind::Import(SourceId::default()))]
+    #[case::import_as("import \"foo\" as bar", "foo", SymbolKind::Import(SourceId::default()))]
+    #[case::import_as_alias_ident("import \"foo\" as bar", "bar", SymbolKind::Ident)]
     #[case::module("module a: def b(): 1; end", "a", SymbolKind::Module(SourceId::default()))]
     #[case::module_name_ident("module math: def add(): 1; end", "math", SymbolKind::Ident)]
     fn test_add_code(#[case] code: &str, #[case] expected_name: &str, #[case] expected_kind: SymbolKind) {

--- a/crates/mq-hir/src/hir/lower.rs
+++ b/crates/mq-hir/src/hir/lower.rs
@@ -447,7 +447,9 @@ impl Hir {
             ..
         } = &**node
         {
-            let _ = node.children_without_token().first().map(|child| {
+            let children = node.children_without_token();
+
+            let _ = children.first().map(|child| {
                 let module_name = child.name().unwrap();
                 let module_path = self.module_loader.get_module_path(&module_name);
 
@@ -464,6 +466,20 @@ impl Hir {
                         parent,
                         insertion_order: 0,
                     });
+
+                    // `import "path" as alias` also binds a plain Ident symbol for the
+                    // alias, mirroring how `module` registers its name (see add_module_expr).
+                    if let Some(alias_node) = children.get(1) {
+                        self.add_symbol(Symbol {
+                            value: alias_node.name(),
+                            kind: SymbolKind::Ident,
+                            source: SourceInfo::new(Some(source_id), Some(alias_node.range())),
+                            scope: scope_id,
+                            doc: node.comments(),
+                            parent,
+                            insertion_order: 0,
+                        });
+                    }
                 }
             });
         }

--- a/crates/mq-lang/src/ast/code.rs
+++ b/crates/mq-lang/src/ast/code.rs
@@ -274,9 +274,12 @@ impl Node {
                 buf.push_str("include ");
                 format_literal(path, buf);
             }
-            Expr::Import(path) => {
+            Expr::Import(path, alias) => {
                 buf.push_str("import ");
                 format_literal(path, buf);
+                if let Some(alias) = alias {
+                    write!(buf, " as {}", alias).unwrap();
+                }
             }
         }
     }
@@ -998,8 +1001,15 @@ mod tests {
         r#"include "file.mq""#
     )]
     #[case::import(
-        Expr::Import(Literal::String("module.mq".to_string())),
+        Expr::Import(Literal::String("module.mq".to_string()), None),
         r#"import "module.mq""#
+    )]
+    #[case::import_as(
+        Expr::Import(
+            Literal::String("module.mq".to_string()),
+            Some(IdentWithToken::new("m"))
+        ),
+        r#"import "module.mq" as m"#
     )]
     fn test_to_code_include_import(#[case] expr: Expr, #[case] expected: &str) {
         let node = create_node(expr);

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -194,7 +194,7 @@ impl Node {
             | Expr::Selector(_)
             | Expr::SelectorChain(_)
             | Expr::Include(_)
-            | Expr::Import(_)
+            | Expr::Import(_, _)
             | Expr::InterpolatedString(_)
             | Expr::QualifiedAccess(_, _)
             | Expr::Nodes
@@ -365,7 +365,8 @@ pub enum Expr {
     If(Branches),
     Match(Shared<Node>, MatchArms),
     Include(Literal),
-    Import(Literal),
+    /// `import "path"` or `import "path" as alias`; the alias rebinds the module name.
+    Import(Literal, Option<IdentWithToken>),
     Module(IdentWithToken, Program),
     QualifiedAccess(Vec<IdentWithToken>, AccessTarget),
     Self_,

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -460,7 +460,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                     // Only allow 'let', 'def', or 'module' at the top-level of a module block
                     for node in &program {
                         match &*node.expr {
-                            Expr::Let(_, _) | Expr::Def(_, _, _) | Expr::Module(_, _) | Expr::Import(_) => {}
+                            Expr::Let(_, _) | Expr::Def(_, _, _) | Expr::Module(_, _) | Expr::Import(_, _) => {}
                             _ => {
                                 return Err(SyntaxError::UnexpectedToken((*self.token_arena[node.token_id]).clone()));
                             }
@@ -2151,9 +2151,28 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         match &token.kind {
             TokenKind::StringLiteral(module) => {
                 let module_name = module.to_owned();
+                let alias = if let Some(token) = self.tokens.peek()
+                    && matches!(token.kind, TokenKind::As)
+                {
+                    self.tokens.next();
+                    let name_token = match self.tokens.next() {
+                        Some(token) => token,
+                        None => return Err(SyntaxError::UnexpectedEOFDetected(self.module_id)),
+                    };
+
+                    match &name_token.kind {
+                        TokenKind::Ident(name) => {
+                            Some(IdentWithToken::new_with_token(name, Some(Shared::clone(name_token))))
+                        }
+                        _ => return Err(SyntaxError::UnexpectedToken((**name_token).clone())),
+                    }
+                } else {
+                    None
+                };
+
                 Ok(Shared::new(Node {
                     token_id,
-                    expr: Shared::new(Expr::Import(Literal::String(module_name))),
+                    expr: Shared::new(Expr::Import(Literal::String(module_name), alias)),
                 }))
             }
             _ => Err(SyntaxError::InsufficientTokens((*token).clone())),
@@ -7556,6 +7575,7 @@ mod tests {
                 token_id: 0.into(),
                 expr: Shared::new(Expr::Import(
                     Literal::String("name".to_owned()),
+                    None,
                 )),
             })
             ]))]
@@ -7563,6 +7583,8 @@ mod tests {
             vec![
             token(TokenKind::Import),
             token(TokenKind::StringLiteral("name".to_owned())),
+            token(TokenKind::As),
+            token(TokenKind::Ident(SmolStr::new("alias"))),
             token(TokenKind::Eof),
             ],
             Ok(vec![
@@ -7570,9 +7592,21 @@ mod tests {
                 token_id: 0.into(),
                 expr: Shared::new(Expr::Import(
                     Literal::String("name".to_owned()),
+                    Some(IdentWithToken::new_with_token(
+                        "alias",
+                        Some(Shared::new(token(TokenKind::Ident(SmolStr::new("alias"))))),
+                    )),
                 )),
             })
             ]))]
+    #[case::import_as_missing_ident(
+            vec![
+            token(TokenKind::Import),
+            token(TokenKind::StringLiteral("name".to_owned())),
+            token(TokenKind::As),
+            token(TokenKind::Eof),
+            ],
+            Err(SyntaxError::UnexpectedToken(token(TokenKind::Eof))))]
     #[case::qualified_access(
             vec![
             token(TokenKind::Ident(SmolStr::new("test"))),

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -1170,14 +1170,19 @@ impl<'a> Parser<'a> {
     fn parse_import(&mut self, leading_trivia: Vec<Trivia>) -> Result<Shared<Node>, ParseError> {
         let token = self.advance();
         let trailing_trivia = self.parse_trailing_trivia();
-        let child = self.next_node(|kind| matches!(kind, TokenKind::StringLiteral(_)), NodeKind::Literal)?;
+        let mut children = vec![self.next_node(|kind| matches!(kind, TokenKind::StringLiteral(_)), NodeKind::Literal)?];
+
+        if self.try_next_token(|kind| matches!(kind, TokenKind::As)) {
+            children.push(self.next_node(|kind| matches!(kind, TokenKind::As), NodeKind::Token)?);
+            children.push(self.next_node(|kind| matches!(kind, TokenKind::Ident(_)), NodeKind::Ident)?);
+        }
 
         Ok(Shared::new(Node {
             kind: NodeKind::Import,
             token: Some(Shared::clone(token.unwrap())),
             leading_trivia,
             trailing_trivia,
-            children: vec![child],
+            children,
         }))
     }
 
@@ -4058,6 +4063,78 @@ mod tests {
                         Shared::new(Node {
                             kind: NodeKind::Literal,
                             token: Some(Shared::new(token(TokenKind::StringLiteral("module".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::import(
+        vec![
+            Shared::new(token(TokenKind::Import)),
+            Shared::new(token(TokenKind::Whitespace(1))),
+            Shared::new(token(TokenKind::StringLiteral("module".into()))),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Import,
+                    token: Some(Shared::new(token(TokenKind::Import))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: vec![Trivia::Whitespace(Shared::new(token(TokenKind::Whitespace(1))))],
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::StringLiteral("module".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: Vec::new(),
+                            children: Vec::new(),
+                        }),
+                    ],
+                }),
+            ],
+            ErrorReporter::default()
+        )
+    )]
+    #[case::import_as(
+        vec![
+            Shared::new(token(TokenKind::Import)),
+            Shared::new(token(TokenKind::Whitespace(1))),
+            Shared::new(token(TokenKind::StringLiteral("module".into()))),
+            Shared::new(token(TokenKind::Whitespace(1))),
+            Shared::new(token(TokenKind::As)),
+            Shared::new(token(TokenKind::Whitespace(1))),
+            Shared::new(token(TokenKind::Ident("m".into()))),
+        ],
+        (
+            vec![
+                Shared::new(Node {
+                    kind: NodeKind::Import,
+                    token: Some(Shared::new(token(TokenKind::Import))),
+                    leading_trivia: Vec::new(),
+                    trailing_trivia: vec![Trivia::Whitespace(Shared::new(token(TokenKind::Whitespace(1))))],
+                    children: vec![
+                        Shared::new(Node {
+                            kind: NodeKind::Literal,
+                            token: Some(Shared::new(token(TokenKind::StringLiteral("module".into())))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: vec![Trivia::Whitespace(Shared::new(token(TokenKind::Whitespace(1))))],
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Token,
+                            token: Some(Shared::new(token(TokenKind::As))),
+                            leading_trivia: Vec::new(),
+                            trailing_trivia: vec![Trivia::Whitespace(Shared::new(token(TokenKind::Whitespace(1))))],
+                            children: Vec::new(),
+                        }),
+                        Shared::new(Node {
+                            kind: NodeKind::Ident,
+                            token: Some(Shared::new(token(TokenKind::Ident("m".into())))),
                             leading_trivia: Vec::new(),
                             trailing_trivia: Vec::new(),
                             children: Vec::new(),

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -501,6 +501,32 @@ mod tests {
         assert_eq!(values.len(), 1);
     }
 
+    #[test]
+    fn test_eval_import_as_alias() {
+        let (temp_dir, temp_file_path) =
+            create_file("greeter_engine_test.mq", r#"def greet(name): "Hello, " + name + "!";"#);
+        let temp_file_path_clone = temp_file_path.clone();
+
+        defer! {
+            if temp_file_path_clone.exists() {
+                std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+            }
+        }
+
+        let mut engine = DefaultEngine::default();
+        engine.set_search_paths(vec![temp_dir]);
+
+        let result = engine.eval(
+            r#"import "greeter_engine_test" as g | g::greet("World")"#,
+            vec!["".to_string().into()].into_iter(),
+        );
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(
+            result.unwrap().into_iter().next(),
+            Some(crate::RuntimeValue::String("Hello, World!".to_string()))
+        );
+    }
+
     #[rstest]
     #[case("add(1, 1)", "add(1, 1)")]
     #[case(".", ".")]

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -238,9 +238,13 @@ impl<T: ModuleResolver> Evaluator<T> {
                         self.eval_include(module_id.to_owned(), &Shared::clone(&self.env))
                             .map_err(InnerError::from)?;
                     }
-                    ast::Expr::Import(module_path) => {
-                        self.eval_import(module_path.to_owned(), &Shared::clone(&self.env))
-                            .map_err(|e| e.into_inner_error())?;
+                    ast::Expr::Import(module_path, alias) => {
+                        self.eval_import(
+                            module_path.to_owned(),
+                            alias.as_ref().map(|ident| ident.name),
+                            &Shared::clone(&self.env),
+                        )
+                        .map_err(|e| e.into_inner_error())?;
                     }
                     ast::Expr::Module(ident, program) => {
                         self.eval_module(&RuntimeValue::NONE, ident, program, &Shared::clone(&self.env))
@@ -375,7 +379,7 @@ impl<T: ModuleResolver> Evaluator<T> {
     }
 
     pub(crate) fn import_module(&mut self, module: Module) -> Result<RuntimeValue, RuntimeError> {
-        self.import_module_with_env(module, &Shared::clone(&self.env))
+        self.import_module_with_env(module, None, &Shared::clone(&self.env))
             .map_err(|e| e.into_runtime_error())
     }
 
@@ -399,8 +403,8 @@ impl<T: ModuleResolver> Evaluator<T> {
                 ast::Expr::Module(ident, program) => self
                     .eval_module(&RuntimeValue::NONE, ident, program, env)
                     .map_err(|e| e.into_runtime_error())?,
-                ast::Expr::Import(module_path) => self
-                    .eval_import(module_path.to_owned(), env)
+                ast::Expr::Import(module_path, alias) => self
+                    .eval_import(module_path.to_owned(), alias.as_ref().map(|ident| ident.name), env)
                     .map_err(|e| e.into_runtime_error())?,
                 _ => {
                     return Err(RuntimeError::InternalError(
@@ -644,8 +648,12 @@ impl<T: ModuleResolver> Evaluator<T> {
                         }
                     }
                 }
-                ast::Expr::Import(module_path) => {
-                    self.eval_import(module_path.to_owned(), &Shared::clone(&module_env))?;
+                ast::Expr::Import(module_path, alias) => {
+                    self.eval_import(
+                        module_path.to_owned(),
+                        alias.as_ref().map(|ident| ident.name),
+                        &Shared::clone(&module_env),
+                    )?;
                 }
                 ast::Expr::Module(ident, program) => {
                     // Collect macros from the module
@@ -670,7 +678,12 @@ impl<T: ModuleResolver> Evaluator<T> {
         Ok(runtime_value.clone())
     }
 
-    fn import_module_with_env(&mut self, module: Module, env: &Shared<SharedCell<Env>>) -> EvalResult {
+    fn import_module_with_env(
+        &mut self,
+        module: Module,
+        alias: Option<Ident>,
+        env: &Shared<SharedCell<Env>>,
+    ) -> EvalResult {
         // Collect macros from the module
         // Create a new environment for the module exports
         let module_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
@@ -684,12 +697,19 @@ impl<T: ModuleResolver> Evaluator<T> {
             Shared::clone(&module_env),
         ));
 
-        define(&self.env, Ident::new(&module_name_to_use), module_runtime_value);
+        // The alias, if given, rebinds the module under that name instead of its canonical one.
+        let bind_name = alias.unwrap_or_else(|| Ident::new(&module_name_to_use));
+        define(&self.env, bind_name, module_runtime_value);
 
         Ok(RuntimeValue::Module(ModuleEnv::new(&module_name_to_use, module_env)))
     }
 
-    fn eval_import(&mut self, module_path: ast::Literal, env: &Shared<SharedCell<Env>>) -> EvalResult {
+    fn eval_import(
+        &mut self,
+        module_path: ast::Literal,
+        alias: Option<Ident>,
+        env: &Shared<SharedCell<Env>>,
+    ) -> EvalResult {
         match module_path {
             ast::Literal::String(module_name) => {
                 let module = self
@@ -699,7 +719,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     Ok(module) => {
                         #[cfg(feature = "http-import")]
                         self.module_loader.push_http_boundary();
-                        let result = self.import_module_with_env(module, env);
+                        let result = self.import_module_with_env(module, alias, env);
                         #[cfg(feature = "http-import")]
                         self.module_loader.pop_http_boundary();
                         result
@@ -707,7 +727,13 @@ impl<T: ModuleResolver> Evaluator<T> {
                     Err(ModuleError::AlreadyLoaded(_)) => {
                         let canonical = self.module_loader.canonical_name(&module_name).to_owned();
                         match resolve(&canonical, env) {
-                            Ok(value) => Ok(value),
+                            Ok(value) => {
+                                // Already loaded under its canonical name; also bind the alias if given.
+                                if let Some(alias) = alias {
+                                    define(env, alias, value.clone());
+                                }
+                                Ok(value)
+                            }
                             Err(_) => {
                                 Err(RuntimeError::ModuleLoadError(ModuleError::NotFound(Cow::Owned(canonical))).into())
                             }
@@ -1206,7 +1232,9 @@ impl<T: ModuleResolver> Evaluator<T> {
                 self.eval_include(module_id.to_owned(), env)?;
                 Ok(runtime_value.clone())
             }
-            ast::Expr::Import(module_path) => self.eval_import(module_path.to_owned(), env),
+            ast::Expr::Import(module_path, alias) => {
+                self.eval_import(module_path.to_owned(), alias.as_ref().map(|ident| ident.name), env)
+            }
             ast::Expr::Module(ident, program) => self.eval_module(runtime_value, ident, program, env),
 
             ast::Expr::Match(value_node, arms) => self.eval_match(runtime_value, value_node, arms, env),
@@ -7052,7 +7080,10 @@ mod tests {
         let program = vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String("test_qualified".to_string()))),
+                expr: Shared::new(ast::Expr::Import(
+                    ast::Literal::String("test_qualified".to_string()),
+                    None,
+                )),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),
@@ -7073,6 +7104,82 @@ mod tests {
     }
 
     #[test]
+    fn test_import_alias_qualified_access() {
+        let (temp_dir, temp_file_path) = create_file("test_alias.mq", r#"def greet(name): "Hello, " + name + "!";"#);
+
+        defer! {
+            if temp_file_path.exists() {
+                std::fs::remove_file(&temp_file_path).expect("Failed to delete temp file");
+            }
+        }
+
+        let loader = ModuleLoader::new(DefaultModuleResolver::new(vec![temp_dir.clone()]));
+
+        let program = vec![
+            Shared::new(ast::Node {
+                token_id: 0.into(),
+                expr: Shared::new(ast::Expr::Import(
+                    ast::Literal::String("test_alias".to_string()),
+                    Some(IdentWithToken::new("greeter")),
+                )),
+            }),
+            Shared::new(ast::Node {
+                token_id: 0.into(),
+                expr: Shared::new(ast::Expr::QualifiedAccess(
+                    vec![IdentWithToken::new("greeter")],
+                    ast::AccessTarget::Call(
+                        IdentWithToken::new("greet"),
+                        smallvec![ast_node(ast::Expr::Literal(ast::Literal::String("World".to_string())))],
+                    ),
+                )),
+            }),
+        ];
+        assert_eq!(
+            Evaluator::new(loader, token_arena())
+                .eval(&program, vec![RuntimeValue::String("".to_string())].into_iter()),
+            Ok(vec![RuntimeValue::String("Hello, World!".to_string())])
+        );
+    }
+
+    /// The canonical module name is not bound when the import is aliased, mirroring
+    /// how `import "x" as y` in other languages only exposes `y`.
+    #[test]
+    fn test_import_alias_does_not_bind_canonical_name() {
+        let (temp_dir, temp_file_path) = create_file("test_alias_only.mq", r#"let answer = 42"#);
+
+        defer! {
+            if temp_file_path.exists() {
+                std::fs::remove_file(&temp_file_path).expect("Failed to delete temp file");
+            }
+        }
+
+        let loader = ModuleLoader::new(DefaultModuleResolver::new(vec![temp_dir.clone()]));
+
+        let program = vec![
+            Shared::new(ast::Node {
+                token_id: 0.into(),
+                expr: Shared::new(ast::Expr::Import(
+                    ast::Literal::String("test_alias_only".to_string()),
+                    Some(IdentWithToken::new("m")),
+                )),
+            }),
+            Shared::new(ast::Node {
+                token_id: 0.into(),
+                expr: Shared::new(ast::Expr::QualifiedAccess(
+                    vec![IdentWithToken::new("test_alias_only")],
+                    ast::AccessTarget::Ident(IdentWithToken::new("answer")),
+                )),
+            }),
+        ];
+        let result = Evaluator::new(loader, token_arena())
+            .eval(&program, vec![RuntimeValue::String("".to_string())].into_iter());
+        assert!(matches!(
+            result,
+            Err(InnerError::Runtime(RuntimeError::UndefinedReference(_, _, _)))
+        ));
+    }
+
+    #[test]
     fn test_import_qualified_access_value() {
         let (temp_dir, temp_file_path) = create_file("test_qualified_val.mq", r#"let answer = 42"#);
 
@@ -7087,9 +7194,10 @@ mod tests {
         let program = vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String(
-                    "test_qualified_val".to_string(),
-                ))),
+                expr: Shared::new(ast::Expr::Import(
+                    ast::Literal::String("test_qualified_val".to_string()),
+                    None,
+                )),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),
@@ -7112,7 +7220,7 @@ mod tests {
         vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String(module_name.to_string()))),
+                expr: Shared::new(ast::Expr::Import(ast::Literal::String(module_name.to_string()), None)),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),
@@ -7228,9 +7336,10 @@ mod tests {
         let program = vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String(
-                    "test_qualified_math".to_string(),
-                ))),
+                expr: Shared::new(ast::Expr::Import(
+                    ast::Literal::String("test_qualified_math".to_string()),
+                    None,
+                )),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),
@@ -7258,7 +7367,7 @@ mod tests {
         let loader: ModuleLoader = ModuleLoader::default();
         let program = vec![Shared::new(ast::Node {
             token_id: 0.into(),
-            expr: Shared::new(ast::Expr::Import(ast::Literal::String("not_found".to_string()))),
+            expr: Shared::new(ast::Expr::Import(ast::Literal::String("not_found".to_string()), None)),
         })];
         assert_eq!(
             Evaluator::new(loader, token_arena())
@@ -7513,7 +7622,7 @@ mod tests {
         let program = vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String("test_macro".to_string()))),
+                expr: Shared::new(ast::Expr::Import(ast::Literal::String("test_macro".to_string()), None)),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),
@@ -7556,7 +7665,7 @@ mod tests {
         let program = vec![
             Shared::new(ast::Node {
                 token_id: 0.into(),
-                expr: Shared::new(ast::Expr::Import(ast::Literal::String("test_macro2".to_string()))),
+                expr: Shared::new(ast::Expr::Import(ast::Literal::String("test_macro2".to_string()), None)),
             }),
             Shared::new(ast::Node {
                 token_id: 0.into(),

--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -407,7 +407,7 @@ impl Macro {
             | Expr::Nodes
             | Expr::Self_
             | Expr::Include(_)
-            | Expr::Import(_)
+            | Expr::Import(_, _)
             | Expr::Break(None)
             | Expr::Continue => Ok(Shared::clone(node)),
             Expr::Break(Some(value)) => {
@@ -815,7 +815,7 @@ impl Macro {
             | Expr::Nodes
             | Expr::Self_
             | Expr::Include(_)
-            | Expr::Import(_)
+            | Expr::Import(_, _)
             | Expr::Macro(_, _, _)
             | Expr::Break(None)
             | Expr::Continue => Shared::clone(node),

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -184,7 +184,7 @@ impl<T: ModuleResolver> ModuleLoader<T> {
             .filter(|node| {
                 matches!(
                     *node.expr,
-                    ast::Expr::Include(_) | ast::Expr::Module(_, _) | ast::Expr::Import(_)
+                    ast::Expr::Include(_) | ast::Expr::Module(_, _) | ast::Expr::Import(_, _)
                 )
             })
             .cloned()

--- a/crates/mq-lang/src/optimizer.rs
+++ b/crates/mq-lang/src/optimizer.rs
@@ -424,7 +424,7 @@ impl Optimizer {
             | ast::Expr::Break(None)
             | ast::Expr::Continue
             | ast::Expr::Include(_)
-            | ast::Expr::Import(_)
+            | ast::Expr::Import(_, _)
             | ast::Expr::Module(_, _)
             | ast::Expr::Macro(_, _, _)
             | ast::Expr::Quote(_)
@@ -745,7 +745,7 @@ impl Optimizer {
             | ast::Expr::Break(None)
             | ast::Expr::Continue
             | ast::Expr::Include(_)
-            | ast::Expr::Import(_)
+            | ast::Expr::Import(_, _)
             | ast::Expr::Macro(_, _, _)
             | ast::Expr::Quote(_)
             | ast::Expr::QualifiedAccess(_, _) => node,

--- a/crates/mq-wasm/src/script.rs
+++ b/crates/mq-wasm/src/script.rs
@@ -1144,7 +1144,7 @@ fn extract_local_import_names(code: &str) -> Vec<String> {
         .iter()
         .filter_map(|node| {
             let path = match &*node.expr {
-                mq_lang::AstExpr::Import(mq_lang::AstLiteral::String(p)) => p,
+                mq_lang::AstExpr::Import(mq_lang::AstLiteral::String(p), _) => p,
                 mq_lang::AstExpr::Include(mq_lang::AstLiteral::String(p)) => p,
                 _ => return None,
             };
@@ -1168,7 +1168,7 @@ fn extract_http_import_urls(code: &str) -> Vec<String> {
         .iter()
         .filter_map(|node| {
             let url = match &*node.expr {
-                mq_lang::AstExpr::Import(mq_lang::AstLiteral::String(url)) => url,
+                mq_lang::AstExpr::Import(mq_lang::AstLiteral::String(url), _) => url,
                 mq_lang::AstExpr::Include(mq_lang::AstLiteral::String(url)) => url,
                 _ => return None,
             };

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -70,6 +70,19 @@ import "math"
 | math::sub(10, 5)  # Returns 5
 ```
 
+### Import Aliases
+
+Use `import "module_path" as alias` to bind the module under a different name, useful for
+shortening long module paths or avoiding naming conflicts. Only the alias is bound; the
+module's original name is not available.
+
+```mq
+import "math" as m
+
+| m::add(10, 5)  # Returns 15
+| m::sub(10, 5)  # Returns 5
+```
+
 ## Include
 
 Loads functions from an external file directly into the current namespace using the syntax `include "module_name"`.


### PR DESCRIPTION
## Summary

Allow `import "path" as alias` to bind an imported module under a custom name instead of its canonical module name, across the parser, CST, formatter, evaluator, HIR, and type checker.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
