### PR TITLE
✨ feat(mq-lint): add dangerous_capability_call security rule

### DIFF
--- a/crates/mq-lint/README.md
+++ b/crates/mq-lint/README.md
@@ -2,7 +2,7 @@
 
 Static analysis linter for the mq language.
 
-`mq-lint` analyses mq programs by walking the HIR (High-level Intermediate Representation) and reporting diagnostics across five categories: correctness, style, complexity, selector, and module.
+`mq-lint` analyses mq programs by walking the HIR (High-level Intermediate Representation) and reporting diagnostics across six categories: correctness, style, complexity, selector, module, and security.
 
 ## Usage
 
@@ -298,6 +298,23 @@ module a: def foo(): 1; end  # style: module `a` has no documentation comment
 module a: def foo(): 1; end
 | module b: def foo(): 2; end
 ```
+
+### Security
+
+| Rule ID                      | Severity | Description                                                                                |
+| ----------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `dangerous_capability_call`  | warn     | Call to a capability-gated builtin (`http`, `read_file`, `read_file_bytes`, `write_file`) |
+
+**Example — `dangerous_capability_call`**
+
+```mq
+# warn: call to capability-gated function `http` (requires `--allow-net` at runtime)
+http("https://example.com", "GET")
+```
+
+This rule is especially useful for reviewing HTTP-imported third-party modules before enabling
+`--allow-net`/`--allow-read`/`--allow-write`, since those flags apply process-wide to every module
+in the query, including transitively imported ones.
 
 ## Support
 

--- a/crates/mq-lint/src/lib.rs
+++ b/crates/mq-lint/src/lib.rs
@@ -1,7 +1,7 @@
 //! Linter for the mq language.
 //!
 //! This crate provides static analysis rules for mq programs, organized into
-//! categories: correctness, style, complexity, selector, and module.
+//! categories: correctness, style, complexity, selector, module, and security.
 //!
 //! ## Example
 //!

--- a/crates/mq-lint/src/message.rs
+++ b/crates/mq-lint/src/message.rs
@@ -45,6 +45,7 @@ pub enum RuleId {
     UnusedParameter,
     ConstantStringConcat,
     NegatedCondition,
+    DangerousCapabilityCall,
 }
 
 impl RuleId {
@@ -83,6 +84,7 @@ impl RuleId {
         RuleId::UnusedParameter,
         RuleId::ConstantStringConcat,
         RuleId::NegatedCondition,
+        RuleId::DangerousCapabilityCall,
     ];
 
     /// The rule's `snake_case` identifier, as used in config and CLI flags.
@@ -121,6 +123,7 @@ impl RuleId {
             RuleId::UnusedParameter => "unused_parameter",
             RuleId::ConstantStringConcat => "constant_string_concat",
             RuleId::NegatedCondition => "negated_condition",
+            RuleId::DangerousCapabilityCall => "dangerous_capability_call",
         }
     }
 }
@@ -239,6 +242,10 @@ pub enum LintMessage {
     },
     ConstantStringConcat,
     NegatedCondition,
+    DangerousCapabilityCall {
+        name: String,
+        flag: String,
+    },
 }
 
 impl LintMessage {
@@ -278,6 +285,7 @@ impl LintMessage {
             LintMessage::UnusedParameter { .. } => RuleId::UnusedParameter,
             LintMessage::ConstantStringConcat => RuleId::ConstantStringConcat,
             LintMessage::NegatedCondition => RuleId::NegatedCondition,
+            LintMessage::DangerousCapabilityCall { .. } => RuleId::DangerousCapabilityCall,
         }
     }
 
@@ -380,6 +388,10 @@ impl LintMessage {
             LintMessage::NegatedCondition => {
                 Some("invert the condition and swap the `then` and `else` branches".to_string())
             }
+            LintMessage::DangerousCapabilityCall { flag, .. } => Some(format!(
+                "review this call before enabling `{flag}`; if the code came from an untrusted or \
+                 HTTP-imported module, avoid granting the flag process-wide"
+            )),
         }
     }
 }
@@ -490,6 +502,12 @@ impl fmt::Display for LintMessage {
                 write!(
                     f,
                     "negated condition in `if`/`else` — consider swapping the branches and inverting the condition"
+                )
+            }
+            LintMessage::DangerousCapabilityCall { name, flag } => {
+                write!(
+                    f,
+                    "call to capability-gated function `{name}` (requires `{flag}` at runtime)"
                 )
             }
         }

--- a/crates/mq-lint/src/rules.rs
+++ b/crates/mq-lint/src/rules.rs
@@ -3,6 +3,7 @@
 pub mod complexity;
 pub mod correctness;
 pub mod module;
+pub mod security;
 pub mod selector;
 pub mod style;
 
@@ -16,5 +17,6 @@ pub fn all_rules() -> Vec<Box<dyn LintRule>> {
     rules.extend(complexity::all());
     rules.extend(selector::all());
     rules.extend(module::all());
+    rules.extend(security::all());
     rules
 }

--- a/crates/mq-lint/src/rules/security.rs
+++ b/crates/mq-lint/src/rules/security.rs
@@ -1,0 +1,7 @@
+pub mod dangerous_capability_call;
+
+use crate::LintRule;
+
+pub fn all() -> Vec<Box<dyn LintRule>> {
+    vec![Box::new(dangerous_capability_call::DangerousCapabilityCall)]
+}

--- a/crates/mq-lint/src/rules/security/dangerous_capability_call.rs
+++ b/crates/mq-lint/src/rules/security/dangerous_capability_call.rs
@@ -1,0 +1,119 @@
+use crate::{Diagnostic, LintContext, LintMessage, LintRule, RuleId, Severity};
+use mq_hir::SymbolKind;
+
+/// Maps a capability-gated builtin function name to the CLI flag that unlocks it.
+///
+/// Kept in sync with the functions gated in
+/// `mq-lang/src/eval/builtin/capability.rs` (`http`, `read_file`,
+/// `read_file_bytes`, `write_file`).
+fn capability_flag(name: &str) -> Option<&'static str> {
+    match name {
+        "http" => Some("--allow-net"),
+        "read_file" | "read_file_bytes" => Some("--allow-read"),
+        "write_file" => Some("--allow-write"),
+        _ => None,
+    }
+}
+
+pub struct DangerousCapabilityCall;
+
+impl LintRule for DangerousCapabilityCall {
+    fn id(&self) -> RuleId {
+        RuleId::DangerousCapabilityCall
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Warn
+    }
+
+    fn check(&self, ctx: &LintContext<'_>) -> Vec<Diagnostic> {
+        ctx.all_symbols()
+            .filter_map(|(_, s)| {
+                if !matches!(s.kind, SymbolKind::Call) {
+                    return None;
+                }
+
+                let name = s.value.as_deref()?;
+                let flag = capability_flag(name)?;
+
+                let mut d = Diagnostic::new(
+                    LintMessage::DangerousCapabilityCall {
+                        name: name.to_string(),
+                        flag: flag.to_string(),
+                    },
+                    self.severity(),
+                );
+                if let Some(range) = s.source.text_range {
+                    d = d.with_range(range);
+                }
+                Some(d)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mq_hir::Hir;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{LintConfig, LintContext};
+
+    fn check(code: &str) -> Vec<Diagnostic> {
+        let mut hir = Hir::default();
+        let (source_id, _) = hir.add_code(None, code);
+        let config = LintConfig::default();
+        let ctx = LintContext::new(&hir, source_id, &config);
+        DangerousCapabilityCall.check(&ctx)
+    }
+
+    #[rstest]
+    #[case(r#"http("https://example.com", "GET")"#, 1, "http", "--allow-net")]
+    #[case(r#"read_file("secrets.txt")"#, 1, "read_file", "--allow-read")]
+    #[case(r#"read_file_bytes("image.png")"#, 1, "read_file_bytes", "--allow-read")]
+    #[case(r#"write_file("out.txt", "data")"#, 1, "write_file", "--allow-write")]
+    #[case(r#"def wrapper(): read_file("x.txt"); | wrapper()"#, 1, "read_file", "--allow-read")]
+    #[case(
+        r#"module m: def leak(): http("https://evil.example", "GET"); end | m::leak()"#,
+        1,
+        "http",
+        "--allow-net"
+    )]
+    fn detects_dangerous_capability_call(
+        #[case] code: &str,
+        #[case] expected: usize,
+        #[case] fn_name: &str,
+        #[case] flag: &str,
+    ) {
+        let diags = check(code);
+        assert_eq!(diags.len(), expected);
+        assert!(diags[0].message().contains(fn_name));
+        assert!(diags[0].message().contains(flag));
+        assert!(diags[0].help().unwrap().contains(flag));
+    }
+
+    #[test]
+    fn detects_multiple_dangerous_calls() {
+        let diags = check(r#"read_file("a.txt") | write_file("b.txt", "data")"#);
+        assert_eq!(diags.len(), 2);
+        let names: Vec<_> = diags.iter().map(|d| d.message()).collect();
+        assert!(names.iter().any(|m| m.contains("read_file")));
+        assert!(names.iter().any(|m| m.contains("write_file")));
+    }
+
+    #[rstest]
+    #[case(".h1")]
+    #[case(r#"let x = "http""#)]
+    #[case(r#"def http_like(): 1; | http_like()"#)]
+    #[case(r#"to_text("read_file")"#)]
+    fn no_diagnostic(#[case] code: &str) {
+        let diags = check(code);
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn severity_is_warn() {
+        assert_eq!(DangerousCapabilityCall.severity(), Severity::Warn);
+    }
+}


### PR DESCRIPTION
## Summary

Flags calls to capability-gated builtins (http, read_file, read_file_bytes, write_file) that require --allow-net/--allow-read/--allow-write at runtime, making these calls visible for review before granting a flag process-wide to a query that may import untrusted HTTP modules.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
