### PR TITLE
👷 ci(workflows): add path-scoped CI for Node.js package and VS Code extension

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,61 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/mq-nodejs/**"
+      - "crates/mq-wasm/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/mq-nodejs/**"
+      - "crates/mq-wasm/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
+        with:
+          tool: wasm-pack
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: packages/mq-nodejs/package.json
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .tool-versions
+          package-manager-cache: false
+      - name: Install dependencies
+        working-directory: packages/mq-nodejs
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: just build-node
+      - name: Type check
+        working-directory: packages/mq-nodejs
+        run: pnpm run type-check
+      - name: Lint
+        working-directory: packages/mq-nodejs
+        run: pnpm run lint
+      - name: Test
+        working-directory: packages/mq-nodejs
+        run: pnpm run test

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -1,0 +1,43 @@
+name: VS Code Extension CI
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "editors/vscode/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "editors/vscode/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .tool-versions
+      - name: Install dependencies
+        working-directory: editors/vscode
+        run: npm ci
+      - name: Type check
+        working-directory: editors/vscode
+        run: npm run check-types
+      - name: Lint
+        working-directory: editors/vscode
+        run: npm run lint
+      - name: Run tests
+        working-directory: editors/vscode
+        run: xvfb-run -a npm test


### PR DESCRIPTION
## Summary

Add node-ci.yml and vscode-ci.yml, each triggered only when files under packages/mq-nodejs (and crates/mq-wasm) or editors/vscode change.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [x] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
