### PR TITLE
✨ feat(mq-lang): add configurable evaluation timeout

### DIFF
--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -119,6 +119,15 @@ impl<T: ModuleResolver> Engine<T> {
         self.evaluator.options.max_call_stack_depth = max_call_stack_depth;
     }
 
+    /// Set the maximum wall-clock duration allowed for a single `eval` call.
+    ///
+    /// Disabled by default (no timeout). When exceeded, evaluation stops with
+    /// `RuntimeError::Timeout`; the deadline is checked periodically inside loops and
+    /// function calls, so it may be exceeded slightly before evaluation actually stops.
+    pub fn set_timeout(&mut self, timeout: std::time::Duration) {
+        self.evaluator.options.timeout = Some(timeout);
+    }
+
     /// Enables or disables the `http` builtin for the current process.
     ///
     /// Disabled by default. This is a process-wide setting (see
@@ -448,6 +457,43 @@ mod tests {
 
         engine.set_max_call_stack_depth(new_depth);
         assert_eq!(engine.evaluator.options.max_call_stack_depth, new_depth);
+    }
+
+    #[test]
+    fn test_set_timeout() {
+        let mut engine = DefaultEngine::default();
+        assert_eq!(engine.evaluator.options.timeout, None);
+
+        let timeout = std::time::Duration::from_secs(1);
+        engine.set_timeout(timeout);
+        assert_eq!(engine.evaluator.options.timeout, Some(timeout));
+    }
+
+    #[rstest]
+    #[case::while_loop("while(true): 1;")]
+    #[case::bare_loop("loop: 1;")]
+    #[case::foreach_large_array("foreach(x, range(999999)): x;")]
+    fn test_timeout_aborts_runaway_query(#[case] query: &str) {
+        let mut engine = DefaultEngine::default();
+        // A zero timeout guarantees the deadline is already passed by the first
+        // periodic check, regardless of how fast the machine running this test is.
+        engine.set_timeout(std::time::Duration::ZERO);
+
+        let started = std::time::Instant::now();
+        let result = engine.eval(query, vec!["".to_string().into()].into_iter());
+
+        assert!(matches!(
+            result.unwrap_err().cause,
+            crate::error::InnerError::Runtime(crate::error::runtime::RuntimeError::Timeout(_))
+        ));
+        assert!(started.elapsed() < std::time::Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_no_timeout_by_default() {
+        let mut engine = DefaultEngine::default();
+        let result = engine.eval("1 + 1", vec!["".to_string().into()].into_iter());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -314,6 +314,9 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::RecursionError(_)) => {
                 Some(Cow::Borrowed("Maximum recursion depth exceeded."))
             }
+            InnerError::Runtime(RuntimeError::Timeout(_)) => Some(Cow::Borrowed(
+                "Execution exceeded the configured timeout. Increase it or simplify the query.",
+            )),
             InnerError::Runtime(RuntimeError::ModuleLoadError(_)) => {
                 Some(Cow::Borrowed("Failed to load module. Check module paths and names."))
             }

--- a/crates/mq-lang/src/error/runtime.rs
+++ b/crates/mq-lang/src/error/runtime.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use smol_str::SmolStr;
 use thiserror::Error;
 
@@ -33,6 +35,8 @@ pub enum RuntimeError {
     InvalidDefinition(ErrorToken, String),
     #[error("Maximum recursion depth exceeded ({0})")]
     RecursionError(u32),
+    #[error("Execution timed out after {:.3}s", .0.as_secs_f64())]
+    Timeout(Duration),
     #[error(r#"Invalid types for "{}", got {}"#, name, args.join(", "))]
     InvalidTypes {
         token: ErrorToken,
@@ -102,6 +106,7 @@ impl RuntimeError {
             RuntimeError::IndexOutOfBounds(token, _) => Some(token),
             RuntimeError::InvalidDefinition(token, _) => Some(token),
             RuntimeError::RecursionError(_) => None,
+            RuntimeError::Timeout(_) => None,
             RuntimeError::InvalidTypes { token, .. } => Some(token),
             RuntimeError::InvalidNumberOfArguments { token, .. } => Some(token),
             RuntimeError::InvalidRegularExpression(token, _) => Some(token),
@@ -150,6 +155,7 @@ mod tests {
     #[case(RuntimeError::IndexOutOfBounds(eof_token(), Number::from(1.0)), true)]
     #[case(RuntimeError::InvalidDefinition(eof_token(), "d".to_string()), true)]
     #[case(RuntimeError::RecursionError(10), false)]
+    #[case(RuntimeError::Timeout(Duration::from_secs(1)), false)]
     #[case(RuntimeError::InvalidTypes { token: eof_token(), name: "f".to_string(), args: vec![] }, true)]
     #[case(RuntimeError::InvalidNumberOfArguments { token: eof_token(), name: "f".to_string(), expected: 1, actual: 0 }, true)]
     #[case(RuntimeError::InvalidRegularExpression(eof_token(), "pat".to_string()), true)]
@@ -176,6 +182,10 @@ mod tests {
 
     #[rstest]
     #[case(RuntimeError::RecursionError(42), "Maximum recursion depth exceeded (42)")]
+    #[case(
+        RuntimeError::Timeout(Duration::from_millis(1500)),
+        "Execution timed out after 1.500s"
+    )]
     #[case(RuntimeError::RecursionLimit, "Maximum macro recursion depth exceeded")]
     #[case(RuntimeError::UndefinedMacro(Ident::new("foo")), "Undefined macro: foo")]
     #[case(RuntimeError::ArityMismatch { macro_name: Ident::new("bar"), expected: 2, got: 1 }, "Macro bar expects 2 arguments, got 1")]

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "debugger")]
 use crate::DebuggerHandler;
@@ -43,6 +44,10 @@ pub mod runtime_value;
 
 use env::Env;
 use runtime_value::RuntimeValue;
+
+/// Number of loop iterations / function calls between wall-clock deadline checks.
+/// Must be a power of two so the check is a cheap bitmask instead of a modulo.
+const TIMEOUT_CHECK_INTERVAL: u32 = 1024;
 
 static TYPE_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new("type"));
 static DYNAMIC_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new("<dynamic>"));
@@ -116,6 +121,9 @@ enum BreakpointDecision {
 pub struct Options {
     /// Maximum depth of the call stack to prevent infinite recursion.
     pub max_call_stack_depth: u32,
+    /// Maximum wall-clock duration for a single evaluation. Disabled (`None`) by default;
+    /// checked periodically, so a run may overshoot the deadline slightly.
+    pub timeout: Option<Duration>,
 }
 
 #[cfg(debug_assertions)]
@@ -123,6 +131,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             max_call_stack_depth: 40,
+            timeout: None,
         }
     }
 }
@@ -132,6 +141,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             max_call_stack_depth: 192,
+            timeout: None,
         }
     }
 }
@@ -146,6 +156,10 @@ pub struct Evaluator<T: ModuleResolver = DefaultModuleResolver> {
     token_arena: Shared<SharedCell<Arena<Shared<Token>>>>,
 
     call_stack_depth: u32,
+    /// Deadline for the current `eval` call; `None` if no timeout is set.
+    deadline: Option<Instant>,
+    /// Step counter so `Instant::now()` is only sampled every `TIMEOUT_CHECK_INTERVAL` steps.
+    timeout_step: u32,
     pub(crate) options: Options,
     pub(crate) module_loader: module::ModuleLoader<T>,
     pub(crate) macro_expander: Macro,
@@ -162,6 +176,8 @@ impl<T: ModuleResolver> Default for Evaluator<T> {
             env: Shared::new(SharedCell::new(Env::default())),
             token_arena: Shared::new(SharedCell::new(Arena::new(10))),
             call_stack_depth: 0,
+            deadline: None,
+            timeout_step: 0,
             options: Options::default(),
             module_loader: module::ModuleLoader::new(T::default()),
             macro_expander: Macro::new(),
@@ -180,6 +196,8 @@ impl<T: ModuleResolver> Clone for Evaluator<T> {
             env: Shared::clone(&self.env),
             token_arena: Shared::clone(&self.token_arena),
             call_stack_depth: self.call_stack_depth,
+            deadline: self.deadline,
+            timeout_step: self.timeout_step,
             options: self.options.clone(),
             module_loader: self.module_loader.clone(),
             macro_expander: self.macro_expander.clone(),
@@ -242,6 +260,9 @@ impl<T: ModuleResolver> Evaluator<T> {
     where
         I: Iterator<Item = RuntimeValue>,
     {
+        self.deadline = self.options.timeout.map(|timeout| Instant::now() + timeout);
+        self.timeout_step = 0;
+
         // First pass: handle includes and imports, collect other nodes
         let program = program.iter().try_fold(
             Vec::with_capacity(program.len()),
@@ -1487,6 +1508,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 let mut results = Vec::with_capacity(values.len());
 
                 for value in values {
+                    self.check_timeout()?;
                     define(&env, ident, value.clone());
                     match self.eval_program(body, value, &env) {
                         Ok(result) => results.push(result),
@@ -1504,6 +1526,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 let mut results = Vec::with_capacity(s.len());
 
                 for c in s.chars() {
+                    self.check_timeout()?;
                     define(&env, ident, RuntimeValue::String(c.to_string()));
                     match self.eval_program(body, RuntimeValue::String(c.to_string()), &env) {
                         Ok(result) => results.push(result),
@@ -1546,6 +1569,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         let mut first = true;
 
         while cond_value.is_truthy() {
+            self.check_timeout()?;
             match self.eval_program(body, runtime_value.clone(), &env) {
                 Ok(mut new_runtime_value) => {
                     std::mem::swap(&mut runtime_value, &mut new_runtime_value);
@@ -1579,6 +1603,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         let env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
 
         loop {
+            self.check_timeout()?;
             match self.eval_program(body, runtime_value.clone(), &env) {
                 Ok(mut new_runtime_value) => {
                     std::mem::swap(&mut runtime_value, &mut new_runtime_value);
@@ -2010,6 +2035,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         if self.call_stack_depth >= self.options.max_call_stack_depth {
             return Err(RuntimeError::RecursionError(self.options.max_call_stack_depth).into());
         }
+        self.check_timeout()?;
         self.call_stack_depth += 1;
         Ok(())
     }
@@ -2018,6 +2044,27 @@ impl<T: ModuleResolver> Evaluator<T> {
     fn exit_scope(&mut self) {
         if self.call_stack_depth > 0 {
             self.call_stack_depth -= 1;
+        }
+    }
+
+    /// Checks the configured `timeout`; a no-op when unset.
+    #[inline(always)]
+    fn check_timeout(&mut self) -> Result<(), RuntimeError> {
+        let Some(deadline) = self.deadline else {
+            return Ok(());
+        };
+
+        self.timeout_step = self.timeout_step.wrapping_add(1);
+        if self.timeout_step & (TIMEOUT_CHECK_INTERVAL - 1) != 0 {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            Err(RuntimeError::Timeout(
+                self.options.timeout.expect("deadline implies options.timeout is set"),
+            ))
+        } else {
+            Ok(())
         }
     }
 

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -93,6 +93,11 @@ pub struct Cli {
     /// Optimization level for AST transformations (none = no changes, basic = constant folding and dead-branch elimination, full = all passes).
     #[arg(short='O', long = "optimize-level", value_enum, default_value_t = OptimizeLevel::None)]
     optimize_level: OptimizeLevel,
+
+    /// Maximum time in seconds allowed for query evaluation before aborting (e.g. 0.5, 5).
+    /// No timeout by default.
+    #[arg(long, value_name = "SECONDS")]
+    timeout: Option<f64>,
 }
 
 #[cfg(unix)]
@@ -873,6 +878,13 @@ impl Cli {
         engine.set_allow_read(self.input.allow_read);
         engine.set_allow_write(self.input.allow_write);
 
+        if let Some(secs) = self.timeout {
+            if secs <= 0.0 {
+                return Err(miette!("--timeout must be greater than 0"));
+            }
+            engine.set_timeout(std::time::Duration::from_secs_f64(secs));
+        }
+
         #[cfg(feature = "debugger")]
         {
             use crate::debugger::DebuggerHandler;
@@ -1618,6 +1630,62 @@ mod tests {
             ..Cli::default()
         };
         assert!(allowed_cli.run().is_ok(), "read_file should succeed with --allow-read");
+    }
+
+    #[rstest]
+    #[case(0.0)]
+    #[case(-1.0)]
+    fn test_timeout_rejects_non_positive(#[case] secs: f64) {
+        let cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some("1".to_string()),
+            files: None,
+            timeout: Some(secs),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_err());
+    }
+
+    #[test]
+    fn test_timeout_aborts_infinite_loop() {
+        let cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some("while(true): 1;".to_string()),
+            files: None,
+            timeout: Some(0.001),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_err());
+    }
+
+    #[test]
+    fn test_timeout_allows_normal_query() {
+        let cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some("1 + 1".to_string()),
+            files: None,
+            timeout: Some(5.0),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Loops (while/loop/foreach) and function calls now check a wall-clock deadline derived from Options.timeout, guarding against runaway queries similar to a WASM VM's fuel/epoch interruption. Disabled by default; the deadline is only sampled every 1024 steps to keep the per-iteration overhead negligible.

Exposed via Engine::set_timeout and the mq CLI's --timeout flag.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x]  I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
