### PR TITLE
✨ feat(mq-web-api): make query evaluation timeout configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,6 +2654,7 @@ dependencies = [
  "url",
  "uuid",
  "web-sys",
+ "web-time",
  "yaml-rust2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ uuid = "1.23.4"
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.55"
 wasm-bindgen-test = "0.3.65"
+web-time = "1.1.0"
 yaml-rust2 = "0.11.0"
 
 [profile.release]

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -53,6 +53,7 @@ uuid = {workspace = true, features = ["v4", "v7"]}
 web-sys = { version = "0.3", features = ["console"] }
 uuid = {workspace = true, features = ["js"]}
 getrandom = { version = "0.4", features = ["wasm_js"] }
+web-time = {workspace = true}
 
 [features]
 ast-json = ["smallvec/serde", "smol_str/serde"]

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1,7 +1,11 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 #[cfg(feature = "debugger")]
 use crate::DebuggerHandler;

--- a/crates/mq-wasm/src/script.rs
+++ b/crates/mq-wasm/src/script.rs
@@ -43,6 +43,8 @@ export interface Options {
     linkUrlStyle: 'angle' | 'none' | null,
     /** Domains permitted for HTTP module imports in addition to github.com/harehare (always allowed). */
     allowedDomains?: string[],
+    /** Maximum time in milliseconds a query may run before evaluation is aborted. Disabled (no timeout) if omitted. */
+    timeoutMs?: number,
 }
 
 export function definedValues(code: string, module?: string): Promise<ReadonlyArray<DefinedValue>>;
@@ -107,6 +109,7 @@ struct Options {
     link_title_style: Option<TitleSurroundStyle>,
     link_url_style: Option<UrlSurroundStyle>,
     allowed_domains: Option<Vec<String>>,
+    timeout_ms: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -629,6 +632,9 @@ pub async fn run(code: &str, content: &str, options: JsValue) -> Result<String, 
     let mut engine = mq_lang::Engine::new(resolver);
 
     engine.load_builtin_module();
+    if let Some(timeout_ms) = options.timeout_ms {
+        engine.set_timeout(std::time::Duration::from_millis(timeout_ms as u64));
+    }
 
     let input = match options.input_format.as_ref().unwrap_or(&InputFormat::Markdown) {
         InputFormat::Text => mq_lang::parse_text_input(content),
@@ -1245,6 +1251,7 @@ mod tests {
                 link_title_style: None,
                 link_url_style: None,
                 allowed_domains: None,
+                timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1264,6 +1271,7 @@ mod tests {
                 link_title_style: None,
                 link_url_style: None,
                 allowed_domains: None,
+                timeout_ms: None,
             })
             .unwrap(),
         );
@@ -1283,10 +1291,33 @@ mod tests {
                 link_title_style: None,
                 link_url_style: Some(UrlSurroundStyle::Angle),
                 allowed_domains: None,
+                timeout_ms: None,
             })
             .unwrap(),
         );
         assert_eq!(result.await.unwrap(), "[test](<https://example.com>)\n");
+    }
+
+    #[allow(unused)]
+    #[wasm_bindgen_test]
+    async fn test_script_run_timeout() {
+        let result = run(
+            "while(true): 1;",
+            "test",
+            serde_wasm_bindgen::to_value(&Options {
+                is_update: true,
+                input_format: None,
+                list_style: None,
+                link_title_style: None,
+                link_url_style: None,
+                allowed_domains: None,
+                // A zero timeout guarantees the deadline is already passed by the first
+                // periodic check, regardless of how fast the machine running this test is.
+                timeout_ms: Some(0),
+            })
+            .unwrap(),
+        );
+        assert!(result.await.is_err());
     }
 
     #[allow(unused)]
@@ -1303,6 +1334,7 @@ mod tests {
                     link_title_style: None,
                     link_url_style: None,
                     allowed_domains: None,
+                    timeout_ms: None,
                 })
                 .unwrap()
             )

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -135,6 +135,7 @@ All settings are controlled through environment variables.
 | `RUST_LOG` | `mq_web_api=debug,tower_http=debug` | Log level filter |
 | `LOG_FORMAT` | `json` | Log format: `json` or `text` |
 | `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
+| `QUERY_TIMEOUT_SECONDS` | `10` | Max seconds a single query may run before it's aborted |
 
 ### Rate Limiting
 

--- a/crates/mq-web-api/src/api.rs
+++ b/crates/mq-web-api/src/api.rs
@@ -206,8 +206,8 @@ pub struct LintApiResponse {
     pub diagnostics: Vec<LintDiagnostic>,
 }
 
-pub fn query(request: ApiRequest) -> miette::Result<QueryApiResponse> {
-    execute_query(request)
+pub fn query(request: ApiRequest, timeout: std::time::Duration) -> miette::Result<QueryApiResponse> {
+    execute_query(request, timeout)
 }
 
 /// Type-checks the given query and returns any errors found.
@@ -343,9 +343,10 @@ fn type_error_kind(e: &mq_check::TypeError) -> String {
     .to_string()
 }
 
-fn execute_query(request: ApiRequest) -> miette::Result<QueryApiResponse> {
+fn execute_query(request: ApiRequest, timeout: std::time::Duration) -> miette::Result<QueryApiResponse> {
     let mut engine = mq_lang::DefaultEngine::default();
     engine.load_builtin_module();
+    engine.set_timeout(timeout);
 
     if let Some(modules) = &request.modules {
         for module_name in modules {
@@ -528,7 +529,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok(), "{:?}", result.err());
         assert!(!result.unwrap().results.is_empty());
     }
@@ -558,7 +559,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
         assert!(!result.unwrap().results.is_empty());
     }
@@ -574,7 +575,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
     }
 
@@ -589,7 +590,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_err());
     }
 
@@ -605,7 +606,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
     }
 
@@ -621,7 +622,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_err());
     }
 
@@ -639,7 +640,7 @@ mod tests {
             output_format: None,
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
         let resp = result.unwrap();
         assert!(!resp.results.is_empty());
@@ -656,7 +657,7 @@ mod tests {
             output_format: Some(OutputFormat::Html),
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
         let resp = result.unwrap();
         assert!(!resp.results.is_empty());
@@ -674,7 +675,7 @@ mod tests {
             output_format: Some(OutputFormat::None),
             aggregate: None,
         };
-        let result = query(req);
+        let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
         assert!(result.unwrap().results.is_empty());
     }

--- a/crates/mq-web-api/src/config.rs
+++ b/crates/mq-web-api/src/config.rs
@@ -1,5 +1,5 @@
 use crate::rate_limiter::RateLimitConfig;
-use std::env;
+use std::{env, time::Duration};
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -13,6 +13,8 @@ pub struct Config {
     pub otel_endpoint: Option<String>,
     /// Service name reported to the OpenTelemetry collector.
     pub otel_service_name: String,
+    /// Maximum duration a single query evaluation may run before it's aborted.
+    pub query_timeout: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -32,6 +34,7 @@ impl Default for Config {
             rate_limit: RateLimitConfig::default(),
             otel_endpoint: None,
             otel_service_name: "mq-web-api".to_string(),
+            query_timeout: Duration::from_secs(10),
         }
     }
 }
@@ -125,6 +128,17 @@ impl Config {
             && !service_name.is_empty()
         {
             config.otel_service_name = service_name;
+        }
+
+        if let Ok(timeout_str) = env::var("QUERY_TIMEOUT_SECONDS") {
+            if let Ok(timeout) = timeout_str.parse::<u64>() {
+                config.query_timeout = Duration::from_secs(timeout);
+            } else {
+                eprintln!(
+                    "Warning: Invalid QUERY_TIMEOUT_SECONDS value '{}', using default {:?}",
+                    timeout_str, config.query_timeout
+                );
+            }
         }
 
         config

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
+use std::time::Duration;
 use tracing::{debug, error, info};
 use utoipa::{OpenApi, ToSchema};
 
@@ -19,7 +20,10 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct AppState {}
+pub struct AppState {
+    /// Maximum duration a single query evaluation may run before it's aborted.
+    pub query_timeout: Duration,
+}
 
 #[derive(Deserialize)]
 pub struct QueryParams {
@@ -122,7 +126,7 @@ pub struct ApiDoc;
 )]
 pub async fn get_query_api(
     ValidatedQuery(params): ValidatedQuery<QueryParams>,
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
 ) -> Result<Json<QueryApiResponse>, ProblemDetails> {
     debug!("GET /query called with query: {}", params.query);
 
@@ -142,8 +146,9 @@ pub async fn get_query_api(
         output_format: None,
         aggregate: None,
     };
+    let timeout = state.query_timeout;
 
-    match tokio::task::spawn_blocking(move || crate::api::query(request))
+    match tokio::task::spawn_blocking(move || crate::api::query(request, timeout))
         .await
         .map_err(|e| {
             error!("Query task panicked: {}", e);
@@ -178,14 +183,15 @@ pub async fn get_query_api(
     request_body = ApiRequest
 )]
 pub async fn post_query_api(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Json(request): Json<ApiRequest>,
 ) -> Result<Json<QueryApiResponse>, ProblemDetails> {
     debug!("POST /query called with query: {}", request.query);
     debug!("Processing request with input_format: {:?}", request.input_format);
 
     let query_str = request.query.clone();
-    match tokio::task::spawn_blocking(move || crate::api::query(request))
+    let timeout = state.query_timeout;
+    match tokio::task::spawn_blocking(move || crate::api::query(request, timeout))
         .await
         .map_err(|e| {
             error!("Query task panicked: {}", e);
@@ -252,7 +258,7 @@ fn sniff_input_format(body: &str) -> Option<InputFormat> {
     )
 )]
 pub async fn post_shorthand_query_api(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Path(query): Path<String>,
     ValidatedQuery(params): ValidatedQuery<ShorthandQueryParams>,
     body: String,
@@ -276,8 +282,9 @@ pub async fn post_shorthand_query_api(
         output_format,
         aggregate: None,
     };
+    let timeout = state.query_timeout;
 
-    match tokio::task::spawn_blocking(move || crate::api::query(request))
+    match tokio::task::spawn_blocking(move || crate::api::query(request, timeout))
         .await
         .map_err(|e| {
             error!("Shorthand query task panicked: {}", e);

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -26,7 +26,9 @@ use crate::{
 };
 
 pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router {
-    let state = AppState {};
+    let state = AppState {
+        query_timeout: config.query_timeout,
+    };
 
     let cors = if config.cors_origins.contains(&"*".to_string()) {
         CorsLayer::new()

--- a/crates/mq-web-api/src/server.rs
+++ b/crates/mq-web-api/src/server.rs
@@ -141,6 +141,7 @@ pub async fn start_server(config: Config) -> Result<(), Box<dyn std::error::Erro
     info!("  RATE_LIMIT_REQUESTS_PER_WINDOW: Requests per window (default: 100)");
     info!("  RATE_LIMIT_WINDOW_SIZE_SECONDS: Window size in seconds (default: 3600)");
     info!("  RATE_LIMIT_CLEANUP_INTERVAL_SECONDS: Cleanup interval in seconds (default: 3600)");
+    info!("  QUERY_TIMEOUT_SECONDS: Max seconds a single query may run before it's aborted (default: 10)");
 
     // Start cleanup service
     let mut cleanup_service = CleanupService::new(


### PR DESCRIPTION
## Summary

Adds a `QUERY_TIMEOUT_SECONDS` environment variable (default 10s) that sets the per-query evaluation timeout, threaded from Config through AppState into every query execution path instead of a hardcoded value.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
