### PR TITLE
✨ feat(mq-lang): add get_path/set_path/paths for nested key access

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -952,6 +952,56 @@ def has(v, key):
     false
 end
 
+# Retrieves a nested value by following an array of keys/indices, e.g. `get_path(d, ["a", "b", 0])`.
+# Returns None as soon as any intermediate step is missing.
+def get_path(value, path):
+  do
+    var result = value
+    | var i = 0
+    | while (i < len(path)):
+        result = get(result, path[i])
+        | i += 1
+      end
+    | result
+  end
+end
+
+# Sets a nested value by following an array of keys/indices, e.g. `set_path(d, ["a", "b", 0], 1)`.
+# Missing intermediate dicts/arrays are created automatically, choosing an array when the
+# corresponding path element is a number and a dict otherwise.
+def set_path(value, path, new_value):
+  if (is_empty(path)):
+    new_value
+  else:
+    do
+      let key = first(path)
+      | let rest = skip(path, 1)
+      | let container = if (is_dict(value) || is_array(value)): value elif (is_number(key)): [] else: {}
+      | let updated = set_path(get(container, key), rest, new_value)
+      | set(container, key, updated)
+    end
+end
+
+# Returns an array of leaf-path arrays for a value, e.g. `paths({"a": {"b": 1}})` returns `[["a", "b"]]`.
+# Each returned path can be passed to `get_path`/`set_path`. Containers with no leaves (e.g. `{}`, `[]`)
+# contribute no paths.
+def paths(value):
+  if (is_dict(value)):
+    fold(entries(value), [], fn(acc, entry): acc + map(paths(entry[1]), fn(p): [entry[0]] + p;);)
+  elif (is_array(value)):
+    do
+      var result = []
+      | var i = 0
+      | while (i < len(value)):
+          result = result + map(paths(value[i]), fn(p): [i] + p;)
+          | i += 1
+        end
+      | result
+    end
+  else:
+    [[]]
+end
+
 # Builds a dict from an array of [key, value] pairs, as produced by `entries`.
 # If the same key appears more than once, the last occurrence wins.
 def from_entries(arr):

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -908,6 +908,57 @@ def test_has():
   | assert_eq(result6, false)
 end
 
+def test_get_path():
+  let result1 = get_path({"a": {"b": [1, 2, 3]}}, ["a", "b", 1])
+  | assert_eq(result1, 2)
+
+  # Missing intermediate key short-circuits to None
+  | let result2 = get_path({"a": {"b": 1}}, ["a", "x", "y"])
+  | assert_eq(result2, None)
+
+  # Empty path returns the value itself
+  | let result3 = get_path({"a": 1}, [])
+  | assert_eq(result3, {"a": 1})
+
+  # Out-of-bounds array index yields None
+  | let result4 = get_path([1, 2, 3], [10])
+  | assert_eq(result4, None)
+end
+
+def test_set_path():
+  let result1 = set_path({"a": {"b": [1, 2, 3]}}, ["a", "b", 1], 99)
+  | assert_eq(result1, {"a": {"b": [1, 99, 3]}})
+
+  # Missing intermediate containers are created automatically
+  | let result2 = set_path({}, ["a", "b", 0], 42)
+  | assert_eq(result2, {"a": {"b": [42]}})
+
+  # Empty path replaces the whole value
+  | let result3 = set_path({"a": 1}, [], 99)
+  | assert_eq(result3, 99)
+
+  # A round-trip through paths()/get_path() reconstructs every leaf via set_path()
+  | let v = {"a": {"b": 1, "c": 2}, "d": [3, 4]}
+  | let result4 = fold(paths(v), v, fn(acc, p): set_path(acc, p, get_path(v, p) * 10);)
+  | assert_eq(result4, {"a": {"b": 10, "c": 20}, "d": [30, 40]})
+end
+
+def test_paths():
+  let result1 = paths({"a": {"b": 1, "c": 2}, "d": [3, 4]})
+  | assert_eq(result1, [["a", "b"], ["a", "c"], ["d", 0], ["d", 1]])
+
+  # Containers with no leaves contribute no paths
+  | let result2 = paths({})
+  | assert_eq(result2, [])
+
+  | let result3 = paths([])
+  | assert_eq(result3, [])
+
+  # A bare scalar has a single, empty leaf path
+  | let result4 = paths(42)
+  | assert_eq(result4, [[]])
+end
+
 def test_from_entries():
   let result1 = from_entries([["a", 1], ["b", 2]])
   | assert_eq(result1, {"a": 1, "b": 2})


### PR DESCRIPTION
## Summary

Adds jq-style getpath/setpath/leaf_paths equivalents to builtin.mq, built purely on top of the existing get/set builtins, so runtime-computed key sequences no longer require manual get(get(get(...))) chaining.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
