### PR TITLE
✨ feat(mq-check): add --format json/sarif for CI-consumable output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,7 @@ dependencies = [
  "mq-lang",
  "rstest",
  "rustc-hash",
+ "serde_json",
  "slotmap",
  "smol_str",
  "thiserror 2.0.18",

--- a/crates/mq-check/Cargo.toml
+++ b/crates/mq-check/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/harehare/mq"
 version = "0.6.5"
 
 [features]
-cli = ["dep:clap", "dep:colored", "dep:url"]
+cli = ["dep:clap", "dep:colored", "dep:serde_json", "dep:url"]
 
 [[bin]]
 name = "mq-check"
@@ -31,6 +31,7 @@ miette = {workspace = true, features = ["fancy"]}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["cst", "file-io"]}
 rustc-hash = {workspace = true}
+serde_json = {workspace = true, optional = true}
 slotmap = {workspace = true}
 smol_str = {workspace = true}
 thiserror = {workspace = true}

--- a/crates/mq-check/README.md
+++ b/crates/mq-check/README.md
@@ -110,6 +110,7 @@ When used as a command-line tool (`mq-typecheck`), the following options are ava
 | `--show-types`   | Display inferred types for all user-defined symbols                |
 | `--no-builtins`  | Disable automatic builtin preloading                               |
 | `--strict-array` | Reject heterogeneous arrays (e.g., `[1, "hello"]` is a type error) |
+| `--format`       | Diagnostic output format: `text` (default), `json`, or `sarif`      |
 
 ### `--strict-array`
 
@@ -119,6 +120,33 @@ Enforces that all elements in an array literal share the same type.
 echo '[1, "hello"]' | mq-check --strict-array
 # Error: heterogeneous array: [number, string]
 ```
+
+### CI Integration
+
+`--format` controls how diagnostics are rendered, independent of `--show-types` and the other checks above:
+
+- `text` (default) — colored, human-readable report.
+- `json` — a single JSON array of diagnostics (syntax errors/warnings and type errors) across every
+  checked file, each with `file`, `severity` (`error`/`warning`), `code`, `message`, and an optional
+  `range`.
+- `sarif` — a single SARIF 2.1.0 log covering every checked file, suitable for
+  [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif) or any
+  other SARIF-consuming tool.
+
+```bash
+mq-check --format json script.mq
+mq-check --format sarif $(git ls-files '*.mq') > mq-check.sarif
+```
+
+```yaml
+# .github/workflows/check.yml
+- run: mq-check --format sarif $(git ls-files '*.mq') > mq-check.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: mq-check.sarif
+```
+
+Exits with a non-zero status if any error-severity diagnostic was found, regardless of `--format`.
 
 ## Development
 

--- a/crates/mq-check/src/format.rs
+++ b/crates/mq-check/src/format.rs
@@ -15,6 +15,16 @@ pub(crate) enum Severity {
     Warning,
 }
 
+impl Severity {
+    /// Returns the wire representation shared by the JSON and SARIF output formats.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
+}
+
 /// A single syntax or type-check diagnostic, in a form suitable for machine consumption.
 #[derive(Clone, Debug)]
 pub(crate) struct CheckDiagnostic {

--- a/crates/mq-check/src/format.rs
+++ b/crates/mq-check/src/format.rs
@@ -1,0 +1,134 @@
+//! Machine-readable diagnostic output formats for the `mq-check` CLI.
+
+mod json;
+mod sarif;
+
+use std::io::{self, Write};
+
+use mq_check::TypeError;
+use mq_hir::{Hir, HirError, HirWarning};
+
+/// Severity of a check diagnostic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Severity {
+    Error,
+    Warning,
+}
+
+/// A single syntax or type-check diagnostic, in a form suitable for machine consumption.
+#[derive(Clone, Debug)]
+pub(crate) struct CheckDiagnostic {
+    pub(crate) severity: Severity,
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    pub(crate) range: Option<mq_lang::Range>,
+}
+
+/// Machine-readable diagnostic output format.
+#[derive(Clone, Copy, Debug, Default, PartialEq, clap::ValueEnum)]
+pub(crate) enum OutputFormat {
+    /// Human-readable colored report (default)
+    #[default]
+    Text,
+    /// A single JSON array of diagnostics across every checked file
+    Json,
+    /// SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF consumers
+    Sarif,
+}
+
+/// Returns the syntax errors and warnings on `hir` as [`CheckDiagnostic`]s.
+pub(crate) fn syntax_diagnostics(hir: &Hir) -> Vec<CheckDiagnostic> {
+    let mut diagnostics: Vec<CheckDiagnostic> = hir
+        .errors()
+        .iter()
+        .map(|error| CheckDiagnostic {
+            severity: Severity::Error,
+            code: hir_error_code(error),
+            message: error.to_string(),
+            range: Some(hir_error_range(error)),
+        })
+        .collect();
+
+    diagnostics.extend(hir.warnings().iter().map(|warning| CheckDiagnostic {
+        severity: Severity::Warning,
+        code: hir_warning_code(warning),
+        message: warning.to_string(),
+        range: Some(hir_warning_range(warning)),
+    }));
+
+    diagnostics
+}
+
+/// Returns a stable rule code for a [`HirError`] variant.
+fn hir_error_code(error: &HirError) -> &'static str {
+    match error {
+        HirError::UnresolvedSymbol { .. } => "hir::unresolved_symbol",
+        HirError::ModuleNotFound { .. } => "hir::module_not_found",
+    }
+}
+
+fn hir_error_range(error: &HirError) -> mq_lang::Range {
+    match error {
+        HirError::UnresolvedSymbol { symbol, .. } => symbol.source.text_range.unwrap_or_default(),
+        HirError::ModuleNotFound { symbol, .. } => symbol.source.text_range.unwrap_or_default(),
+    }
+}
+
+/// Returns a stable rule code for a [`HirWarning`] variant.
+fn hir_warning_code(warning: &HirWarning) -> &'static str {
+    match warning {
+        HirWarning::UnreachableCode { .. } => "hir::unreachable_code",
+    }
+}
+
+fn hir_warning_range(warning: &HirWarning) -> mq_lang::Range {
+    match warning {
+        HirWarning::UnreachableCode { symbol } => symbol.source.text_range.unwrap_or_default(),
+    }
+}
+
+/// Converts type-check errors into [`CheckDiagnostic`]s.
+pub(crate) fn type_diagnostics(errors: &[TypeError]) -> Vec<CheckDiagnostic> {
+    errors
+        .iter()
+        .map(|error| CheckDiagnostic {
+            severity: Severity::Error,
+            code: type_error_code(error),
+            message: error.to_string(),
+            range: error.location(),
+        })
+        .collect()
+}
+
+/// Returns the `miette` diagnostic code for a [`TypeError`] variant.
+fn type_error_code(error: &TypeError) -> &'static str {
+    match error {
+        TypeError::Mismatch { .. } => "typechecker::type_mismatch",
+        TypeError::UnificationError { .. } => "typechecker::unification_error",
+        TypeError::OccursCheck { .. } => "typechecker::occurs_check",
+        TypeError::UndefinedSymbol { .. } => "typechecker::undefined_symbol",
+        TypeError::WrongArity { .. } => "typechecker::wrong_arity",
+        TypeError::UndefinedField { .. } => "typechecker::undefined_field",
+        TypeError::HeterogeneousArray { .. } => "typechecker::heterogeneous_array",
+        TypeError::TypeVarNotFound(_) => "typechecker::type_var_not_found",
+        TypeError::Internal(_) => "typechecker::internal_error",
+        TypeError::NullablePropagation { .. } => "typechecker::nullable_propagation",
+        TypeError::UnreachableCode { .. } => "typechecker::unreachable_code",
+        TypeError::NonExhaustiveMatch { .. } => "typechecker::non_exhaustive_patterns",
+    }
+}
+
+/// Dispatches to the writer for the requested machine-readable output format.
+///
+/// Must not be called with [`OutputFormat::Text`], which is rendered separately.
+pub(crate) fn write_report(
+    w: &mut impl Write,
+    format: OutputFormat,
+    results: &[(String, Vec<CheckDiagnostic>)],
+) -> io::Result<()> {
+    match format {
+        OutputFormat::Text => unreachable!("text output is handled separately"),
+        OutputFormat::Json => json::write_json_report(w, results),
+        OutputFormat::Sarif => sarif::write_sarif_report(w, results),
+    }
+}

--- a/crates/mq-check/src/format/json.rs
+++ b/crates/mq-check/src/format/json.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use super::{CheckDiagnostic, Severity};
+use super::CheckDiagnostic;
 
 /// Writes a single JSON array of diagnostics across every checked file.
 pub(super) fn write_json_report(w: &mut impl Write, results: &[(String, Vec<CheckDiagnostic>)]) -> io::Result<()> {
@@ -10,7 +10,7 @@ pub(super) fn write_json_report(w: &mut impl Write, results: &[(String, Vec<Chec
             diagnostics.iter().map(move |diagnostic| {
                 serde_json::json!({
                     "file": file_label,
-                    "severity": severity_str(diagnostic.severity),
+                    "severity": diagnostic.severity.as_str(),
                     "code": diagnostic.code,
                     "message": diagnostic.message,
                     "range": diagnostic.range.map(|range| serde_json::json!({
@@ -31,17 +31,10 @@ pub(super) fn write_json_report(w: &mut impl Write, results: &[(String, Vec<Chec
     )
 }
 
-/// Maps a check [`Severity`] to its JSON string representation.
-fn severity_str(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Error => "error",
-        Severity::Warning => "warning",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::format::Severity;
 
     #[test]
     fn test_write_json_report_produces_expected_shape() {

--- a/crates/mq-check/src/format/json.rs
+++ b/crates/mq-check/src/format/json.rs
@@ -1,0 +1,75 @@
+use std::io::{self, Write};
+
+use super::{CheckDiagnostic, Severity};
+
+/// Writes a single JSON array of diagnostics across every checked file.
+pub(super) fn write_json_report(w: &mut impl Write, results: &[(String, Vec<CheckDiagnostic>)]) -> io::Result<()> {
+    let entries: Vec<serde_json::Value> = results
+        .iter()
+        .flat_map(|(file_label, diagnostics)| {
+            diagnostics.iter().map(move |diagnostic| {
+                serde_json::json!({
+                    "file": file_label,
+                    "severity": severity_str(diagnostic.severity),
+                    "code": diagnostic.code,
+                    "message": diagnostic.message,
+                    "range": diagnostic.range.map(|range| serde_json::json!({
+                        "startLine": range.start.line,
+                        "startColumn": range.start.column,
+                        "endLine": range.end.line,
+                        "endColumn": range.end.column,
+                    })),
+                })
+            })
+        })
+        .collect();
+
+    writeln!(
+        w,
+        "{}",
+        serde_json::to_string_pretty(&entries).map_err(io::Error::other)?
+    )
+}
+
+/// Maps a check [`Severity`] to its JSON string representation.
+fn severity_str(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_json_report_produces_expected_shape() {
+        let diagnostics = vec![CheckDiagnostic {
+            severity: Severity::Error,
+            code: "typechecker::undefined_symbol",
+            message: "Undefined symbol: foo".to_string(),
+            range: Some(mq_lang::Range::default()),
+        }];
+        let results = vec![("test.mq".to_string(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_json_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+
+        assert_eq!(json[0]["file"], "test.mq");
+        assert_eq!(json[0]["severity"], "error");
+        assert_eq!(json[0]["code"], "typechecker::undefined_symbol");
+        assert_eq!(json[0]["message"], "Undefined symbol: foo");
+        assert!(json[0]["range"].is_object());
+    }
+
+    #[test]
+    fn test_write_json_report_empty_diagnostics() {
+        let results = vec![("test.mq".to_string(), Vec::new())];
+        let mut buf = Vec::new();
+        write_json_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/mq-check/src/format/sarif.rs
+++ b/crates/mq-check/src/format/sarif.rs
@@ -1,0 +1,104 @@
+use std::io::{self, Write};
+
+use super::{CheckDiagnostic, Severity};
+
+/// Writes a single SARIF 2.1.0 log document covering every checked file.
+///
+/// See <https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html>.
+pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, Vec<CheckDiagnostic>)]) -> io::Result<()> {
+    let sarif_results: Vec<serde_json::Value> = results
+        .iter()
+        .flat_map(|(file_label, diagnostics)| {
+            diagnostics.iter().map(move |diagnostic| {
+                let mut physical_location = serde_json::json!({
+                    "artifactLocation": {"uri": file_label},
+                });
+                if let Some(range) = &diagnostic.range {
+                    physical_location["region"] = serde_json::json!({
+                        "startLine": range.start.line,
+                        "startColumn": range.start.column,
+                        "endLine": range.end.line,
+                        "endColumn": range.end.column,
+                    });
+                }
+
+                serde_json::json!({
+                    "ruleId": diagnostic.code,
+                    "level": sarif_level(diagnostic.severity),
+                    "message": {"text": diagnostic.message},
+                    "locations": [{"physicalLocation": physical_location}],
+                })
+            })
+        })
+        .collect();
+
+    let sarif = serde_json::json!({
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "mq-check",
+                    "informationUri": "https://github.com/harehare/mq",
+                    "version": env!("CARGO_PKG_VERSION"),
+                }
+            },
+            "results": sarif_results,
+        }],
+    });
+
+    writeln!(w, "{}", serde_json::to_string_pretty(&sarif).map_err(io::Error::other)?)
+}
+
+/// Maps a check [`Severity`] to a SARIF result `level` (`error` or `warning`).
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_sarif_report_produces_valid_sarif_shape() {
+        let diagnostics = vec![CheckDiagnostic {
+            severity: Severity::Error,
+            code: "typechecker::undefined_symbol",
+            message: "Undefined symbol: foo".to_string(),
+            range: Some(mq_lang::Range::default()),
+        }];
+        let results = vec![("test.mq".to_string(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_sarif_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+
+        assert_eq!(json["version"], "2.1.0");
+        assert_eq!(json["runs"][0]["tool"]["driver"]["name"], "mq-check");
+        let result = &json["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "typechecker::undefined_symbol");
+        assert_eq!(result["level"], "error");
+        assert_eq!(
+            result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            "test.mq"
+        );
+    }
+
+    #[test]
+    fn test_write_sarif_report_empty_diagnostics() {
+        let results = vec![("test.mq".to_string(), Vec::new())];
+        let mut buf = Vec::new();
+        write_sarif_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(json["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_sarif_level_maps_severity() {
+        assert_eq!(sarif_level(Severity::Error), "error");
+        assert_eq!(sarif_level(Severity::Warning), "warning");
+    }
+}

--- a/crates/mq-check/src/format/sarif.rs
+++ b/crates/mq-check/src/format/sarif.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use super::{CheckDiagnostic, Severity};
+use super::CheckDiagnostic;
 
 /// Writes a single SARIF 2.1.0 log document covering every checked file.
 ///
@@ -24,7 +24,7 @@ pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, Vec<Che
 
                 serde_json::json!({
                     "ruleId": diagnostic.code,
-                    "level": sarif_level(diagnostic.severity),
+                    "level": diagnostic.severity.as_str(),
                     "message": {"text": diagnostic.message},
                     "locations": [{"physicalLocation": physical_location}],
                 })
@@ -50,17 +50,10 @@ pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, Vec<Che
     writeln!(w, "{}", serde_json::to_string_pretty(&sarif).map_err(io::Error::other)?)
 }
 
-/// Maps a check [`Severity`] to a SARIF result `level` (`error` or `warning`).
-fn sarif_level(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Error => "error",
-        Severity::Warning => "warning",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::format::Severity;
 
     #[test]
     fn test_write_sarif_report_produces_valid_sarif_shape() {
@@ -94,11 +87,5 @@ mod tests {
         write_sarif_report(&mut buf, &results).unwrap();
         let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
         assert_eq!(json["runs"][0]["results"].as_array().unwrap().len(), 0);
-    }
-
-    #[test]
-    fn test_sarif_level_maps_severity() {
-        assert_eq!(sarif_level(Severity::Error), "error");
-        assert_eq!(sarif_level(Severity::Warning), "warning");
     }
 }

--- a/crates/mq-check/src/main.rs
+++ b/crates/mq-check/src/main.rs
@@ -1,9 +1,12 @@
+mod format;
+
 use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
 use colored::Colorize;
+use format::OutputFormat;
 use mq_check::{TypeChecker, TypeCheckerOptions, TypeError};
 use mq_hir::Hir;
 use url::Url;
@@ -30,6 +33,12 @@ struct Cli {
     /// Disable exhaustiveness checking for pattern match expressions
     #[arg(long)]
     no_exhaustive_patterns: bool,
+
+    /// Diagnostic output format: `text` (human-readable), `json` (a single JSON array of
+    /// diagnostics), or `sarif` (SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF
+    /// consumers)
+    #[arg(long, value_enum, default_value_t)]
+    format: OutputFormat,
 }
 
 /// Options for a single file check
@@ -52,6 +61,11 @@ fn main() -> ExitCode {
 
 fn run() -> io::Result<()> {
     let cli = Cli::parse();
+
+    if cli.format != OutputFormat::Text {
+        return run_machine_format(&cli);
+    }
+
     let mut w = BufWriter::new(io::stderr());
     let multi = cli.files.len() > 1;
     let tc_options = TypeCheckerOptions {
@@ -120,6 +134,79 @@ fn run() -> io::Result<()> {
     } else {
         Ok(())
     }
+}
+
+/// Runs syntax and type checks across all inputs and writes a single machine-readable
+/// report (JSON or SARIF) to stdout, instead of the colored text report.
+fn run_machine_format(cli: &Cli) -> io::Result<()> {
+    let tc_options = TypeCheckerOptions {
+        strict_array: cli.strict_array,
+        no_exhaustive_patterns: cli.no_exhaustive_patterns,
+    };
+
+    let mut results: Vec<(String, Vec<format::CheckDiagnostic>)> = Vec::new();
+
+    if cli.files.is_empty() {
+        let mut code = String::new();
+        io::stdin().read_to_string(&mut code)?;
+        let source_url = Url::parse("file:///stdin").ok();
+        results.push((
+            "<stdin>".to_string(),
+            collect_check_diagnostics(&code, source_url, cli.no_builtins, &tc_options),
+        ));
+    } else {
+        for path in &cli.files {
+            let code = std::fs::read_to_string(path)
+                .map_err(|e| io::Error::other(format!("reading file {}: {}", path.display(), e)))?;
+            let source_url = Url::from_file_path(std::fs::canonicalize(path).unwrap_or(path.clone())).ok();
+            results.push((
+                path.display().to_string(),
+                collect_check_diagnostics(&code, source_url, cli.no_builtins, &tc_options),
+            ));
+        }
+    }
+
+    let had_errors = results
+        .iter()
+        .any(|(_, diagnostics)| diagnostics.iter().any(|d| d.severity == format::Severity::Error));
+
+    let mut w = BufWriter::new(io::stdout());
+    format::write_report(&mut w, cli.format, &results)?;
+    w.flush()?;
+
+    if had_errors {
+        Err(io::Error::other("type check failed"))
+    } else {
+        Ok(())
+    }
+}
+
+/// Runs syntax and type checks on a single source, returning every diagnostic found.
+/// Type checking is skipped when syntax errors are present, matching the text report's behavior.
+fn collect_check_diagnostics(
+    code: &str,
+    source_url: Option<Url>,
+    no_builtins: bool,
+    type_checker_options: &TypeCheckerOptions,
+) -> Vec<format::CheckDiagnostic> {
+    let mut hir = Hir::default();
+
+    if no_builtins {
+        hir.builtin.disabled = true;
+    }
+
+    hir.add_code(source_url, code);
+
+    let mut diagnostics = format::syntax_diagnostics(&hir);
+    let has_syntax_errors = diagnostics.iter().any(|d| d.severity == format::Severity::Error);
+
+    if !has_syntax_errors {
+        let mut checker = TypeChecker::with_options(*type_checker_options);
+        let errors = checker.check(&hir);
+        diagnostics.extend(format::type_diagnostics(&errors));
+    }
+
+    diagnostics
 }
 
 /// Runs syntax and type checks on a single source, returns `true` if any errors were found.
@@ -445,5 +532,38 @@ mod tests {
     fn test_cli_no_builtins() {
         let cli = Cli::try_parse_from(["mq-check", "--no-builtins"]).unwrap();
         assert!(cli.no_builtins);
+    }
+
+    #[rstest]
+    #[case(vec!["mq-check"], OutputFormat::Text)]
+    #[case(vec!["mq-check", "--format", "text"], OutputFormat::Text)]
+    #[case(vec!["mq-check", "--format", "json"], OutputFormat::Json)]
+    #[case(vec!["mq-check", "--format", "sarif"], OutputFormat::Sarif)]
+    fn test_cli_format(#[case] args: Vec<&str>, #[case] expected: OutputFormat) {
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert_eq!(cli.format, expected);
+    }
+
+    #[test]
+    fn test_cli_format_invalid() {
+        let result = Cli::try_parse_from(["mq-check", "--format", "bogus"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_collect_check_diagnostics_reports_undefined_symbol() {
+        let diagnostics = collect_check_diagnostics("undefined_fn()", None, false, &TypeCheckerOptions::default());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "typechecker::undefined_symbol" || d.code == "hir::unresolved_symbol")
+        );
+        assert!(diagnostics.iter().any(|d| d.severity == format::Severity::Error));
+    }
+
+    #[test]
+    fn test_collect_check_diagnostics_no_errors_on_valid_code() {
+        let diagnostics = collect_check_diagnostics(".h1", None, true, &TypeCheckerOptions::default());
+        assert!(!diagnostics.iter().any(|d| d.severity == format::Severity::Error));
     }
 }


### PR DESCRIPTION
## Summary

mq-lint already supports --format sarif/github for CI annotations; mq-check only had colored text output. Adds a --format flag (text/json/sarif) so type-check results can be consumed by CI pipelines and PR annotation tooling the same way lint results already are.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
