### PR TITLE
🐛 fix(mq-lang): require --allow-read for collection/file_exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "tabled",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "which",
 ]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3922,9 +3922,17 @@ fn read_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
     }
 }
 
+/// Checks whether `path` exists on the filesystem. Requires the `--allow-read` CLI flag (see
+/// [`capability`]).
 #[cfg(feature = "file-io")]
 #[mq_macros::mq_fn(name = "file_exists", params = Fixed(1))]
 fn file_exists_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    if !capability::is_read_allowed() {
+        return Err(Error::Runtime(
+            "file_exists: filesystem reads are disabled; re-run mq with --allow-read to enable file_exists".into(),
+        ));
+    }
+
     match args.as_mut_slice() {
         [RuntimeValue::String(path)] => Ok(std::path::Path::new(path).exists().into()),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -4091,9 +4099,17 @@ fn collect_markdown_files(
     Ok(paths)
 }
 
+/// Recursively reads every Markdown file under `dir`. Requires the `--allow-read` CLI flag (see
+/// [`capability`]).
 #[cfg(feature = "file-io")]
 #[mq_macros::mq_fn(name = "collection", params = Fixed(1))]
 fn collection_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    if !capability::is_read_allowed() {
+        return Err(Error::Runtime(
+            "collection: filesystem reads are disabled; re-run mq with --allow-read to enable collection".into(),
+        ));
+    }
+
     match args.as_mut_slice() {
         [RuntimeValue::String(dir)] => {
             let mut ancestors = std::collections::HashSet::new();
@@ -5886,7 +5902,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("file_exists"),
         BuiltinFunctionDoc {
-            description: "Checks if a file exists at the given path.",
+            description: "Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
             params: &["path"],
         },
     );
@@ -5902,7 +5918,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("collection"),
         BuiltinFunctionDoc {
-            description: "Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once.",
+            description: "Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
             params: &["dir"],
         },
     );
@@ -9570,45 +9586,24 @@ mod tests {
         }
     }
 
+    // READ_ALLOWED is a single process-wide flag shared by read_file, read_file_bytes,
+    // file_exists, and collection, so every case that toggles it must run in one #[test]
+    // function — cargo test
+    // runs tests in parallel by default, and two tests flipping the same global independently
+    // would race and flake.
     #[cfg(feature = "file-io")]
     #[test]
-    fn test_file_exists_with_existing_file() {
+    fn test_read_capability_gate_and_success() {
         use std::io::Write;
-        let mut tmp = tempfile::NamedTempFile::new().expect("failed to create temp file");
-        tmp.write_all(b"hello").expect("failed to write");
-        let path = tmp.path().to_string_lossy().to_string();
-        assert_eq!(
-            call("file_exists", vec![RuntimeValue::String(path)]),
-            Ok(RuntimeValue::Boolean(true))
-        );
-    }
 
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_file_exists_with_nonexistent_file() {
-        assert_eq!(
-            call(
-                "file_exists",
-                vec![RuntimeValue::String("/nonexistent/path/no_such_file.md".into())]
-            ),
-            Ok(RuntimeValue::Boolean(false))
-        );
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_file_exists_invalid_type() {
-        let result = call("file_exists", vec![RuntimeValue::Number(42.into())]);
-        assert!(result.is_err());
-    }
-
-    // READ_ALLOWED is a single process-wide flag, so every case that toggles it must run in
-    // one #[test] function — cargo test runs tests in parallel by default, and two tests
-    // flipping the same global independently would race and flake.
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_read_file_capability_gate_and_success() {
-        use std::io::Write;
+        let get = |entry: &RuntimeValue, key: &str| match entry {
+            RuntimeValue::Dict(d) => d.get(&Ident::new(key)).cloned().unwrap_or(RuntimeValue::NONE),
+            other => panic!("expected Dict, got {other:?}"),
+        };
+        let as_entries = |result: RuntimeValue| match result {
+            RuntimeValue::Array(entries) => entries,
+            other => panic!("expected Array, got {other:?}"),
+        };
 
         let mut text_tmp = tempfile::NamedTempFile::new().expect("failed to create temp file");
         text_tmp.write_all(b"hello").expect("failed to write");
@@ -9618,6 +9613,9 @@ mod tests {
         bytes_tmp.write_all(&[0x89, 0x50, 0x4e, 0x47]).expect("failed to write");
         let bytes_path = bytes_tmp.path().to_string_lossy().to_string();
 
+        let collection_dir = tempfile::tempdir().expect("failed to create temp dir");
+        std::fs::write(collection_dir.path().join("root.md"), "# Root\n").expect("failed to write");
+
         capability::set_allow_read(false);
         assert!(
             call("read_file", vec![RuntimeValue::String(text_path.clone())]).is_err(),
@@ -9626,6 +9624,20 @@ mod tests {
         assert!(
             call("read_file_bytes", vec![RuntimeValue::String(bytes_path.clone())]).is_err(),
             "read_file_bytes should be blocked when --allow-read is not set"
+        );
+        assert!(
+            call(
+                "collection",
+                vec![RuntimeValue::String(
+                    collection_dir.path().to_string_lossy().into_owned()
+                )],
+            )
+            .is_err(),
+            "collection should be blocked when --allow-read is not set"
+        );
+        assert!(
+            call("file_exists", vec![RuntimeValue::String(text_path.clone())]).is_err(),
+            "file_exists should be blocked when --allow-read is not set"
         );
 
         capability::set_allow_read(true);
@@ -9649,6 +9661,232 @@ mod tests {
             vec![RuntimeValue::String("/nonexistent/path/no_such_file.md".into())],
         );
         assert!(result.is_err(), "read_file should error for a nonexistent file");
+
+        assert_eq!(
+            call("file_exists", vec![RuntimeValue::String(text_path.clone())]),
+            Ok(RuntimeValue::Boolean(true))
+        );
+        assert_eq!(
+            call(
+                "file_exists",
+                vec![RuntimeValue::String("/nonexistent/path/no_such_file.md".into())]
+            ),
+            Ok(RuntimeValue::Boolean(false))
+        );
+        assert!(call("file_exists", vec![RuntimeValue::Number(42.into())]).is_err());
+
+        // Basic collection: YAML/TOML frontmatter, title, content, sorted by path.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            std::fs::write(
+                dir.path().join("b.md"),
+                "---\ntitle: Hello\ntags:\n  - rust\n---\n\n# Hello\n\nbody text\n",
+            )
+            .expect("failed to write");
+            std::fs::write(dir.path().join("a.md"), "+++\ntitle = \"World\"\n+++\n\n# World\n")
+                .expect("failed to write");
+            std::fs::write(dir.path().join("c.md"), "# No frontmatter\n\nplain\n").expect("failed to write");
+            std::fs::write(dir.path().join("ignore.txt"), "not markdown").expect("failed to write");
+
+            let entries = as_entries(
+                call(
+                    "collection",
+                    vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                )
+                .expect("collection should succeed"),
+            );
+            assert_eq!(entries.len(), 3);
+
+            // sorted by path: a.md, b.md, c.md
+            assert_eq!(get(&entries[0], "title"), RuntimeValue::String("World".into()));
+            let mut toml_frontmatter = BTreeMap::new();
+            toml_frontmatter.insert(Ident::new("title"), RuntimeValue::String("World".into()));
+            assert_eq!(get(&entries[0], "frontmatter"), RuntimeValue::Dict(toml_frontmatter));
+
+            assert_eq!(get(&entries[1], "title"), RuntimeValue::String("Hello".into()));
+            match get(&entries[1], "frontmatter") {
+                RuntimeValue::Dict(d) => {
+                    assert_eq!(d.get(&Ident::new("title")), Some(&RuntimeValue::String("Hello".into())));
+                    assert_eq!(
+                        d.get(&Ident::new("tags")),
+                        Some(&RuntimeValue::Array(vec![RuntimeValue::String("rust".into())]))
+                    );
+                }
+                other => panic!("expected Dict, got {other:?}"),
+            }
+            match get(&entries[1], "content") {
+                RuntimeValue::Array(nodes) => {
+                    assert!(nodes.iter().any(|n| match n {
+                        RuntimeValue::Markdown(node, _) => node.value().contains("body text"),
+                        _ => false,
+                    }));
+                    assert!(
+                        !nodes
+                            .iter()
+                            .any(|n| matches!(n, RuntimeValue::Markdown(node, _) if node.is_yaml()))
+                    );
+                }
+                other => panic!("expected Array, got {other:?}"),
+            }
+
+            assert_eq!(get(&entries[2], "title"), RuntimeValue::String("No frontmatter".into()));
+            assert_eq!(get(&entries[2], "frontmatter"), RuntimeValue::NONE);
+        }
+
+        // Recurses into subdirectories.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
+
+            let sub = dir.path().join("sub");
+            std::fs::create_dir(&sub).expect("failed to create subdir");
+            std::fs::write(sub.join("nested.md"), "# Nested\n").expect("failed to write");
+
+            let nested_sub = sub.join("deeper");
+            std::fs::create_dir(&nested_sub).expect("failed to create nested subdir");
+            std::fs::write(nested_sub.join("deepest.md"), "# Deepest\n").expect("failed to write");
+
+            let entries = as_entries(
+                call(
+                    "collection",
+                    vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                )
+                .expect("collection should succeed"),
+            );
+            assert_eq!(entries.len(), 3);
+
+            let titles: Vec<_> = entries
+                .iter()
+                .map(|entry| match get(entry, "title") {
+                    RuntimeValue::String(s) => s,
+                    other => panic!("expected String, got {other:?}"),
+                })
+                .collect();
+            assert!(titles.contains(&"Root".to_string()));
+            assert!(titles.contains(&"Nested".to_string()));
+            assert!(titles.contains(&"Deepest".to_string()));
+        }
+
+        #[cfg(unix)]
+        {
+            // Follows symlinks to both files and directories.
+            {
+                let dir = tempfile::tempdir().expect("failed to create temp dir");
+                std::fs::write(dir.path().join("real.md"), "# Real\n").expect("failed to write");
+
+                let real_sub = dir.path().join("real_sub");
+                std::fs::create_dir(&real_sub).expect("failed to create subdir");
+                std::fs::write(real_sub.join("inside.md"), "# Inside\n").expect("failed to write");
+
+                // Symlink to a file, placed directly in the root directory.
+                std::os::unix::fs::symlink(dir.path().join("real.md"), dir.path().join("linked.md"))
+                    .expect("failed to create file symlink");
+
+                // Symlink to a directory, which should be traversed like a normal directory.
+                std::os::unix::fs::symlink(&real_sub, dir.path().join("linked_dir"))
+                    .expect("failed to create dir symlink");
+
+                let entries = as_entries(
+                    call(
+                        "collection",
+                        vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                    )
+                    .expect("collection should succeed"),
+                );
+                let titles: Vec<_> = entries
+                    .iter()
+                    .map(|entry| match get(entry, "title") {
+                        RuntimeValue::String(s) => s,
+                        other => panic!("expected String, got {other:?}"),
+                    })
+                    .collect();
+
+                // real.md, linked.md (-> real.md), real_sub/inside.md, linked_dir/inside.md (-> real_sub/inside.md)
+                assert_eq!(entries.len(), 4);
+                assert_eq!(titles.iter().filter(|t| *t == "Real").count(), 2);
+                assert_eq!(titles.iter().filter(|t| *t == "Inside").count(), 2);
+            }
+
+            // Detects and stops at symlink cycles.
+            {
+                let dir = tempfile::tempdir().expect("failed to create temp dir");
+                std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
+
+                let sub = dir.path().join("sub");
+                std::fs::create_dir(&sub).expect("failed to create subdir");
+
+                // Symlink back to the root directory, creating a cycle.
+                std::os::unix::fs::symlink(dir.path(), sub.join("back_to_root")).expect("failed to create dir symlink");
+
+                let entries = as_entries(
+                    call(
+                        "collection",
+                        vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                    )
+                    .expect("collection should succeed despite the symlink cycle"),
+                );
+                assert_eq!(entries.len(), 1);
+            }
+
+            // Skips broken symlinks instead of erroring.
+            {
+                let dir = tempfile::tempdir().expect("failed to create temp dir");
+                std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
+
+                std::os::unix::fs::symlink(dir.path().join("does_not_exist.md"), dir.path().join("broken.md"))
+                    .expect("failed to create broken symlink");
+
+                let entries = as_entries(
+                    call(
+                        "collection",
+                        vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                    )
+                    .expect("collection should succeed despite the broken symlink"),
+                );
+                assert_eq!(entries.len(), 1);
+            }
+        }
+
+        // Skips empty subdirectories.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
+            std::fs::create_dir(dir.path().join("empty_sub")).expect("failed to create empty subdir");
+
+            let entries = as_entries(
+                call(
+                    "collection",
+                    vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                )
+                .expect("collection should succeed with an empty subdirectory present"),
+            );
+            assert_eq!(entries.len(), 1);
+        }
+
+        // Errors when the path is a file rather than a directory.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            let file_path = dir.path().join("not_a_dir.md");
+            std::fs::write(&file_path, "# Root\n").expect("failed to write");
+
+            let result = call(
+                "collection",
+                vec![RuntimeValue::String(file_path.to_string_lossy().into_owned())],
+            );
+            assert!(result.is_err());
+        }
+
+        // Errors for a nonexistent directory.
+        assert!(
+            call(
+                "collection",
+                vec![RuntimeValue::String("/nonexistent/path/no_such_dir".into())],
+            )
+            .is_err()
+        );
+
+        // Errors for an invalid argument type.
+        assert!(call("collection", vec![RuntimeValue::Number(42.into())]).is_err());
 
         capability::set_allow_read(false);
     }
@@ -9703,257 +9941,5 @@ mod tests {
         );
 
         capability::set_allow_write(false);
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(
-            dir.path().join("b.md"),
-            "---\ntitle: Hello\ntags:\n  - rust\n---\n\n# Hello\n\nbody text\n",
-        )
-        .expect("failed to write");
-        std::fs::write(dir.path().join("a.md"), "+++\ntitle = \"World\"\n+++\n\n# World\n").expect("failed to write");
-        std::fs::write(dir.path().join("c.md"), "# No frontmatter\n\nplain\n").expect("failed to write");
-        std::fs::write(dir.path().join("ignore.txt"), "not markdown").expect("failed to write");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-        assert_eq!(entries.len(), 3);
-
-        // sorted by path: a.md, b.md, c.md
-        let get = |entry: &RuntimeValue, key: &str| match entry {
-            RuntimeValue::Dict(d) => d.get(&Ident::new(key)).cloned().unwrap_or(RuntimeValue::NONE),
-            other => panic!("expected Dict, got {other:?}"),
-        };
-
-        assert_eq!(get(&entries[0], "title"), RuntimeValue::String("World".into()));
-        let mut toml_frontmatter = BTreeMap::new();
-        toml_frontmatter.insert(Ident::new("title"), RuntimeValue::String("World".into()));
-        assert_eq!(get(&entries[0], "frontmatter"), RuntimeValue::Dict(toml_frontmatter));
-
-        assert_eq!(get(&entries[1], "title"), RuntimeValue::String("Hello".into()));
-        match get(&entries[1], "frontmatter") {
-            RuntimeValue::Dict(d) => {
-                assert_eq!(d.get(&Ident::new("title")), Some(&RuntimeValue::String("Hello".into())));
-                assert_eq!(
-                    d.get(&Ident::new("tags")),
-                    Some(&RuntimeValue::Array(vec![RuntimeValue::String("rust".into())]))
-                );
-            }
-            other => panic!("expected Dict, got {other:?}"),
-        }
-        match get(&entries[1], "content") {
-            RuntimeValue::Array(nodes) => {
-                assert!(nodes.iter().any(|n| match n {
-                    RuntimeValue::Markdown(node, _) => node.value().contains("body text"),
-                    _ => false,
-                }));
-                assert!(
-                    !nodes
-                        .iter()
-                        .any(|n| matches!(n, RuntimeValue::Markdown(node, _) if node.is_yaml()))
-                );
-            }
-            other => panic!("expected Array, got {other:?}"),
-        }
-
-        assert_eq!(get(&entries[2], "title"), RuntimeValue::String("No frontmatter".into()));
-        assert_eq!(get(&entries[2], "frontmatter"), RuntimeValue::NONE);
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection_recurses_into_subdirectories() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
-
-        let sub = dir.path().join("sub");
-        std::fs::create_dir(&sub).expect("failed to create subdir");
-        std::fs::write(sub.join("nested.md"), "# Nested\n").expect("failed to write");
-
-        let nested_sub = sub.join("deeper");
-        std::fs::create_dir(&nested_sub).expect("failed to create nested subdir");
-        std::fs::write(nested_sub.join("deepest.md"), "# Deepest\n").expect("failed to write");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-        assert_eq!(entries.len(), 3);
-
-        let get = |entry: &RuntimeValue, key: &str| match entry {
-            RuntimeValue::Dict(d) => d.get(&Ident::new(key)).cloned().unwrap_or(RuntimeValue::NONE),
-            other => panic!("expected Dict, got {other:?}"),
-        };
-        let titles: Vec<_> = entries
-            .iter()
-            .map(|entry| match get(entry, "title") {
-                RuntimeValue::String(s) => s,
-                other => panic!("expected String, got {other:?}"),
-            })
-            .collect();
-        assert!(titles.contains(&"Root".to_string()));
-        assert!(titles.contains(&"Nested".to_string()));
-        assert!(titles.contains(&"Deepest".to_string()));
-    }
-
-    #[cfg(all(feature = "file-io", unix))]
-    #[test]
-    fn test_collection_follows_symlinks() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(dir.path().join("real.md"), "# Real\n").expect("failed to write");
-
-        let real_sub = dir.path().join("real_sub");
-        std::fs::create_dir(&real_sub).expect("failed to create subdir");
-        std::fs::write(real_sub.join("inside.md"), "# Inside\n").expect("failed to write");
-
-        // Symlink to a file, placed directly in the root directory.
-        std::os::unix::fs::symlink(dir.path().join("real.md"), dir.path().join("linked.md"))
-            .expect("failed to create file symlink");
-
-        // Symlink to a directory, which should be traversed like a normal directory.
-        std::os::unix::fs::symlink(&real_sub, dir.path().join("linked_dir")).expect("failed to create dir symlink");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-
-        let get = |entry: &RuntimeValue, key: &str| match entry {
-            RuntimeValue::Dict(d) => d.get(&Ident::new(key)).cloned().unwrap_or(RuntimeValue::NONE),
-            other => panic!("expected Dict, got {other:?}"),
-        };
-        let titles: Vec<_> = entries
-            .iter()
-            .map(|entry| match get(entry, "title") {
-                RuntimeValue::String(s) => s,
-                other => panic!("expected String, got {other:?}"),
-            })
-            .collect();
-
-        // real.md, linked.md (-> real.md), real_sub/inside.md, linked_dir/inside.md (-> real_sub/inside.md)
-        assert_eq!(entries.len(), 4);
-        assert_eq!(titles.iter().filter(|t| *t == "Real").count(), 2);
-        assert_eq!(titles.iter().filter(|t| *t == "Inside").count(), 2);
-    }
-
-    #[cfg(all(feature = "file-io", unix))]
-    #[test]
-    fn test_collection_handles_symlink_cycle() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
-
-        let sub = dir.path().join("sub");
-        std::fs::create_dir(&sub).expect("failed to create subdir");
-
-        // Symlink back to the root directory, creating a cycle.
-        std::os::unix::fs::symlink(dir.path(), sub.join("back_to_root")).expect("failed to create dir symlink");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed despite the symlink cycle");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-        assert_eq!(entries.len(), 1);
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection_skips_empty_subdirectories() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
-        std::fs::create_dir(dir.path().join("empty_sub")).expect("failed to create empty subdir");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed with an empty subdirectory present");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-        assert_eq!(entries.len(), 1);
-    }
-
-    #[cfg(all(feature = "file-io", unix))]
-    #[test]
-    fn test_collection_skips_broken_symlinks() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        std::fs::write(dir.path().join("root.md"), "# Root\n").expect("failed to write");
-
-        std::os::unix::fs::symlink(dir.path().join("does_not_exist.md"), dir.path().join("broken.md"))
-            .expect("failed to create broken symlink");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
-        )
-        .expect("collection should succeed despite the broken symlink");
-
-        let entries = match result {
-            RuntimeValue::Array(entries) => entries,
-            other => panic!("expected Array, got {other:?}"),
-        };
-        assert_eq!(entries.len(), 1);
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection_with_path_that_is_a_file() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let file_path = dir.path().join("not_a_dir.md");
-        std::fs::write(&file_path, "# Root\n").expect("failed to write");
-
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String(file_path.to_string_lossy().into_owned())],
-        );
-        assert!(result.is_err());
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection_with_nonexistent_dir() {
-        let result = call(
-            "collection",
-            vec![RuntimeValue::String("/nonexistent/path/no_such_dir".into())],
-        );
-        assert!(result.is_err());
-    }
-
-    #[cfg(feature = "file-io")]
-    #[test]
-    fn test_collection_invalid_type() {
-        let result = call("collection", vec![RuntimeValue::Number(42.into())]);
-        assert!(result.is_err());
     }
 }

--- a/crates/mq-lang/src/eval/builtin/capability.rs
+++ b/crates/mq-lang/src/eval/builtin/capability.rs
@@ -1,6 +1,6 @@
 //! Process-wide opt-in flags gating capabilities with real-world side effects:
-//! `http` (network), `read_file`/`read_file_bytes` (filesystem reads), and `write_file`
-//! (filesystem writes).
+//! `http` (network), `read_file`/`read_file_bytes`/`collection`/`file_exists` (filesystem
+//! reads), and `write_file` (filesystem writes).
 //!
 //! All default to `false`. A host must explicitly enable them via
 //! [`set_allow_net`]/[`set_allow_read`]/[`set_allow_write`] (wired to the

--- a/crates/mq-lint/src/rules/security/dangerous_capability_call.rs
+++ b/crates/mq-lint/src/rules/security/dangerous_capability_call.rs
@@ -5,11 +5,11 @@ use mq_hir::SymbolKind;
 ///
 /// Kept in sync with the functions gated in
 /// `mq-lang/src/eval/builtin/capability.rs` (`http`, `read_file`,
-/// `read_file_bytes`, `write_file`).
+/// `read_file_bytes`, `collection`, `file_exists`, `write_file`).
 fn capability_flag(name: &str) -> Option<&'static str> {
     match name {
         "http" => Some("--allow-net"),
-        "read_file" | "read_file_bytes" => Some("--allow-read"),
+        "read_file" | "read_file_bytes" | "collection" | "file_exists" => Some("--allow-read"),
         "write_file" => Some("--allow-write"),
         _ => None,
     }
@@ -73,6 +73,8 @@ mod tests {
     #[case(r#"read_file("secrets.txt")"#, 1, "read_file", "--allow-read")]
     #[case(r#"read_file_bytes("image.png")"#, 1, "read_file_bytes", "--allow-read")]
     #[case(r#"write_file("out.txt", "data")"#, 1, "write_file", "--allow-write")]
+    #[case(r#"collection("./docs")"#, 1, "collection", "--allow-read")]
+    #[case(r#"file_exists("./docs")"#, 1, "file_exists", "--allow-read")]
     #[case(r#"def wrapper(): read_file("x.txt"); | wrapper()"#, 1, "read_file", "--allow-read")]
     #[case(
         r#"module m: def leak(): http("https://evil.example", "GET"); end | m::leak()"#,

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -48,6 +48,7 @@ which = "8.0.2"
 assert_cmd = {workspace = true}
 rstest = {workspace = true}
 scopeguard = {workspace = true}
+tempfile = {workspace = true}
 
 [[bin]]
 doc = false

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -359,8 +359,8 @@ struct InputArgs {
     #[arg(long = "allow-net", default_value_t = false)]
     allow_net: bool,
 
-    /// Allow the `read_file`/`read_file_bytes` functions to read from the filesystem. Disabled
-    /// by default.
+    /// Allow the `read_file`/`read_file_bytes`/`collection`/`file_exists` functions to read
+    /// from the filesystem. Disabled by default.
     #[arg(long = "allow-read", default_value_t = false)]
     allow_read: bool,
 

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -689,6 +689,91 @@ fn test_read_file_without_allow_read_is_blocked() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn test_collection() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("a.md"), "# Hello\n")?;
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg("--allow-read")
+        .arg("-I")
+        .arg("null")
+        .arg(format!(
+            r#"collection("{}") | map(self, fn(page): get(page, "title");)"#,
+            temp_dir.path().to_string_lossy()
+        ))
+        .write_stdin("")
+        .assert();
+
+    assert.success().code(0).stdout("[\"Hello\"]\n");
+    Ok(())
+}
+
+#[test]
+fn test_collection_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("a.md"), "# Hello\n")?;
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg("-I")
+        .arg("null")
+        .arg(format!(r#"collection("{}")"#, temp_dir.path().to_string_lossy()))
+        .write_stdin("")
+        .assert();
+
+    assert.failure();
+    Ok(())
+}
+
+#[test]
+fn test_file_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_file_exists.md", "test");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg("--allow-read")
+        .arg(format!(r#"file_exists("{}")"#, temp_file_path.to_string_lossy()))
+        .arg(temp_file_path.to_string_lossy().to_string())
+        .assert();
+
+    assert.success().code(0).stdout("true\n");
+    Ok(())
+}
+
+#[test]
+fn test_file_exists_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_file_exists_blocked.md", "test");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg(format!(r#"file_exists("{}")"#, temp_file_path.to_string_lossy()))
+        .arg(temp_file_path.to_string_lossy().to_string())
+        .assert();
+
+    assert.failure();
+    Ok(())
+}
+
+#[test]
 fn test_output_format_toml_requires_dict() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = cargo::cargo_bin_cmd!("mq");
     let assert = cmd

--- a/docs/books/src/builtins.html
+++ b/docs/books/src/builtins.html
@@ -570,7 +570,7 @@
                 </tr>
                 <tr>
                   <td><code>collection</code></td>
-                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once.</td>
+                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
                   <td><code>dir</code></td>
                   <td><code>collection(dir)</code></td>
                 </tr>
@@ -729,7 +729,7 @@
                 </tr>
                 <tr>
                   <td><code>file_exists</code></td>
-                  <td>Checks if a file exists at the given path.</td>
+                  <td>Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
                   <td><code>path</code></td>
                   <td><code>file_exists(path)</code></td>
                 </tr>
@@ -3047,7 +3047,7 @@
                 </tr>
                 <tr>
                   <td><code>collection</code></td>
-                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once.</td>
+                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
                   <td><code>dir</code></td>
                   <td><code>collection(dir)</code></td>
                 </tr>
@@ -3206,7 +3206,7 @@
                 </tr>
                 <tr>
                   <td><code>file_exists</code></td>
-                  <td>Checks if a file exists at the given path.</td>
+                  <td>Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
                   <td><code>path</code></td>
                   <td><code>file_exists(path)</code></td>
                 </tr>

--- a/docs/books/src/builtins.html
+++ b/docs/books/src/builtins.html
@@ -570,7 +570,7 @@
                 </tr>
                 <tr>
                   <td><code>collection</code></td>
-                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
+                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once.</td>
                   <td><code>dir</code></td>
                   <td><code>collection(dir)</code></td>
                 </tr>
@@ -729,7 +729,7 @@
                 </tr>
                 <tr>
                   <td><code>file_exists</code></td>
-                  <td>Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
+                  <td>Checks if a file exists at the given path.</td>
                   <td><code>path</code></td>
                   <td><code>file_exists(path)</code></td>
                 </tr>
@@ -3047,7 +3047,7 @@
                 </tr>
                 <tr>
                   <td><code>collection</code></td>
-                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
+                  <td>Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once.</td>
                   <td><code>dir</code></td>
                   <td><code>collection(dir)</code></td>
                 </tr>
@@ -3206,7 +3206,7 @@
                 </tr>
                 <tr>
                   <td><code>file_exists</code></td>
-                  <td>Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.</td>
+                  <td>Checks if a file exists at the given path.</td>
                   <td><code>path</code></td>
                   <td><code>file_exists(path)</code></td>
                 </tr>

--- a/skills/web-scraping/SKILL.md
+++ b/skills/web-scraping/SKILL.md
@@ -41,7 +41,7 @@ mq-crawl https://docs.example.com --depth 2 --allowed-domains docs.example.com \
 
 - `--headless` needs local Chrome (or `--webdriver-url` for a remote WebDriver).
 - `--allowed-domains` is an **exact-match** domain list, not a wildcard — list every subdomain you want crawled.
-- `-o DIR` saves one Markdown file per page instead of stdout; aggregate them with `mq -I null 'collection("./crawled") | map(self, fn(page): get(page, "title");)' /dev/null`.
+- `-o DIR` saves one Markdown file per page instead of stdout; aggregate them with `mq -I null --allow-read 'collection("./crawled") | map(self, fn(page): get(page, "title");)' /dev/null` (`collection` reads from disk, so it requires `--allow-read`).
 
 ## In-Query HTTP (`--allow-net`)
 


### PR DESCRIPTION
## Summary

BREAKING CHANGE: `collection(dir)` and `file_exists(path)` now require the `--allow-read` CLI flag, matching `read_file`/`read_file_bytes`. Previously both bypassed the capability gate entirely: `collection` could recursively read every Markdown file under an arbitrary directory, and `file_exists` could probe the filesystem for a path's existence, without the host ever opting in via `--allow-read`. This let a third-party module fetched via HTTP import silently read local files or fingerprint the filesystem, defeating the sandboxing that --allow-read/--allow-write/--allow-net are meant to provide.

Scripts calling `collection` or `file_exists` now need to pass `--allow-read` on the command line, or the calls fail at runtime with a capability error.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
