### PR TITLE
✨ feat(mq-lang): add sanitize_html builtin function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ammonia"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+dependencies = [
+ "cssparser",
+ "html5ever",
+ "maplit",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markdown"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2631,7 @@ dependencies = [
 name = "mq-lang"
 version = "0.6.5"
 dependencies = [
+ "ammonia",
  "base64",
  "chrono",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ mq-macros = {path = "crates/mq-macros", version = "0.6.5"}
 mq-markdown = {path = "crates/mq-markdown", version = "0.6.5"}
 mq-repl = {path = "crates/mq-repl", version = "0.6.5"}
 # External dependencies
+ammonia = "4.1.3"
 arbitrary = {version = "1.4.2", features = ["derive"]}
 arboard = {version = "3.6.1", default-features = false}
 assert_cmd = "2.2.2"

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -360,6 +360,7 @@ fn register_string(ctx: &mut InferenceContext) {
             "html_escape",
             "html_unescape",
             "strip_tags",
+            "sanitize_html",
         ],
         vec![Type::String],
         Type::String,
@@ -402,6 +403,7 @@ fn register_string(ctx: &mut InferenceContext) {
             "html_escape",
             "html_unescape",
             "strip_tags",
+            "sanitize_html",
             "utf8bytelen",
         ],
     );
@@ -1567,6 +1569,8 @@ mod tests {
     #[case::html_unescape_number("html_unescape(42)", false)] // Should fail: wrong type
     #[case::strip_tags("strip_tags(\"<b>hi</b>\")", true)]
     #[case::strip_tags_number("strip_tags(42)", false)] // Should fail: wrong type
+    #[case::sanitize_html("sanitize_html(\"<script>alert(1)</script>\")", true)]
+    #[case::sanitize_html_number("sanitize_html(42)", false)] // Should fail: wrong type
     fn test_string_case_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -48,6 +48,7 @@ similar = "3.0.0"
 tiktoken-rs = { version = "0.12", optional = true }
 ureq = { workspace = true, optional = true }
 uuid = {workspace = true, features = ["v4", "v7"]}
+ammonia = {workspace = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["console"] }

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -835,6 +835,25 @@ fn html_unescape_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
     }
 }
 
+#[mq_macros::mq_fn(name = "sanitize_html", params = Fixed(1))]
+fn sanitize_html_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => convert::sanitize_html(s),
+        [node @ RuntimeValue::Markdown(_, _)] => node
+            .markdown_node()
+            .map(|md| {
+                convert::sanitize_html(md.value().as_str()).and_then(|o| match o {
+                    RuntimeValue::String(s) => Ok(node.update_markdown_value(&s)),
+                    a => Err(Error::InvalidTypes(ident.to_string(), vec![a.clone()])),
+                })
+            })
+            .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
+        [RuntimeValue::None] => Ok(RuntimeValue::NONE),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("sanitize_html should always receive exactly one argument"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "strip_tags", params = Fixed(1))]
 fn strip_tags_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4191,6 +4210,7 @@ mq_macros::builtin_dispatch! {
     HTML_ESCAPE,
     HTML_UNESCAPE,
     STRIP_TAGS,
+    SANITIZE_HTML,
     TO_MARKDOWN_STRING,
     TO_STRING,
     TO_NUMBER,
@@ -5059,6 +5079,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Removes HTML tags from the given string, keeping the surrounding text content.",
             params: &["string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("sanitize_html"),
+        BuiltinFunctionDoc {
+            description: "Sanitizes the given HTML string using an allowlist of safe tags and attributes, removing scripts and other XSS vectors.",
+            params: &["html"],
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -488,6 +488,12 @@ pub(super) fn strip_tags(input: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(result))
 }
 
+/// Sanitize HTML using an allowlist of safe tags/attributes (XSS protection).
+#[inline(always)]
+pub(super) fn sanitize_html(input: &str) -> Result<RuntimeValue, Error> {
+    Ok(RuntimeValue::String(ammonia::clean(input)))
+}
+
 /// Compute MD5 hash and return lowercase hex string.
 ///
 /// Note: MD5 is cryptographically broken and should not be used for security
@@ -796,6 +802,21 @@ mod tests {
     #[case("a > b", "a > b")]
     fn test_strip_tags(#[case] input: &str, #[case] expected: &str) {
         let result = strip_tags(input).unwrap();
+        assert_eq!(result, RuntimeValue::String(expected.to_string()));
+    }
+
+    // Test sanitize_html
+    #[rstest]
+    #[case("<script>alert('xss')</script><p>hi</p>", "<p>hi</p>")]
+    #[case(r#"<img src=x onerror="alert(1)">"#, r#"<img src="x">"#)]
+    #[case(
+        r#"<a href="javascript:alert(1)">click</a>"#,
+        r#"<a rel="noopener noreferrer">click</a>"#
+    )]
+    #[case("<b>bold</b> and <i>italic</i>", "<b>bold</b> and <i>italic</i>")]
+    #[case("", "")]
+    fn test_sanitize_html(#[case] input: &str, #[case] expected: &str) {
+        let result = sanitize_html(input).unwrap();
         assert_eq!(result, RuntimeValue::String(expected.to_string()));
     }
 

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3132,6 +3132,9 @@ fn engine() -> DefaultEngine {
 // strip_tags
 #[case::strip_tags_basic(r#"strip_tags("<p>Hello <em>world</em>!</p>")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("Hello world!".to_string())].into()))]
 #[case::strip_tags_no_tags(r#"strip_tags("plain text")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("plain text".to_string())].into()))]
+// sanitize_html
+#[case::sanitize_html_script(r#"sanitize_html("<script>alert('xss')</script><p>hi</p>")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("<p>hi</p>".to_string())].into()))]
+#[case::sanitize_html_safe_tags(r#"sanitize_html("<b>bold</b>")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("<b>bold</b>".to_string())].into()))]
 // to_number conversion
 #[case::to_number_string(r#"to_number("42")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // to_boolean conversion
@@ -3381,6 +3384,8 @@ fn engine() -> DefaultEngine {
 #[case::html_unescape_none("html_unescape(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // strip_tags: None input → None
 #[case::strip_tags_none("strip_tags(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
+// sanitize_html: None input → None
+#[case::sanitize_html_none("sanitize_html(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // ltrim: None input → None
 #[case::ltrim_none("ltrim(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // rtrim: None input → None
@@ -3681,6 +3686,8 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 #[case::html_unescape_non_string("html_unescape(42)", vec![RuntimeValue::None],)]
 // strip_tags: non-string/non-markdown/non-none → type error
 #[case::strip_tags_non_string("strip_tags(42)", vec![RuntimeValue::None],)]
+// sanitize_html: non-string/non-markdown/non-none → type error
+#[case::sanitize_html_non_string("sanitize_html(42)", vec![RuntimeValue::None],)]
 // token_count: non-string/non-markdown text → type error
 #[case::token_count_non_string(r#"token_count(42, "gpt-4")"#, vec![RuntimeValue::None],)]
 #[case::token_count_no_model_non_string(r#"token_count(42)"#, vec![RuntimeValue::None],)]


### PR DESCRIPTION
## Summary

Adds an allowlist-based HTML sanitizer (via ammonia) to safely render user-generated HTML, stripping scripts, event handler attributes, and javascript:/data: URLs.

Close #2001

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
