### PR TITLE
✨ feat(mq-lang): add css/css_text/css_attr builtins for CSS-selector HTML extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "rstest",
  "rustc-hash",
  "scopeguard",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -32,6 +32,7 @@ rand = {workspace = true}
 regex-lite = {workspace = true}
 ropey = {workspace = true, optional = true}
 rustc-hash = {workspace = true}
+scraper = {workspace = true, optional = true}
 serde = {workspace = true, features = ["derive", "rc"]}
 serde_json = {workspace = true}
 yaml-rust2 = {workspace = true}
@@ -59,6 +60,7 @@ web-time = {workspace = true}
 [features]
 ast-json = ["smallvec/serde", "smol_str/serde"]
 cst = ["dep:ropey"]
+css-selector = ["dep:scraper"]
 debugger = ["sync"]
 default = ["std"]
 file-io = []

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1,6 +1,8 @@
 pub(super) mod bytes;
 pub(crate) mod capability;
 pub(super) mod convert;
+#[cfg(feature = "css-selector")]
+mod css;
 pub(super) mod date;
 #[cfg(feature = "http")]
 mod http;
@@ -4043,6 +4045,69 @@ fn http_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
     }
 }
 
+/// Returns the outer HTML of every element in `html` matching the CSS `selector`, as an array
+/// of strings. Queries the raw HTML string directly, bypassing the Markdown conversion `-I html`
+/// otherwise applies, so tags/classes/ids/`data-*` attributes lost during that conversion are
+/// still available.
+#[cfg(feature = "css-selector")]
+#[mq_macros::mq_fn(name = "css", params = Fixed(2))]
+fn css_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(
+            css::select_html(html, selector)?
+                .into_iter()
+                .map(RuntimeValue::from)
+                .collect(),
+        )),
+        args => Err(Error::InvalidTypes(
+            ident.to_string(),
+            args.iter_mut().map(std::mem::take).collect(),
+        )),
+    }
+}
+
+/// Returns the text content of every element in `html` matching the CSS `selector`, as an array
+/// of strings.
+#[cfg(feature = "css-selector")]
+#[mq_macros::mq_fn(name = "css_text", params = Fixed(2))]
+fn css_text_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(
+            css::select_text(html, selector)?
+                .into_iter()
+                .map(RuntimeValue::from)
+                .collect(),
+        )),
+        args => Err(Error::InvalidTypes(
+            ident.to_string(),
+            args.iter_mut().map(std::mem::take).collect(),
+        )),
+    }
+}
+
+/// Returns the value of attribute `name` for every element in `html` matching the CSS
+/// `selector`, as an array; elements without that attribute produce `None` in the array.
+#[cfg(feature = "css-selector")]
+#[mq_macros::mq_fn(name = "css_attr", params = Fixed(3))]
+fn css_attr_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [
+            RuntimeValue::String(html),
+            RuntimeValue::String(selector),
+            RuntimeValue::String(name),
+        ] => Ok(RuntimeValue::Array(
+            css::select_attr(html, selector, name)?
+                .into_iter()
+                .map(|attr| attr.map(RuntimeValue::from).unwrap_or(RuntimeValue::NONE))
+                .collect(),
+        )),
+        args => Err(Error::InvalidTypes(
+            ident.to_string(),
+            args.iter_mut().map(std::mem::take).collect(),
+        )),
+    }
+}
+
 #[cfg(feature = "file-io")]
 fn collection_record(path: String, raw: &str) -> Result<RuntimeValue, Error> {
     let nodes = mq_markdown::Markdown::from_markdown_str(raw)
@@ -4370,6 +4435,12 @@ mq_macros::builtin_dispatch! {
     WRITE_FILE,
     #[cfg(feature = "http")]
     HTTP,
+    #[cfg(feature = "css-selector")]
+    CSS,
+    #[cfg(feature = "css-selector")]
+    CSS_TEXT,
+    #[cfg(feature = "css-selector")]
+    CSS_ATTR,
 }
 
 #[derive(Clone, Debug)]
@@ -5963,6 +6034,30 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Performs an HTTPS request with the given method (a string or symbol, e.g. \"post\" or :post — get, post, put, delete, patch, head, ... are all supported) and returns the response body as a string. An optional body argument (string) sends a request body regardless of method, and an optional headers argument (a dict of string to string, e.g. {\"Content-Type\": \"application/json\"}) is applied to the request. Requires the --allow-net CLI flag; otherwise returns a runtime error. Only https:// URLs are allowed.",
             params: &["method", "url", "body", "headers"],
+        },
+    );
+    #[cfg(feature = "css-selector")]
+    map.insert(
+        SmolStr::new("css"),
+        BuiltinFunctionDoc {
+            description: "Returns the outer HTML of every element in the html string matching the CSS selector, as an array of strings. Queries the raw HTML directly instead of going through the -I html Markdown conversion, so tags, classes, ids, and data-* attributes that conversion discards are still available.",
+            params: &["html", "selector"],
+        },
+    );
+    #[cfg(feature = "css-selector")]
+    map.insert(
+        SmolStr::new("css_text"),
+        BuiltinFunctionDoc {
+            description: "Returns the text content of every element in the html string matching the CSS selector, as an array of strings.",
+            params: &["html", "selector"],
+        },
+    );
+    #[cfg(feature = "css-selector")]
+    map.insert(
+        SmolStr::new("css_attr"),
+        BuiltinFunctionDoc {
+            description: "Returns the value of the named attribute for every element in the html string matching the CSS selector, as an array; elements without that attribute produce None.",
+            params: &["html", "selector", "name"],
         },
     );
 

--- a/crates/mq-lang/src/eval/builtin/css.rs
+++ b/crates/mq-lang/src/eval/builtin/css.rs
@@ -1,0 +1,112 @@
+//! `css`/`css_text`/`css_attr` builtins: CSS-selector search directly over a raw HTML string.
+//!
+//! `-I html` (see [`crate::parse_html_input`]) always routes through
+//! `mq_markdown::Markdown::from_html_str`, which unconditionally converts the document into a
+//! Markdown AST and discards container tags (`div`/`span`/`section`, ...) along with their
+//! `class`/`id`/`data-*` attributes. That conversion has no toggle, so information that only
+//! lives on those attributes is unrecoverable once a value has gone through it. These builtins
+//! query the pre-conversion HTML string instead — typically the raw `-I html` input or an
+//! `http()` response body — so element tags and attributes are still available.
+//!
+//! Gated at compile time by the `css-selector` feature.
+
+use scraper::{Html, Selector};
+
+use super::Error;
+
+fn err(msg: impl std::fmt::Display) -> Error {
+    Error::Runtime(format!("css: {msg}"))
+}
+
+fn parse_selector(selector: &str) -> Result<Selector, Error> {
+    Selector::parse(selector).map_err(|e| err(format!("invalid CSS selector {selector:?}: {e}")))
+}
+
+/// Returns the outer HTML of every element in `html` matching `selector`.
+pub(super) fn select_html(html: &str, selector: &str) -> Result<Vec<String>, Error> {
+    let selector = parse_selector(selector)?;
+    let document = Html::parse_document(html);
+    Ok(document.select(&selector).map(|el| el.html()).collect())
+}
+
+/// Returns the concatenated text content of every element in `html` matching `selector`.
+pub(super) fn select_text(html: &str, selector: &str) -> Result<Vec<String>, Error> {
+    let selector = parse_selector(selector)?;
+    let document = Html::parse_document(html);
+    Ok(document
+        .select(&selector)
+        .map(|el| el.text().collect::<String>())
+        .collect())
+}
+
+/// Returns the value of attribute `name` for every element in `html` matching `selector`,
+/// `None` where the element doesn't have that attribute.
+pub(super) fn select_attr(html: &str, selector: &str, name: &str) -> Result<Vec<Option<String>>, Error> {
+    let selector = parse_selector(selector)?;
+    let document = Html::parse_document(html);
+    Ok(document
+        .select(&selector)
+        .map(|el| el.value().attr(name).map(str::to_string))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HTML: &str = r#"
+        <html><body>
+            <div class="price" data-id="1">$10</div>
+            <div class="price" data-id="2">$20</div>
+            <a href="https://example.com">link</a>
+            <span class="empty"></span>
+        </body></html>
+    "#;
+
+    #[test]
+    fn test_select_html_returns_outer_html_of_matches() {
+        let result = select_html(HTML, ".price").unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result[0].contains("data-id=\"1\""));
+        assert!(result[1].contains("data-id=\"2\""));
+    }
+
+    #[test]
+    fn test_select_html_no_matches_returns_empty_array() {
+        assert_eq!(select_html(HTML, ".missing").unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_select_text_returns_text_content() {
+        assert_eq!(select_text(HTML, ".price").unwrap(), vec!["$10", "$20"]);
+    }
+
+    #[test]
+    fn test_select_text_empty_element_returns_empty_string() {
+        assert_eq!(select_text(HTML, ".empty").unwrap(), vec![""]);
+    }
+
+    #[test]
+    fn test_select_attr_returns_named_attribute_values() {
+        assert_eq!(
+            select_attr(HTML, ".price", "data-id").unwrap(),
+            vec![Some("1".to_string()), Some("2".to_string())]
+        );
+        assert_eq!(
+            select_attr(HTML, "a", "href").unwrap(),
+            vec![Some("https://example.com".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_select_attr_missing_attribute_is_none() {
+        assert_eq!(select_attr(HTML, ".price", "data-missing").unwrap(), vec![None, None]);
+    }
+
+    #[test]
+    fn test_invalid_selector_is_error() {
+        assert!(select_html(HTML, "[[[").is_err());
+        assert!(select_text(HTML, "[[[").is_err());
+        assert!(select_attr(HTML, "[[[", "href").is_err());
+    }
+}

--- a/crates/mq-lsp/Cargo.toml
+++ b/crates/mq-lsp/Cargo.toml
@@ -19,7 +19,7 @@ itertools = {workspace = true}
 mq-check = {workspace = true}
 mq-formatter = {workspace = true}
 mq-hir = {workspace = true}
-mq-lang = {workspace = true, features = ["ast-json", "sync", "file-io", "http"]}
+mq-lang = {workspace = true, features = ["ast-json", "sync", "file-io", "http", "css-selector"]}
 mq-lint = {workspace = true}
 mq-markdown = {workspace = true}
 serde_json = {workspace = true}

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -13,8 +13,9 @@ version = "0.6.5"
 default-run = "mq"
 
 [features]
+css-selector = ["mq-lang/css-selector"]
 debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex-lite", "mq-dap"]
-default = ["std", "use_mimalloc", "http-import"]
+default = ["std", "use_mimalloc", "http-import", "css-selector"]
 http-import = ["mq-lang/http-import-ureq"]
 std = []
 tiktoken = ["mq-lang/tiktoken"]

--- a/skills/web-scraping/SKILL.md
+++ b/skills/web-scraping/SKILL.md
@@ -69,7 +69,17 @@ curl -s https://example.com | mq -I html '.h | to_text()'
 curl -s https://example.com | mq -I html 'select(.link) | .link.url'
 ```
 
-`-I html` converts to Markdown first — use Markdown selectors (`.link`, `.h`, `.text`), not HTML tags.
+`-I html` converts to Markdown first — use Markdown selectors (`.link`, `.h`, `.text`), not HTML tags. Container elements (`div`/`span`/`section`) and their `class`/`id`/`data-*` attributes are discarded in that conversion.
+
+To query the raw HTML directly instead — e.g. `.price` divs, `a.download[href]`, attribute-driven card UIs — use the `css()`/`css_text()`/`css_attr()` builtins on the pre-conversion HTML string (needs the CLI built with the `css-selector` feature, on by default):
+
+```bash
+curl -s https://example.com | mq -I text 'css_text(self, ".price")'                 # text of every .price match
+curl -s https://example.com | mq -I text 'css_attr(self, "a.download", "href")'     # href of every a.download match
+curl -s https://example.com | mq -I text 'css(self, ".card") | map(self, fn(card): css_text(card, ".card-title") | get(0);)'  # filter by selector, then extract from each match
+```
+
+`css_attr` returns `null` for elements missing that attribute instead of dropping them, so array positions line up across parallel `css_*` calls.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

-I html always converts through mq-markdown's HTML→Markdown pipeline, which unwraps container elements and discards their tag/class/id/data-* attributes with no way to recover them. These builtins query a raw HTML string (the pre-conversion -I html input, or an http() response body) directly via scraper, bypassing that conversion, so CSS-selector-based extraction (htmlq-style) becomes possible for content that isn't Markdown-shaped.

Gated behind the new css-selector Cargo feature (on by default in the CLI and LSP). scraper is already linked into the default mq binary via mq-markdown's html-to-markdown feature, so this adds ~16KB to the release binary rather than a new dependency tree.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
