### PR TITLE
♻️ refactor(mq-lang): centralize capability gate checks in mq_fn macro

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3899,14 +3899,8 @@ fn path_join_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
 /// Reads the contents of `path` as a string. Requires the `--allow-read` CLI flag (see
 /// [`capability`]).
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "read_file", params = Fixed(1))]
+#[mq_macros::mq_fn(name = "read_file", params = Fixed(1), capability = "read")]
 fn read_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    if !capability::is_read_allowed() {
-        return Err(Error::Runtime(
-            "read_file: filesystem reads are disabled; re-run mq with --allow-read to enable read_file".into(),
-        ));
-    }
-
     match args.as_mut_slice() {
         [RuntimeValue::String(path)] => match std::fs::read_to_string(&path) {
             Ok(content) => Ok(RuntimeValue::String(content)),
@@ -3920,14 +3914,8 @@ fn read_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
 /// Checks whether `path` exists on the filesystem. Requires the `--allow-read` CLI flag (see
 /// [`capability`]).
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "file_exists", params = Fixed(1))]
+#[mq_macros::mq_fn(name = "file_exists", params = Fixed(1), capability = "read")]
 fn file_exists_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    if !capability::is_read_allowed() {
-        return Err(Error::Runtime(
-            "file_exists: filesystem reads are disabled; re-run mq with --allow-read to enable file_exists".into(),
-        ));
-    }
-
     match args.as_mut_slice() {
         [RuntimeValue::String(path)] => Ok(std::path::Path::new(path).exists().into()),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -3938,15 +3926,8 @@ fn file_exists_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
 /// Reads the contents of `path` as raw bytes. Requires the `--allow-read` CLI flag (see
 /// [`capability`]).
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "read_file_bytes", params = Fixed(1))]
+#[mq_macros::mq_fn(name = "read_file_bytes", params = Fixed(1), capability = "read")]
 fn read_file_bytes_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    if !capability::is_read_allowed() {
-        return Err(Error::Runtime(
-            "read_file_bytes: filesystem reads are disabled; re-run mq with --allow-read to enable read_file_bytes"
-                .into(),
-        ));
-    }
-
     match args.as_mut_slice() {
         [RuntimeValue::String(path)] => match std::fs::read(&path) {
             Ok(content) => Ok(RuntimeValue::Bytes(content)),
@@ -3960,13 +3941,8 @@ fn read_file_bytes_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Sha
 /// Writes `content` (string or bytes) to `path`, creating or truncating the file.
 /// Requires the `--allow-write` CLI flag (see [`capability`]).
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "write_file", params = Fixed(2))]
+#[mq_macros::mq_fn(name = "write_file", params = Fixed(2), capability = "write")]
 fn write_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    if !capability::is_write_allowed() {
-        return Err(Error::Runtime(
-            "write_file: filesystem writes are disabled; re-run mq with --allow-write to enable write_file".into(),
-        ));
-    }
     fn write(path: &str, content: impl AsRef<[u8]>) -> Result<RuntimeValue, Error> {
         std::fs::write(path, content)
             .map(|()| RuntimeValue::NONE)
@@ -3989,7 +3965,7 @@ fn write_file_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
 /// `headers`, a dict of string to string, is applied to the request when given.
 /// Requires the `--allow-net` CLI flag (see [`capability`]).
 #[cfg(feature = "http")]
-#[mq_macros::mq_fn(name = "http", params = Range(2, 4))]
+#[mq_macros::mq_fn(name = "http", params = Range(2, 4), capability = "net")]
 fn http_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [
@@ -4160,14 +4136,8 @@ fn collect_markdown_files(
 /// Recursively reads every Markdown file under `dir`. Requires the `--allow-read` CLI flag (see
 /// [`capability`]).
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "collection", params = Fixed(1))]
+#[mq_macros::mq_fn(name = "collection", params = Fixed(1), capability = "read")]
 fn collection_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    if !capability::is_read_allowed() {
-        return Err(Error::Runtime(
-            "collection: filesystem reads are disabled; re-run mq with --allow-read to enable collection".into(),
-        ));
-    }
-
     match args.as_mut_slice() {
         [RuntimeValue::String(dir)] => {
             let mut ancestors = std::collections::HashSet::new();

--- a/crates/mq-lang/src/eval/builtin/http.rs
+++ b/crates/mq-lang/src/eval/builtin/http.rs
@@ -2,10 +2,11 @@
 //! `patch`, `head`, ...) and returns the response body as a string.
 //!
 //! Gated at compile time by the `http` feature (implied by `http-import-ureq`) and at
-//! runtime by the `--allow-net` CLI flag (see [`super::capability`]) — both must be satisfied before a
-//! request is made. Requests go through the same SSRF-hardened agent used for HTTP module
-//! imports (see [`crate::module::resolver::ssrf`]): HTTPS only, no automatic redirects, and
-//! DNS resolution filtered to publicly routable addresses so a hostname can't be rebound to
+//! runtime by the `--allow-net` CLI flag (checked by the `#[mq_fn(capability = "net")]` guard
+//! on `http_impl` in the parent module, see [`super::capability`]) — both must be satisfied
+//! before a request is made. Requests go through the same SSRF-hardened agent used for HTTP
+//! module imports (see [`crate::module::resolver::ssrf`]): HTTPS only, no automatic redirects,
+//! and DNS resolution filtered to publicly routable addresses so a hostname can't be rebound to
 //! an internal address after the initial check.
 
 use std::collections::BTreeMap;
@@ -14,6 +15,7 @@ use std::sync::LazyLock;
 use ureq::http;
 
 use super::Error;
+#[cfg(test)]
 use super::capability;
 use crate::module::resolver::ssrf::{is_https, ssrf_safe_agent};
 use crate::{Ident, RuntimeValue};
@@ -28,16 +30,6 @@ static AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| ssrf_safe_agent(TIMEOUT, 
 /// Builds an `Error::Runtime` with the `http: ` prefix shared by every error in this module.
 fn err(msg: impl std::fmt::Display) -> Error {
     Error::Runtime(format!("http: {msg}"))
-}
-
-fn ensure_net_allowed() -> Result<(), Error> {
-    if capability::is_net_allowed() {
-        Ok(())
-    } else {
-        Err(err(
-            "network access is disabled; re-run mq with --allow-net to enable http",
-        ))
-    }
 }
 
 fn ensure_https(url: &str) -> Result<(), Error> {
@@ -102,7 +94,6 @@ pub(super) fn request(
     body: Option<&str>,
     headers: Option<&BTreeMap<Ident, RuntimeValue>>,
 ) -> Result<RuntimeValue, Error> {
-    ensure_net_allowed()?;
     ensure_https(url)?;
     let method = parse_method(method)?;
     let builder = apply_headers(http::Request::builder().method(method).uri(url), headers)?;

--- a/crates/mq-macros/src/lib.rs
+++ b/crates/mq-macros/src/lib.rs
@@ -17,6 +17,11 @@ use syn::{
 ///   (`SORT_DESC`).
 /// - `params`: The `ParamNum` variant without the `ParamNum::` prefix (e.g., `None`, `Fixed(1)`,
 ///   `Range(0, 255)`).
+/// - `capability` (optional): one of `"read"`, `"write"`, `"net"`. When given, a guard is
+///   inserted as the first statement of the function body that returns
+///   `Err(Error::Runtime(...))` unless the matching `capability::is_{read,write,net}_allowed()`
+///   check passes — the same gate every capability-restricted builtin needs, generated instead
+///   of hand-written per function.
 ///
 /// # Example
 /// ```ignore
@@ -31,10 +36,15 @@ use syn::{
 /// }
 /// // Generates: static SORT_DESC: LazyLock<BuiltinFunction> = LazyLock::new(|| ...);
 /// // Register SORT_DESC in `builtin_dispatch!` to make it callable.
+///
+/// #[mq_fn(name = "read_file", params = Fixed(1), capability = "read")]
+/// fn read_file_impl(...) -> Result<RuntimeValue, Error> {
+///     // capability::is_read_allowed() is checked before this body runs.
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn mq_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let item_fn = parse_macro_input!(item as syn::ItemFn);
+    let mut item_fn = parse_macro_input!(item as syn::ItemFn);
 
     let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
     let metas = match parser.parse(attr) {
@@ -44,6 +54,7 @@ pub fn mq_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut name_lit: Option<LitStr> = None;
     let mut params_expr: Option<Expr> = None;
+    let mut capability_lit: Option<LitStr> = None;
 
     for meta in &metas {
         match meta {
@@ -57,6 +68,14 @@ pub fn mq_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
             Meta::NameValue(nv) if nv.path.is_ident("params") => {
                 params_expr = Some(nv.value.clone());
+            }
+            Meta::NameValue(nv) if nv.path.is_ident("capability") => {
+                if let Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s), ..
+                }) = &nv.value
+                {
+                    capability_lit = Some(s.clone());
+                }
             }
             _ => {
                 return syn::Error::new_spanned(meta, "unknown mq_fn attribute key")
@@ -83,6 +102,30 @@ pub fn mq_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into();
         }
     };
+
+    if let Some(capability) = &capability_lit {
+        let (getter, phrase, verb, flag) = match capability.value().as_str() {
+            "read" => ("is_read_allowed", "filesystem reads", "are", "--allow-read"),
+            "write" => ("is_write_allowed", "filesystem writes", "are", "--allow-write"),
+            "net" => ("is_net_allowed", "network access", "is", "--allow-net"),
+            other => {
+                return syn::Error::new_spanned(
+                    capability,
+                    format!("unknown capability {other:?}, expected \"read\", \"write\", or \"net\""),
+                )
+                .to_compile_error()
+                .into();
+            }
+        };
+        let getter_ident = Ident::new(getter, Span::call_site());
+        let message = format!("{{name}}: {phrase} {verb} disabled; re-run mq with {flag} to enable {{name}}");
+        let check: syn::Stmt = syn::parse_quote! {
+            if !capability::#getter_ident() {
+                return Err(Error::Runtime(format!(#message, name = #name)));
+            }
+        };
+        item_fn.block.stmts.insert(0, check);
+    }
 
     let fn_ident = &item_fn.sig.ident;
     let static_name = name.value().to_uppercase();


### PR DESCRIPTION
## Summary

read_file, file_exists, read_file_bytes, write_file, collection, and http each hand-wrote the same "if capability not allowed, return Runtime error" guard. mq_fn now accepts capability = "read" | "write" | "net" and injects the check as the function's first statement, so the five builtins drop their manual blocks and http's check moves from deep inside http::request() up to the same call-site gate as everything else. Error text is unchanged.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
