### PR TITLE
✨ feat(mq-lang): add error binder to try/catch (`catch(e):`)

### DIFF
--- a/crates/mq-check/src/constraint.rs
+++ b/crates/mq-check/src/constraint.rs
@@ -211,8 +211,24 @@ pub(super) fn generate_symbol_constraints(
 
         // Parameters and pattern variables get fresh type variables
         SymbolKind::Parameter | SymbolKind::PatternVariable { .. } => {
-            let ty_var = ctx.fresh_var();
-            ctx.set_symbol_type(symbol_id, Type::Var(ty_var));
+            // `catch(e):` always binds `e` to `{message: string}` (see `Evaluator::eval_try`).
+            let is_catch_error_binder = matches!(kind, SymbolKind::Parameter)
+                && hir
+                    .symbol(symbol_id)
+                    .and_then(|s| s.parent)
+                    .and_then(|parent_id| hir.symbol(parent_id))
+                    .is_some_and(|parent| matches!(parent.kind, SymbolKind::Catch));
+
+            if is_catch_error_binder {
+                let ty = Type::record(
+                    std::collections::BTreeMap::from([("message".to_string(), Type::String)]),
+                    Type::RowEmpty,
+                );
+                ctx.set_symbol_type(symbol_id, ty);
+            } else {
+                let ty_var = ctx.fresh_var();
+                ctx.set_symbol_type(symbol_id, Type::Var(ty_var));
+            }
         }
 
         // Variables get fresh type variables, constrained to their initializer
@@ -1856,8 +1872,8 @@ pub(super) fn generate_symbol_constraints(
                     // Different concrete types: use Union type to represent both possibilities
                     let union_ty = Type::union(vec![resolved_try, resolved_catch]);
                     ctx.set_symbol_type(symbol_id, union_ty);
-                } else {
-                    // Same type or at least one is a type variable: unify them
+                } else if both_concrete {
+                    // Same concrete type: unify them directly.
                     ctx.add_constraint(Constraint::Equal(
                         try_ty.clone(),
                         catch_ty,
@@ -1865,6 +1881,16 @@ pub(super) fn generate_symbol_constraints(
                         ConstraintOrigin::General,
                     ));
                     ctx.set_symbol_type(symbol_id, try_ty);
+                } else {
+                    // A branch type is still pending deferred resolution — decide later.
+                    let ty_var = ctx.fresh_var();
+                    ctx.set_symbol_type(symbol_id, Type::Var(ty_var));
+                    ctx.add_deferred_try_catch(infer::DeferredTryCatch {
+                        symbol_id,
+                        try_ty,
+                        catch_ty,
+                        range,
+                    });
                 }
             } else if !children.is_empty() {
                 let try_ty = ctx.get_or_create_symbol_type(children[0]);

--- a/crates/mq-check/src/deferred.rs
+++ b/crates/mq-check/src/deferred.rs
@@ -395,6 +395,50 @@ fn check_union_members(
     }
 }
 
+/// Resolves deferred try/catch branch-type merges, after other deferred passes
+/// (record/tuple access, overloads, ...) have settled the branch types.
+pub(crate) fn resolve_deferred_try_catches(ctx: &mut InferenceContext) -> bool {
+    let entries = ctx.take_deferred_try_catches();
+    if entries.is_empty() {
+        return false;
+    }
+
+    for entry in entries {
+        let Some(result_ty) = ctx.get_symbol_type(entry.symbol_id).cloned() else {
+            continue;
+        };
+        let resolved_try = ctx.resolve_type(&entry.try_ty);
+        let resolved_catch = ctx.resolve_type(&entry.catch_ty);
+        let both_concrete = !resolved_try.is_var() && !resolved_catch.is_var();
+        let same_discriminant =
+            both_concrete && std::mem::discriminant(&resolved_try) == std::mem::discriminant(&resolved_catch);
+
+        let merged_ty = if both_concrete && !same_discriminant {
+            types::Type::union(vec![resolved_try, resolved_catch])
+        } else {
+            ctx.add_constraint(Constraint::Equal(
+                entry.try_ty.clone(),
+                entry.catch_ty,
+                entry.range,
+                ConstraintOrigin::General,
+            ));
+            entry.try_ty
+        };
+        ctx.add_constraint(Constraint::Equal(
+            result_ty,
+            merged_ty,
+            entry.range,
+            ConstraintOrigin::General,
+        ));
+
+        // Solve immediately so an outer try/catch that depends on this result
+        // (nested `try: (try: ... catch: ...) catch: ...`) sees it resolved.
+        unify::solve_constraints(ctx);
+    }
+
+    true
+}
+
 /// Resolves deferred overloads after the first round of unification.
 ///
 /// Binary/unary operators whose operands were type variables during constraint

--- a/crates/mq-check/src/infer.rs
+++ b/crates/mq-check/src/infer.rs
@@ -138,6 +138,22 @@ pub struct DeferredTupleAccess {
     pub range: Option<mq_lang::Range>,
 }
 
+/// A deferred try/catch branch-type merge for post-unification resolution.
+///
+/// A branch's type may depend on another deferred pass (e.g. record field
+/// access), so deciding Union-vs-Equal must wait until that pass has run.
+#[derive(Debug, Clone)]
+pub struct DeferredTryCatch {
+    /// The `Try` symbol whose type is being resolved
+    pub symbol_id: SymbolId,
+    /// The try body's type
+    pub try_ty: Type,
+    /// The catch body's type
+    pub catch_ty: Type,
+    /// Source range for error reporting
+    pub range: Option<mq_lang::Range>,
+}
+
 /// A single variable type narrowing entry.
 ///
 /// Represents a narrowing of a variable's type within a specific branch,
@@ -211,6 +227,8 @@ pub struct InferenceContext {
     deferred_tuple_accesses: Vec<DeferredTupleAccess>,
     /// Deferred bracket accesses on function call return values (e.g. `f(x)["key"]`)
     deferred_call_return_accesses: Vec<DeferredCallReturnAccess>,
+    /// Deferred try/catch branch-type merges for post-unification resolution
+    deferred_try_catches: Vec<DeferredTryCatch>,
     /// Type narrowings collected from type predicate conditions in if/elif expressions
     type_narrowings: Vec<TypeNarrowing>,
     /// Cross-arm narrowings collected from match expressions
@@ -242,6 +260,7 @@ impl InferenceContext {
             deferred_selector_accesses: Vec::new(),
             deferred_tuple_accesses: Vec::new(),
             deferred_call_return_accesses: Vec::new(),
+            deferred_try_catches: Vec::new(),
             type_narrowings: Vec::new(),
             cross_arm_narrowings: Vec::new(),
             strict_array,
@@ -359,6 +378,16 @@ impl InferenceContext {
     /// Takes all deferred call return accesses (consumes them)
     pub fn take_deferred_call_return_accesses(&mut self) -> Vec<DeferredCallReturnAccess> {
         std::mem::take(&mut self.deferred_call_return_accesses)
+    }
+
+    /// Adds a deferred try/catch branch-type merge
+    pub fn add_deferred_try_catch(&mut self, entry: DeferredTryCatch) {
+        self.deferred_try_catches.push(entry);
+    }
+
+    /// Takes all deferred try/catch entries (consumes them)
+    pub fn take_deferred_try_catches(&mut self) -> Vec<DeferredTryCatch> {
+        std::mem::take(&mut self.deferred_try_catches)
     }
 
     /// Adds a type narrowing collected from a type predicate condition

--- a/crates/mq-check/src/lib.rs
+++ b/crates/mq-check/src/lib.rs
@@ -352,6 +352,14 @@ impl TypeChecker {
             unify::solve_constraints(&mut ctx);
         }
 
+        // Resolve deferred try/catch branch-type merges, then retry accesses/operators
+        // that depend on a `let v = try: ... catch: ...` variable's now-final type.
+        deferred::resolve_deferred_try_catches(&mut ctx);
+        if deferred::resolve_deferred_tuple_accesses(&mut ctx) {
+            unify::solve_constraints(&mut ctx);
+        }
+        deferred::resolve_deferred_overloads(&mut ctx);
+
         // Check operators inside user-defined function bodies against call-site types.
         // Uses local substitution (original params → call-site args) without modifying
         // global state, so multiple call sites don't interfere.

--- a/crates/mq-check/tests/integration_test.rs
+++ b/crates/mq-check/tests/integration_test.rs
@@ -527,6 +527,19 @@ fn test_try_catch() {
     );
 }
 
+#[test]
+fn test_try_catch_error_binder() {
+    assert!(check_types(r#"try: 42 / 0 catch(e): e["message"];"#).is_empty());
+}
+
+#[test]
+fn test_try_catch_error_binder_undefined_field() {
+    assert!(
+        !check_types(r#"try: 42 / 0 catch(e): e["not_a_field"];"#).is_empty(),
+        "accessing a field the error binder doesn't have should be a type error"
+    );
+}
+
 // Polymorphic Function Type Checking
 
 #[rstest]

--- a/crates/mq-formatter/src/formatter.rs
+++ b/crates/mq-formatter/src/formatter.rs
@@ -1061,12 +1061,24 @@ impl Formatter {
         self.append_indent(indent_level);
         self.output.push_str(&node.to_string());
 
-        if let Some(colon) = node.children.first() {
+        // Optional error binder: `catch(e):`. Render the `(`, ident, `)` as-is
+        // before the colon-or-do separator handled below.
+        let colon_index = match Self::find_token_position(node, |kind| matches!(kind, mq_lang::TokenKind::RParen)) {
+            Some(rparen_index) => {
+                node.children.iter().take(rparen_index + 1).for_each(|child| {
+                    self.format_node(mq_lang::Shared::clone(child), 0);
+                });
+                rparen_index + 1
+            }
+            None => 0,
+        };
+
+        if let Some(colon) = node.children.get(colon_index) {
             self.output.push_str(&colon.to_string());
             self.append_space();
         }
 
-        for child in node.children.iter().skip(1) {
+        for child in node.children.iter().skip(colon_index + 1) {
             let child_indent = if child.has_new_line() {
                 indent_level + 1
             } else {
@@ -2275,6 +2287,25 @@ catch:
 "
     )]
     #[case::try_catch_oneline("try: process() catch: handle_error()", "try: process() catch: handle_error()")]
+    #[case::try_catch_with_binder(
+        "try: process() catch(e): handle_error(e)",
+        "try: process() catch(e): handle_error(e)"
+    )]
+    #[case::try_catch_with_binder_extra_spaces(
+        "try: process() catch( e ): handle_error(e)",
+        "try: process() catch(e): handle_error(e)"
+    )]
+    #[case::try_catch_with_binder_multiline(
+        r#"try:
+  process()
+catch(e):
+  handle_error(e)"#,
+        "try:
+  process()
+catch(e):
+  handle_error(e)
+"
+    )]
     #[case::try_catch_with_finally(
         r#"try:
   process()

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -400,6 +400,8 @@ def foo(): 1", vec![" test".to_owned(), " test".to_owned(), "".to_owned()], vec!
     #[case::block("do \"hello\" end", "hello", SymbolKind::String)]
     #[case::try_("try: 1 catch: 2", "try", SymbolKind::Try)]
     #[case::catch_("try: 1 catch: 2", "catch", SymbolKind::Catch)]
+    #[case::catch_with_binder("try: 1 catch(e): e", "catch", SymbolKind::Catch)]
+    #[case::catch_error_binder_param("try: 1 catch(e): e", "e", SymbolKind::Parameter)]
     #[case::symbol_ident(":foo", "foo", SymbolKind::Symbol)]
     #[case::symbol_string(":\"hello\"", "hello", SymbolKind::Symbol)]
     #[case::pattern_match("match (v): | [1,2,3]: 1 end", "match", SymbolKind::Match)]
@@ -595,6 +597,68 @@ end"#;
         assert_eq!(resolved_symbol.value.as_deref(), Some("x"));
 
         assert!(hir.errors().is_empty(), "Should have no unresolved symbols");
+    }
+
+    #[test]
+    fn test_catch_error_binder_resolution() {
+        let mut hir = Hir::default();
+        hir.builtin.disabled = true;
+
+        let code = "try: 1 catch(e): e";
+        hir.add_code(None, code);
+
+        let binder_symbol = hir
+            .symbols()
+            .find(|(_, s)| s.kind == SymbolKind::Parameter && s.value.as_deref() == Some("e"));
+        assert!(binder_symbol.is_some(), "catch(e) should declare e as a Parameter");
+
+        let ref_symbol = hir
+            .symbols()
+            .find(|(_, s)| s.kind == SymbolKind::Ref && s.value.as_deref() == Some("e"));
+        assert!(ref_symbol.is_some(), "Should have a Ref symbol for e in the catch body");
+
+        let (ref_id, _) = ref_symbol.unwrap();
+        let resolved = hir.resolve_reference_symbol(ref_id);
+
+        assert_eq!(
+            resolved,
+            Some(binder_symbol.unwrap().0),
+            "e in the catch body should resolve to the catch(e) binder"
+        );
+        assert!(hir.errors().is_empty(), "Should have no unresolved symbols");
+    }
+
+    #[test]
+    fn test_catch_error_binder_shadows_outer_variable() {
+        let mut hir = Hir::default();
+        hir.builtin.disabled = true;
+
+        let code = "let e = \"hello\" | try: 1 catch(e): e";
+        hir.add_code(None, code);
+
+        let outer_e = hir
+            .symbols()
+            .find(|(_, s)| s.kind == SymbolKind::Variable && s.value.as_deref() == Some("e"))
+            .unwrap()
+            .0;
+        let binder_e = hir
+            .symbols()
+            .find(|(_, s)| s.kind == SymbolKind::Parameter && s.value.as_deref() == Some("e"))
+            .unwrap()
+            .0;
+
+        let ref_symbol = hir
+            .symbols()
+            .find(|(_, s)| s.kind == SymbolKind::Ref && s.value.as_deref() == Some("e"));
+        let (ref_id, _) = ref_symbol.unwrap();
+        let resolved = hir.resolve_reference_symbol(ref_id);
+
+        assert_eq!(
+            resolved,
+            Some(binder_e),
+            "e inside the catch body should resolve to the catch(e) binder, not the outer `let e`"
+        );
+        assert_ne!(resolved, Some(outer_e));
     }
 
     #[test]

--- a/crates/mq-hir/src/hir/lower.rs
+++ b/crates/mq-hir/src/hir/lower.rs
@@ -251,9 +251,72 @@ impl Hir {
         SymbolKind::QualifiedAccess
     );
     simple_expr!(add_try_expr, mq_lang::CstNodeKind::Try, SymbolKind::Try);
-    simple_expr!(add_catch_expr, mq_lang::CstNodeKind::Catch, SymbolKind::Catch);
     simple_expr!(add_array_expr, mq_lang::CstNodeKind::Array, SymbolKind::Array);
     simple_expr!(add_spread_expr, mq_lang::CstNodeKind::Spread, SymbolKind::Spread);
+
+    /// Lowers a `CstNodeKind::Catch` node into a `SymbolKind::Catch` symbol.
+    ///
+    /// `catch(e):` carries an optional error binder before the leading `(`,
+    /// `Ident`, `)` tokens; when present, it declares `e` as a `Parameter`
+    /// in a fresh child scope so the catch body can reference it without
+    /// resolving to an unrelated same-named symbol in an enclosing scope.
+    fn add_catch_expr(
+        &mut self,
+        node: &mq_lang::Shared<mq_lang::CstNode>,
+        source_id: SourceId,
+        scope_id: ScopeId,
+        parent: Option<SymbolId>,
+    ) {
+        if let mq_lang::CstNode {
+            kind: mq_lang::CstNodeKind::Catch,
+            ..
+        } = &**node
+        {
+            let symbol_id = self.add_symbol(Symbol {
+                value: node.name(),
+                kind: SymbolKind::Catch,
+                source: SourceInfo::new(Some(source_id), Some(node.range())),
+                scope: scope_id,
+                doc: node.comments(),
+                parent,
+                insertion_order: 0,
+            });
+
+            let has_binder = node
+                .children
+                .first()
+                .and_then(|child| child.token.clone())
+                .is_some_and(|token| matches!(token.kind, mq_lang::TokenKind::LParen));
+
+            let body_scope_id = if has_binder {
+                self.add_scope(Scope::new(
+                    SourceInfo::new(Some(source_id), Some(node.node_range())),
+                    ScopeKind::Block(symbol_id),
+                    Some(scope_id),
+                ))
+            } else {
+                scope_id
+            };
+
+            let mut children = node.children_without_token().into_iter();
+
+            if has_binder && let Some(binder) = children.next() {
+                self.add_symbol(Symbol {
+                    value: binder.name(),
+                    kind: SymbolKind::Parameter,
+                    source: SourceInfo::new(Some(source_id), Some(binder.range())),
+                    scope: body_scope_id,
+                    doc: Vec::new(),
+                    parent: Some(symbol_id),
+                    insertion_order: 0,
+                });
+            }
+
+            for child in children {
+                self.add_expr(&child, source_id, body_scope_id, Some(symbol_id));
+            }
+        }
+    }
 
     /// Lowers a `CstNodeKind::Assign` node into a `SymbolKind::Assign` symbol.
     ///

--- a/crates/mq-lang/src/ast/code.rs
+++ b/crates/mq-lang/src/ast/code.rs
@@ -241,10 +241,13 @@ impl Node {
                 node.format_to_code(buf, indent);
                 buf.push(')');
             }
-            Expr::Try(try_expr, catch_expr) => {
+            Expr::Try(try_expr, error_binder, catch_expr) => {
                 buf.push_str("try ");
                 try_expr.format_to_code(buf, indent);
-                buf.push_str(" catch: ");
+                match error_binder {
+                    Some(binder) => write!(buf, " catch({}): ", binder).unwrap(),
+                    None => buf.push_str(" catch: "),
+                }
                 catch_expr.format_to_code(buf, indent);
             }
             Expr::Module(name, program) => {
@@ -950,9 +953,18 @@ mod tests {
     #[case::simple(
         Expr::Try(
             Shared::new(create_node(Expr::Ident(IdentWithToken::new("risky")))),
+            None,
             Shared::new(create_node(Expr::Literal(Literal::String("error".to_string()))))
         ),
         r#"try risky catch: "error""#
+    )]
+    #[case::with_binder(
+        Expr::Try(
+            Shared::new(create_node(Expr::Ident(IdentWithToken::new("risky")))),
+            Some(IdentWithToken::new("e")),
+            Shared::new(create_node(Expr::Ident(IdentWithToken::new("e"))))
+        ),
+        "try risky catch(e): e"
     )]
     fn test_to_code_try(#[case] expr: Expr, #[case] expected: &str) {
         let node = create_node(expr);

--- a/crates/mq-lang/src/ast/node.rs
+++ b/crates/mq-lang/src/ast/node.rs
@@ -161,7 +161,7 @@ impl Node {
                 Range { start, end }
             }
             Expr::Paren(node) => node.range(Shared::clone(&arena)),
-            Expr::Try(try_expr, catch_expr) => {
+            Expr::Try(try_expr, _, catch_expr) => {
                 let start = try_expr.range(Shared::clone(&arena)).start;
                 let end = catch_expr.range(Shared::clone(&arena)).end;
                 Range { start, end }
@@ -374,7 +374,10 @@ pub enum Expr {
     Paren(Shared<Node>),
     Quote(Shared<Node>),
     Unquote(Shared<Node>),
-    Try(Shared<Node>, Shared<Node>),
+    /// `try <expr> catch: <expr>` or `try <expr> catch(<binder>): <expr>`.
+    /// When present, `binder` is bound to a dict describing the failure (currently `{"message": ...}`)
+    /// while evaluating the catch expression.
+    Try(Shared<Node>, Option<IdentWithToken>, Shared<Node>),
     Break(Option<Shared<Node>>),
     Continue,
 }
@@ -485,6 +488,7 @@ mod tests {
                 token_id: ArenaId::new(0),
                 expr: Shared::new(Expr::Literal(Literal::String("try".to_string()))),
             }),
+            None,
             Shared::new(Node {
                 token_id: ArenaId::new(1),
                 expr: Shared::new(Expr::Literal(Literal::String("catch".to_string()))),

--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -1192,6 +1192,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                         token_id: question_token_id,
                         expr: Shared::new(Expr::Try(
                             call_node,
+                            None,
                             Shared::new(Node {
                                 token_id,
                                 expr: Shared::new(Expr::Literal(Literal::None)),
@@ -1640,6 +1641,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
                 token_id,
                 expr: Shared::new(Expr::Try(
                     try_expr,
+                    None,
                     Shared::new(Node {
                         token_id,
                         expr: Shared::new(Expr::Literal(Literal::None)),
@@ -1649,7 +1651,26 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         }
 
         // Expect 'catch' keyword
-        self.next_token(|token_kind| matches!(token_kind, TokenKind::Catch))?;
+        let catch_token_id = self.next_token(|token_kind| matches!(token_kind, TokenKind::Catch))?;
+
+        // Optional error binder: `catch(e):` binds `e` to a dict describing the failure.
+        let error_binder = if self.is_next_token(|token_kind| matches!(token_kind, TokenKind::LParen)) {
+            let args = self.parse_args()?;
+            match args.as_slice() {
+                [arg] => match &*arg.expr {
+                    Expr::Ident(ident) => Some(ident.clone()),
+                    _ => return Err(SyntaxError::UnexpectedToken((*self.token_arena[arg.token_id]).clone())),
+                },
+                _ => {
+                    return Err(SyntaxError::UnexpectedToken(
+                        (*self.token_arena[catch_token_id]).clone(),
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+
         self.consume_colon_or_do();
 
         // Parse catch expression
@@ -1660,7 +1681,7 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
 
         Ok(Shared::new(Node {
             token_id,
-            expr: Shared::new(Expr::Try(try_expr, catch_expr)),
+            expr: Shared::new(Expr::Try(try_expr, error_binder, catch_expr)),
         }))
     }
 
@@ -4071,9 +4092,37 @@ mod tests {
                     token_id: 2.into(),
                     expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("error_expr", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("error_expr")))))))),
                 }),
+                None,
                 Shared::new(Node {
                     token_id: 5.into(),
                     expr: Shared::new(Expr::Literal(Literal::String("fallback".to_owned()))),
+                }),
+            )),
+        })]))]
+    #[case::try_catch_with_binder(
+        vec![
+            token(TokenKind::Try),
+            token(TokenKind::Colon),
+            token(TokenKind::Ident(SmolStr::new("error_expr"))),
+            token(TokenKind::Catch),
+            token(TokenKind::LParen),
+            token(TokenKind::Ident(SmolStr::new("e"))),
+            token(TokenKind::RParen),
+            token(TokenKind::Colon),
+            token(TokenKind::Ident(SmolStr::new("e"))),
+            token(TokenKind::Eof),
+        ],
+        Ok(vec![Shared::new(Node {
+            token_id: 2.into(),
+            expr: Shared::new(Expr::Try(
+                Shared::new(Node {
+                    token_id: 2.into(),
+                    expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("error_expr", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("error_expr")))))))),
+                }),
+                Some(IdentWithToken::new_with_token("e", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("e"))))))),
+                Shared::new(Node {
+                    token_id: 6.into(),
+                    expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("e", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("e")))))))),
                 }),
             )),
         })]))]
@@ -7049,6 +7098,7 @@ mod tests {
                         token_id: 2.into(),
                         expr: Shared::new(Expr::Ident(IdentWithToken::new_with_token("error_expr", Some(Shared::new(token(TokenKind::Ident(SmolStr::new("error_expr")))))))),
                     }),
+                    None,
                     Shared::new(Node {
                         token_id: 0.into(),
                         expr: Shared::new(Expr::Literal(Literal::None)),
@@ -7364,6 +7414,7 @@ mod tests {
                             ],
                         )),
                     }),
+                    None,
                     Shared::new(Node {
                         token_id: 1.into(),
                         expr: Shared::new(Expr::Literal(Literal::None)),
@@ -7390,6 +7441,7 @@ mod tests {
                                     SmallVec::new(),
                                 )),
                             }),
+                            None,
                             Shared::new(Node {
                                 token_id: 0.into(),
                                 expr: Shared::new(Expr::Literal(Literal::None)),
@@ -7422,6 +7474,7 @@ mod tests {
                                     ],
                                 )),
                             }),
+                            None,
                             Shared::new(Node {
                                 token_id: 1.into(),
                                 expr: Shared::new(Expr::Literal(Literal::None)),

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -1774,6 +1774,11 @@ impl<'a> Parser<'a> {
             children: Vec::new(),
         };
 
+        // Optional error binder: `catch(e):`
+        if self.peek().is_some_and(|t| matches!(t.kind, TokenKind::LParen)) {
+            children.append(&mut self.parse_params()?);
+        }
+
         self.push_colon_or_do_token_if_present(&mut children)?;
 
         let leading_trivia = self.parse_leading_trivia();

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -58,6 +58,7 @@ static DYNAMIC_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new("<dynamic>")
 static SPREAD_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new(constants::builtins::SPREAD));
 static ARRAY_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new(constants::builtins::ARRAY));
 static DICT_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new(constants::builtins::DICT));
+static ERROR_MESSAGE_IDENT: LazyLock<Ident> = LazyLock::new(|| Ident::new("message"));
 
 /// Control flow signals for internal evaluation.
 ///
@@ -1413,7 +1414,9 @@ impl<T: ModuleResolver> Evaluator<T> {
             ast::Expr::Or(operands) => self.eval_or(runtime_value, operands, env),
             ast::Expr::While(cond, program) => self.eval_while(runtime_value, cond, program, env),
             ast::Expr::Loop(program) => self.eval_loop(runtime_value, program, env),
-            ast::Expr::Try(try_expr, catch_expr) => self.eval_try(runtime_value, try_expr, catch_expr, env),
+            ast::Expr::Try(try_expr, error_binder, catch_expr) => {
+                self.eval_try(runtime_value, try_expr, error_binder, catch_expr, env)
+            }
             ast::Expr::Foreach(ident, values, body) => {
                 self.eval_foreach(runtime_value, ident.name, values, body, node.token_id, env)
             }
@@ -1630,12 +1633,24 @@ impl<T: ModuleResolver> Evaluator<T> {
         &mut self,
         runtime_value: &RuntimeValue,
         try_expr: &Shared<ast::Node>,
+        error_binder: &Option<IdentWithToken>,
         catch_expr: &Shared<ast::Node>,
         env: &Shared<SharedCell<Env>>,
     ) -> EvalResult {
         match self.eval_expr(runtime_value, try_expr, env) {
             Ok(result) => Ok(result),
-            Err(_) => self.eval_expr(runtime_value, catch_expr, env),
+            // Control flow signals (break/continue) are not errors; let them propagate.
+            Err(EvalError::Flow(flow)) => Err(EvalError::Flow(flow)),
+            Err(EvalError::Runtime(err)) => match error_binder {
+                Some(binder) => {
+                    let mut error_dict = BTreeMap::new();
+                    error_dict.insert(*ERROR_MESSAGE_IDENT, RuntimeValue::String(err.to_string()));
+                    let catch_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
+                    define(&catch_env, binder.name, RuntimeValue::Dict(error_dict));
+                    self.eval_expr(runtime_value, catch_expr, &catch_env)
+                }
+                None => self.eval_expr(runtime_value, catch_expr, env),
+            },
         }
     }
 

--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -340,12 +340,12 @@ impl Macro {
                     expr: Shared::new(Expr::Unquote(expanded_inner)),
                 }))
             }
-            Expr::Try(try_expr, catch_expr) => {
+            Expr::Try(try_expr, error_binder, catch_expr) => {
                 let expanded_try = self.expand_node(try_expr, evaluator)?;
                 let expanded_catch = self.expand_node(catch_expr, evaluator)?;
                 Ok(Shared::new(Node {
                     token_id: node.token_id,
-                    expr: Shared::new(Expr::Try(expanded_try, expanded_catch)),
+                    expr: Shared::new(Expr::Try(expanded_try, error_binder.clone(), expanded_catch)),
                 }))
             }
             Expr::InterpolatedString(segments) => {
@@ -731,12 +731,12 @@ impl Macro {
                     expr: Shared::new(Expr::Paren(substituted_inner)),
                 })
             }
-            Expr::Try(try_expr, catch_expr) => {
+            Expr::Try(try_expr, error_binder, catch_expr) => {
                 let substituted_try = self.substitute_node(try_expr, substitutions);
                 let substituted_catch = self.substitute_node(catch_expr, substitutions);
                 Shared::new(Node {
                     token_id: node.token_id,
-                    expr: Shared::new(Expr::Try(substituted_try, substituted_catch)),
+                    expr: Shared::new(Expr::Try(substituted_try, error_binder.clone(), substituted_catch)),
                 })
             }
             Expr::InterpolatedString(segments) => {
@@ -1065,12 +1065,12 @@ impl Macro {
                     expr: Shared::new(Expr::Paren(substituted_inner)),
                 })
             }
-            Expr::Try(try_expr, catch_expr) => {
+            Expr::Try(try_expr, error_binder, catch_expr) => {
                 let substituted_try = self.substitute_in_quote(try_expr, substitutions);
                 let substituted_catch = self.substitute_in_quote(catch_expr, substitutions);
                 Shared::new(Node {
                     token_id: node.token_id,
-                    expr: Shared::new(Expr::Try(substituted_try, substituted_catch)),
+                    expr: Shared::new(Expr::Try(substituted_try, error_binder.clone(), substituted_catch)),
                 })
             }
             Expr::InterpolatedString(segments) => {

--- a/crates/mq-lang/src/optimizer.rs
+++ b/crates/mq-lang/src/optimizer.rs
@@ -374,10 +374,12 @@ impl Optimizer {
                 token_id,
                 expr: Shared::new(ast::Expr::Paren(self.substitute_literals(Shared::clone(inner), env))),
             }),
-            ast::Expr::Try(try_expr, catch_expr) => Shared::new(ast::Node {
+            // No error binder: neither branch introduces a new binding, so substitution is safe.
+            ast::Expr::Try(try_expr, None, catch_expr) => Shared::new(ast::Node {
                 token_id,
                 expr: Shared::new(ast::Expr::Try(
                     self.substitute_literals(Shared::clone(try_expr), env),
+                    None,
                     self.substitute_literals(Shared::clone(catch_expr), env),
                 )),
             }),
@@ -411,6 +413,7 @@ impl Optimizer {
             | ast::Expr::While(_, _)
             | ast::Expr::Loop(_)
             | ast::Expr::Foreach(_, _, _)
+            | ast::Expr::Try(_, Some(_), _)
             | ast::Expr::Let(_, _)
             | ast::Expr::Var(_, _)
             | ast::Expr::As(_, _)
@@ -480,10 +483,11 @@ impl Optimizer {
                     ops.iter().map(|o| self.apply_inline(Shared::clone(o), fns)).collect(),
                 )),
             }),
-            ast::Expr::Try(try_expr, catch_expr) => Shared::new(ast::Node {
+            ast::Expr::Try(try_expr, None, catch_expr) => Shared::new(ast::Node {
                 token_id,
                 expr: Shared::new(ast::Expr::Try(
                     self.apply_inline(Shared::clone(try_expr), fns),
+                    None,
                     self.apply_inline(Shared::clone(catch_expr), fns),
                 )),
             }),
@@ -621,7 +625,7 @@ impl Optimizer {
                     expr: Shared::new(ast::Expr::Assign(ident.clone(), opt_inner)),
                 })
             }
-            ast::Expr::Try(try_expr, catch_expr) => {
+            ast::Expr::Try(try_expr, error_binder, catch_expr) => {
                 let opt_try = self.optimize_node(Shared::clone(try_expr), user_defs);
                 let opt_catch = self.optimize_node(Shared::clone(catch_expr), user_defs);
                 if ptr_eq(&opt_try, try_expr) && ptr_eq(&opt_catch, catch_expr) {
@@ -629,7 +633,7 @@ impl Optimizer {
                 }
                 Shared::new(ast::Node {
                     token_id,
-                    expr: Shared::new(ast::Expr::Try(opt_try, opt_catch)),
+                    expr: Shared::new(ast::Expr::Try(opt_try, error_binder.clone(), opt_catch)),
                 })
             }
             ast::Expr::Break(Some(val)) => {
@@ -1193,7 +1197,7 @@ fn has_recursion(node: &Shared<ast::Node>, fn_name: Ident) -> bool {
         ast::Expr::If(branches) => branches.iter().any(|(cond, body)| {
             cond.as_ref().is_some_and(|c| has_recursion(c, fn_name)) || has_recursion(body, fn_name)
         }),
-        ast::Expr::Try(t, c) => has_recursion(t, fn_name) || has_recursion(c, fn_name),
+        ast::Expr::Try(t, _, c) => has_recursion(t, fn_name) || has_recursion(c, fn_name),
         ast::Expr::SelectorCall(_, args) => args.iter().any(|a| has_recursion(a, fn_name)),
         ast::Expr::Paren(inner) => has_recursion(inner, fn_name),
         _ => false,
@@ -1219,7 +1223,8 @@ fn has_free_vars(node: &Shared<ast::Node>, params: &[Ident]) -> bool {
         ast::Expr::If(branches) => branches
             .iter()
             .any(|(cond, body)| cond.as_ref().is_some_and(|c| has_free_vars(c, params)) || has_free_vars(body, params)),
-        ast::Expr::Try(t, c) => has_free_vars(t, params) || has_free_vars(c, params),
+        // Try with an error binder falls through to `_ => true` (unsafe to inline).
+        ast::Expr::Try(t, None, c) => has_free_vars(t, params) || has_free_vars(c, params),
         ast::Expr::Paren(inner) => has_free_vars(inner, params),
         _ => true,
     }
@@ -1295,10 +1300,12 @@ fn substitute_params(
                 expr: Shared::new(ast::Expr::If(branches)),
             })
         }
-        ast::Expr::Try(t, c) => Shared::new(ast::Node {
+        // `has_free_vars` already excludes error-binder bodies from inlining.
+        ast::Expr::Try(t, error_binder, c) => Shared::new(ast::Node {
             token_id,
             expr: Shared::new(ast::Expr::Try(
                 substitute_params(Shared::clone(t), params, args, call_token_id),
+                error_binder.clone(),
                 substitute_params(Shared::clone(c), params, args, call_token_id),
             )),
         }),
@@ -1391,7 +1398,7 @@ fn contains_self_call(node: &Shared<ast::Node>, fn_name: Ident) -> bool {
         ast::Expr::If(branches) => branches.iter().any(|(cond, body)| {
             cond.as_ref().is_some_and(|c| contains_self_call(c, fn_name)) || contains_self_call(body, fn_name)
         }),
-        ast::Expr::Try(t, c) => contains_self_call(t, fn_name) || contains_self_call(c, fn_name),
+        ast::Expr::Try(t, _, c) => contains_self_call(t, fn_name) || contains_self_call(c, fn_name),
         ast::Expr::SelectorCall(_, args) => args.iter().any(|a| contains_self_call(a, fn_name)),
         ast::Expr::Paren(inner) | ast::Expr::Break(Some(inner)) | ast::Expr::Unquote(inner) => {
             contains_self_call(inner, fn_name)
@@ -1528,7 +1535,7 @@ fn collect_called_fns_node(node: &Shared<ast::Node>, set: &mut FxHashSet<Ident>)
                 collect_called_fns_node(o, set);
             }
         }
-        ast::Expr::Try(t, c) => {
+        ast::Expr::Try(t, _, c) => {
             collect_called_fns_node(t, set);
             collect_called_fns_node(c, set);
         }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -138,6 +138,13 @@ fn engine() -> DefaultEngine {
     ",
       vec![RuntimeValue::Number(0.into())],
       Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// break inside a try body must propagate to the loop, not be swallowed by catch
+#[case::loop_break_through_try_catch("
+    loop:
+      try: break: 42 catch(e): 0;
+    ",
+      vec![RuntimeValue::Number(0.into())],
+      Ok(vec![RuntimeValue::Number(42.into())].into()))]
 #[case::loop_break_with_value_complex("
     var x = 0 |
     loop:
@@ -3017,6 +3024,16 @@ fn engine() -> DefaultEngine {
 #[case::try_no_catch_failure("try: undefined_func()", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // try/catch: nested try blocks
 #[case::try_nested("try: (try: undefined_func() catch: \"inner\") catch: \"outer\"", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("inner".to_string())].into()))]
+// try/catch(e): error binder is bound to a dict with the failure message
+#[case::try_catch_binder(r#"try: error("boom") catch(e): e["message"]"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("boom".to_string())].into()))]
+// try/catch(e): the full error dict is accessible when bound directly
+#[case::try_catch_binder_dict(r#"try: error("boom") catch(e): e"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+    (Ident::new("message"), RuntimeValue::String("boom".to_string())),
+]))].into()))]
+// try/catch(e): the binder is unused when the try expression succeeds
+#[case::try_catch_binder_unused_on_success("try: 42 catch(e): 0", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+// try/catch(e): binder name does not leak outside the catch expression
+#[case::try_catch_binder_scoped(r#"try: error("boom") catch(e): e["message"] | try: e catch: "e is undefined outside catch""#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("e is undefined outside catch".to_string())].into()))]
 // foreach over string: iterates each character
 #[case::foreach_string("foreach(c, \"abc\"): c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])].into()))]
 // foreach over string with break

--- a/docs/books/src/reference/try_catch.md
+++ b/docs/books/src/reference/try_catch.md
@@ -6,6 +6,7 @@ The try-catch expression allows you to handle errors gracefully by providing a f
 
 ```
 try <expr> catch <expr>
+try <expr> catch(<binder>) <expr>
 ```
 
 ## Behavior
@@ -13,6 +14,8 @@ try <expr> catch <expr>
 - If the `try` expression succeeds, its result is returned
 - If the `try` expression fails (produces an error), the `catch` expression is evaluated instead
 - The `catch` expression receives the same input as the `try` expression
+- With `catch(<binder>)`, `<binder>` is bound to a dict describing the failure (currently `{"message": <string>}`) for the duration of the `catch` expression
+- `break`/`continue` inside the `try` expression are not treated as errors; they propagate to the enclosing loop instead of triggering `catch`
 
 ## Examples
 
@@ -41,6 +44,14 @@ try: do get("data") | from_json(); catch: []
 ```mq
 # Multiple fallback levels
 try: get("primary") catch: try: get("secondary") catch: "default"
+```
+
+### Error Binder
+
+```mq
+# Bind the failure to `e` and inspect its message
+try: error("boom") catch(e): e["message"]
+# => "boom"
 ```
 
 ## Error Suppression (`?`)


### PR DESCRIPTION
## Summary

catch(e): binds e to a {"message": ...} dict describing the failure, scoped to the catch expression. Plain `catch:` keeps working unchanged.

Also fixes break/continue inside a try body being swallowed by catch instead of propagating to the enclosing loop, and threads the new optional binder through the CST parser, optimizer, and macro expander (with shadow-safe handling in constant folding and function inlining).

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
