### PR TITLE
✨ feat(mq-lang): add word_wrap and truncate string functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,7 @@ dependencies = [
  "tiktoken-rs",
  "toml 1.1.2+spec-1.1.0",
  "toon-format",
+ "unicode-width 0.2.2",
  "ureq",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ tower-lsp-server = "0.23.0"
 tracing = "0.1.44"
 tracing-opentelemetry = "0.33"
 tracing-subscriber = "0.3.23"
+unicode-width = "0.2.2"
 ureq = {version = "3"}
 url = "2.5.8"
 utoipa = "5.5"

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -323,6 +323,11 @@ fn register_string(ctx: &mut InferenceContext) {
     register_ternary(ctx, "replace", Type::Var(a), Type::String, Type::String, Type::Var(a));
     register_ternary(ctx, "gsub", Type::String, Type::String, Type::String, Type::String);
     register_binary(ctx, "split", Type::String, Type::String, Type::array(Type::String));
+
+    // word_wrap: (string, number) -> string
+    register_binary(ctx, "word_wrap", Type::String, Type::Number, Type::String);
+    // truncate: (string, number, string) -> string
+    register_ternary(ctx, "truncate", Type::String, Type::Number, Type::String, Type::String);
     register_binary(ctx, "join", Type::array(Type::String), Type::String, Type::String);
 
     // contains: (string, string) -> bool
@@ -410,6 +415,10 @@ fn register_string(ctx: &mut InferenceContext) {
     // gsub/replace: (none, string, string) -> none
     register_ternary(ctx, "gsub", Type::None, Type::String, Type::String, Type::None);
     register_ternary(ctx, "replace", Type::None, Type::String, Type::String, Type::None);
+
+    // word_wrap/truncate: none propagation
+    register_binary(ctx, "word_wrap", Type::None, Type::Number, Type::None);
+    register_ternary(ctx, "truncate", Type::None, Type::Number, Type::String, Type::None);
 
     // lines: (string) -> [string]
     register_unary(ctx, "lines", Type::String, Type::array(Type::String));

--- a/crates/mq-check/tests/type_errors_test.rs
+++ b/crates/mq-check/tests/type_errors_test.rs
@@ -669,6 +669,8 @@ fn test_cross_arm_narrowing(#[case] code: &str, #[case] should_succeed: bool, #[
 #[case::split_dot("split(., \"x\")", true, "dynamic as string, separator explicit")]
 #[case::starts_with_dot("starts_with(., \"hello\")", true, "dynamic as string")]
 #[case::replace_two_explicit("replace(\"l\", \"r\")", true, "dynamic piped + 2 explicit = 3 args")]
+#[case::word_wrap_dot("word_wrap(., 10)", true, "dynamic as string, width explicit")]
+#[case::truncate_dot("truncate(., 10, \"...\")", true, "dynamic as string, width and ellipsis explicit")]
 // pipe chains: dynamic pinned to concrete type, then further typed ops
 #[case::chain_to_len("upcase(.) | len", true, "dynamic -> string -> number")]
 #[case::chain_two_string_ops("upcase(.) | trim(.)", true, "string -> string")]
@@ -684,6 +686,8 @@ fn test_cross_arm_narrowing(#[case] code: &str, #[case] should_succeed: bool, #[
 #[case::string_pinned_abs_fails("upcase(.) | abs(.)", false, "upcase pins to string, abs needs number")]
 #[case::number_pinned_upcase_fails("len() | upcase(.)", false, "len pins to number, upcase needs string")]
 #[case::replace_arity_error("replace(\"l\")", false, "1 explicit + dynamic = 2, needs 3")]
+#[case::word_wrap_width_wrong_type("word_wrap(\"hello\", \"wide\")", false, "width must be a number")]
+#[case::truncate_ellipsis_wrong_type("truncate(\"hello\", 3, 42)", false, "ellipsis must be a string")]
 fn test_dynamic_piped_input(#[case] code: &str, #[case] should_succeed: bool, #[case] description: &str) {
     let result = check_types_with_builtins(code);
     assert_eq!(result.is_empty(), should_succeed, "{}: {result:?}", description);

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = {workspace = true}
 url = {workspace = true}
 toon-format = { version = "0.5", default-features = false }
 quick-xml = {workspace = true}
+unicode-width = {workspace = true}
 similar = "3.0.0"
 tiktoken-rs = { version = "0.12", optional = true }
 ureq = { workspace = true, optional = true }

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -35,6 +35,7 @@ use std::io;
 use std::process::exit;
 use std::sync::LazyLock;
 use thiserror::Error;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use self::range::{generate_char_range, generate_multi_char_range, generate_numeric_range};
 use self::regex::{capture_re, is_match_re, match_re, replace_re, scan_re, split_re};
@@ -1183,6 +1184,52 @@ fn repeat_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
             vec![std::mem::take(a), std::mem::take(b)],
         )),
         _ => unreachable!("repeat should always receive exactly two arguments"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "word_wrap", params = Fixed(2))]
+fn word_wrap_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s), RuntimeValue::Number(width)] => Ok(word_wrap(s, width.value() as usize).into()),
+        [node @ RuntimeValue::Markdown(_, _), RuntimeValue::Number(width)] => {
+            let width = width.value() as usize;
+            node.markdown_node()
+                .map(|md| Ok(node.update_markdown_value(&word_wrap(&md.value(), width))))
+                .unwrap_or_else(|| Ok(RuntimeValue::NONE))
+        }
+        [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::NONE),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("word_wrap should always receive exactly two arguments"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "truncate", params = Fixed(3))]
+fn truncate_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [
+            RuntimeValue::String(s),
+            RuntimeValue::Number(len),
+            RuntimeValue::String(ellipsis),
+        ] => Ok(truncate_str(s, len.value() as usize, ellipsis).into()),
+        [
+            node @ RuntimeValue::Markdown(_, _),
+            RuntimeValue::Number(len),
+            RuntimeValue::String(ellipsis),
+        ] => {
+            let len = len.value() as usize;
+            node.markdown_node()
+                .map(|md| Ok(node.update_markdown_value(&truncate_str(&md.value(), len, ellipsis))))
+                .unwrap_or_else(|| Ok(RuntimeValue::NONE))
+        }
+        [RuntimeValue::None, RuntimeValue::Number(_), RuntimeValue::String(_)] => Ok(RuntimeValue::NONE),
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("truncate should always receive exactly three arguments"),
     }
 }
 
@@ -4250,6 +4297,8 @@ mq_macros::builtin_dispatch! {
     GSUB,
     REPLACE,
     REPEAT,
+    WORD_WRAP,
+    TRUNCATE,
     EXPLODE,
     IMPLODE,
     TRIM,
@@ -5358,6 +5407,20 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Repeats the given string a specified number of times.",
             params: &["string", "count"],
+        },
+    );
+    map.insert(
+        SmolStr::new("word_wrap"),
+        BuiltinFunctionDoc {
+            description: "Wraps the given string into lines no wider than the specified display width, breaking on word boundaries (CJK and other wide characters count as two columns).",
+            params: &["string", "width"],
+        },
+    );
+    map.insert(
+        SmolStr::new("truncate"),
+        BuiltinFunctionDoc {
+            description: "Truncates the given string to the specified display width, appending the ellipsis string when truncated (CJK and other wide characters count as two columns).",
+            params: &["string", "width", "ellipsis"],
         },
     );
     map.insert(
@@ -6597,6 +6660,105 @@ fn eval_recursive_selector(node: &mq_markdown::Node) -> RuntimeValue {
             .map(RuntimeValue::new_markdown)
             .collect(),
     )
+}
+
+/// Wraps `text` on word boundaries to `width` display columns (Unicode East Asian Width, so CJK counts as 2).
+fn word_wrap(text: &str, width: usize) -> String {
+    if width == 0 {
+        return text.to_string();
+    }
+
+    text.split('\n')
+        .map(|line| word_wrap_line(line, width))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn word_wrap_line(line: &str, width: usize) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+
+    for word in line.split_whitespace() {
+        let word_width = word.width();
+
+        if word_width > width {
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+                current_width = 0;
+            }
+            for c in word.chars() {
+                let cw = c.width().unwrap_or(0);
+                if current_width > 0 && current_width + cw > width {
+                    lines.push(std::mem::take(&mut current));
+                    current_width = 0;
+                }
+                current.push(c);
+                current_width += cw;
+            }
+            continue;
+        }
+
+        let needed = if current.is_empty() {
+            word_width
+        } else {
+            current_width + 1 + word_width
+        };
+
+        if !current.is_empty() && needed > width {
+            lines.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+
+        if !current.is_empty() {
+            current.push(' ');
+            current_width += 1;
+        }
+        current.push_str(word);
+        current_width += word_width;
+    }
+
+    lines.push(current);
+    lines.join("\n")
+}
+
+/// Truncates `text` to `max_width` display columns, appending `ellipsis` (CJK counts as 2 columns).
+fn truncate_str(text: &str, max_width: usize, ellipsis: &str) -> String {
+    if text.width() <= max_width {
+        return text.to_string();
+    }
+
+    let ellipsis_width = ellipsis.width();
+
+    if ellipsis_width >= max_width {
+        let mut result = String::new();
+        let mut width = 0;
+        for c in ellipsis.chars() {
+            let cw = c.width().unwrap_or(0);
+            if width + cw > max_width {
+                break;
+            }
+            result.push(c);
+            width += cw;
+        }
+        return result;
+    }
+
+    let target_width = max_width - ellipsis_width;
+    let mut result = String::new();
+    let mut width = 0;
+
+    for c in text.chars() {
+        let cw = c.width().unwrap_or(0);
+        if width + cw > target_width {
+            break;
+        }
+        result.push(c);
+        width += cw;
+    }
+
+    result.push_str(ellipsis);
+    result
 }
 
 fn repeat(value: &mut RuntimeValue, n: usize) -> Result<RuntimeValue, Error> {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3288,6 +3288,24 @@ fn engine() -> DefaultEngine {
 #[case::set_array_extend("set([1, 2], 4, 99) | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 // repeat: via builtin
 #[case::repeat_string_builtin(r#"repeat("ab", 3)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ababab".to_string())].into()))]
+// word_wrap: wraps ASCII text on word boundaries
+#[case::word_wrap_ascii(r#"word_wrap("the quick brown fox", 10)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("the quick\nbrown fox".to_string())].into()))]
+// word_wrap: text shorter than width is unchanged
+#[case::word_wrap_short(r#"word_wrap("hi", 10)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hi".to_string())].into()))]
+// word_wrap: a single word longer than width is hard-broken
+#[case::word_wrap_hard_break(r#"word_wrap("abcdefgh", 3)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("abc\ndef\ngh".to_string())].into()))]
+// word_wrap: CJK characters count as two display columns each
+#[case::word_wrap_cjk(r#"word_wrap("あいうえお", 4)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("あい\nうえ\nお".to_string())].into()))]
+// word_wrap: width 0 returns the text unchanged
+#[case::word_wrap_zero_width(r#"word_wrap("ab cd", 0)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ab cd".to_string())].into()))]
+#[case::word_wrap_none("word_wrap(None, 10)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
+// truncate: text shorter than the width is unchanged
+#[case::truncate_short(r#"truncate("hello", 10, "...")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
+// truncate: text longer than width is cut and ellipsis appended
+#[case::truncate_ascii(r#"truncate("hello world", 8, "...")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello...".to_string())].into()))]
+// truncate: CJK characters count as two display columns each
+#[case::truncate_cjk(r#"truncate("あいうえお", 6, "...")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("あ...".to_string())].into()))]
+#[case::truncate_none("truncate(None, 10, \"...\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // update: non-None non-Markdown returns second value
 #[case::update_non_markdown_returns_value("update(42, 99)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(99.into())].into()))]
 // match expression


### PR DESCRIPTION
## Summary

Adds display-width-aware word_wrap(text, width) and truncate(text, len, ellipsis) builtins, using unicode-width so CJK and other wide characters count as two columns. Useful with the table module for controlling column width in terminal output.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
