### PR TITLE
✨ feat(mq-lang): add glob_match path function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "csv",
  "dirs 6.0.0",
  "getrandom 0.4.3",
+ "glob",
  "html-escape",
  "itertools 0.15.0",
  "md5",

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -1283,6 +1283,7 @@ fn register_file_io(ctx: &mut InferenceContext) {
         Type::String,
     );
     register_binary(ctx, "path_join", Type::String, Type::String, Type::String);
+    register_binary(ctx, "glob_match", Type::String, Type::String, Type::Bool);
 
     // write_file: (string, string | bytes) -> none
     register_binary(ctx, "write_file", Type::String, Type::String, Type::None);
@@ -1851,6 +1852,7 @@ mod tests {
     #[case::extname("extname(\"a/b.md\")", true)]
     #[case::stem("stem(\"a/b.md\")", true)]
     #[case::path_join("path_join(\"a\", \"b.md\")", true)]
+    #[case::glob_match("glob_match(\"*.md\", \"a.md\")", true)]
     #[case::write_file_string("write_file(\"a.md\", \"content\")", true)]
     #[case::write_file_bytes("write_file(\"a.md\", to_bytes(\"content\"))", true)]
     #[case::http_get("http(\"get\", \"https://example.invalid\")", true)]
@@ -1875,6 +1877,7 @@ mod tests {
     #[case::collection_number("collection(42)", false)] // Should fail: wrong type
     #[case::basename_number("basename(42)", false)] // Should fail: wrong type
     #[case::path_join_number("path_join(42, \"b\")", false)] // Should fail: wrong type
+    #[case::glob_match_number("glob_match(42, \"a.md\")", false)] // Should fail: wrong type
     #[case::write_file_number("write_file(42, \"content\")", false)] // Should fail: wrong type
     #[case::http_get_number("http(\"get\", 42)", false)] // Should fail: wrong type
     #[case::http_headers_number("http(\"get\", \"https://example.invalid\", 42)", false)] // Should fail: wrong type

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -21,6 +21,7 @@ md5 = {workspace = true}
 sha2 = {workspace = true}
 chrono = {workspace = true}
 dirs = {workspace = true}
+glob = {workspace = true}
 itertools = {workspace = true}
 miette = {workspace = true}
 mq-markdown = {workspace = true, features = ["html-to-markdown", "json", "obsidian"]}

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3943,6 +3943,21 @@ fn path_join_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
     }
 }
 
+/// Returns whether `path` matches the glob `pattern` (e.g. `*.md`, `docs/**/*.rs`).
+#[mq_macros::mq_fn(name = "glob_match", params = Fixed(2))]
+fn glob_match_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(pattern), RuntimeValue::String(path)] => {
+            path::glob_match(pattern, path).map(RuntimeValue::Boolean)
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("glob_match should always receive exactly two arguments"),
+    }
+}
+
 /// Reads the contents of `path` as a string. Requires the `--allow-read` CLI flag (see
 /// [`capability`]).
 #[cfg(feature = "file-io")]
@@ -4414,6 +4429,7 @@ mq_macros::builtin_dispatch! {
     EXTNAME,
     STEM,
     PATH_JOIN,
+    GLOB_MATCH,
     #[cfg(feature = "file-io")]
     READ_FILE,
     #[cfg(feature = "file-io")]
@@ -6085,6 +6101,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Joins a base path with a component path and returns the resulting path string (e.g. path_join(\"/a/b\", \"c.txt\") → \"/a/b/c.txt\").",
             params: &["base", "component"],
+        },
+    );
+    map.insert(
+        SmolStr::new("glob_match"),
+        BuiltinFunctionDoc {
+            description: "Checks whether the given path matches the glob pattern (e.g. \"*.md\", \"docs/**/*.rs\"), commonly used to filter file lists.",
+            params: &["pattern", "path"],
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/path.rs
+++ b/crates/mq-lang/src/eval/builtin/path.rs
@@ -39,6 +39,17 @@ pub(super) fn stem(path: &str) -> String {
         .unwrap_or_default()
 }
 
+/// Returns whether `path` matches the glob `pattern` (e.g. `*.md`, `docs/**/*.rs`).
+pub(super) fn glob_match(pattern: &str, path: &str) -> Result<bool, Error> {
+    let options = glob::MatchOptions {
+        require_literal_separator: true,
+        ..glob::MatchOptions::new()
+    };
+    glob::Pattern::new(pattern)
+        .map(|p| p.matches_with(path, options))
+        .map_err(|e| Error::Runtime(format!("glob_match: invalid pattern {:?}: {}", pattern, e)))
+}
+
 /// Joins a base path with a component path, returning the resulting path string.
 pub(super) fn path_join(base: &str, component: &str) -> Result<String, Error> {
     let joined = Path::new(base).join(component);
@@ -100,5 +111,25 @@ mod tests {
     #[case("/a", "b/c", "/a/b/c")]
     fn test_path_join(#[case] base: &str, #[case] component: &str, #[case] expected: &str) {
         assert_eq!(path_join(base, component).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case("*.md", "file.md", true)]
+    #[case("*.md", "file.txt", false)]
+    #[case("*.md", "dir/file.md", false)]
+    #[case("docs/*.md", "docs/a.md", true)]
+    #[case("docs/*.md", "docs/sub/a.md", false)]
+    #[case("docs/**/*.md", "docs/sub/a.md", true)]
+    #[case("docs/**/*.md", "docs/a.md", true)]
+    #[case("**/*.rs", "src/lib.rs", true)]
+    #[case("file?.md", "file1.md", true)]
+    #[case("file?.md", "file12.md", false)]
+    fn test_glob_match(#[case] pattern: &str, #[case] path: &str, #[case] expected: bool) {
+        assert_eq!(glob_match(pattern, path).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_glob_match_invalid_pattern() {
+        assert!(glob_match("[", "file.md").is_err());
     }
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3269,6 +3269,11 @@ fn engine() -> DefaultEngine {
 #[case::stem_basic(r#"stem("file.txt")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("file".to_string())].into()))]
 #[case::stem_no_ext(r#"stem("file")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("file".to_string())].into()))]
 #[case::path_join_basic(r#"path_join("/path", "file.txt") | type"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("string".to_string())].into()))]
+// glob_match: glob pattern matching against a path
+#[case::glob_match_true(r#"glob_match("*.md", "file.md")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
+#[case::glob_match_false(r#"glob_match("*.md", "file.txt")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(false)].into()))]
+#[case::glob_match_star_no_cross_separator(r#"glob_match("*.md", "dir/file.md")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(false)].into()))]
+#[case::glob_match_recursive(r#"glob_match("docs/**/*.md", "docs/sub/a.md")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 // add: various type combinations
 #[case::add_string_number(r#"add("hello", 42)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello42".to_string())].into()))]
 #[case::add_number_string(r#"add(42, "!")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("!42".to_string())].into()))]
@@ -3742,6 +3747,8 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 #[case::stem_non_string("stem(42)", vec![RuntimeValue::None],)]
 // path_join: non-string → type error
 #[case::path_join_non_string(r#"path_join(42, "component")"#, vec![RuntimeValue::None],)]
+// glob_match: non-string → type error
+#[case::glob_match_non_string(r#"glob_match(42, "file.md")"#, vec![RuntimeValue::None],)]
 // min: mixed types → type error
 #[case::min_mixed_types(r#"min("str", 42)"#, vec![RuntimeValue::None],)]
 // max: mixed types → type error


### PR DESCRIPTION
## Summary

Adds glob_match(pattern, path), matching shell-style glob patterns (*.md, docs/**/*.rs, file?.md) against a path string via the glob crate. Pure string matching with no filesystem access, so it needs no --allow-read gate and lives alongside basename/dirname/extname/ stem/path_join.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
