### PR TITLE
🐛 fix(mq-run): apply --allow-read/write/net capability flags in REPL

### DIFF
--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -308,6 +308,11 @@ impl Repl {
 
         engine.load_builtin_module();
 
+        Self::with_engine(engine, input)
+    }
+
+    /// Creates a REPL from a pre-configured engine (e.g. with capabilities already set).
+    pub fn with_engine(engine: mq_lang::DefaultEngine, input: Vec<mq_lang::RuntimeValue>) -> Self {
         Self {
             command_context: Rc::new(RefCell::new(CommandContext::new(engine, input))),
         }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -767,9 +767,13 @@ impl Cli {
         }
 
         match &self.commands {
-            Some(Commands::Repl) => mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run(),
+            Some(Commands::Repl) => {
+                let engine = self.create_engine()?;
+                mq_repl::Repl::with_engine(engine, vec![mq_lang::RuntimeValue::String("".to_string())]).run()
+            }
             None if self.query.is_none() => {
-                mq_repl::Repl::new(vec![mq_lang::RuntimeValue::String("".to_string())]).run()
+                let engine = self.create_engine()?;
+                mq_repl::Repl::with_engine(engine, vec![mq_lang::RuntimeValue::String("".to_string())]).run()
             }
             #[cfg(feature = "debugger")]
             Some(Commands::Dap) => mq_dap::start().map_err(|e| miette!(e.to_string())),

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -689,6 +689,67 @@ fn test_read_file_without_allow_read_is_blocked() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn test_repl_with_allow_read_permits_read_file() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_repl_read_file.md", "repl-read-content");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    #[cfg(unix)]
+    let path = temp_file_path.to_string_lossy().to_string();
+    #[cfg(windows)]
+    let path = temp_file_path.to_string_lossy().replace("\\", "/");
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--allow-read")
+        .arg("repl")
+        .write_stdin(format!("read_file(\"{}\")\n", path))
+        .assert();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("repl-read-content"),
+        "expected repl output to contain file contents, got: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_repl_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_repl_read_file_blocked.md", "repl-read-content");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    #[cfg(unix)]
+    let path = temp_file_path.to_string_lossy().to_string();
+    #[cfg(windows)]
+    let path = temp_file_path.to_string_lossy().replace("\\", "/");
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("repl")
+        .write_stdin(format!("read_file(\"{}\")\n", path))
+        .assert();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("filesystem reads are disabled"),
+        "expected repl output to report reads are disabled, got: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_collection() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     std::fs::write(temp_dir.path().join("a.md"), "# Hello\n")?;


### PR DESCRIPTION
## Summary

The REPL built its own DefaultEngine directly, bypassing Cli::create_engine(), so --allow-read/--allow-write/--allow-net (and other CLI-derived engine config) had no effect when running `mq repl`. Repl::new now delegates to a new Repl::with_engine(engine, input) constructor, and cli.rs passes the engine built via create_engine() into the REPL.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
