### PR TITLE
✨ feat(mq-lang): add random_string(len, charset) function

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -438,6 +438,9 @@ fn register_string(ctx: &mut InferenceContext) {
     register_nullary(ctx, "uuid", Type::String);
     register_nullary(ctx, "uuid_v4", Type::String);
     register_nullary(ctx, "uuid_v7", Type::String);
+
+    // random_string: (number, string) -> string
+    register_binary(ctx, "random_string", Type::Number, Type::String, Type::String);
 }
 
 /// Array functions: flatten, reverse, sort, uniq, compact, len, slice, insert, range, repeat
@@ -1645,6 +1648,8 @@ mod tests {
     #[case::uuid("uuid()", true)]
     #[case::uuid_v4("uuid_v4()", true)]
     #[case::uuid_v7("uuid_v7()", true)]
+    #[case::random_string("random_string(10, \"abc\")", true)]
+    #[case::random_string_wrong_types("random_string(\"10\", 1)", false)] // Should fail: wrong types
     fn test_string_encoding_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -609,6 +609,26 @@ fn sample_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
     }
 }
 
+/// Returns a random string of `len` characters, each independently chosen (with
+/// replacement) from `charset`.
+#[mq_macros::mq_fn(name = "random_string", params = Fixed(2))]
+fn random_string_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Number(len), RuntimeValue::String(charset)] if len.is_int() && len.value() >= 0.0 => {
+            let len = len.to_int() as usize;
+            let charset: Vec<char> = charset.chars().collect();
+            random::next_string(len, &charset)
+                .map(RuntimeValue::String)
+                .ok_or_else(|| Error::Runtime("random_string: charset must not be empty".to_string()))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("random_string should always receive exactly two arguments"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "from_hex", params = Fixed(1))]
 fn from_hex_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4210,6 +4230,7 @@ mq_macros::builtin_dispatch! {
     UUID_V7,
     RAND,
     RAND_INT,
+    RANDOM_STRING,
     SHUFFLE,
     SAMPLE,
     MIN,
@@ -5260,6 +5281,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Generates a pseudo-random integer uniformly distributed in [min, max] (inclusive). Not cryptographically secure.",
             params: &["min", "max"],
+        },
+    );
+    map.insert(
+        SmolStr::new("random_string"),
+        BuiltinFunctionDoc {
+            description: "Generates a random string of `len` characters, each independently chosen (with replacement) from `charset`. Not cryptographically secure.",
+            params: &["len", "charset"],
         },
     );
     map.insert(
@@ -6897,6 +6925,81 @@ mod tests {
             &env,
         );
         assert!(result.is_err(), "rand_int(10, 1) should error since min > max");
+    }
+
+    #[test]
+    fn test_random_string_uses_only_charset_chars_and_requested_length() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("random_string"),
+            vec![RuntimeValue::Number(12.into()), RuntimeValue::String("abc".into())],
+            &env,
+        )
+        .unwrap();
+        match result {
+            RuntimeValue::String(s) => {
+                assert_eq!(s.chars().count(), 12);
+                assert!(s.chars().all(|c| "abc".contains(c)));
+            }
+            other => panic!("random_string should return a string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_random_string_zero_length_is_empty() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("random_string"),
+            vec![RuntimeValue::Number(0.into()), RuntimeValue::String("abc".into())],
+            &env,
+        )
+        .unwrap();
+        assert_eq!(result, RuntimeValue::String("".into()));
+    }
+
+    #[test]
+    fn test_random_string_empty_charset_errors() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("random_string"),
+            vec![RuntimeValue::Number(5.into()), RuntimeValue::String("".into())],
+            &env,
+        );
+        assert!(
+            result.is_err(),
+            "random_string(5, \"\") should error since charset is empty"
+        );
+    }
+
+    #[test]
+    fn test_random_string_calls_are_unique() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let values: std::collections::HashSet<String> = (0..200)
+            .map(|_| {
+                match eval_builtin(
+                    &RuntimeValue::None,
+                    &Ident::new("random_string"),
+                    vec![
+                        RuntimeValue::Number(16.into()),
+                        RuntimeValue::String("abcdefghijklmnopqrstuvwxyz0123456789".into()),
+                    ],
+                    &env,
+                )
+                .unwrap()
+                {
+                    RuntimeValue::String(s) => s.to_string(),
+                    other => panic!("random_string should return a string, got {other:?}"),
+                }
+            })
+            .collect();
+        assert_eq!(
+            values.len(),
+            200,
+            "random_string(16, ...) should not repeat across calls"
+        );
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin/random.rs
+++ b/crates/mq-lang/src/eval/builtin/random.rs
@@ -42,6 +42,17 @@ pub(super) fn sample(items: &[RuntimeValue], n: usize) -> Vec<RuntimeValue> {
     items
 }
 
+/// Returns a random string of `len` characters, each chosen uniformly at random
+/// (with replacement) from `charset`. Returns `None` if `charset` is empty.
+pub(super) fn next_string(len: usize, charset: &[char]) -> Option<String> {
+    if charset.is_empty() {
+        return None;
+    }
+
+    let mut rng = rand::rng();
+    Some((0..len).map(|_| charset[rng.random_range(0..charset.len())]).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +140,24 @@ mod tests {
     fn test_sample_zero() {
         let items = nums(&[1, 2, 3]);
         assert_eq!(sample(&items, 0), Vec::<RuntimeValue>::new());
+    }
+
+    #[test]
+    fn test_next_string_uses_only_charset_chars() {
+        let charset: Vec<char> = "abc".chars().collect();
+        let s = next_string(20, &charset).unwrap();
+        assert_eq!(s.chars().count(), 20);
+        assert!(s.chars().all(|c| charset.contains(&c)));
+    }
+
+    #[test]
+    fn test_next_string_zero_length() {
+        let charset: Vec<char> = "abc".chars().collect();
+        assert_eq!(next_string(0, &charset), Some(String::new()));
+    }
+
+    #[test]
+    fn test_next_string_empty_charset() {
+        assert_eq!(next_string(5, &[]), None);
     }
 }


### PR DESCRIPTION
## Summary

Adds a nanoid-style random string generator alongside the existing uuid/uuid_v4/uuid_v7/rand/rand_int builtins, reusing the existing rand-backed random module. Registers the (number, string) -> string type signature in mq-check.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
