### PR TITLE
✨ feat(mq-lang): support arrays in ngram (each_cons-style sliding window)

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -842,7 +842,8 @@ def geomean(arr):
     end
 end
 
-# Returns the n-grams of an array, which are contiguous subarrays of length n.
+# Returns the n-grams of an array or string, which are overlapping contiguous
+# subarrays (or substrings) of length n, sliding one element at a time.
 def ngram(s, n):
   if (n <= 0):
     error("n must be a positive integer")
@@ -856,6 +857,16 @@ def ngram(s, n):
           | var i = 0
           | while (i <= len(s) - n):
               result += [s[i:i + n]]
+              | i += 1
+            end
+          | result
+        end
+      | :array:
+        do
+          var result = []
+          | var i = 0
+          | while (i <= len(s) - n):
+              result += [slice(s, i, i + n)]
               | i += 1
             end
           | result

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -859,6 +859,15 @@ def test_ngram():
 
   | let result3 = ngram("abc", 4)
   | assert_eq(result3, [])
+
+  | let result4 = ngram([1, 2, 3, 4], 2)
+  | assert_eq(result4, [[1, 2], [2, 3], [3, 4]])
+
+  | let result5 = ngram([1, 2, 3], 1)
+  | assert_eq(result5, [[1], [2], [3]])
+
+  | let result6 = ngram([1, 2], 4)
+  | assert_eq(result6, [])
 end
 
 def test_zip():


### PR DESCRIPTION
## Summary

ngram(s, n) previously only handled the :string case despite its doc comment claiming array support; passing an array fell through to the trailing error arm. Adds the :array match arm using slice(), mirroring how chunks/chunk_by already handle both array and string inputs.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
