### PR TITLE
✨ feat(mq-crawler): add retry/backoff and auth/header/cookie support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
 name = "mq-crawler"
 version = "0.6.5"
 dependencies = [
+ "base64",
  "chromiumoxide",
  "clap",
  "crossbeam",

--- a/crates/mq-crawler/Cargo.toml
+++ b/crates/mq-crawler/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/harehare/mq"
 version = "0.6.5"
 
 [dependencies]
+base64 = {workspace = true}
 chromiumoxide = {workspace = true}
 clap = {workspace = true, features = ["derive"]}
 crossbeam = {workspace = true}

--- a/crates/mq-crawler/README.md
+++ b/crates/mq-crawler/README.md
@@ -27,6 +27,9 @@ Make web scraping and content extraction effortless with intelligent Markdown co
 - **WebDriver Support**: Use Selenium WebDriver for browser-based crawling
 - **Domain Filtering**: Restrict crawling to specific domains
 - **Sitemap Ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
+- **Retry with Backoff**: Automatically retries failed requests (network errors, 429, 5xx) with exponential backoff
+- **Custom Headers & Cookies**: Send custom HTTP headers and cookies with every request
+- **Authentication**: Basic and bearer-token authentication for protected sites
 
 ## Installation
 
@@ -122,6 +125,37 @@ mq-crawl --sitemap https://example.com/sitemap.xml https://example.com
 # without following links at all.
 mq-crawl --depth 0 --sitemap https://example.com/sitemap.xml https://example.com
 ```
+
+### Retry & Backoff
+
+```bash
+# Retry failed requests (network errors, 429, 5xx) up to 5 times,
+# starting at a 1s delay and doubling up to a 30s cap
+mq-crawl --max-retries 5 --retry-initial-backoff 1 --retry-max-backoff 30 https://example.com
+
+# Disable retries entirely
+mq-crawl --max-retries 0 https://example.com
+```
+
+### Custom Headers, Cookies & Authentication
+
+```bash
+# Send a custom header with every request
+mq-crawl --header "X-Api-Key: secret" https://example.com
+
+# Send one or more cookies
+mq-crawl --cookie "session=abc123" --cookie "theme=dark" https://example.com
+
+# HTTP Basic authentication
+mq-crawl --basic-auth alice:s3cret https://example.com
+
+# Bearer token authentication
+mq-crawl --bearer-token eyJhbGciOi... https://example.com
+```
+
+> **Note**: `--header`, `--cookie`, `--basic-auth`, and `--bearer-token` apply
+> only to standard (non-browser) crawling; they are ignored with `--headless`
+> or `-U/--webdriver-url`.
 
 ### Custom Robots.txt
 
@@ -240,6 +274,22 @@ Options:
           Output format: text or json [default: text]
       --sitemap <SITEMAP_URL>
           URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from
+      --max-retries <MAX_RETRIES>
+          Maximum retry attempts for failed requests (network errors, 429, 5xx) [default: 3]
+      --retry-initial-backoff <RETRY_INITIAL_BACKOFF>
+          Delay in seconds before the first retry [default: 0.5]
+      --retry-max-backoff <RETRY_MAX_BACKOFF>
+          Maximum delay in seconds between retries [default: 10]
+      --retry-backoff-multiplier <RETRY_BACKOFF_MULTIPLIER>
+          Multiplier applied to the retry delay after each failed attempt [default: 2]
+      --header <KEY: VALUE>
+          Custom HTTP header to send with every request (repeatable); non-browser crawling only
+      --cookie <NAME=VALUE>
+          Cookie to send with every request (repeatable); non-browser crawling only
+      --basic-auth <USER:PASS>
+          HTTP Basic authentication credentials; non-browser crawling only
+      --bearer-token <TOKEN>
+          Bearer token for Authorization header; non-browser crawling only
       --extract-scripts-as-code-blocks
           Extract <script> tags as code blocks in Markdown
       --generate-front-matter

--- a/crates/mq-crawler/src/http_client.rs
+++ b/crates/mq-crawler/src/http_client.rs
@@ -11,20 +11,18 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use tokio::time::sleep;
 use url::Url;
 
-/// Configuration for retrying failed requests with exponential backoff.
+/// Exponential backoff config for retrying failed requests.
 ///
-/// Retries apply to network-level failures and to responses with status
-/// `429 Too Many Requests` or any `5xx` server error. Other client errors
-/// (e.g. `404`, `401`, `403`) are not retried.
+/// Retries on network errors, `429`, and `5xx`; other client errors (e.g. `404`) are not retried.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RetryConfig {
-    /// Maximum number of retry attempts after the initial request fails.
+    /// Retry attempts after the initial request fails.
     pub max_retries: u32,
     /// Delay before the first retry.
     pub initial_backoff: Duration,
-    /// Upper bound on the backoff delay between retries.
+    /// Upper bound on the backoff delay.
     pub max_backoff: Duration,
-    /// Multiplier applied to the backoff delay after each failed attempt.
+    /// Multiplier applied to the backoff delay after each attempt.
     pub backoff_multiplier: f64,
 }
 
@@ -54,18 +52,16 @@ impl RetryConfig {
     }
 }
 
-/// Authentication credentials applied as a default `Authorization` header
-/// on requests made by a `reqwest`-based [`HttpClient`].
+/// Default `Authorization` header credentials for a `reqwest`-based [`HttpClient`].
 #[derive(Debug, Clone)]
 pub enum AuthConfig {
-    /// HTTP Basic authentication (`Authorization: Basic <base64(user:pass)>`).
+    /// `Authorization: Basic <base64(user:pass)>`.
     Basic { username: String, password: Option<String> },
-    /// Bearer token authentication (`Authorization: Bearer <token>`).
+    /// `Authorization: Bearer <token>`.
     Bearer { token: String },
 }
 
-/// Distinguishes transient failures (worth retrying) from failures that
-/// will not be resolved by retrying the same request.
+/// Transient (worth retrying) vs. fatal failures.
 enum FetchError {
     Retryable(String),
     Fatal(String),
@@ -145,13 +141,9 @@ impl HttpClient {
         )
     }
 
-    /// Create a new reqwest-based HTTP client with full control over retry
-    /// behavior, default headers/cookies, and authentication.
+    /// Create a reqwest-based HTTP client with retry, default headers/cookies, and auth.
     ///
-    /// `headers` is sent as default headers on every request (useful for
-    /// custom headers or a static `Cookie` header). `auth`, if provided,
-    /// sets the `Authorization` header and takes precedence over any
-    /// `Authorization` entry already present in `headers`.
+    /// `auth`, if set, overrides any `Authorization` entry already in `headers`.
     pub fn new_reqwest_with_options(
         timeout: f64,
         max_idle_per_host: usize,

--- a/crates/mq-crawler/src/http_client.rs
+++ b/crates/mq-crawler/src/http_client.rs
@@ -2,10 +2,82 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use chromiumoxide::cdp::browser_protocol::page::EventLifecycleEvent;
 use futures::StreamExt;
 use reqwest::Client as ReqwestClient;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use tokio::time::sleep;
 use url::Url;
+
+/// Configuration for retrying failed requests with exponential backoff.
+///
+/// Retries apply to network-level failures and to responses with status
+/// `429 Too Many Requests` or any `5xx` server error. Other client errors
+/// (e.g. `404`, `401`, `403`) are not retried.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts after the initial request fails.
+    pub max_retries: u32,
+    /// Delay before the first retry.
+    pub initial_backoff: Duration,
+    /// Upper bound on the backoff delay between retries.
+    pub max_backoff: Duration,
+    /// Multiplier applied to the backoff delay after each failed attempt.
+    pub backoff_multiplier: f64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(500),
+            max_backoff: Duration::from_secs(10),
+            backoff_multiplier: 2.0,
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Disables retries; a failed request fails immediately.
+    pub fn disabled() -> Self {
+        Self {
+            max_retries: 0,
+            ..Default::default()
+        }
+    }
+
+    fn next_backoff(&self, current: Duration) -> Duration {
+        let multiplier = self.backoff_multiplier.max(1.0);
+        Duration::from_secs_f64(current.as_secs_f64() * multiplier).min(self.max_backoff)
+    }
+}
+
+/// Authentication credentials applied as a default `Authorization` header
+/// on requests made by a `reqwest`-based [`HttpClient`].
+#[derive(Debug, Clone)]
+pub enum AuthConfig {
+    /// HTTP Basic authentication (`Authorization: Basic <base64(user:pass)>`).
+    Basic { username: String, password: Option<String> },
+    /// Bearer token authentication (`Authorization: Bearer <token>`).
+    Bearer { token: String },
+}
+
+/// Distinguishes transient failures (worth retrying) from failures that
+/// will not be resolved by retrying the same request.
+enum FetchError {
+    Retryable(String),
+    Fatal(String),
+}
+
+impl FetchError {
+    fn into_message(self) -> String {
+        match self {
+            FetchError::Retryable(msg) | FetchError::Fatal(msg) => msg,
+        }
+    }
+}
 
 /// Wait strategy configuration for headless Chrome.
 ///
@@ -30,8 +102,8 @@ pub struct ChromiumWaitConfig {
 /// Enum for different HTTP client implementations
 #[derive(Debug, Clone)]
 pub enum HttpClient {
-    Reqwest(ReqwestClient),
-    Fantoccini(fantoccini::Client),
+    Reqwest(ReqwestClient, RetryConfig),
+    Fantoccini(fantoccini::Client, RetryConfig),
     /// Headless Chrome via CDP.
     /// `new_page()` waits for the `load` event, which covers synchronous JS
     /// execution. Additional wait strategies in [`ChromiumWaitConfig`] can be
@@ -39,6 +111,7 @@ pub enum HttpClient {
     Chromium(
         Arc<chromiumoxide::Browser>,
         ChromiumWaitConfig,
+        RetryConfig,
         Option<Arc<tempfile::TempDir>>,
     ),
 }
@@ -50,6 +123,7 @@ impl Default for HttpClient {
                 .user_agent(format!("mq crawler/0.1 ({})", env!("CARGO_PKG_HOMEPAGE")))
                 .build()
                 .expect("Failed to build default reqwest client"),
+            RetryConfig::default(),
         )
     }
 }
@@ -57,31 +131,64 @@ impl Default for HttpClient {
 impl HttpClient {
     /// Create a new reqwest-based HTTP client optimized for single-domain crawling
     pub fn new_reqwest(timeout: f64) -> Result<Self, String> {
-        let client = ReqwestClient::builder()
-            .user_agent(format!("mq crawler/0.1 ({})", env!("CARGO_PKG_HOMEPAGE")))
-            // Optimize for single-domain crawling
-            .pool_max_idle_per_host(3)
-            .pool_idle_timeout(Duration::from_secs(90))
-            .timeout(Duration::from_secs(timeout as u64))
-            .connect_timeout(Duration::from_secs(10))
-            .tcp_keepalive(Duration::from_secs(120))
-            .build()
-            .map_err(|e| format!("Failed to build reqwest client: {}", e))?;
-        Ok(Self::Reqwest(client))
+        Self::new_reqwest_with_options(timeout, 3, RetryConfig::default(), HeaderMap::new(), None)
     }
 
     /// Create a new reqwest-based HTTP client optimized for multi-domain crawling
     pub fn new_reqwest_multi_domain(timeout: f64, max_idle_per_host: usize) -> Result<Self, String> {
-        let client = ReqwestClient::builder()
+        Self::new_reqwest_with_options(
+            timeout,
+            max_idle_per_host,
+            RetryConfig::default(),
+            HeaderMap::new(),
+            None,
+        )
+    }
+
+    /// Create a new reqwest-based HTTP client with full control over retry
+    /// behavior, default headers/cookies, and authentication.
+    ///
+    /// `headers` is sent as default headers on every request (useful for
+    /// custom headers or a static `Cookie` header). `auth`, if provided,
+    /// sets the `Authorization` header and takes precedence over any
+    /// `Authorization` entry already present in `headers`.
+    pub fn new_reqwest_with_options(
+        timeout: f64,
+        max_idle_per_host: usize,
+        retry_config: RetryConfig,
+        headers: HeaderMap,
+        auth: Option<AuthConfig>,
+    ) -> Result<Self, String> {
+        let mut header_map = headers;
+
+        if let Some(auth) = auth {
+            let value = match auth {
+                AuthConfig::Basic { username, password } => {
+                    let credentials = format!("{}:{}", username, password.unwrap_or_default());
+                    format!("Basic {}", BASE64.encode(credentials))
+                }
+                AuthConfig::Bearer { token } => format!("Bearer {}", token),
+            };
+            let header_value = HeaderValue::from_str(&value).map_err(|e| format!("Invalid auth credentials: {}", e))?;
+            header_map.insert(AUTHORIZATION, header_value);
+        }
+
+        let mut builder = ReqwestClient::builder()
             .user_agent(format!("mq crawler/0.1 ({})", env!("CARGO_PKG_HOMEPAGE")))
             .pool_max_idle_per_host(max_idle_per_host)
             .pool_idle_timeout(Duration::from_secs(90))
             .timeout(Duration::from_secs(timeout as u64))
             .connect_timeout(Duration::from_secs(10))
-            .tcp_keepalive(Duration::from_secs(120))
+            .tcp_keepalive(Duration::from_secs(120));
+
+        if !header_map.is_empty() {
+            builder = builder.default_headers(header_map);
+        }
+
+        let client = builder
             .build()
             .map_err(|e| format!("Failed to build reqwest client: {}", e))?;
-        Ok(Self::Reqwest(client))
+        Ok(Self::Reqwest(client, retry_config))
     }
 
     /// Create a headless Chrome client that launches Chrome/Chromium automatically.
@@ -92,7 +199,11 @@ impl HttpClient {
     /// synchronous JavaScript execution. Additional wait strategies in
     /// [`ChromiumWaitConfig`] (network-idle, CSS selector polling, fixed delay)
     /// can be layered on top for SPAs that fetch data asynchronously after load.
-    pub async fn new_chromium(chrome_path: Option<PathBuf>, wait_config: ChromiumWaitConfig) -> Result<Self, String> {
+    pub async fn new_chromium(
+        chrome_path: Option<PathBuf>,
+        wait_config: ChromiumWaitConfig,
+        retry_config: RetryConfig,
+    ) -> Result<Self, String> {
         let mut config_builder = chromiumoxide::browser::BrowserConfig::builder().arg("--disable-gpu");
 
         if let Some(path) = chrome_path {
@@ -122,44 +233,93 @@ impl HttpClient {
             }
         });
 
-        Ok(Self::Chromium(Arc::new(browser), wait_config, Some(Arc::new(temp_dir))))
+        Ok(Self::Chromium(
+            Arc::new(browser),
+            wait_config,
+            retry_config,
+            Some(Arc::new(temp_dir)),
+        ))
     }
 
-    /// Fetch content from a URL
-    pub async fn fetch(&self, url: Url) -> Result<String, String> {
+    fn retry_config(&self) -> &RetryConfig {
         match self {
-            HttpClient::Reqwest(client) => {
+            HttpClient::Reqwest(_, retry_config) => retry_config,
+            HttpClient::Fantoccini(_, retry_config) => retry_config,
+            HttpClient::Chromium(_, _, retry_config, _) => retry_config,
+        }
+    }
+
+    /// Fetch content from a URL, retrying transient failures with
+    /// exponential backoff according to this client's [`RetryConfig`].
+    pub async fn fetch(&self, url: Url) -> Result<String, String> {
+        let retry_config = self.retry_config().clone();
+        let mut backoff = retry_config.initial_backoff;
+        let mut attempt: u32 = 0;
+
+        loop {
+            match self.fetch_once(url.clone()).await {
+                Ok(content) => return Ok(content),
+                Err(FetchError::Retryable(msg)) if attempt < retry_config.max_retries => {
+                    attempt += 1;
+                    tracing::warn!(
+                        "Fetch attempt {}/{} failed for {}: {}. Retrying in {:?}.",
+                        attempt,
+                        retry_config.max_retries,
+                        url,
+                        msg,
+                        backoff
+                    );
+                    sleep(backoff).await;
+                    backoff = retry_config.next_backoff(backoff);
+                }
+                Err(err) => return Err(err.into_message()),
+            }
+        }
+    }
+
+    async fn fetch_once(&self, url: Url) -> Result<String, FetchError> {
+        match self {
+            HttpClient::Reqwest(client, _) => {
                 let response = client
                     .get(url.clone())
                     .send()
                     .await
-                    .map_err(|e| format!("Failed to fetch URL {}: {}", url, e))?;
+                    .map_err(|e| FetchError::Retryable(format!("Failed to fetch URL {}: {}", url, e)))?;
 
-                if response.status().is_success() {
+                let status = response.status();
+                if status.is_success() {
                     response
                         .text()
                         .await
-                        .map_err(|e| format!("Failed to read response text: {}", e))
+                        .map_err(|e| FetchError::Retryable(format!("Failed to read response text: {}", e)))
+                } else if status.as_u16() == 429 || status.is_server_error() {
+                    Err(FetchError::Retryable(format!(
+                        "Request to {} failed with status: {}",
+                        url, status
+                    )))
                 } else {
-                    Err(format!("Request to {} failed with status: {}", url, response.status()))
+                    Err(FetchError::Fatal(format!(
+                        "Request to {} failed with status: {}",
+                        url, status
+                    )))
                 }
             }
-            HttpClient::Fantoccini(client) => {
+            HttpClient::Fantoccini(client, _) => {
                 let url_str = url.as_str();
 
                 client
                     .goto(url_str)
                     .await
-                    .map_err(|e| format!("Fantoccini failed to navigate to {}: {}", url, e))?;
+                    .map_err(|e| FetchError::Retryable(format!("Fantoccini failed to navigate to {}: {}", url, e)))?;
 
                 let page_source = client
                     .source()
                     .await
-                    .map_err(|e| format!("Fantoccini failed to get page source: {}", e))?;
+                    .map_err(|e| FetchError::Retryable(format!("Fantoccini failed to get page source: {}", e)))?;
 
                 Ok(page_source)
             }
-            HttpClient::Chromium(browser, config, _) => {
+            HttpClient::Chromium(browser, config, _, _) => {
                 // Open a blank page first so we can register event listeners
                 // BEFORE navigating. This eliminates the race condition where
                 // networkIdle fires between the `load` event and listener
@@ -167,7 +327,7 @@ impl HttpClient {
                 let page = browser
                     .new_page("about:blank")
                     .await
-                    .map_err(|e| format!("Chrome failed to open blank page: {}", e))?;
+                    .map_err(|e| FetchError::Retryable(format!("Chrome failed to open blank page: {}", e)))?;
 
                 // Strategy 1: register the networkIdle listener BEFORE navigation
                 // so no lifecycle event can slip past between load and registration.
@@ -244,7 +404,7 @@ impl HttpClient {
 
                 let _ = page.close().await;
 
-                result
+                result.map_err(FetchError::Retryable)
             }
         }
     }
@@ -257,12 +417,121 @@ mod tests {
     #[test]
     fn test_default_client_creation() {
         let client = HttpClient::default();
-        assert!(matches!(client, HttpClient::Reqwest(_)));
+        assert!(matches!(client, HttpClient::Reqwest(_, _)));
     }
 
     #[test]
     fn test_new_reqwest_client() {
         let client = HttpClient::new_reqwest(30.0).unwrap();
-        assert!(matches!(client, HttpClient::Reqwest(_)));
+        assert!(matches!(client, HttpClient::Reqwest(_, _)));
+        assert_eq!(client.retry_config(), &RetryConfig::default());
+    }
+
+    #[test]
+    fn test_new_reqwest_with_basic_auth() {
+        let client = HttpClient::new_reqwest_with_options(
+            30.0,
+            3,
+            RetryConfig::default(),
+            HeaderMap::new(),
+            Some(AuthConfig::Basic {
+                username: "user".to_string(),
+                password: Some("pass".to_string()),
+            }),
+        )
+        .unwrap();
+        assert!(matches!(client, HttpClient::Reqwest(_, _)));
+    }
+
+    #[test]
+    fn test_new_reqwest_with_bearer_auth() {
+        let client = HttpClient::new_reqwest_with_options(
+            30.0,
+            3,
+            RetryConfig::default(),
+            HeaderMap::new(),
+            Some(AuthConfig::Bearer {
+                token: "secret-token".to_string(),
+            }),
+        )
+        .unwrap();
+        assert!(matches!(client, HttpClient::Reqwest(_, _)));
+    }
+
+    #[test]
+    fn test_retry_config_next_backoff_respects_max() {
+        let retry_config = RetryConfig {
+            max_retries: 5,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(3),
+            backoff_multiplier: 2.0,
+        };
+
+        let backoff = retry_config.next_backoff(Duration::from_secs(1));
+        assert_eq!(backoff, Duration::from_secs(2));
+
+        let backoff = retry_config.next_backoff(backoff);
+        assert_eq!(backoff, Duration::from_secs(3));
+
+        let backoff = retry_config.next_backoff(backoff);
+        assert_eq!(backoff, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_retry_config_disabled() {
+        let retry_config = RetryConfig::disabled();
+        assert_eq!(retry_config.max_retries, 0);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_retries_on_server_error_then_succeeds() {
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/flaky");
+                then.status(503);
+            })
+            .await;
+
+        let retry_config = RetryConfig {
+            max_retries: 2,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(5),
+            backoff_multiplier: 2.0,
+        };
+        let client = HttpClient::new_reqwest_with_options(5.0, 3, retry_config, HeaderMap::new(), None).unwrap();
+        let url = Url::parse(&format!("http://{}/flaky", server.address())).unwrap();
+
+        let result = client.fetch(url).await;
+        assert!(result.is_err());
+        assert_eq!(mock.calls_async().await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_does_not_retry_on_client_error() {
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/missing");
+                then.status(404);
+            })
+            .await;
+
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(5),
+            backoff_multiplier: 2.0,
+        };
+        let client = HttpClient::new_reqwest_with_options(5.0, 3, retry_config, HeaderMap::new(), None).unwrap();
+        let url = Url::parse(&format!("http://{}/missing", server.address())).unwrap();
+
+        let result = client.fetch(url).await;
+        assert!(result.is_err());
+        assert_eq!(mock.calls_async().await, 1);
     }
 }

--- a/crates/mq-crawler/src/lib.rs
+++ b/crates/mq-crawler/src/lib.rs
@@ -12,7 +12,9 @@
 //! - Link discovery and following
 //! - sitemap.xml ingestion as a seed-URL source
 //! - Crawl statistics and result tracking
-//! - Support for custom HTTP headers and user agents
+//! - Support for custom HTTP headers, cookies, and user agents
+//! - Basic and bearer authentication for protected sites
+//! - Automatic retry with exponential backoff for failed requests
 //! - Rate limiting and politeness delays
 //!
 //! # Usage

--- a/crates/mq-crawler/src/main.rs
+++ b/crates/mq-crawler/src/main.rs
@@ -103,41 +103,35 @@ struct CliArgs {
     /// subject to robots.txt, domain filtering, and depth limits.
     #[clap(long, value_name = "SITEMAP_URL")]
     sitemap: Option<Url>,
-    /// Maximum number of retry attempts for a request that fails with a network error,
-    /// a 429 (Too Many Requests), or a 5xx server error.
+    /// Max retry attempts on network error, 429, or 5xx.
     #[clap(long, default_value_t = 3)]
     max_retries: u32,
-    /// Delay (in seconds) before the first retry.
+    /// Delay (seconds) before the first retry.
     #[clap(long, default_value_t = 0.5)]
     retry_initial_backoff: f64,
-    /// Maximum delay (in seconds) between retries.
+    /// Max delay (seconds) between retries.
     #[clap(long, default_value_t = 10.0)]
     retry_max_backoff: f64,
-    /// Multiplier applied to the retry delay after each failed attempt.
+    /// Retry delay multiplier per failed attempt.
     #[clap(long, default_value_t = 2.0)]
     retry_backoff_multiplier: f64,
-    /// Custom HTTP header to send with every request, in "Key: Value" form.
-    /// Can be specified multiple times. Only applies to non-browser crawling.
+    /// Custom header ("Key: Value"), repeatable. Non-browser crawling only.
     #[clap(long = "header", value_name = "KEY: VALUE")]
     headers: Vec<String>,
-    /// Cookie to send with every request, in "name=value" form. Can be specified
-    /// multiple times; all values are combined into a single Cookie header.
-    /// Only applies to non-browser crawling.
+    /// Cookie ("name=value"), repeatable, combined into one Cookie header. Non-browser crawling only.
     #[clap(long, value_name = "NAME=VALUE")]
     cookie: Vec<String>,
-    /// HTTP Basic authentication credentials, in "username:password" form.
-    /// Only applies to non-browser crawling.
+    /// HTTP Basic auth ("username:password"). Non-browser crawling only.
     #[clap(long, value_name = "USER:PASS", conflicts_with = "bearer_token")]
     basic_auth: Option<String>,
-    /// Bearer token sent as "Authorization: Bearer <token>".
-    /// Only applies to non-browser crawling.
+    /// Bearer token for "Authorization: Bearer <token>". Non-browser crawling only.
     #[clap(long, value_name = "TOKEN", conflicts_with = "basic_auth")]
     bearer_token: Option<String>,
     #[clap(flatten)]
     pub conversion: ConversionArgs,
 }
 
-/// Parses a "Key: Value" header string into a `(HeaderName, HeaderValue)` pair.
+/// Parses a "Key: Value" header string.
 fn parse_header(raw: &str) -> Result<(reqwest::header::HeaderName, reqwest::header::HeaderValue), String> {
     let (name, value) = raw
         .split_once(':')
@@ -149,8 +143,7 @@ fn parse_header(raw: &str) -> Result<(reqwest::header::HeaderName, reqwest::head
     Ok((name, value))
 }
 
-/// Builds the default `HeaderMap` (custom headers plus a combined Cookie header)
-/// applied to every request made by the reqwest-based HTTP client.
+/// Builds the default headers (custom headers plus a combined Cookie header).
 fn build_header_map(headers: &[String], cookies: &[String]) -> Result<reqwest::header::HeaderMap, String> {
     let mut header_map = reqwest::header::HeaderMap::new();
 

--- a/crates/mq-crawler/src/main.rs
+++ b/crates/mq-crawler/src/main.rs
@@ -103,8 +103,70 @@ struct CliArgs {
     /// subject to robots.txt, domain filtering, and depth limits.
     #[clap(long, value_name = "SITEMAP_URL")]
     sitemap: Option<Url>,
+    /// Maximum number of retry attempts for a request that fails with a network error,
+    /// a 429 (Too Many Requests), or a 5xx server error.
+    #[clap(long, default_value_t = 3)]
+    max_retries: u32,
+    /// Delay (in seconds) before the first retry.
+    #[clap(long, default_value_t = 0.5)]
+    retry_initial_backoff: f64,
+    /// Maximum delay (in seconds) between retries.
+    #[clap(long, default_value_t = 10.0)]
+    retry_max_backoff: f64,
+    /// Multiplier applied to the retry delay after each failed attempt.
+    #[clap(long, default_value_t = 2.0)]
+    retry_backoff_multiplier: f64,
+    /// Custom HTTP header to send with every request, in "Key: Value" form.
+    /// Can be specified multiple times. Only applies to non-browser crawling.
+    #[clap(long = "header", value_name = "KEY: VALUE")]
+    headers: Vec<String>,
+    /// Cookie to send with every request, in "name=value" form. Can be specified
+    /// multiple times; all values are combined into a single Cookie header.
+    /// Only applies to non-browser crawling.
+    #[clap(long, value_name = "NAME=VALUE")]
+    cookie: Vec<String>,
+    /// HTTP Basic authentication credentials, in "username:password" form.
+    /// Only applies to non-browser crawling.
+    #[clap(long, value_name = "USER:PASS", conflicts_with = "bearer_token")]
+    basic_auth: Option<String>,
+    /// Bearer token sent as "Authorization: Bearer <token>".
+    /// Only applies to non-browser crawling.
+    #[clap(long, value_name = "TOKEN", conflicts_with = "basic_auth")]
+    bearer_token: Option<String>,
     #[clap(flatten)]
     pub conversion: ConversionArgs,
+}
+
+/// Parses a "Key: Value" header string into a `(HeaderName, HeaderValue)` pair.
+fn parse_header(raw: &str) -> Result<(reqwest::header::HeaderName, reqwest::header::HeaderValue), String> {
+    let (name, value) = raw
+        .split_once(':')
+        .ok_or_else(|| format!("Invalid header '{}': expected 'Key: Value'", raw))?;
+    let name = reqwest::header::HeaderName::from_bytes(name.trim().as_bytes())
+        .map_err(|e| format!("Invalid header name in '{}': {}", raw, e))?;
+    let value = reqwest::header::HeaderValue::from_str(value.trim())
+        .map_err(|e| format!("Invalid header value in '{}': {}", raw, e))?;
+    Ok((name, value))
+}
+
+/// Builds the default `HeaderMap` (custom headers plus a combined Cookie header)
+/// applied to every request made by the reqwest-based HTTP client.
+fn build_header_map(headers: &[String], cookies: &[String]) -> Result<reqwest::header::HeaderMap, String> {
+    let mut header_map = reqwest::header::HeaderMap::new();
+
+    for raw in headers {
+        let (name, value) = parse_header(raw)?;
+        header_map.insert(name, value);
+    }
+
+    if !cookies.is_empty() {
+        let cookie_value = cookies.join("; ");
+        let value = reqwest::header::HeaderValue::from_str(&cookie_value)
+            .map_err(|e| format!("Invalid cookie value '{}': {}", cookie_value, e))?;
+        header_map.insert(reqwest::header::COOKIE, value);
+    }
+
+    Ok(header_map)
 }
 
 /// Options for Markdown conversion.
@@ -153,25 +215,65 @@ async fn main() {
         v
     });
 
-    let client = if let Some(url) = args.webdriver_url {
-        mq_crawler::http_client::HttpClient::Fantoccini({
-            let fantoccini_client = fantoccini::ClientBuilder::rustls()
-                .expect("Failed to create rustls client builder")
-                .connect(url.as_ref())
-                .await
-                .expect("Failed to connect to WebDriver");
+    let retry_config = mq_crawler::http_client::RetryConfig {
+        max_retries: args.max_retries,
+        initial_backoff: std::time::Duration::from_secs_f64(args.retry_initial_backoff.max(0.0)),
+        max_backoff: std::time::Duration::from_secs_f64(args.retry_max_backoff.max(0.0)),
+        backoff_multiplier: args.retry_backoff_multiplier,
+    };
 
-            fantoccini_client
-                .update_timeouts(TimeoutConfiguration::new(
-                    Some(std::time::Duration::from_secs_f64(args.script_timeout)),
-                    Some(std::time::Duration::from_secs_f64(args.page_load_timeout)),
-                    Some(std::time::Duration::from_secs_f64(args.implicit_timeout)),
-                ))
-                .await
-                .expect("Failed to set timeouts on Fantoccini client");
+    let header_map = match build_header_map(&args.headers, &args.cookie) {
+        Ok(header_map) => header_map,
+        Err(e) => {
+            tracing::error!("{}", e);
+            return;
+        }
+    };
 
-            fantoccini_client
+    let auth = if let Some(ref basic) = args.basic_auth {
+        let (username, password) = basic.split_once(':').unwrap_or((basic.as_str(), ""));
+        Some(mq_crawler::http_client::AuthConfig::Basic {
+            username: username.to_string(),
+            password: if password.is_empty() {
+                None
+            } else {
+                Some(password.to_string())
+            },
         })
+    } else {
+        args.bearer_token
+            .clone()
+            .map(|token| mq_crawler::http_client::AuthConfig::Bearer { token })
+    };
+
+    if (args.webdriver_url.is_some() || args.headless) && (!header_map.is_empty() || auth.is_some()) {
+        tracing::warn!(
+            "--header, --cookie, --basic-auth, and --bearer-token only apply to non-browser crawling and will be ignored."
+        );
+    }
+
+    let client = if let Some(url) = args.webdriver_url {
+        mq_crawler::http_client::HttpClient::Fantoccini(
+            {
+                let fantoccini_client = fantoccini::ClientBuilder::rustls()
+                    .expect("Failed to create rustls client builder")
+                    .connect(url.as_ref())
+                    .await
+                    .expect("Failed to connect to WebDriver");
+
+                fantoccini_client
+                    .update_timeouts(TimeoutConfiguration::new(
+                        Some(std::time::Duration::from_secs_f64(args.script_timeout)),
+                        Some(std::time::Duration::from_secs_f64(args.page_load_timeout)),
+                        Some(std::time::Duration::from_secs_f64(args.implicit_timeout)),
+                    ))
+                    .await
+                    .expect("Failed to set timeouts on Fantoccini client");
+
+                fantoccini_client
+            },
+            retry_config.clone(),
+        )
     } else if args.headless {
         let headless_wait_secs = if !args.headless_wait.is_finite() || args.headless_wait < 0.0 {
             tracing::warn!(
@@ -203,14 +305,27 @@ async fn main() {
             strategy_timeout,
         };
 
-        mq_crawler::http_client::HttpClient::new_chromium(args.chrome_path, wait_config)
+        mq_crawler::http_client::HttpClient::new_chromium(args.chrome_path, wait_config, retry_config.clone())
             .await
             .expect("Failed to launch headless Chrome. Ensure Chrome or Chromium is installed.")
     } else if effective_allowed.is_some() {
-        mq_crawler::http_client::HttpClient::new_reqwest_multi_domain(args.page_load_timeout, args.concurrency.max(5))
-            .unwrap()
+        mq_crawler::http_client::HttpClient::new_reqwest_with_options(
+            args.page_load_timeout,
+            args.concurrency.max(5),
+            retry_config,
+            header_map,
+            auth,
+        )
+        .unwrap()
     } else {
-        mq_crawler::http_client::HttpClient::new_reqwest(args.page_load_timeout).unwrap()
+        mq_crawler::http_client::HttpClient::new_reqwest_with_options(
+            args.page_load_timeout,
+            3,
+            retry_config,
+            header_map,
+            auth,
+        )
+        .unwrap()
     };
 
     let format = match args.format {

--- a/docs/books/src/start/crawler.md
+++ b/docs/books/src/start/crawler.md
@@ -13,6 +13,9 @@ mq-crawler is a web crawler that fetches HTML content from websites, converts it
 - **WebDriver support**: Browser-based crawling via Selenium WebDriver
 - **Domain filtering**: Restrict crawling to specific domains
 - **Sitemap ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
+- **Retry with backoff**: Automatically retries failed requests (network errors, 429, 5xx) with exponential backoff
+- **Custom headers & cookies**: Send custom HTTP headers and cookies with every request
+- **Authentication**: Basic and bearer-token authentication for protected sites
 
 ## Installation
 
@@ -68,6 +71,14 @@ mq-crawl [OPTIONS] <URL>
 | `--robots-path <PATH>` | Custom robots.txt file path | — |
 | `--allowed-domains <DOMAINS>` | Comma-separated list of extra domains to crawl; the start URL's domain is always included | start domain only |
 | `--sitemap <SITEMAP_URL>` | URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from | — |
+| `--max-retries <N>` | Maximum retry attempts for failed requests (network errors, 429, 5xx) | `3` |
+| `--retry-initial-backoff <SECONDS>` | Delay before the first retry | `0.5` |
+| `--retry-max-backoff <SECONDS>` | Maximum delay between retries | `10` |
+| `--retry-backoff-multiplier <FLOAT>` | Multiplier applied to the retry delay after each failed attempt | `2` |
+| `--header <KEY: VALUE>` | Custom HTTP header to send with every request (repeatable); non-browser crawling only | — |
+| `--cookie <NAME=VALUE>` | Cookie to send with every request (repeatable); non-browser crawling only | — |
+| `--basic-auth <USER:PASS>` | HTTP Basic authentication credentials; non-browser crawling only | — |
+| `--bearer-token <TOKEN>` | Bearer token for `Authorization` header; non-browser crawling only | — |
 | `--headless` | Use built-in headless Chrome (Chrome/Chromium must be installed) | — |
 | `--chrome-path <PATH>` | Path to Chrome/Chromium executable (requires `--headless`) | auto-detect |
 | `-U, --webdriver-url <URL>` | External WebDriver URL for browser-based crawling | — |
@@ -118,6 +129,36 @@ mq-crawl --sitemap https://example.com/sitemap.xml https://example.com
 # Combine with --depth 0 to crawl exactly the pages listed in the sitemap
 # without following any links.
 mq-crawl --depth 0 --sitemap https://example.com/sitemap.xml https://example.com
+```
+
+### Retry & Backoff
+
+Failed requests (network errors, `429 Too Many Requests`, and `5xx` server errors) are retried automatically with exponential backoff:
+
+```bash
+# Retry up to 5 times, starting at a 1s delay and doubling up to a 30s cap
+mq-crawl --max-retries 5 --retry-initial-backoff 1 --retry-max-backoff 30 https://example.com
+
+# Disable retries entirely
+mq-crawl --max-retries 0 https://example.com
+```
+
+### Custom Headers, Cookies & Authentication
+
+Use `--header`, `--cookie`, `--basic-auth`, or `--bearer-token` to crawl sites that require authentication. These apply to standard (non-browser) crawling only — they are ignored with `--headless` or `-U/--webdriver-url`:
+
+```bash
+# Custom header
+mq-crawl --header "X-Api-Key: secret" https://example.com
+
+# One or more cookies (combined into a single Cookie header)
+mq-crawl --cookie "session=abc123" --cookie "theme=dark" https://example.com
+
+# HTTP Basic authentication
+mq-crawl --basic-auth alice:s3cret https://example.com
+
+# Bearer token authentication
+mq-crawl --bearer-token eyJhbGciOi... https://example.com
 ```
 
 ### Headless Chrome


### PR DESCRIPTION
## Summary

Failed requests (network errors, 429, 5xx) are now retried with configurable exponential backoff, and crawls can carry custom HTTP headers, cookies, and basic/bearer auth credentials for sites that require authentication.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
