### PR TITLE
✨ feat(mq-web-api): add POST /api/v1/batch endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rayon",
  "rstest",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The [Playground](https://mqlang.org/playground) lets you run mq queries in the b
 
 ### mq-web-api
 
-[mq-web-api](https://github.com/harehare/mq/tree/main/crates/mq-web-api) is an HTTP/REST server that exposes mq queries over the network, with a curl-friendly shortcut endpoint, JSON API, OpenAPI spec, and Swagger UI. See the [mq-web-api documentation](https://mqlang.org/book/start/web_api.html) for endpoints, configuration, and self-hosting instructions.
+[mq-web-api](https://github.com/harehare/mq/tree/main/crates/mq-web-api) is an HTTP/REST server that exposes mq queries over the network, with a curl-friendly shortcut endpoint, JSON API, OpenAPI spec, and Swagger UI. See the [mq-web-api documentation](https://mqlang.org/book/start/web_api) for endpoints, configuration, and self-hosting instructions.
 
 ```bash
 curl --data-binary @doc.md https://api.mqlang.org/.h1

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -30,6 +30,7 @@ mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["cst"]}
 mq-lint = {workspace = true}
 mq-markdown = {workspace = true, features = ["json"]}
+rayon = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
 thiserror = {workspace = true}

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -10,6 +10,7 @@ HTTP/REST server that exposes the [mq](https://mqlang.org/) markdown query langu
 | `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw body (Markdown/HTML/XML/JSON/CSV/...) |
 | `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
+| `POST` | `/api/v1/batch` | Execute a query against multiple documents in one request |
 | `POST` | `/api/v1/check` | Type-check a query |
 | `POST` | `/api/v1/format` | Format a query |
 | `GET` | `/api/v1/functions` | List builtin mq functions |
@@ -85,6 +86,42 @@ For queries that need `modules`, `args`, or `aggregate`, use `POST /api/v1/query
 | `modules` | `string[]?` | Builtin module names to load (e.g. `"json"`, `"csv"`) |
 | `args` | `object?` | String variables passed to the engine |
 | `aggregate` | `bool?` | Aggregate all input nodes before querying (equivalent to CLI `-A`) |
+
+### `POST /api/v1/batch`
+
+Runs one query against multiple documents in a single request, avoiding an HTTP round trip per document. Each document is processed independently — one failing document doesn't fail the others.
+
+```json
+{
+  "query": ".h1",
+  "inputs": ["# Doc One\n\nBody.", "# Doc Two\n\nBody."],
+  "input_format": "markdown",
+  "output_format": "markdown"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query` | `string` | mq query string |
+| `inputs` | `string[]` | Documents to run the query against, one per entry (max 100) |
+| `input_format` | `string?` | Same as `POST /api/v1/query` |
+| `output_format` | `string?` | Same as `POST /api/v1/query` |
+| `modules` | `string[]?` | Same as `POST /api/v1/query` |
+| `args` | `object?` | Same as `POST /api/v1/query` |
+| `aggregate` | `bool?` | Same as `POST /api/v1/query` |
+
+Response, `items` ordered like `inputs`:
+
+```json
+{
+  "items": [
+    { "results": ["# Doc One"], "error": null },
+    { "results": ["# Doc Two"], "error": null }
+  ]
+}
+```
+
+Returns HTTP 400 if `inputs` has more than 100 entries.
 
 ### `POST /api/v1/check`
 
@@ -232,6 +269,18 @@ curl -X POST http://localhost:8080/api/v1/query \
   -d '{
     "query": ".h",
     "input": "# Title\n\nContent",
+    "input_format": "markdown"
+  }'
+```
+
+### Batch query (multiple documents in one request)
+
+```bash
+curl -X POST http://localhost:8080/api/v1/batch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": ".h1",
+    "inputs": ["# Doc One\n\nBody.", "# Doc Two\n\nBody."],
     "input_format": "markdown"
   }'
 ```

--- a/crates/mq-web-api/src/api.rs
+++ b/crates/mq-web-api/src/api.rs
@@ -2,8 +2,12 @@ use std::collections::HashMap;
 
 use miette::miette;
 use mq_formatter::{Formatter, FormatterConfig};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+
+/// Maximum number of documents allowed in a single `POST /api/v1/batch` request.
+pub const MAX_BATCH_SIZE: usize = 100;
 
 #[derive(Deserialize, Serialize, ToSchema, Clone, Debug)]
 pub struct ApiRequest {
@@ -26,6 +30,36 @@ pub struct ApiRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct QueryApiResponse {
     pub results: Vec<String>,
+}
+
+/// Request body for `POST /api/v1/batch`. Runs `query` against each entry
+/// of `inputs`, avoiding one HTTP round trip per document.
+#[derive(Deserialize, Serialize, ToSchema, Clone, Debug)]
+pub struct BatchApiRequest {
+    #[schema(example = ".h")]
+    pub query: String,
+    /// At most [`MAX_BATCH_SIZE`] entries are accepted.
+    pub inputs: Vec<String>,
+    pub input_format: Option<InputFormat>,
+    pub modules: Option<Vec<String>>,
+    pub args: Option<HashMap<String, String>>,
+    pub output_format: Option<OutputFormat>,
+    pub aggregate: Option<bool>,
+}
+
+/// Result of running the batch query against a single input document.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct BatchItemResult {
+    /// Empty when `error` is set.
+    pub results: Vec<String>,
+    /// A failure here doesn't affect other documents in the batch.
+    pub error: Option<String>,
+}
+
+/// Response body for `POST /api/v1/batch`. `items` is ordered like `inputs`.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct BatchApiResponse {
+    pub items: Vec<BatchItemResult>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Default, PartialEq, Eq)]
@@ -205,6 +239,46 @@ pub struct LintApiResponse {
 
 pub fn query(request: ApiRequest, timeout: std::time::Duration) -> miette::Result<QueryApiResponse> {
     execute_query(request, timeout)
+}
+
+/// Runs `request.query` against every document in `request.inputs` in
+/// parallel, each with its own engine instance.
+pub fn batch_query(request: BatchApiRequest, timeout: std::time::Duration) -> miette::Result<BatchApiResponse> {
+    if request.inputs.len() > MAX_BATCH_SIZE {
+        return Err(miette!(
+            "Batch request exceeds maximum of {} documents (got {})",
+            MAX_BATCH_SIZE,
+            request.inputs.len()
+        ));
+    }
+
+    let items = request
+        .inputs
+        .par_iter()
+        .map(|input| {
+            let item_request = ApiRequest {
+                query: request.query.clone(),
+                input: Some(input.clone()),
+                input_format: request.input_format.clone(),
+                modules: request.modules.clone(),
+                args: request.args.clone(),
+                output_format: request.output_format.clone(),
+                aggregate: request.aggregate,
+            };
+            match execute_query(item_request, timeout) {
+                Ok(response) => BatchItemResult {
+                    results: response.results,
+                    error: None,
+                },
+                Err(e) => BatchItemResult {
+                    results: vec![],
+                    error: Some(e.to_string()),
+                },
+            }
+        })
+        .collect();
+
+    Ok(BatchApiResponse { items })
 }
 
 /// Type-checks the given query and returns any errors found.
@@ -673,6 +747,76 @@ mod tests {
         let result = query(req, std::time::Duration::from_secs(10));
         assert!(result.is_ok());
         assert!(result.unwrap().results.is_empty());
+    }
+
+    #[test]
+    fn test_batch_query_multiple_documents() {
+        let req = BatchApiRequest {
+            query: ".h1".to_string(),
+            inputs: vec!["# Title One".to_string(), "# Title Two".to_string()],
+            input_format: Some(InputFormat::Markdown),
+            modules: None,
+            args: None,
+            output_format: None,
+            aggregate: None,
+        };
+        let result = batch_query(req, std::time::Duration::from_secs(10));
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.items.len(), 2);
+        assert!(resp.items[0].error.is_none());
+        assert_eq!(resp.items[0].results, vec!["# Title One\n"]);
+        assert_eq!(resp.items[1].results, vec!["# Title Two\n"]);
+    }
+
+    #[test]
+    fn test_batch_query_preserves_order_and_isolates_errors() {
+        let req = BatchApiRequest {
+            query: "invalid query".to_string(),
+            inputs: vec!["# Title One".to_string()],
+            input_format: Some(InputFormat::Markdown),
+            modules: None,
+            args: None,
+            output_format: None,
+            aggregate: None,
+        };
+        let result = batch_query(req, std::time::Duration::from_secs(10));
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.items.len(), 1);
+        assert!(resp.items[0].error.is_some());
+        assert!(resp.items[0].results.is_empty());
+    }
+
+    #[test]
+    fn test_batch_query_empty_inputs() {
+        let req = BatchApiRequest {
+            query: ".h1".to_string(),
+            inputs: vec![],
+            input_format: Some(InputFormat::Markdown),
+            modules: None,
+            args: None,
+            output_format: None,
+            aggregate: None,
+        };
+        let result = batch_query(req, std::time::Duration::from_secs(10));
+        assert!(result.is_ok());
+        assert!(result.unwrap().items.is_empty());
+    }
+
+    #[test]
+    fn test_batch_query_exceeds_max_size() {
+        let req = BatchApiRequest {
+            query: ".h1".to_string(),
+            inputs: vec!["# Title".to_string(); MAX_BATCH_SIZE + 1],
+            input_format: Some(InputFormat::Markdown),
+            modules: None,
+            args: None,
+            output_format: None,
+            aggregate: None,
+        };
+        let result = batch_query(req, std::time::Duration::from_secs(10));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -12,9 +12,9 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::{
-        ApiRequest, CheckApiRequest, CheckApiResponse, CheckError, FormatApiRequest, FormatApiResponse, FunctionDoc,
-        FunctionsApiResponse, InputFormat, LintApiRequest, LintApiResponse, LintDiagnostic, OutputFormat,
-        QueryApiResponse, SelectorDoc, SelectorsApiResponse,
+        ApiRequest, BatchApiRequest, BatchApiResponse, BatchItemResult, CheckApiRequest, CheckApiResponse, CheckError,
+        FormatApiRequest, FormatApiResponse, FunctionDoc, FunctionsApiResponse, InputFormat, LintApiRequest,
+        LintApiResponse, LintDiagnostic, OutputFormat, QueryApiResponse, SelectorDoc, SelectorsApiResponse,
     },
     problem::ProblemDetails,
 };
@@ -80,6 +80,7 @@ pub async fn health_check() -> Json<HealthResponse> {
         get_query_api,
         post_query_api,
         post_shorthand_query_api,
+        post_batch_api,
         post_check_api,
         post_format_api,
         get_functions_api,
@@ -92,6 +93,9 @@ pub async fn health_check() -> Json<HealthResponse> {
         schemas(InputFormat),
         schemas(OutputFormat),
         schemas(QueryApiResponse),
+        schemas(BatchApiRequest),
+        schemas(BatchApiResponse),
+        schemas(BatchItemResult),
         schemas(CheckApiRequest),
         schemas(CheckApiResponse),
         schemas(CheckError),
@@ -211,6 +215,52 @@ pub async fn post_query_api(
             error!("Failed to process query '{}': {}", query_str, e);
             Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
                 .with_title("Invalid query")
+                .with_detail("error", &e.to_string()))
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/batch",
+    responses(
+        (status = 200, description = "Batch processed (see per-item `error` fields for per-document failures)", body = BatchApiResponse),
+        (status = 400, description = "Invalid request parameters, or `inputs` exceeds the batch size limit"),
+    ),
+    request_body = BatchApiRequest
+)]
+pub async fn post_batch_api(
+    State(state): State<AppState>,
+    Json(request): Json<BatchApiRequest>,
+) -> Result<Json<BatchApiResponse>, ProblemDetails> {
+    debug!(
+        "POST /batch called with query: {}, {} documents",
+        request.query,
+        request.inputs.len()
+    );
+
+    let query_str = request.query.clone();
+    let timeout = state.query_timeout;
+    match tokio::task::spawn_blocking(move || crate::api::batch_query(request, timeout))
+        .await
+        .map_err(|e| {
+            error!("Batch task panicked: {}", e);
+            ProblemDetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Internal error")
+                .with_detail("error", &e.to_string())
+        })? {
+        Ok(response) => {
+            info!(
+                "Successfully processed batch query: {}, documents: {}",
+                query_str,
+                response.items.len()
+            );
+            Ok(Json(response))
+        }
+        Err(e) => {
+            error!("Failed to process batch query '{}': {}", query_str, e);
+            Err(ProblemDetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid batch request")
                 .with_detail("error", &e.to_string()))
         }
     }

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -18,8 +18,8 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::{
     config::Config,
     handlers::{
-        ApiDoc, AppState, get_functions_api, get_query_api, get_selectors_api, health_check, post_check_api,
-        post_format_api, post_lint_api, post_query_api, post_shorthand_query_api,
+        ApiDoc, AppState, get_functions_api, get_query_api, get_selectors_api, health_check, post_batch_api,
+        post_check_api, post_format_api, post_lint_api, post_query_api, post_shorthand_query_api,
     },
     middleware::rate_limit_middleware,
     rate_limiter::RateLimiter,
@@ -55,6 +55,7 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
 
     let v1_routes = Router::new()
         .route("/query", get(get_query_api).post(post_query_api))
+        .route("/batch", post(post_batch_api))
         .route("/check", post(post_check_api))
         .route("/format", post(post_format_api))
         .route("/functions", get(get_functions_api))

--- a/docs/books/src/sitemap.xml
+++ b/docs/books/src/sitemap.xml
@@ -45,6 +45,10 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://mqlang.org/book/start/web_api</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
     <loc>https://mqlang.org/book/start/debugger</loc>
     <priority>1.0</priority>
   </url>

--- a/docs/books/src/start/web_api.md
+++ b/docs/books/src/start/web_api.md
@@ -12,6 +12,7 @@ The server exposes the following endpoints:
 | `POST` | `/{query}` | Curl-friendly shortcut: query in the path, raw body (Markdown/HTML/XML/JSON/CSV/...) |
 | `GET` | `/api/v1/query` | Execute a query (query-string parameters) |
 | `POST` | `/api/v1/query` | Execute a query (JSON body) |
+| `POST` | `/api/v1/batch` | Execute a query against multiple documents in one request |
 | `POST` | `/api/v1/check` | Type-check a query |
 | `POST` | `/api/v1/format` | Format a query |
 | `GET` | `/api/v1/functions` | List builtin mq functions |
@@ -130,6 +131,20 @@ curl -X POST http://localhost:8080/api/v1/query \
   -d '{
     "query": ".h",
     "input": "# Title\n\nContent",
+    "input_format": "markdown"
+  }'
+```
+
+### Batch query (multiple documents in one request)
+
+`POST /api/v1/batch` runs one query against multiple documents in a single request, avoiding an HTTP round trip per document. Each document is processed independently — one failing document doesn't fail the others, and `items` in the response is ordered like `inputs` (max 100 entries).
+
+```bash
+curl -X POST http://localhost:8080/api/v1/batch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": ".h1",
+    "inputs": ["# Doc One\n\nBody.", "# Doc Two\n\nBody."],
     "input_format": "markdown"
   }'
 ```


### PR DESCRIPTION
## Summary

Runs one query against multiple documents in a single request, processed in parallel via rayon, so callers no longer need one HTTP round trip per document. Each document is isolated: a failure on one input is reported in that item's `error` field without failing the rest of the batch. Inputs are capped at 100 documents per request.
<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
