### PR TITLE
fix(cli): remove misleading in-place aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Options:
   -F, --output-format <OUTPUT_FORMAT>
           Set output format [default: markdown] [possible values: markdown, html, text, json, table, grep, raw, none]
   -U, --update
-          Update the input markdown (aliases: -i, --in-place, --inplace)
+          Update matching Markdown nodes and write the result to stdout
       --unbuffered
           Unbuffered output
       --list-style <LIST_STYLE>

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -381,14 +381,8 @@ struct OutputArgs {
     #[arg(short = 'F', long, value_enum, default_value_t)]
     output_format: OutputFormat,
 
-    /// Update the input markdown (aliases: -i, --in-place, --inplace)
-    #[arg(
-        short = 'U',
-        long = "update",
-        short_alias='i',
-        aliases=["in-place", "inplace"],
-        default_value_t = false
-    )]
+    /// Update matching Markdown nodes and write the result to stdout
+    #[arg(short = 'U', long = "update", default_value_t = false)]
     update: bool,
 
     /// Unbuffered output

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -29,6 +29,16 @@ fn test_cli_run_with_stdin() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[rstest]
+#[case("-i")]
+#[case("--in-place")]
+#[case("--inplace")]
+fn update_does_not_accept_misleading_in_place_aliases(#[case] alias: &str) {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+
+    cmd.arg(alias).arg("self").write_stdin("# Title\n").assert().failure();
+}
+
+#[rstest]
 #[case::json(
     vec!["--unbuffered", "-F", "json", ".code_inline"],
     "`inline code`",

--- a/docs/books/src/reference/cli.md
+++ b/docs/books/src/reference/cli.md
@@ -51,7 +51,7 @@ Options:
   -F, --output-format <OUTPUT_FORMAT>
           Set output format [default: markdown] [possible values: markdown, html, text, json, table, grep, raw, none]
   -U, --update
-          Update the input markdown (aliases: -i, --in-place, --inplace)
+          Update matching Markdown nodes and write the result to stdout
       --unbuffered
           Unbuffered output
       --list-style <LIST_STYLE>


### PR DESCRIPTION
## Summary

Remove the misleading `-i`, `--in-place`, and `--inplace` aliases from `--update`. These aliases only wrote transformed Markdown to stdout, so they could silently leave the named input file unchanged. The supported `-U`/`--update` behavior is unchanged and its help text now states that output goes to stdout.

Closes #2063.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [x] Test
- [ ] Build / dependencies
- [ ] CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

Focused validation: `cargo test -p mq-run update_does_not_accept_misleading_in_place_aliases` (3 passed), `cargo fmt --all -- --check`, and `git diff --check`.
