### PR TITLE
⚡ perf(mq-lang): make RuntimeValue::Array/Dict clone-on-write

### DIFF
--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -341,7 +341,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 self.eval_program(&nodes_program, values?.into(), &Shared::clone(&self.env))
                     .map(|value| {
                         if let RuntimeValue::Array(values) = value {
-                            values
+                            Shared::unwrap_or_clone(values)
                         } else {
                             vec![value]
                         }
@@ -911,7 +911,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     .flat_map(|value| match value {
                         RuntimeValue::Markdown(node_value, _) => {
                             match builtin::eval_selector_with_args(node_value, selector, args) {
-                                RuntimeValue::Array(arr) => arr,
+                                RuntimeValue::Array(arr) => Shared::unwrap_or_clone(arr),
                                 other => vec![other],
                             }
                         }
@@ -924,7 +924,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                         _ => vec![RuntimeValue::NONE],
                     })
                     .collect::<Vec<_>>();
-                RuntimeValue::Array(values)
+                RuntimeValue::Array(Shared::new(values))
             }
             RuntimeValue::Dict(map) => {
                 let new_map: BTreeMap<_, _> = map
@@ -941,7 +941,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 if new_map.is_empty() {
                     RuntimeValue::NONE
                 } else {
-                    RuntimeValue::Dict(new_map)
+                    RuntimeValue::Dict(Shared::new(new_map))
                 }
             }
             _ => RuntimeValue::NONE,
@@ -958,7 +958,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                         _ => RuntimeValue::NONE,
                     })
                     .collect::<Vec<_>>();
-                RuntimeValue::Array(values)
+                RuntimeValue::Array(Shared::new(values))
             }
             RuntimeValue::Dict(map) => map.get(property_name).cloned().unwrap_or(RuntimeValue::NONE),
             _ => RuntimeValue::NONE,
@@ -970,7 +970,7 @@ impl<T: ModuleResolver> Evaluator<T> {
         let mut result = vec![value.clone()];
         match value {
             RuntimeValue::Array(items) => {
-                for item in items {
+                for item in items.iter() {
                     result.extend(Self::collect_recursive(item));
                 }
             }
@@ -999,28 +999,30 @@ impl<T: ModuleResolver> Evaluator<T> {
                     .iter()
                     .flat_map(|value| match value {
                         RuntimeValue::Markdown(node_value, _) => match builtin::eval_selector(node_value, selector) {
-                            RuntimeValue::Array(arr) => arr,
+                            RuntimeValue::Array(arr) => Shared::unwrap_or_clone(arr),
                             other => vec![other],
                         },
                         _ if matches!(selector, Selector::List(None, None)) => {
                             vec![value.clone()]
                         }
                         RuntimeValue::Dict(_) => match Self::eval_selector_expr(value, selector) {
-                            RuntimeValue::Array(arr) if matches!(selector, Selector::Recursive) => arr,
+                            RuntimeValue::Array(arr) if matches!(selector, Selector::Recursive) => {
+                                Shared::unwrap_or_clone(arr)
+                            }
                             other => vec![other],
                         },
                         _ => vec![RuntimeValue::NONE],
                     })
                     .collect::<Vec<_>>();
 
-                RuntimeValue::Array(values)
+                RuntimeValue::Array(Shared::new(values))
             }
             RuntimeValue::Dict(map) => {
                 if matches!(selector, Selector::List(None, None)) {
-                    return RuntimeValue::Array(map.values().cloned().collect());
+                    return RuntimeValue::Array(Shared::new(map.values().cloned().collect()));
                 }
                 if matches!(selector, Selector::Recursive) {
-                    return RuntimeValue::Array(Self::collect_recursive(runtime_value));
+                    return RuntimeValue::Array(Shared::new(Self::collect_recursive(runtime_value)));
                 }
                 let new_map: BTreeMap<_, _> = map
                     .iter()
@@ -1037,7 +1039,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 if new_map.is_empty() {
                     RuntimeValue::NONE
                 } else {
-                    RuntimeValue::Dict(new_map)
+                    RuntimeValue::Dict(Shared::new(new_map))
                 }
             }
             _ => RuntimeValue::NONE,
@@ -1514,7 +1516,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                 let env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
                 let mut results = Vec::with_capacity(values.len());
 
-                for value in values {
+                for value in Shared::unwrap_or_clone(values) {
                     self.check_timeout()?;
                     define(&env, ident, value.clone());
                     match self.eval_program(body, value, &env) {
@@ -1556,7 +1558,7 @@ impl<T: ModuleResolver> Evaluator<T> {
             }
         };
 
-        Ok(RuntimeValue::Array(values))
+        Ok(RuntimeValue::Array(Shared::new(values)))
     }
 
     fn eval_while(
@@ -1646,7 +1648,7 @@ impl<T: ModuleResolver> Evaluator<T> {
                     let mut error_dict = BTreeMap::new();
                     error_dict.insert(*ERROR_MESSAGE_IDENT, RuntimeValue::String(err.to_string()));
                     let catch_env = Shared::new(SharedCell::new(Env::with_parent(Shared::downgrade(env))));
-                    define(&catch_env, binder.name, RuntimeValue::Dict(error_dict));
+                    define(&catch_env, binder.name, RuntimeValue::Dict(Shared::new(error_dict)));
                     self.eval_expr(runtime_value, catch_expr, &catch_env)
                 }
                 None => self.eval_expr(runtime_value, catch_expr, env),
@@ -1895,7 +1897,7 @@ impl<T: ModuleResolver> Evaluator<T> {
 
                     // Bind the rest of the array
                     let rest_values = values[patterns.len()..].to_vec();
-                    all_bindings.push((rest_binding.name, RuntimeValue::Array(rest_values)));
+                    all_bindings.push((rest_binding.name, RuntimeValue::Array(Shared::new(rest_values))));
 
                     Ok(Some(all_bindings))
                 } else {
@@ -2013,13 +2015,14 @@ impl<T: ModuleResolver> Evaluator<T> {
             RuntimeValue::None => Ok(()),
             RuntimeValue::Dict(map) if *ident == *DICT_IDENT => {
                 out.extend(
-                    map.into_iter()
-                        .map(|(k, v)| RuntimeValue::Array(vec![RuntimeValue::Symbol(k), v])),
+                    Shared::unwrap_or_clone(map)
+                        .into_iter()
+                        .map(|(k, v)| RuntimeValue::Array(Shared::new(vec![RuntimeValue::Symbol(k), v]))),
                 );
                 Ok(())
             }
             RuntimeValue::Array(items) if *ident != *DICT_IDENT => {
-                out.extend(items);
+                out.extend(Shared::unwrap_or_clone(items));
                 Ok(())
             }
             other => Err(EvalError::from(
@@ -2158,7 +2161,11 @@ impl<T: ModuleResolver> Evaluator<T> {
                     for arg in arg_iter.by_ref() {
                         variadic_args.push(self.eval_expr(runtime_value, arg, env)?);
                     }
-                    define(&new_env, param.ident.name, RuntimeValue::Array(variadic_args));
+                    define(
+                        &new_env,
+                        param.ident.name,
+                        RuntimeValue::Array(Shared::new(variadic_args)),
+                    );
                 } else if let Some(arg) = arg_iter.next() {
                     let val = self.eval_expr(runtime_value, arg, env)?;
                     define(&new_env, param.ident.name, val);
@@ -2333,14 +2340,14 @@ mod tests {
             ast_call("starts_with", smallvec![ast_node(ast::Expr::Literal(ast::Literal::String("st".to_string())))])
        ],
        Ok(vec![RuntimeValue::FALSE]))]
-    #[case::starts_with(vec![RuntimeValue::Array(vec!["start".to_string().into(), "end".to_string().into()])],
+    #[case::starts_with(vec![RuntimeValue::Array(Shared::new(vec!["start".to_string().into(), "end".to_string().into()]))],
        vec![
             ast_call("starts_with", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("start".to_string())))
             ])
        ],
        Ok(vec![RuntimeValue::TRUE]))]
-    #[case::starts_with(vec![RuntimeValue::Array(vec!["start".to_string().into(), "end".to_string().into()])],
+    #[case::starts_with(vec![RuntimeValue::Array(Shared::new(vec!["start".to_string().into(), "end".to_string().into()]))],
        vec![
             ast_call("starts_with", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("end".to_string())))
@@ -2377,14 +2384,14 @@ mod tests {
             ])
        ],
        Ok(vec![RuntimeValue::FALSE]))]
-    #[case::ends_with(vec![RuntimeValue::Array(vec!["start".to_string().into(), "end".to_string().into()])],
+    #[case::ends_with(vec![RuntimeValue::Array(Shared::new(vec!["start".to_string().into(), "end".to_string().into()]))],
        vec![
             ast_call("ends_with", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("end".to_string())))
             ])
        ],
        Ok(vec![RuntimeValue::TRUE]))]
-    #[case::ends_with(vec![RuntimeValue::Array(vec!["start".to_string().into(), "end".to_string().into()])],
+    #[case::ends_with(vec![RuntimeValue::Array(Shared::new(vec!["start".to_string().into(), "end".to_string().into()]))],
        vec![
             ast_call("ends_with", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("start".to_string())))
@@ -2525,7 +2532,7 @@ mod tests {
             ast_call("utf8bytelen", SmallVec::new())
        ],
        Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "4".to_string(), position: None}))]))]
-    #[case::utf8bytelen(vec![RuntimeValue::Array(vec![RuntimeValue::String("test".to_string())])],
+    #[case::utf8bytelen(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test".to_string())]))],
        vec![
             ast_call("utf8bytelen", SmallVec::new())
        ],
@@ -2558,14 +2565,14 @@ mod tests {
        Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                     name: "index".to_string(),
                                                     args: vec!["number".into(), "string".into()]})))]
-    #[case::array_index(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())])],
+    #[case::array_index(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())]))],
         vec![
               ast_call("index", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("test2".to_string())))
               ])
         ],
         Ok(vec![RuntimeValue::Number(1.into())]))]
-    #[case::array_index_not_found(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())])],
+    #[case::array_index_not_found(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())]))],
         vec![
               ast_call("index", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("test4".to_string())))
@@ -2595,21 +2602,21 @@ mod tests {
        Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                     name: "rindex".to_string(),
                                                     args: vec!["number".into(), "string".into()]})))]
-    #[case::array_rindex(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test1".to_string())])],
+    #[case::array_rindex(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test1".to_string())]))],
         vec![
               ast_call("rindex", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("test1".to_string())))
               ])
         ],
         Ok(vec![RuntimeValue::Number(2.into())]))]
-    #[case::array_rindex(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())])],
+    #[case::array_rindex(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string()), RuntimeValue::String("test3".to_string())]))],
         vec![
               ast_call("rindex", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("test4".to_string())))
               ])
         ],
         Ok(vec![RuntimeValue::Number((-1).into())]))]
-    #[case::array_rindex_empty(vec![RuntimeValue::Array(Vec::new())],
+    #[case::array_rindex_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
               ast_call("rindex", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("test".to_string())))
@@ -3011,7 +3018,7 @@ mod tests {
                     ])
                 ]),
        ],
-       Ok(vec![RuntimeValue::Array(vec!["te".to_string().into(), "te".to_string().into()])]))]
+       Ok(vec![RuntimeValue::Array(Shared::new(vec!["te".to_string().into(), "te".to_string().into()]))]))]
     #[case::add(vec![RuntimeValue::String("testString".to_string())],
        vec![
             ast_call("add", smallvec![
@@ -3295,7 +3302,7 @@ mod tests {
                         ast_node(ast::Expr::Literal(ast::Literal::String(",".to_string())))]
                         )
        ],
-       Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())])]))]
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())]))]))]
     #[case::split2(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test1,test2".to_string(), position: None}))],
        vec![
             ast_call("split", smallvec![
@@ -3310,75 +3317,75 @@ mod tests {
        Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                     name: "split".to_string(),
                                                     args: vec!["number".into(), "string".into()]})))]
-    #[case::split_array(vec![RuntimeValue::Array(vec![
+    #[case::split_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("value1".to_string()),
             RuntimeValue::String("separator".to_string()),
             RuntimeValue::String("value2".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("split", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("separator".to_string())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![RuntimeValue::String("value1".to_string())]),
-            RuntimeValue::Array(vec![RuntimeValue::String("value2".to_string())])
-        ])]))]
-    #[case::split_array_multiple_separators(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("value1".to_string())])),
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("value2".to_string())]))
+        ]))]))]
+    #[case::split_array_multiple_separators(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("value1".to_string()),
             RuntimeValue::String("separator".to_string()),
             RuntimeValue::String("value2".to_string()),
             RuntimeValue::String("separator".to_string()),
             RuntimeValue::String("value3".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("split", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("separator".to_string())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![RuntimeValue::String("value1".to_string())]),
-            RuntimeValue::Array(vec![RuntimeValue::String("value2".to_string())]),
-            RuntimeValue::Array(vec![RuntimeValue::String("value3".to_string())])
-        ])]))]
-    #[case::split_array_no_separator(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("value1".to_string())])),
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("value2".to_string())])),
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("value3".to_string())]))
+        ]))]))]
+    #[case::split_array_no_separator(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("value1".to_string()),
             RuntimeValue::String("value2".to_string()),
             RuntimeValue::String("value3".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("split", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("separator".to_string())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
-        RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
+        RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("value1".to_string()),
             RuntimeValue::String("value2".to_string()),
             RuntimeValue::String("value3".to_string())
-        ])
-        ])]))]
-    #[case::split_array_empty(vec![RuntimeValue::Array(Vec::new())],
+        ]))
+        ]))]))]
+    #[case::split_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
             ast_call("split", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("separator".to_string())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(Vec::new())])]))]
-    #[case::split_array_mixed_types(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]))]
+    #[case::split_array_mixed_types(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::String("separator".to_string()),
             RuntimeValue::Boolean(true),
-        ])],
+        ]))],
         vec![
             ast_call("split", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::String("separator".to_string())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]),
-            RuntimeValue::Array(vec![RuntimeValue::Boolean(true)])
-        ])]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())])),
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Boolean(true)]))
+        ]))]))]
     #[case::join1(vec![RuntimeValue::String("test1,test2".to_string())],
        vec![
             ast_call("join", smallvec![
@@ -3408,24 +3415,24 @@ mod tests {
             ast_call("reverse", SmallVec::new())
        ],
        Ok(vec![RuntimeValue::String("".to_string())]))]
-    #[case::reverse_array(vec![RuntimeValue::Array(vec![
+    #[case::reverse_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("reverse", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("c".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("a".to_string()),
-        ])]))]
-    #[case::reverse_array_empty(vec![RuntimeValue::Array(Vec::new())],
+        ]))]))]
+    #[case::reverse_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
             ast_call("reverse", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
     #[case::reverse_number(vec![RuntimeValue::Number(123.into())],
        vec![
             ast_call("reverse", SmallVec::new())
@@ -3523,7 +3530,7 @@ mod tests {
                 ast_node(ast::Expr::Literal(ast::Literal::String("test1,test2".to_string()))),
             ]),
        ],
-       Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())])]))]
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())]))]))]
     #[case::def2(vec![RuntimeValue::String("Hello".to_string())],
        vec![
             ast_node(ast::Expr::Def(
@@ -3580,7 +3587,7 @@ mod tests {
             ast_call("type", SmallVec::new())
        ],
        Ok(vec![RuntimeValue::String("bool".to_string())]))]
-    #[case::type_array(vec![RuntimeValue::Array(vec![RuntimeValue::String("test".to_string())])],
+    #[case::type_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test".to_string())]))],
        vec![
             ast_call("type", SmallVec::new())
        ],
@@ -3700,92 +3707,92 @@ mod tests {
             ])
        ],
        Ok(vec![RuntimeValue::NONE]))]
-    #[case::slice_array(vec![RuntimeValue::Array(vec![
+    #[case::slice_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
             RuntimeValue::String("item5".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(4.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
-        ])]))]
-    #[case::slice_array_from_start(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::slice_array_from_start(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
-        ])]))]
-    #[case::slice_array_to_end(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::slice_array_to_end(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(3.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
-       ])]))]
-    #[case::slice_array_out_of_bounds(vec![RuntimeValue::Array(vec![
+       ]))]))]
+    #[case::slice_array_out_of_bounds(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(5.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::slice_array_empty(vec![RuntimeValue::Array(Vec::new())],
+        ]))]))]
+    #[case::slice_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::slice_array_mixed_types(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::slice_array_mixed_types(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::Number(42.into()),
             RuntimeValue::Boolean(true),
             RuntimeValue::String("item4".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(3.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(42.into()),
             RuntimeValue::Boolean(true),
-        ])]))]
+        ]))]))]
     #[case::slice(vec![RuntimeValue::Number(123.into())],
        vec![
             ast_call("slice", smallvec![
@@ -3802,7 +3809,7 @@ mod tests {
                 ast_node(ast::Expr::Literal(ast::Literal::String(r"\d+".to_string()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("123".to_string())])]))]
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("123".to_string())]))]))]
     #[case::match_regex2(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test123".to_string(), position: None}))],
        vec![
             ast_call("regex_match", smallvec![
@@ -3823,11 +3830,11 @@ mod tests {
        vec![
             ast_call("explode", SmallVec::new())
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(65.into()),
             RuntimeValue::Number(66.into()),
             RuntimeValue::Number(67.into()),
-       ])]))]
+       ]))]))]
     #[case::explode(vec![RuntimeValue::Number(123.into())],
        vec![
             ast_call("explode", SmallVec::new())
@@ -3835,11 +3842,11 @@ mod tests {
        Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                     name: "explode".to_string(),
                                                     args: vec!["number".into()]})))]
-    #[case::implode(vec![RuntimeValue::Array(vec![
+    #[case::implode(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(65.into()),
             RuntimeValue::Number(66.into()),
             RuntimeValue::Number(67.into()),
-       ])],
+       ]))],
        vec![
             ast_call("implode", SmallVec::new())
        ],
@@ -3876,31 +3883,31 @@ mod tests {
             ast_call("to_number", SmallVec::new())
        ],
        Err(InnerError::Runtime(RuntimeError::Runtime(Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()}, "invalid float literal".to_string()))))]
-    #[case::to_number_array(vec![RuntimeValue::Array(vec![RuntimeValue::String("42".to_string()), RuntimeValue::String("43".to_string()), RuntimeValue::String("44".to_string())])],
+    #[case::to_number_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("42".to_string()), RuntimeValue::String("43".to_string()), RuntimeValue::String("44".to_string())]))],
         vec![
               ast_call("to_number", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into()), RuntimeValue::Number(43.into()), RuntimeValue::Number(44.into())])]))]
-    #[case::to_number_array(vec![RuntimeValue::Array(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "42".to_string(), position: None}))])],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into()), RuntimeValue::Number(43.into()), RuntimeValue::Number(44.into())]))]))]
+    #[case::to_number_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "42".to_string(), position: None}))]))],
         vec![
               ast_call("to_number", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into())])]))]
-    #[case::to_number_array_with_invalid(vec![RuntimeValue::Array(vec![RuntimeValue::String("42".to_string()), RuntimeValue::String("not a number".to_string()), RuntimeValue::String("44".to_string())])],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into())]))]))]
+    #[case::to_number_array_with_invalid(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("42".to_string()), RuntimeValue::String("not a number".to_string()), RuntimeValue::String("44".to_string())]))],
         vec![
               ast_call("to_number", SmallVec::new())
         ],
         Err(InnerError::Runtime(RuntimeError::Runtime(Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()}, "invalid float literal".to_string()))))]
-    #[case::to_number_array_empty(vec![RuntimeValue::Array(Vec::new())],
+    #[case::to_number_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
               ast_call("to_number", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::to_number_array_mixed_types(vec![RuntimeValue::Array(vec![RuntimeValue::String("42".to_string()), RuntimeValue::Number(43.into()), RuntimeValue::String("44".to_string())])],
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::to_number_array_mixed_types(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("42".to_string()), RuntimeValue::Number(43.into()), RuntimeValue::String("44".to_string())]))],
         vec![
               ast_call("to_number", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into()), RuntimeValue::Number(43.into()), RuntimeValue::Number(44.into())])]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into()), RuntimeValue::Number(43.into()), RuntimeValue::Number(44.into())]))]))]
     #[case::trunc(vec![RuntimeValue::Number(42.5.into())],
        vec![
             ast_call("trunc", SmallVec::new())
@@ -3996,20 +4003,20 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                      name: "floor".to_string(),
                                                      args: vec!["string".into()]})))]
-    #[case::del(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())])],
+    #[case::del(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())]))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("test2".to_string())])]))]
-    #[case::del(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())])],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test2".to_string())]))]))]
+    #[case::del(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string()), RuntimeValue::String("test2".to_string())]))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("test1".to_string())])]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("test1".to_string())]))]))]
     #[case::del(vec![RuntimeValue::String("test1".to_string())],
         vec![
               ast_call("del", smallvec![
@@ -4188,10 +4195,10 @@ mod tests {
         ],
         Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::List(
             mq_markdown::List{values: vec!["list".to_string().into()], ordered: false, index: 0, level: 1_u8, checked: None, position: None}))]))]
-    #[case::to_md_fragment(vec![RuntimeValue::Array(vec![
+    #[case::to_md_fragment(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "first".to_string(), position: None})),
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "second".to_string(), position: None})),
-        ])],
+        ]))],
         vec![
               ast_call("to_md_fragment", SmallVec::new()),
         ],
@@ -4199,15 +4206,15 @@ mod tests {
             mq_markdown::Node::Text(mq_markdown::Text{value: "first".to_string(), position: None}),
             mq_markdown::Node::Text(mq_markdown::Text{value: "second".to_string(), position: None}),
         ]}))]))]
-    #[case::to_md_fragment_flattens_nested_arrays(vec![RuntimeValue::Array(vec![
+    #[case::to_md_fragment_flattens_nested_arrays(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "first".to_string(), position: None})),
-            RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "second".to_string(), position: None})),
-                RuntimeValue::Array(vec![
+                RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "third".to_string(), position: None})),
-                ]),
-            ]),
-        ])],
+                ])),
+            ])),
+        ]))],
         vec![
               ast_call("to_md_fragment", SmallVec::new()),
         ],
@@ -4216,12 +4223,12 @@ mod tests {
             mq_markdown::Node::Text(mq_markdown::Text{value: "second".to_string(), position: None}),
             mq_markdown::Node::Text(mq_markdown::Text{value: "third".to_string(), position: None}),
         ]}))]))]
-    #[case::to_md_table_align(vec![RuntimeValue::Array(vec![
+    #[case::to_md_table_align(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("left".to_string()),
             RuntimeValue::String("right".to_string()),
             RuntimeValue::String("center".to_string()),
             RuntimeValue::String("none".to_string()),
-        ])],
+        ]))],
         vec![
               ast_call("to_md_table_align", SmallVec::new()),
         ],
@@ -4248,55 +4255,55 @@ mod tests {
               ]),
         ],
         Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::List(mq_markdown::List{values: vec!["Unchecked Item".to_string().into()], ordered: false, level: 0, index: 0, checked: Some(false), position: None}))]))]
-    #[case::compact(vec![RuntimeValue::Array(vec![
+    #[case::compact(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::NONE,
             RuntimeValue::String("test2".to_string()),
             RuntimeValue::NONE,
             RuntimeValue::String("test3".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("compact", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
             RuntimeValue::String("test3".to_string()),
-        ])]))]
-    #[case::compact(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::compact(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::NONE,
             RuntimeValue::String("test2".to_string()),
             RuntimeValue::NONE,
             RuntimeValue::String("test3".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("compact", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
             RuntimeValue::String("test3".to_string()),
-        ])]))]
-    #[case::compact_empty(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::compact_empty(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::NONE,
             RuntimeValue::NONE,
-        ])],
+        ]))],
         vec![
             ast_call("compact", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::compact_no_none(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::compact_no_none(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("compact", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
-        ])]))]
+        ]))]))]
     #[case::text_selector(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "test".to_string(), position: None}))],
         vec![
             ast_node(ast::Expr::Selector(Selector::Text)),
@@ -4343,11 +4350,11 @@ mod tests {
             ast_node(ast::Expr::Literal(ast::Literal::String("python".to_string()))),
         ]))],
         Ok(vec![RuntimeValue::NONE]))]
-    #[case::to_md_table_row(vec![RuntimeValue::Array(vec![
+    #[case::to_md_table_row(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("Cell 1".to_string()),
             RuntimeValue::String("Cell 2".to_string()),
             RuntimeValue::String("Cell 3".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("to_md_table_row", SmallVec::new())
         ],
@@ -4433,15 +4440,15 @@ mod tests {
             ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(Number::new(-1.0))))])
         ],
         Ok(vec![RuntimeValue::String("1".to_string())]))]
-    #[case::get_array(vec![RuntimeValue::Array(vec!["1".to_string().into()])],
+    #[case::get_array(vec![RuntimeValue::Array(Shared::new(vec!["1".to_string().into()]))],
         vec![
             ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(2.into())))])
         ],
         Ok(vec![RuntimeValue::NONE]))]
-    #[case::get_array(vec![RuntimeValue::Array(vec![
+    #[case::get_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test1".to_string()),
             RuntimeValue::String("test2".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("get", smallvec![ast_node(ast::Expr::Literal(ast::Literal::Number(Number::new(-1.0))))])
         ],
@@ -4483,17 +4490,17 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                      name: "to_date".to_string(),
                                                      args: vec!["string".into(), "string".into()]})))]
-    #[case::to_string_array(vec![RuntimeValue::Array(vec![
+    #[case::to_string_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("test".to_string()),
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Boolean(false),
-        ])],
+        ]))],
         vec![
             ast_call("to_string", SmallVec::new())
         ],
         Ok(vec![RuntimeValue::String(r#"["test", 1, 2, false]"#.to_string())]))]
-    #[case::to_string_empty_array(vec![RuntimeValue::Array(Vec::new())],
+    #[case::to_string_empty_array(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
             ast_call("to_string", SmallVec::new())
         ],
@@ -4524,7 +4531,7 @@ mod tests {
               smallvec![ast_node(ast::Expr::Literal(ast::Literal::String("Override".to_string())))])
         ],
         Ok(vec!["Override".to_string().into()]))]
-    #[case::to_text(vec![RuntimeValue::Array(vec!["val1".to_string().into(), "val2".to_string().into()])],
+    #[case::to_text(vec![RuntimeValue::Array(Shared::new(vec!["val1".to_string().into(), "val2".to_string().into()]))],
         vec![
              ast_call("to_text", SmallVec::new())
         ],
@@ -4599,37 +4606,37 @@ mod tests {
              ])
         ],
         Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Strong(mq_markdown::Strong{values: vec![mq_markdown::Node::Text(mq_markdown::Text{value: "text2".to_string(), position: None})], position: None}))]))]
-    #[case::sort_string_array(vec![RuntimeValue::Array(vec![
+    #[case::sort_string_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("c".to_string()),
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("sort", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ])]))]
-    #[case::sort_number_array(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::sort_number_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(3.into()),
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
-        ])],
+        ]))],
         vec![
             ast_call("sort", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])]))]
-    #[case::sort_empty_array(vec![RuntimeValue::Array(Vec::new())],
+        ]))]))]
+    #[case::sort_empty_array(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
             ast_call("sort", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
     #[case::sort_error(vec![RuntimeValue::Number(1.into())],
         vec![
             ast_call("sort", SmallVec::new())
@@ -4637,36 +4644,36 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                                      name: "sort".to_string(),
                                                      args: vec!["number".into()]})))]
-    #[case::uniq_string_array(vec![RuntimeValue::Array(vec![
+    #[case::uniq_string_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("c".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("uniq", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ])]))]
-    #[case::uniq_number_array(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::uniq_number_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(3.into()),
             RuntimeValue::Number(2.into()),
-        ])],
+        ]))],
         vec![
             ast_call("uniq", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])]))]
+        ]))]))]
     #[case::uniq_error(vec![RuntimeValue::Number(1.into())],
         vec![
             ast_call("uniq", SmallVec::new())
@@ -4737,31 +4744,31 @@ mod tests {
             ])
         ],
         Ok(vec![RuntimeValue::String("".to_string())]))]
-    #[case::repeat_array(vec![RuntimeValue::Array(vec![
+    #[case::repeat_array(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("repeat", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(2.into())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])]))]
-    #[case::repeat_array_zero(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::repeat_array_zero(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])],
+        ]))],
         vec![
             ast_call("repeat", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(0.into())))
             ])
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
     #[case::repeat_invalid_count(vec![RuntimeValue::String("abc".to_string())],
         vec![
             ast_call("repeat", smallvec![
@@ -4953,88 +4960,88 @@ mod tests {
              ast_call("get_url", SmallVec::new())
         ],
         Ok(vec![RuntimeValue::NONE]))]
-    #[case::flatten_array_of_arrays(vec![RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]),
-                RuntimeValue::Array(vec![RuntimeValue::String("c".to_string()), RuntimeValue::String("d".to_string())])
-            ])],
+    #[case::flatten_array_of_arrays(vec![RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("c".to_string()), RuntimeValue::String("d".to_string())]))
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("d".to_string())
-            ])]))]
-    #[case::flatten_array_with_nested_arrays(vec![RuntimeValue::Array(vec![
+            ]))]))]
+    #[case::flatten_array_with_nested_arrays(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
-                RuntimeValue::Array(vec![RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())]),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])),
                 RuntimeValue::String("d".to_string())
-            ])],
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("d".to_string())
-            ])]))]
-    #[case::flatten_deeply_nested_arrays(vec![RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![
-                    RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]),
+            ]))]))]
+    #[case::flatten_deeply_nested_arrays(vec![RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(vec![
+                    RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])),
                     RuntimeValue::String("c".to_string())
-                ]),
+                ])),
                 RuntimeValue::String("d".to_string())
-            ])],
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("d".to_string())
-            ])]))]
-    #[case::flatten_empty_array(vec![RuntimeValue::Array(Vec::new())],
+            ]))]))]
+    #[case::flatten_empty_array(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::flatten_array_with_empty_arrays(vec![RuntimeValue::Array(vec![
-                RuntimeValue::Array(Vec::new()),
-                RuntimeValue::Array(Vec::new())
-            ])],
+            Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::flatten_array_with_empty_arrays(vec![RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(Vec::new())),
+                RuntimeValue::Array(Shared::new(Vec::new()))
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::flatten_mixed_type_arrays(vec![RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::Number(1.into())]),
-                RuntimeValue::Array(vec![RuntimeValue::Boolean(true), RuntimeValue::String("b".to_string())])
-            ])],
+            Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::flatten_mixed_type_arrays(vec![RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::Number(1.into())])),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::Boolean(true), RuntimeValue::String("b".to_string())]))
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Boolean(true),
                 RuntimeValue::String("b".to_string())
-            ])]))]
-    #[case::flatten_array_with_none_values(vec![RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::NONE]),
-                RuntimeValue::Array(vec![RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])
-            ])],
+            ]))]))]
+    #[case::flatten_array_with_none_values(vec![RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::NONE])),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())]))
+            ]))],
             vec![
                 ast_call("flatten", SmallVec::new())
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::NONE,
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string())
-            ])]))]
+            ]))]))]
     #[case::flatten_non_array(vec![RuntimeValue::String("test".to_string())],
             vec![
                 ast_call("flatten", SmallVec::new())
@@ -5045,156 +5052,156 @@ mod tests {
                 ast_call("flatten", SmallVec::new())
             ],
             Ok(vec![RuntimeValue::NONE]))]
-    #[case::set_array_valid_index(vec![RuntimeValue::Array(vec![
+    #[case::set_array_valid_index(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("updated".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("updated".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::set_array_first_index(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_first_index(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("first".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("first".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::set_array_last_index(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_last_index(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("last".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("last".to_string()),
-        ])]))]
-    #[case::set_array_out_of_bounds_positive(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_out_of_bounds_positive(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(5.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("new".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::NONE,
         RuntimeValue::NONE,
         RuntimeValue::NONE,
         RuntimeValue::String("new".to_string()),
-        ])]))]
-    #[case::set_array_negative_index(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_negative_index(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number((-1).into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("negative".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("negative".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::set_array_empty(vec![RuntimeValue::Array(Vec::new())],
+        ]))]))]
+    #[case::set_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("value".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec!["value".into()])]))]
-    #[case::set_array_mixed_types(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec!["value".into()]))]))]
+    #[case::set_array_mixed_types(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("text".to_string()),
         RuntimeValue::Number(42.into()),
         RuntimeValue::Boolean(true),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("replaced".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("text".to_string()),
         RuntimeValue::String("replaced".to_string()),
         RuntimeValue::Boolean(true),
-        ])]))]
-    #[case::set_array_with_none(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_with_none(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::NONE,
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("not_none".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("not_none".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::set_array_replace_with_none(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_replace_with_none(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
         RuntimeValue::String("item3".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::None)),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::NONE,
         RuntimeValue::String("item3".to_string()),
-        ])]))]
-    #[case::set_array_single_element(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::set_array_single_element(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("only".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
             ast_node(ast::Expr::Literal(ast::Literal::String("changed".to_string()))),
         ])
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("changed".to_string()),
-        ])]))]
+        ]))]))]
     #[case::set_non_array(vec![RuntimeValue::String("not_an_array".to_string())],
         vec![
         ast_call("set", smallvec![
@@ -5205,10 +5212,10 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                              name: "set".to_string(),
                              args: vec!["string".into(), "number".into(), "string".into()]})))]
-    #[case::set_array_non_number_index(vec![RuntimeValue::Array(vec![
+    #[case::set_array_non_number_index(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::String("item1".to_string()),
         RuntimeValue::String("item2".to_string()),
-        ])],
+        ]))],
         vec![
         ast_call("set", smallvec![
             ast_node(ast::Expr::Literal(ast::Literal::String("not_a_number".to_string()))),
@@ -5218,33 +5225,33 @@ mod tests {
         Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                              name: "set".to_string(),
                              args: vec!["array".into(), "string".into(), "string".into()]})))]
-    #[case::del_dict_valid_key(vec![RuntimeValue::Dict(vec![
+    #[case::del_dict_valid_key(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key2"), RuntimeValue::String("value2".to_string())),
             (Ident::new("key3"), RuntimeValue::String("value3".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("key2".to_string()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key3"), RuntimeValue::String("value3".to_string())),
-        ].into_iter().collect())]))]
-    #[case::del_dict_nonexistent_key(vec![RuntimeValue::Dict(vec![
+        ].into_iter().collect()))]))]
+    #[case::del_dict_nonexistent_key(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key2"), RuntimeValue::String("value2".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("nonexistent".to_string()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key2"), RuntimeValue::String("value2".to_string())),
-        ].into_iter().collect())]))]
+        ].into_iter().collect()))]))]
     #[case::del_dict_empty(vec![RuntimeValue::new_dict()],
         vec![
               ast_call("del", smallvec![
@@ -5252,47 +5259,47 @@ mod tests {
               ]),
         ],
         Ok(vec![RuntimeValue::new_dict()]))]
-    #[case::del_dict_single_key(vec![RuntimeValue::Dict(vec![
+    #[case::del_dict_single_key(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("only_key"), RuntimeValue::String("only_value".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("only_key".to_string()))),
               ]),
         ],
         Ok(vec![RuntimeValue::new_dict()]))]
-    #[case::del_dict_mixed_value_types(vec![RuntimeValue::Dict(vec![
+    #[case::del_dict_mixed_value_types(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("str_key"), RuntimeValue::String("string_value".to_string())),
             (Ident::new("num_key"), RuntimeValue::Number(42.into())),
             (Ident::new("bool_key"), RuntimeValue::Boolean(true)),
-            (Ident::new("array_key"), RuntimeValue::Array(vec![RuntimeValue::String("item".to_string())])),
-        ].into_iter().collect())],
+            (Ident::new("array_key"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("item".to_string())]))),
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("num_key".to_string()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("str_key"), RuntimeValue::String("string_value".to_string())),
             (Ident::new("bool_key"), RuntimeValue::Boolean(true)),
-            (Ident::new("array_key"), RuntimeValue::Array(vec![RuntimeValue::String("item".to_string())])),
-        ].into_iter().collect())]))]
-    #[case::del_dict_with_number_key_as_string(vec![RuntimeValue::Dict(vec![
+            (Ident::new("array_key"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("item".to_string())]))),
+        ].into_iter().collect()))]))]
+    #[case::del_dict_with_number_key_as_string(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("2"), RuntimeValue::String("value2".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::String("1".to_string()))),
               ]),
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("2"), RuntimeValue::String("value2".to_string())),
-        ].into_iter().collect())]))]
-    #[case::del_dict_with_number_index_error(vec![RuntimeValue::Dict(vec![
+        ].into_iter().collect()))]))]
+    #[case::del_dict_with_number_index_error(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key2"), RuntimeValue::String("value2".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
               ast_call("del", smallvec![
                     ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
@@ -5418,13 +5425,13 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::Number(5.into()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Number(2.into()),
                 RuntimeValue::Number(3.into()),
                 RuntimeValue::Number(4.into()),
                 RuntimeValue::Number(5.into()),
-            ])]))]
+            ]))]))]
     #[case::range_number_negative(vec![RuntimeValue::Number(5.into())],
             vec![
                 ast_call("range", smallvec![
@@ -5432,13 +5439,13 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(5.into()),
                 RuntimeValue::Number(4.into()),
                 RuntimeValue::Number(3.into()),
                 RuntimeValue::Number(2.into()),
                 RuntimeValue::Number(1.into()),
-            ])]))]
+            ]))]))]
     #[case::range_string(vec![RuntimeValue::String("a".to_string())],
             vec![
                 ast_call("range", smallvec![
@@ -5446,13 +5453,13 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::String("e".to_string()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("d".to_string()),
                 RuntimeValue::String("e".to_string()),
-            ])]))]
+            ]))]))]
     #[case::range_string(vec![RuntimeValue::String("a".to_string())],
             vec![
                 ast_call("range", smallvec![
@@ -5460,10 +5467,10 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::String("a2".to_string()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a1".to_string()),
                 RuntimeValue::String("a2".to_string()),
-            ])]))]
+            ]))]))]
     #[case::range_string_reverse(vec![RuntimeValue::String("e".to_string())],
             vec![
                 ast_call("range", smallvec![
@@ -5471,13 +5478,13 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::String("a".to_string()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("e".to_string()),
                 RuntimeValue::String("d".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("a".to_string()),
-            ])]))]
+            ]))]))]
     #[case::range_string_step_2(vec![RuntimeValue::String("a".to_string())],
             vec![
                 ast_call("range", smallvec![
@@ -5486,11 +5493,11 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("e".to_string()),
-            ])]))]
+            ]))]))]
     #[case::range_string_step_minus_2(vec![RuntimeValue::String("e".to_string())],
             vec![
                 ast_call("range", smallvec![
@@ -5499,100 +5506,100 @@ mod tests {
                     ast_node(ast::Expr::Literal(ast::Literal::Number((-2).into()))),
                 ])
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("e".to_string()),
                 RuntimeValue::String("c".to_string()),
                 RuntimeValue::String("a".to_string()),
-            ])]))]
-    #[case::insert_array_middle(vec![RuntimeValue::Array(vec![
+            ]))]))]
+    #[case::insert_array_middle(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("x".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("a".to_string()),
                     RuntimeValue::String("x".to_string()),
                     RuntimeValue::String("b".to_string()),
                     RuntimeValue::String("c".to_string()),
-                ])]))]
-    #[case::insert_array_start(vec![RuntimeValue::Array(vec![
+                ]))]))]
+    #[case::insert_array_start(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("z".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("z".to_string()),
                     RuntimeValue::String("a".to_string()),
                     RuntimeValue::String("b".to_string()),
-                ])]))]
-    #[case::insert_array_end(vec![RuntimeValue::Array(vec![
+                ]))]))]
+    #[case::insert_array_end(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number(2.into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("c".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("a".to_string()),
                     RuntimeValue::String("b".to_string()),
                     RuntimeValue::String("c".to_string()),
-                ])]))]
-    #[case::insert_array_out_of_bounds(vec![RuntimeValue::Array(vec![
+                ]))]))]
+    #[case::insert_array_out_of_bounds(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number(5.into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("b".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("a".to_string()),
                     RuntimeValue::NONE,
                     RuntimeValue::NONE,
                     RuntimeValue::NONE,
                     RuntimeValue::NONE,
                     RuntimeValue::String("b".to_string()),
-                ])]))]
-    #[case::insert_array_negative_index(vec![RuntimeValue::Array(vec![
+                ]))]))]
+    #[case::insert_array_negative_index(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number((-1).into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("z".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("z".to_string()),
                     RuntimeValue::String("a".to_string()),
                     RuntimeValue::String("b".to_string()),
-                ])]))]
-    #[case::insert_array_empty(vec![RuntimeValue::Array(Vec::new())],
+                ]))]))]
+    #[case::insert_array_empty(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::Number(0.into()))),
                         ast_node(ast::Expr::Literal(ast::Literal::String("first".to_string()))),
                     ])
                 ],
-                Ok(vec![RuntimeValue::Array(vec![
+                Ok(vec![RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("first".to_string()),
-                ])]))]
+                ]))]))]
     #[case::insert_non_array(vec![RuntimeValue::Number(1.into())],
                 vec![
                     ast_call("insert", smallvec![
@@ -5603,10 +5610,10 @@ mod tests {
                 Err(InnerError::Runtime(RuntimeError::InvalidTypes{token: Token { range: Range::default(), kind: TokenKind::Eof, module_id: 1.into()},
                                      name: "insert".to_string(),
                                      args: vec!["number".into(), "number".into(), "string".into()]})))]
-    #[case::insert_array_non_number_index(vec![RuntimeValue::Array(vec![
+    #[case::insert_array_non_number_index(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("item1".to_string()),
                 RuntimeValue::String("item2".to_string()),
-            ])],
+            ]))],
                 vec![
                     ast_call("insert", smallvec![
                         ast_node(ast::Expr::Literal(ast::Literal::String("not_a_number".to_string()))),
@@ -5682,11 +5689,11 @@ mod tests {
                 ],
                 Ok(vec![RuntimeValue::String("".to_string())]))]
     #[case::break_in_foreach(
-       vec![RuntimeValue::Array(vec![
+       vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])],
+        ]))],
             vec![
                 ast_node(ast::Expr::Foreach(
                     IdentWithToken::new("x"),
@@ -5711,16 +5718,16 @@ mod tests {
                     ],
                 )),
             ],
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
-            ])])
+            ]))])
         )]
     #[case::continue_in_foreach(
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])],
+        ]))],
         vec![
             ast_node(ast::Expr::Foreach(
                 IdentWithToken::new("x"),
@@ -5745,10 +5752,10 @@ mod tests {
                 ],
             )),
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(3.into()),
-        ])])
+        ]))])
     )]
     #[case::foreach_string(
         vec![RuntimeValue::String("abc".to_string())],
@@ -5761,11 +5768,11 @@ mod tests {
                 ],
             )),
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ])])
+        ]))])
     )]
     #[case::loop_immediate_break(
         vec![RuntimeValue::Number(10.into())],
@@ -5782,36 +5789,36 @@ mod tests {
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("t".to_string()), RuntimeValue::String("e".to_string()), RuntimeValue::String("s".to_string()), RuntimeValue::String("t".to_string())])]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("t".to_string()), RuntimeValue::String("e".to_string()), RuntimeValue::String("s".to_string()), RuntimeValue::String("t".to_string())]))]))]
     #[case::to_array_number(vec![RuntimeValue::Number(42.into())],
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into())])]))]
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into())]))]))]
     #[case::to_array_bool(vec![RuntimeValue::Boolean(true)],
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Boolean(true)])]))]
-    #[case::to_array_array(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Boolean(true)]))]))]
+    #[case::to_array_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))],
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])]))]
-    #[case::to_array_empty_array(vec![RuntimeValue::Array(Vec::new())],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))]))]
+    #[case::to_array_empty_array(vec![RuntimeValue::Array(Shared::new(Vec::new()))],
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(Vec::new())]))]
-    #[case::to_array_dict(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
+    #[case::to_array_dict(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key"), RuntimeValue::String("value".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("to_array", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key"), RuntimeValue::String("value".to_string())),
-        ].into_iter().collect())])]))]
+        ].into_iter().collect()))]))]))]
     #[case::type_none(vec![RuntimeValue::NONE],
        vec![
             ast_call("type", SmallVec::new())
@@ -5885,57 +5892,57 @@ mod tests {
             ast_call("upcase", SmallVec::new())
        ],
        Ok(vec![RuntimeValue::NONE]))]
-    #[case::slice_array_negative_start_index(vec![RuntimeValue::Array(vec![
+    #[case::slice_array_negative_start_index(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
             RuntimeValue::String("item5".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number((-2).into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number(4.into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item4".to_string()),
-        ])]))]
-    #[case::slice_array_negative_end_index(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::slice_array_negative_end_index(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
             RuntimeValue::String("item5".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number(1.into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number((-1).into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
-        ])]))]
-    #[case::slice_array_both_negative_indices(vec![RuntimeValue::Array(vec![
+        ]))]))]
+    #[case::slice_array_both_negative_indices(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item1".to_string()),
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
             RuntimeValue::String("item4".to_string()),
             RuntimeValue::String("item5".to_string()),
-        ])],
+        ]))],
        vec![
             ast_call("slice", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Number((-4).into()))),
                 ast_node(ast::Expr::Literal(ast::Literal::Number((-2).into()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(vec![
+       Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("item2".to_string()),
             RuntimeValue::String("item3".to_string()),
-        ])]))]
+        ]))]))]
     #[case::slice_string_negative_start_index(vec![RuntimeValue::String("abcdef".to_string())],
        vec![
             ast_call("slice", smallvec![
@@ -6025,7 +6032,7 @@ mod tests {
                 ast_node(ast::Expr::Literal(ast::Literal::String(r"\d+".to_string()))),
             ])
        ],
-       Ok(vec![RuntimeValue::Array(Vec::new())]))]
+       Ok(vec![RuntimeValue::Array(Shared::new(Vec::new()))]))]
     #[case::gsub(vec![RuntimeValue::NONE],
        vec![
             ast_call("gsub", smallvec![
@@ -6053,7 +6060,7 @@ mod tests {
                 ast_node(ast::Expr::Literal(ast::Literal::String("test".to_string()))),
             ])
        ],
-       Ok(vec![RuntimeValue::EMPTY_ARRAY]))]
+       Ok(vec![RuntimeValue::empty_array()]))]
     #[case::to_md_name(vec![RuntimeValue::NONE],
         vec![
               ast_call("to_md_name", SmallVec::new()),
@@ -6552,7 +6559,7 @@ mod tests {
         Ok(vec![RuntimeValue::String("value".to_string())])
     )]
     #[case::coalesce_array(
-        vec![RuntimeValue::Array(vec![RuntimeValue::NONE, RuntimeValue::String("foo".to_string())])],
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::NONE, RuntimeValue::String("foo".to_string())]))],
         vec![
             ast_call("coalesce", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::None)),
@@ -6653,11 +6660,11 @@ mod tests {
         Ok(vec![RuntimeValue::FALSE])
     )]
     #[case::get_dict_symbol_key(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
             (Ident::new("key2"), RuntimeValue::String("value2".to_string())),
             (Ident::new("key3"), RuntimeValue::String("value3".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("get", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("key2")))),
@@ -6666,9 +6673,9 @@ mod tests {
         Ok(vec![RuntimeValue::String("value2".to_string())])
     )]
     #[case::get_dict_symbol_key_not_found(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("key1"), RuntimeValue::String("value1".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("get", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("keyX")))),
@@ -6677,73 +6684,73 @@ mod tests {
         Ok(vec![RuntimeValue::NONE])
     )]
     #[case::set_dict_symbol_key(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
             (Ident::new("sym2"), RuntimeValue::String("v2".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("set", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("sym2")))),
                 ast_node(ast::Expr::Literal(ast::Literal::String("updated".to_string()))),
             ])
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
             (Ident::new("sym2"), RuntimeValue::String("updated".to_string())),
-        ].into_iter().collect())])
+        ].into_iter().collect()))])
     )]
     #[case::set_dict_symbol_key_new(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("set", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("sym3")))),
                 ast_node(ast::Expr::Literal(ast::Literal::String("newval".to_string()))),
             ])
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
             (Ident::new("sym3"), RuntimeValue::String("newval".to_string())),
-        ].into_iter().collect())])
+        ].into_iter().collect()))])
     )]
     #[case::del_dict_symbol_key(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
             (Ident::new("sym2"), RuntimeValue::String("v2".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("del", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("sym1")))),
             ])
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym2"), RuntimeValue::String("v2".to_string())),
-        ].into_iter().collect())])
+        ].into_iter().collect()))])
     )]
     #[case::del_dict_symbol_key_not_found(
-        vec![RuntimeValue::Dict(vec![
+        vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
-        ].into_iter().collect())],
+        ].into_iter().collect()))],
         vec![
             ast_call("del", smallvec![
                 ast_node(ast::Expr::Literal(ast::Literal::Symbol(Ident::new("symX")))),
             ])
         ],
-        Ok(vec![RuntimeValue::Dict(vec![
+        Ok(vec![RuntimeValue::Dict(Shared::new(vec![
             (Ident::new("sym1"), RuntimeValue::String("v1".to_string())),
-        ].into_iter().collect())])
+        ].into_iter().collect()))])
     )]
     #[case::to_markdown_string_to_markdown_array(
         vec![RuntimeValue::String("a\n\nb\n\nc".to_string())],
         vec![
             ast_call("to_markdown", SmallVec::new())
         ],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "a".to_string(), position: None})),
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "b".to_string(), position: None})),
             RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "c".to_string(), position: None})),
-        ])]))
+        ]))]))
     ]
     #[case::to_markdown_none(vec![RuntimeValue::NONE],
                 vec![
@@ -7655,10 +7662,10 @@ mod tests {
         Ok(vec![RuntimeValue::String("None: ".to_string())])
     )]
     #[case::interpolated_string_with_array(
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])],
+        ]))],
         vec![
             ast_node(ast::Expr::InterpolatedString(vec![
                 ast::StringSegment::Text("Array: ".to_string()),
@@ -7998,10 +8005,10 @@ mod tests {
 
         assert_eq!(
             result,
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("[LOG]".to_string()),
                 RuntimeValue::String("message".to_string())
-            ])])
+            ]))])
         );
     }
 
@@ -8041,11 +8048,11 @@ mod tests {
 
         assert_eq!(
             result,
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Number(2.into()),
                 RuntimeValue::Number(3.into())
-            ])])
+            ]))])
         );
     }
 
@@ -8088,11 +8095,11 @@ mod tests {
 
         assert_eq!(
             result,
-            Ok(vec![RuntimeValue::Array(vec![
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Number(4.into()),
                 RuntimeValue::Number(3.into())
-            ])])
+            ]))])
         );
     }
 

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -206,13 +206,13 @@ fn type_impl(_: &Ident, _: &RuntimeValue, args: Args, _: &SharedEnv) -> Result<R
 
 #[mq_macros::mq_fn(name = "array", params = Range(0, u8::MAX))]
 fn array_impl(_: &Ident, _: &RuntimeValue, args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    Ok(RuntimeValue::Array(args))
+    Ok(RuntimeValue::Array(Shared::new(args)))
 }
 
 #[mq_macros::mq_fn(name = "flatten", params = Fixed(1))]
 fn flatten_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::Array(arrays)] => Ok(convert::flatten(std::mem::take(arrays)).into()),
+        [RuntimeValue::Array(arrays)] => Ok(convert::flatten(Shared::unwrap_or_clone(std::mem::take(arrays))).into()),
         [a] => Ok(std::mem::take(a)),
         _ => unreachable!("flatten should always receive exactly one argument"),
     }
@@ -261,7 +261,7 @@ fn now_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<Runti
 
 /// Array format: [year, month (0-11), day (1-31), hour (0-23), minute (0-59), second (0-60), weekday (0=Sun), day-of-year (0-365)]
 fn broken_down_time_array<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> RuntimeValue {
-    RuntimeValue::Array(vec![
+    RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(((dt.year()) as i64).into()),
         RuntimeValue::Number((dt.month0() as i64).into()),
         RuntimeValue::Number((dt.day() as i64).into()),
@@ -270,7 +270,7 @@ fn broken_down_time_array<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> Ru
         RuntimeValue::Number((dt.second() as i64).into()),
         RuntimeValue::Number((dt.weekday().num_days_from_sunday() as i64).into()),
         RuntimeValue::Number((dt.ordinal0() as i64).into()),
-    ])
+    ]))
 }
 
 fn broken_down_time_to_naive(caller: &str, arr: &[RuntimeValue]) -> Result<chrono::NaiveDateTime, Error> {
@@ -580,7 +580,7 @@ fn shuffle_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
     match args.as_mut_slice() {
         [RuntimeValue::Array(arr)] => {
             let mut arr = std::mem::take(arr);
-            random::shuffle(&mut arr);
+            random::shuffle(runtime_value::array_mut(&mut arr));
             Ok(RuntimeValue::Array(arr))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -600,7 +600,7 @@ fn sample_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
                     arr.len()
                 )));
             }
-            Ok(RuntimeValue::Array(random::sample(arr, n)))
+            Ok(RuntimeValue::Array(Shared::new(random::sample(arr, n))))
         }
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
@@ -802,9 +802,10 @@ fn from_html_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
         [RuntimeValue::String(s)] => {
             let markdown = mq_markdown::convert_html_to_markdown(s, mq_markdown::ConversionOptions::default())
                 .map_err(|e| Error::Runtime(format!("Failed to convert HTML: {}", e)))?;
-            Ok(RuntimeValue::Array(parse_markdown_input(&markdown).map_err(|e| {
-                Error::Runtime(format!("Failed to parse converted markdown: {}", e))
-            })?))
+            Ok(RuntimeValue::Array(Shared::new(
+                parse_markdown_input(&markdown)
+                    .map_err(|e| Error::Runtime(format!("Failed to parse converted markdown: {}", e)))?,
+            )))
         }
         [RuntimeValue::None] => Ok(RuntimeValue::NONE),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -1049,8 +1050,8 @@ fn regex_match_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
         [node @ RuntimeValue::Markdown(_, _), RuntimeValue::String(pattern)] => node
             .markdown_node()
             .map(|md| match_re(&md.value(), pattern))
-            .unwrap_or_else(|| Ok(RuntimeValue::EMPTY_ARRAY)),
-        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::EMPTY_ARRAY),
+            .unwrap_or_else(|| Ok(RuntimeValue::empty_array())),
+        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::empty_array()),
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
@@ -1111,8 +1112,8 @@ fn scan_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
         [node @ RuntimeValue::Markdown(_, _), RuntimeValue::String(pattern)] => node
             .markdown_node()
             .map(|md| scan_re(&md.value(), pattern))
-            .unwrap_or_else(|| Ok(RuntimeValue::EMPTY_ARRAY)),
-        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::EMPTY_ARRAY),
+            .unwrap_or_else(|| Ok(RuntimeValue::empty_array())),
+        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::empty_array()),
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
@@ -1256,12 +1257,12 @@ fn truncate_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
 #[mq_macros::mq_fn(name = "explode", params = Fixed(1))]
 fn explode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(s)] => Ok(RuntimeValue::Array(
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::Array(Shared::new(
             s.chars()
                 .map(|c| RuntimeValue::Number((c as u32).into()))
                 .collect::<Vec<_>>(),
-        )),
-        [node @ RuntimeValue::Markdown(_, _)] => Ok(RuntimeValue::Array(
+        ))),
+        [node @ RuntimeValue::Markdown(_, _)] => Ok(RuntimeValue::Array(Shared::new(
             node.markdown_node()
                 .map(|md| {
                     md.value()
@@ -1270,7 +1271,7 @@ fn explode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default(),
-        )),
+        ))),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("explode should always receive exactly one argument"),
     }
@@ -1434,10 +1435,10 @@ fn slice_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
             };
 
             if real_start >= len || real_end <= real_start {
-                return Ok(RuntimeValue::EMPTY_ARRAY);
+                return Ok(RuntimeValue::empty_array());
             }
 
-            Ok(RuntimeValue::Array(arrays[real_start..real_end].to_vec()))
+            Ok(RuntimeValue::Array(Shared::new(arrays[real_start..real_end].to_vec())))
         }
         [
             node @ RuntimeValue::Markdown(_, _),
@@ -1693,14 +1694,14 @@ fn range_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
         // Numeric range: range(end)
         [RuntimeValue::Number(end)] => {
             let end_val = end.value() as isize;
-            generate_numeric_range(0, end_val, 1).map(RuntimeValue::Array)
+            generate_numeric_range(0, end_val, 1).map(|v| RuntimeValue::Array(Shared::new(v)))
         }
         // Numeric range: range(start, end)
         [RuntimeValue::Number(start), RuntimeValue::Number(end)] => {
             let start_val = start.value() as isize;
             let end_val = end.value() as isize;
             let step = if start_val <= end_val { 1 } else { -1 };
-            generate_numeric_range(start_val, end_val, step).map(RuntimeValue::Array)
+            generate_numeric_range(start_val, end_val, step).map(|v| RuntimeValue::Array(Shared::new(v)))
         }
         // Numeric range: range(start, end, step)
         [
@@ -1711,7 +1712,7 @@ fn range_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
             let start_val = start.value() as isize;
             let end_val = end.value() as isize;
             let step_val = step.value() as isize;
-            generate_numeric_range(start_val, end_val, step_val).map(RuntimeValue::Array)
+            generate_numeric_range(start_val, end_val, step_val).map(|v| RuntimeValue::Array(Shared::new(v)))
         }
         // String range: range("a", "z") or range("A", "Z") or range("aa", "zz")
         [RuntimeValue::String(start), RuntimeValue::String(end)] => {
@@ -1719,9 +1720,9 @@ fn range_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
             let end_chars: Vec<char> = end.chars().collect();
 
             if start_chars.len() == 1 && end_chars.len() == 1 {
-                generate_char_range(start_chars[0], end_chars[0], None).map(RuntimeValue::Array)
+                generate_char_range(start_chars[0], end_chars[0], None).map(|v| RuntimeValue::Array(Shared::new(v)))
             } else {
-                generate_multi_char_range(start, end).map(RuntimeValue::Array)
+                generate_multi_char_range(start, end).map(|v| RuntimeValue::Array(Shared::new(v)))
             }
         }
         // String range with step: range("a", "z", step)
@@ -1735,7 +1736,8 @@ fn range_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
 
             if start_chars.len() == 1 && end_chars.len() == 1 {
                 let step_val = step.value() as i32;
-                generate_char_range(start_chars[0], end_chars[0], Some(step_val)).map(RuntimeValue::Array)
+                generate_char_range(start_chars[0], end_chars[0], Some(step_val))
+                    .map(|v| RuntimeValue::Array(Shared::new(v)))
             } else {
                 Err(Error::Runtime(
                     "String range with step is only supported for single characters".to_string(),
@@ -1751,7 +1753,7 @@ fn del_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
     match args.as_mut_slice() {
         [RuntimeValue::Array(array), RuntimeValue::Number(n)] => {
             let mut array = std::mem::take(array);
-            array.remove(n.value() as usize);
+            runtime_value::array_mut(&mut array).remove(n.value() as usize);
             Ok(RuntimeValue::Array(array))
         }
         [RuntimeValue::String(s), RuntimeValue::Number(n)] => {
@@ -1762,12 +1764,12 @@ fn del_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
         [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::NONE),
         [RuntimeValue::Dict(dict), RuntimeValue::String(key)] => {
             let mut dict = std::mem::take(dict);
-            dict.remove(&Ident::new(key));
+            runtime_value::dict_mut(&mut dict).remove(&Ident::new(key));
             Ok(RuntimeValue::Dict(dict))
         }
         [RuntimeValue::Dict(dict), RuntimeValue::Symbol(key)] => {
             let mut dict = std::mem::take(dict);
-            dict.remove(key);
+            runtime_value::dict_mut(&mut dict).remove(key);
             Ok(RuntimeValue::Dict(dict))
         }
         [a, b] => Err(Error::InvalidTypes(
@@ -1795,7 +1797,7 @@ fn reverse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
     match args.as_mut_slice() {
         [RuntimeValue::Array(array)] => {
             let mut vec = std::mem::take(array);
-            vec.reverse();
+            runtime_value::array_mut(&mut vec).reverse();
             Ok(RuntimeValue::Array(vec))
         }
         [RuntimeValue::String(s)] => Ok(s.chars().rev().collect::<String>().into()),
@@ -1814,9 +1816,9 @@ fn sort_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
     match args.as_mut_slice() {
         [RuntimeValue::Array(array)] => {
             let mut vec = std::mem::take(array);
-            vec.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            runtime_value::array_mut(&mut vec).sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-            let vec = vec
+            let vec = Shared::unwrap_or_clone(vec)
                 .into_iter()
                 .map(|v| match v {
                     RuntimeValue::Markdown(mut node, s) => {
@@ -1826,7 +1828,7 @@ fn sort_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
                     _ => v,
                 })
                 .collect();
-            Ok(RuntimeValue::Array(vec))
+            Ok(RuntimeValue::Array(Shared::new(vec)))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("sort should always receive exactly one argument"),
@@ -1838,7 +1840,7 @@ fn _sort_by_impl_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
     match args.as_mut_slice() {
         [RuntimeValue::Array(array)] => {
             let mut vec = std::mem::take(array);
-            vec.sort_by(|a, b| match (a, b) {
+            runtime_value::array_mut(&mut vec).sort_by(|a, b| match (a, b) {
                 (RuntimeValue::Array(a1), RuntimeValue::Array(a2)) => a1
                     .first()
                     .unwrap()
@@ -1846,7 +1848,7 @@ fn _sort_by_impl_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
                     .unwrap_or(std::cmp::Ordering::Equal),
                 _ => unreachable!("_sort_by_impl should only be called with an array of arrays"),
             });
-            let vec = vec
+            let vec = Shared::unwrap_or_clone(vec)
                 .into_iter()
                 .map(|v| match v {
                     RuntimeValue::Array(mut arr) if arr.len() >= 2 => {
@@ -1854,7 +1856,7 @@ fn _sort_by_impl_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
                             let mut new_node = node.clone();
                             new_node.set_position(None);
 
-                            arr[1] = RuntimeValue::Markdown(new_node, s.clone());
+                            runtime_value::array_mut(&mut arr)[1] = RuntimeValue::Markdown(new_node, s.clone());
                             RuntimeValue::Array(arr)
                         } else {
                             RuntimeValue::Array(arr)
@@ -1864,7 +1866,7 @@ fn _sort_by_impl_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
                 })
                 .collect();
 
-            Ok(RuntimeValue::Array(vec))
+            Ok(RuntimeValue::Array(Shared::new(vec)))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("_sort_by_impl should always receive exactly one argument"),
@@ -1874,12 +1876,12 @@ fn _sort_by_impl_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
 #[mq_macros::mq_fn(name = "compact", params = Fixed(1))]
 fn compact_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::Array(array)] => Ok(RuntimeValue::Array(
-            std::mem::take(array)
+        [RuntimeValue::Array(array)] => Ok(RuntimeValue::Array(Shared::new(
+            Shared::unwrap_or_clone(std::mem::take(array))
                 .into_iter()
                 .filter(|v| !v.is_none())
                 .collect::<Vec<_>>(),
-        )),
+        ))),
         [a] => Ok(std::mem::take(a)),
         _ => unreachable!("compact should always receive exactly one argument"),
     }
@@ -1895,7 +1897,7 @@ fn split_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
             .unwrap_or_else(|| Ok(RuntimeValue::NONE)),
         [RuntimeValue::Array(array), v] => {
             if array.is_empty() {
-                return Ok(RuntimeValue::Array(vec![RuntimeValue::Array(Vec::new())]));
+                return Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::empty_array()])));
             }
 
             let mut positions = Vec::new();
@@ -1906,24 +1908,26 @@ fn split_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) ->
             }
 
             if positions.is_empty() {
-                return Ok(RuntimeValue::Array(vec![RuntimeValue::Array(std::mem::take(array))]));
+                return Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(
+                    std::mem::take(array),
+                )])));
             }
 
             let mut result = Vec::with_capacity(positions.len() + 1);
             let mut start = 0;
 
             for pos in positions {
-                result.push(RuntimeValue::Array(array[start..pos].to_vec()));
+                result.push(RuntimeValue::Array(Shared::new(array[start..pos].to_vec())));
                 start = pos + 1;
             }
 
             if start < array.len() {
-                result.push(RuntimeValue::Array(array[start..].to_vec()));
+                result.push(RuntimeValue::Array(Shared::new(array[start..].to_vec())));
             }
 
-            Ok(RuntimeValue::Array(result))
+            Ok(RuntimeValue::Array(Shared::new(result)))
         }
-        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::EMPTY_ARRAY),
+        [RuntimeValue::None, RuntimeValue::String(_)] => Ok(RuntimeValue::empty_array()),
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
@@ -1938,7 +1942,7 @@ fn uniq_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
         [RuntimeValue::Array(array)] => {
             let mut vec = std::mem::take(array);
             let mut seen = FxHashSet::default();
-            vec.retain(|item| seen.insert(item.to_string()));
+            runtime_value::array_mut(&mut vec).retain(|item| seen.insert(item.to_string()));
             Ok(RuntimeValue::Array(vec))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -2108,8 +2112,9 @@ fn add_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
                 )));
             }
             let mut a = std::mem::take(a1);
-            a.reserve(a2.len());
-            a.extend_from_slice(a2);
+            let a_mut = runtime_value::array_mut(&mut a);
+            a_mut.reserve(a2.len());
+            a_mut.extend_from_slice(a2);
             Ok(RuntimeValue::Array(a))
         }
         [RuntimeValue::Array(a1), a2] => {
@@ -2122,8 +2127,9 @@ fn add_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
             }
 
             let mut a = std::mem::take(a1);
-            a.reserve(1);
-            a.push(std::mem::take(a2));
+            let a_mut = runtime_value::array_mut(&mut a);
+            a_mut.reserve(1);
+            a_mut.push(std::mem::take(a2));
             Ok(RuntimeValue::Array(a))
         }
         [v, RuntimeValue::Array(a)] => {
@@ -2137,13 +2143,13 @@ fn add_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
 
             let mut arr = Vec::with_capacity(total_size);
             arr.push(std::mem::take(v));
-            arr.extend(std::mem::take(a));
+            arr.extend(Shared::unwrap_or_clone(std::mem::take(a)));
 
-            Ok(RuntimeValue::Array(arr))
+            Ok(RuntimeValue::Array(Shared::new(arr)))
         }
         [RuntimeValue::Dict(d1), RuntimeValue::Dict(d2)] => {
             let mut result = std::mem::take(d1);
-            result.extend(std::mem::take(d2));
+            runtime_value::dict_mut(&mut result).extend(Shared::unwrap_or_clone(std::mem::take(d2)));
             Ok(RuntimeValue::Dict(result))
         }
         [a, RuntimeValue::None] | [RuntimeValue::None, a] => Ok(std::mem::take(a)),
@@ -2203,7 +2209,7 @@ fn mul_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Resul
                 repeat(&mut RuntimeValue::Array(std::mem::take(array)), n.value() as usize)
             } else {
                 // Non-integer, negative, or too large multiplication: multiply each element
-                let result: Result<Vec<RuntimeValue>, Error> = std::mem::take(array)
+                let result: Result<Vec<RuntimeValue>, Error> = Shared::unwrap_or_clone(std::mem::take(array))
                     .into_iter()
                     .map(|v| {
                         let mut args = vec![v, RuntimeValue::Number(*n)];
@@ -2221,7 +2227,7 @@ fn mul_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Resul
                         }
                     })
                     .collect();
-                result.map(RuntimeValue::Array)
+                result.map(|v| RuntimeValue::Array(Shared::new(v)))
             }
         }
         [v, RuntimeValue::Number(n)] | [RuntimeValue::Number(n), v] => {
@@ -2296,14 +2302,14 @@ fn attr_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Resu
         [RuntimeValue::Markdown(node, _), RuntimeValue::String(attr)] => {
             Ok(node.attr(attr).map(Into::into).unwrap_or(RuntimeValue::NONE))
         }
-        [RuntimeValue::Array(nodes), RuntimeValue::String(attr)] => Ok(nodes
+        [RuntimeValue::Array(nodes), RuntimeValue::String(attr)] => Ok(runtime_value::array_mut(nodes)
             .iter_mut()
             .flat_map(|node| match node {
                 RuntimeValue::Markdown(node, _) => {
                     let value = node.attr(attr).map(Into::into).unwrap_or(RuntimeValue::NONE);
 
                     match value {
-                        RuntimeValue::Array(arr) => arr,
+                        RuntimeValue::Array(arr) => Shared::unwrap_or_clone(arr),
                         RuntimeValue::None => Vec::new(),
                         v => vec![v],
                     }
@@ -2361,7 +2367,7 @@ fn set_children_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
     match args.as_mut_slice() {
         [RuntimeValue::Markdown(node, selector), RuntimeValue::Array(children)] => {
             let mut new_node = std::mem::take(node);
-            let children = children
+            let children = runtime_value::array_mut(children)
                 .iter_mut()
                 .map(|child| match child {
                     RuntimeValue::Markdown(node, _) => (**node).clone(),
@@ -2757,7 +2763,7 @@ fn node_from_runtime_value(value: &RuntimeValue) -> mq_markdown::Node {
 fn flatten_into_nodes(value: &RuntimeValue, out: &mut Vec<mq_markdown::Node>) {
     match value {
         RuntimeValue::Array(values) => {
-            for value in values {
+            for value in values.iter() {
                 flatten_into_nodes(value, out);
             }
         }
@@ -2957,13 +2963,14 @@ fn dict_impl(_: &Ident, _: &RuntimeValue, args: Args, _: &SharedEnv) -> Result<R
 #[mq_macros::mq_fn(name = "get", params = Fixed(2))]
 fn get_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::Dict(map), RuntimeValue::String(key)] => Ok(map
+        [RuntimeValue::Dict(map), RuntimeValue::String(key)] => Ok(runtime_value::dict_mut(map)
             .get_mut(&Ident::new(key))
             .map(std::mem::take)
             .unwrap_or(RuntimeValue::NONE)),
-        [RuntimeValue::Dict(map), RuntimeValue::Symbol(key)] => {
-            Ok(map.get_mut(key).map(std::mem::take).unwrap_or(RuntimeValue::NONE))
-        }
+        [RuntimeValue::Dict(map), RuntimeValue::Symbol(key)] => Ok(runtime_value::dict_mut(map)
+            .get_mut(key)
+            .map(std::mem::take)
+            .unwrap_or(RuntimeValue::NONE)),
         [RuntimeValue::Array(array), RuntimeValue::Number(index)] => {
             let len = array.len();
             let idx = index.value() as isize;
@@ -2972,7 +2979,7 @@ fn get_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
             } else {
                 idx as usize
             };
-            Ok(array
+            Ok(runtime_value::array_mut(array)
                 .get_mut(real_idx)
                 .map(std::mem::take)
                 .unwrap_or(RuntimeValue::NONE))
@@ -3017,12 +3024,12 @@ fn set_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
     match args.as_mut_slice() {
         [RuntimeValue::Dict(map_val), RuntimeValue::String(key_val), value_val] => {
             let mut new_dict = std::mem::take(map_val);
-            new_dict.insert(Ident::new(key_val), std::mem::take(value_val));
+            runtime_value::dict_mut(&mut new_dict).insert(Ident::new(key_val), std::mem::take(value_val));
             Ok(RuntimeValue::Dict(new_dict))
         }
         [RuntimeValue::Dict(map_val), RuntimeValue::Symbol(key_val), value_val] => {
             let mut new_dict = std::mem::take(map_val);
-            new_dict.insert(*key_val, std::mem::take(value_val));
+            runtime_value::dict_mut(&mut new_dict).insert(*key_val, std::mem::take(value_val));
             Ok(RuntimeValue::Dict(new_dict))
         }
         [
@@ -3041,12 +3048,12 @@ fn set_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
                 resized_array
             } else {
                 // If index is within bounds, clone existing array
-                std::mem::take(array_val)
+                Shared::unwrap_or_clone(std::mem::take(array_val))
             };
 
             // Set value at specified index
             new_array[index] = std::mem::take(value_val);
-            Ok(RuntimeValue::Array(new_array))
+            Ok(RuntimeValue::Array(Shared::new(new_array)))
         }
         [a, b, c] => Err(Error::InvalidTypes(
             ident.to_string(),
@@ -3064,7 +3071,7 @@ fn keys_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
                 .keys()
                 .map(|k| RuntimeValue::String(k.as_str()))
                 .collect::<Vec<RuntimeValue>>();
-            Ok(RuntimeValue::Array(keys))
+            Ok(RuntimeValue::Array(Shared::new(keys)))
         }
         [RuntimeValue::None] => Ok(RuntimeValue::NONE),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -3077,7 +3084,7 @@ fn values_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
     match args.as_mut_slice() {
         [RuntimeValue::Dict(map)] => {
             let values = map.values().cloned().collect::<Vec<RuntimeValue>>();
-            Ok(RuntimeValue::Array(values))
+            Ok(RuntimeValue::Array(Shared::new(values)))
         }
         [RuntimeValue::None] => Ok(RuntimeValue::NONE),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -3091,9 +3098,9 @@ fn entries_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
         [RuntimeValue::Dict(map)] => {
             let entries = map
                 .iter()
-                .map(|(k, v)| RuntimeValue::Array(vec![RuntimeValue::String(k.as_str()), v.to_owned()]))
+                .map(|(k, v)| RuntimeValue::Array(Shared::new(vec![RuntimeValue::String(k.as_str()), v.to_owned()])))
                 .collect::<Vec<RuntimeValue>>();
-            Ok(RuntimeValue::Array(entries))
+            Ok(RuntimeValue::Array(Shared::new(entries)))
         }
         [RuntimeValue::None] => Ok(RuntimeValue::NONE),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -3108,10 +3115,11 @@ fn insert_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
         [RuntimeValue::Array(array), RuntimeValue::Number(index), value] => {
             let mut new_array = std::mem::take(array);
             let idx = index.value() as usize;
-            if idx > new_array.len() {
-                new_array.resize(idx, RuntimeValue::NONE);
+            let array_mut = runtime_value::array_mut(&mut new_array);
+            if idx > array_mut.len() {
+                array_mut.resize(idx, RuntimeValue::NONE);
             }
-            new_array.insert(idx, std::mem::take(value));
+            array_mut.insert(idx, std::mem::take(value));
             Ok(RuntimeValue::Array(new_array))
         }
         // Insert into string at index
@@ -3131,12 +3139,12 @@ fn insert_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
         // Insert into dict (same as set, but error if key exists)
         [RuntimeValue::Dict(map_val), RuntimeValue::String(key_val), value_val] => {
             let mut new_dict = std::mem::take(map_val);
-            new_dict.insert(Ident::new(key_val), std::mem::take(value_val));
+            runtime_value::dict_mut(&mut new_dict).insert(Ident::new(key_val), std::mem::take(value_val));
             Ok(RuntimeValue::Dict(new_dict))
         }
         [RuntimeValue::Dict(map_val), RuntimeValue::Symbol(key_val), value_val] => {
             let mut new_dict = std::mem::take(map_val);
-            new_dict.insert(*key_val, std::mem::take(value_val));
+            runtime_value::dict_mut(&mut new_dict).insert(*key_val, std::mem::take(value_val));
             Ok(RuntimeValue::Dict(new_dict))
         }
         [a, b, c] => Err(Error::InvalidTypes(
@@ -3211,22 +3219,20 @@ fn input_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<Run
 
 #[mq_macros::mq_fn(name = "all_symbols", params = None)]
 fn all_symbols_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    Ok(RuntimeValue::Array(
+    Ok(RuntimeValue::Array(Shared::new(
         all_symbols()
             .into_iter()
             .map(|symbol| RuntimeValue::Symbol(Ident::new(&symbol)))
             .collect(),
-    ))
+    )))
 }
 
 #[mq_macros::mq_fn(name = "to_markdown", params = Fixed(1))]
 fn to_markdown_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(s)] => {
-            Ok(RuntimeValue::Array(parse_markdown_input(s).map_err(|e| {
-                Error::Runtime(format!("Failed to parse markdown: {}", e))
-            })?))
-        }
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::Array(Shared::new(
+            parse_markdown_input(s).map_err(|e| Error::Runtime(format!("Failed to parse markdown: {}", e)))?,
+        ))),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("to_markdown should always receive exactly one argument"),
     }
@@ -3235,9 +3241,9 @@ fn to_markdown_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
 #[mq_macros::mq_fn(name = "to_mdx", params = Fixed(1))]
 fn to_mdx_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(s)] => Ok(RuntimeValue::Array(
+        [RuntimeValue::String(s)] => Ok(RuntimeValue::Array(Shared::new(
             parse_mdx_input(s).map_err(|e| Error::Runtime(format!("Failed to parse mdx: {}", e)))?,
-        )),
+        ))),
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("to_mdx should always receive exactly one argument"),
     }
@@ -3334,22 +3340,22 @@ fn _csv_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
                     .zip(record.iter())
                     .map(|(k, v)| (Ident::new(k), RuntimeValue::String(v.to_string())))
                     .collect();
-                Ok(RuntimeValue::Dict(map))
+                Ok(RuntimeValue::Dict(Shared::new(map)))
             })
             .collect();
 
-        Ok(RuntimeValue::Array(rows?))
+        Ok(RuntimeValue::Array(Shared::new(rows?)))
     } else {
         let rows: Result<Vec<RuntimeValue>, Error> = reader
             .records()
             .map(|record| {
                 let record = record.map_err(|e| Error::Runtime(format!("Failed to parse CSV record: {e}")))?;
                 let arr: Vec<RuntimeValue> = record.iter().map(|v| RuntimeValue::String(v.to_string())).collect();
-                Ok(RuntimeValue::Array(arr))
+                Ok(RuntimeValue::Array(Shared::new(arr)))
             })
             .collect();
 
-        Ok(RuntimeValue::Array(rows?))
+        Ok(RuntimeValue::Array(Shared::new(rows?)))
     }
 }
 
@@ -3497,13 +3503,13 @@ fn _xml_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
 
                         let mut dict = BTreeMap::new();
                         dict.insert(Ident::new("tag"), RuntimeValue::String(tag));
-                        dict.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs));
-                        dict.insert(Ident::new("children"), RuntimeValue::Array(children));
+                        dict.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs)));
+                        dict.insert(Ident::new("children"), RuntimeValue::Array(Shared::new(children)));
                         dict.insert(
                             Ident::new("text"),
                             text.map(RuntimeValue::String).unwrap_or(RuntimeValue::NONE),
                         );
-                        let element = RuntimeValue::Dict(dict);
+                        let element = RuntimeValue::Dict(Shared::new(dict));
 
                         if let Some(parent) = stack.last_mut() {
                             parent.2.push(element);
@@ -3517,10 +3523,10 @@ fn _xml_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
                         let attrs = parse_attrs(&e, &reader)?;
                         let mut dict = BTreeMap::new();
                         dict.insert(Ident::new("tag"), RuntimeValue::String(tag));
-                        dict.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs));
-                        dict.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+                        dict.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs)));
+                        dict.insert(Ident::new("children"), RuntimeValue::empty_array());
                         dict.insert(Ident::new("text"), RuntimeValue::NONE);
-                        let element = RuntimeValue::Dict(dict);
+                        let element = RuntimeValue::Dict(Shared::new(dict));
 
                         if let Some(parent) = stack.last_mut() {
                             parent.2.push(element);
@@ -3706,7 +3712,7 @@ fn shift_left_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
             Ok(RuntimeValue::String(shifted))
         }
         [RuntimeValue::Array(arr), v] => {
-            arr.push(std::mem::take(v));
+            runtime_value::array_mut(arr).push(std::mem::take(v));
             Ok(RuntimeValue::Array(std::mem::take(arr)))
         }
         [RuntimeValue::Markdown(node, selector), RuntimeValue::Number(n)] => {
@@ -3748,7 +3754,7 @@ fn shift_right_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) 
             }
         }
         [v, RuntimeValue::Array(arr)] => {
-            arr.insert(0, std::mem::take(v));
+            runtime_value::array_mut(arr).insert(0, std::mem::take(v));
             Ok(RuntimeValue::Array(std::mem::take(arr)))
         }
         [RuntimeValue::Markdown(node, selector), RuntimeValue::Number(n)] => {
@@ -3783,20 +3789,20 @@ fn build_char_inline_diff(s1: &str, s2: &str) -> (Vec<RuntimeValue>, Vec<Runtime
                 let mut m = BTreeMap::new();
                 m.insert(Ident::new("tag"), RuntimeValue::String("delete".into()));
                 m.insert(Ident::new("value"), val);
-                del_inline.push(RuntimeValue::Dict(m));
+                del_inline.push(RuntimeValue::Dict(Shared::new(m)));
             }
             ChangeTag::Insert => {
                 let mut m = BTreeMap::new();
                 m.insert(Ident::new("tag"), RuntimeValue::String("insert".into()));
                 m.insert(Ident::new("value"), val);
-                ins_inline.push(RuntimeValue::Dict(m));
+                ins_inline.push(RuntimeValue::Dict(Shared::new(m)));
             }
             ChangeTag::Equal => {
                 for inline in [&mut del_inline, &mut ins_inline] {
                     let mut m = BTreeMap::new();
                     m.insert(Ident::new("tag"), RuntimeValue::String("equal".into()));
                     m.insert(Ident::new("value"), RuntimeValue::String(c.value().to_string()));
-                    inline.push(RuntimeValue::Dict(m));
+                    inline.push(RuntimeValue::Dict(Shared::new(m)));
                 }
             }
         }
@@ -3830,22 +3836,22 @@ fn _diff_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Res
                         let mut del_map = BTreeMap::new();
                         del_map.insert(Ident::new("tag"), RuntimeValue::String("delete".into()));
                         del_map.insert(Ident::new("value"), old_val.clone());
-                        del_map.insert(Ident::new("inline"), RuntimeValue::Array(del_inline));
-                        result.push(RuntimeValue::Dict(del_map));
+                        del_map.insert(Ident::new("inline"), RuntimeValue::Array(Shared::new(del_inline)));
+                        result.push(RuntimeValue::Dict(Shared::new(del_map)));
                         let mut ins_map = BTreeMap::new();
                         ins_map.insert(Ident::new("tag"), RuntimeValue::String("insert".into()));
                         ins_map.insert(Ident::new("value"), new_val.clone());
-                        ins_map.insert(Ident::new("inline"), RuntimeValue::Array(ins_inline));
-                        result.push(RuntimeValue::Dict(ins_map));
+                        ins_map.insert(Ident::new("inline"), RuntimeValue::Array(Shared::new(ins_inline)));
+                        result.push(RuntimeValue::Dict(Shared::new(ins_map)));
                     } else {
                         let mut del_map = BTreeMap::new();
                         del_map.insert(Ident::new("tag"), RuntimeValue::String("delete".into()));
                         del_map.insert(Ident::new("value"), old_val.clone());
-                        result.push(RuntimeValue::Dict(del_map));
+                        result.push(RuntimeValue::Dict(Shared::new(del_map)));
                         let mut ins_map = BTreeMap::new();
                         ins_map.insert(Ident::new("tag"), RuntimeValue::String("insert".into()));
                         ins_map.insert(Ident::new("value"), new_val.clone());
-                        result.push(RuntimeValue::Dict(ins_map));
+                        result.push(RuntimeValue::Dict(Shared::new(ins_map)));
                     }
                     i += 2;
                 } else {
@@ -3861,11 +3867,11 @@ fn _diff_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Res
                     let mut map = BTreeMap::new();
                     map.insert(Ident::new("tag"), RuntimeValue::String(tag_str.into()));
                     map.insert(Ident::new("value"), value);
-                    result.push(RuntimeValue::Dict(map));
+                    result.push(RuntimeValue::Dict(Shared::new(map)));
                     i += 1;
                 }
             }
-            Ok(RuntimeValue::Array(result))
+            Ok(RuntimeValue::Array(Shared::new(result)))
         }
         [a1, a2] => {
             let s1 = a1.to_string();
@@ -3885,13 +3891,13 @@ fn _diff_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Res
                     let mut del_map = BTreeMap::new();
                     del_map.insert(Ident::new("tag"), RuntimeValue::String("delete".into()));
                     del_map.insert(Ident::new("value"), RuntimeValue::String(old_val.to_string()));
-                    del_map.insert(Ident::new("inline"), RuntimeValue::Array(del_inline));
-                    result.push(RuntimeValue::Dict(del_map));
+                    del_map.insert(Ident::new("inline"), RuntimeValue::Array(Shared::new(del_inline)));
+                    result.push(RuntimeValue::Dict(Shared::new(del_map)));
                     let mut ins_map = BTreeMap::new();
                     ins_map.insert(Ident::new("tag"), RuntimeValue::String("insert".into()));
                     ins_map.insert(Ident::new("value"), RuntimeValue::String(new_val.to_string()));
-                    ins_map.insert(Ident::new("inline"), RuntimeValue::Array(ins_inline));
-                    result.push(RuntimeValue::Dict(ins_map));
+                    ins_map.insert(Ident::new("inline"), RuntimeValue::Array(Shared::new(ins_inline)));
+                    result.push(RuntimeValue::Dict(Shared::new(ins_map)));
                     i += 2;
                 } else {
                     let tag_str = match changes[i].tag() {
@@ -3903,11 +3909,11 @@ fn _diff_impl(_: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Res
                     let mut map = BTreeMap::new();
                     map.insert(Ident::new("tag"), RuntimeValue::String(tag_str.into()));
                     map.insert(Ident::new("value"), RuntimeValue::String(val));
-                    result.push(RuntimeValue::Dict(map));
+                    result.push(RuntimeValue::Dict(Shared::new(map)));
                     i += 1;
                 }
             }
-            Ok(RuntimeValue::Array(result))
+            Ok(RuntimeValue::Array(Shared::new(result)))
         }
         _ => unreachable!("_diff should receive exactly two arguments, both arrays or both non-arrays"),
     }
@@ -4085,12 +4091,12 @@ fn http_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
 #[mq_macros::mq_fn(name = "css", params = Fixed(2))]
 fn css_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(
+        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(Shared::new(
             css::select_html(html, selector)?
                 .into_iter()
                 .map(RuntimeValue::from)
                 .collect(),
-        )),
+        ))),
         args => Err(Error::InvalidTypes(
             ident.to_string(),
             args.iter_mut().map(std::mem::take).collect(),
@@ -4104,12 +4110,12 @@ fn css_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
 #[mq_macros::mq_fn(name = "css_text", params = Fixed(2))]
 fn css_text_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(
+        [RuntimeValue::String(html), RuntimeValue::String(selector)] => Ok(RuntimeValue::Array(Shared::new(
             css::select_text(html, selector)?
                 .into_iter()
                 .map(RuntimeValue::from)
                 .collect(),
-        )),
+        ))),
         args => Err(Error::InvalidTypes(
             ident.to_string(),
             args.iter_mut().map(std::mem::take).collect(),
@@ -4127,12 +4133,12 @@ fn css_attr_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
             RuntimeValue::String(html),
             RuntimeValue::String(selector),
             RuntimeValue::String(name),
-        ] => Ok(RuntimeValue::Array(
+        ] => Ok(RuntimeValue::Array(Shared::new(
             css::select_attr(html, selector, name)?
                 .into_iter()
                 .map(|attr| attr.map(RuntimeValue::from).unwrap_or(RuntimeValue::NONE))
                 .collect(),
-        )),
+        ))),
         args => Err(Error::InvalidTypes(
             ident.to_string(),
             args.iter_mut().map(std::mem::take).collect(),
@@ -4170,7 +4176,9 @@ fn collection_record(path: String, raw: &str) -> Result<RuntimeValue, Error> {
         .map(|node| RuntimeValue::String(node.value()))
         .unwrap_or(RuntimeValue::NONE);
 
-    let content = RuntimeValue::Array(body_nodes.iter().cloned().map(RuntimeValue::from).collect());
+    let content = RuntimeValue::Array(Shared::new(
+        body_nodes.iter().cloned().map(RuntimeValue::from).collect(),
+    ));
 
     let mut record = BTreeMap::new();
     record.insert(Ident::new("path"), RuntimeValue::String(path));
@@ -4178,7 +4186,7 @@ fn collection_record(path: String, raw: &str) -> Result<RuntimeValue, Error> {
     record.insert(Ident::new("frontmatter"), frontmatter);
     record.insert(Ident::new("content"), content);
 
-    Ok(RuntimeValue::Dict(record))
+    Ok(RuntimeValue::Dict(Shared::new(record)))
 }
 
 #[cfg(feature = "file-io")]
@@ -4235,7 +4243,7 @@ fn collection_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
                 })
                 .collect::<Result<Vec<RuntimeValue>, Error>>()?;
 
-            Ok(RuntimeValue::Array(records))
+            Ok(RuntimeValue::Array(Shared::new(records)))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
         _ => unreachable!("collection should always receive exactly one argument"),
@@ -6705,12 +6713,12 @@ fn extract_recursive_node(node: &mq_markdown::Node) -> Vec<mq_markdown::Node> {
 
 /// Evaluates the recursive selector and returns all descendant nodes.
 fn eval_recursive_selector(node: &mq_markdown::Node) -> RuntimeValue {
-    RuntimeValue::Array(
+    RuntimeValue::Array(Shared::new(
         extract_recursive_node(node)
             .into_iter()
             .map(RuntimeValue::new_markdown)
             .collect(),
-    )
+    ))
 }
 
 /// Wraps `text` on word boundaries to `width` display columns (Unicode East Asian Width, so CJK counts as 2).
@@ -6840,7 +6848,7 @@ fn repeat(value: &mut RuntimeValue, n: usize) -> Result<RuntimeValue, Error> {
         }
         RuntimeValue::Array(array) => {
             if n == 0 {
-                return Ok(RuntimeValue::EMPTY_ARRAY);
+                return Ok(RuntimeValue::empty_array());
             }
 
             let total_size = array.len().saturating_mul(n);
@@ -6855,7 +6863,7 @@ fn repeat(value: &mut RuntimeValue, n: usize) -> Result<RuntimeValue, Error> {
             for _ in 0..n {
                 repeated_array.extend_from_slice(array);
             }
-            Ok(RuntimeValue::Array(repeated_array))
+            Ok(RuntimeValue::Array(Shared::new(repeated_array)))
         }
         RuntimeValue::Bytes(b) => {
             if n == 0 {
@@ -6954,7 +6962,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1970.into()), // year
                 RuntimeValue::Number(0.into()),    // mon (Jan=0)
                 RuntimeValue::Number(1.into()),    // mday
@@ -6963,7 +6971,7 @@ mod tests {
                 RuntimeValue::Number(0.into()),    // sec
                 RuntimeValue::Number(4.into()),    // wday (Thu=4)
                 RuntimeValue::Number(0.into()),    // yday
-            ])
+            ]))
         );
     }
 
@@ -6981,7 +6989,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(2024.into()), // year
                 RuntimeValue::Number(0.into()),    // mon (Jan=0)
                 RuntimeValue::Number(1.into()),    // mday
@@ -6990,7 +6998,7 @@ mod tests {
                 RuntimeValue::Number(0.into()),    // sec
                 RuntimeValue::Number(1.into()),    // wday (Mon=1)
                 RuntimeValue::Number(0.into()),    // yday
-            ])
+            ]))
         );
     }
 
@@ -7194,7 +7202,7 @@ mod tests {
         let result = eval_builtin(
             &RuntimeValue::None,
             &Ident::new("shuffle"),
-            vec![RuntimeValue::Array(input.clone())],
+            vec![RuntimeValue::Array(Shared::new(input.clone()))],
             &env,
         )
         .unwrap();
@@ -7202,7 +7210,7 @@ mod tests {
             RuntimeValue::Array(shuffled) => {
                 assert_eq!(shuffled.len(), input.len());
                 let mut sorted_input = input.clone();
-                let mut sorted_shuffled = shuffled.clone();
+                let mut sorted_shuffled = (*shuffled).clone();
                 sorted_input.sort_by(|a, b| a.partial_cmp(b).unwrap());
                 sorted_shuffled.sort_by(|a, b| a.partial_cmp(b).unwrap());
                 assert_eq!(sorted_input, sorted_shuffled);
@@ -7218,17 +7226,20 @@ mod tests {
         let result = eval_builtin(
             &RuntimeValue::None,
             &Ident::new("sample"),
-            vec![RuntimeValue::Array(input.clone()), RuntimeValue::Number(4.into())],
+            vec![
+                RuntimeValue::Array(Shared::new(input.clone())),
+                RuntimeValue::Number(4.into()),
+            ],
             &env,
         )
         .unwrap();
         match result {
             RuntimeValue::Array(sampled) => {
                 assert_eq!(sampled.len(), 4);
-                for v in &sampled {
+                for v in sampled.iter() {
                     assert!(input.contains(v));
                 }
-                let mut sorted = sampled.clone();
+                let mut sorted = (*sampled).clone();
                 sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
                 sorted.dedup();
                 assert_eq!(sorted.len(), 4, "sample should not contain duplicates");
@@ -7244,7 +7255,7 @@ mod tests {
         let result = eval_builtin(
             &RuntimeValue::None,
             &Ident::new("sample"),
-            vec![RuntimeValue::Array(input), RuntimeValue::Number(10.into())],
+            vec![RuntimeValue::Array(Shared::new(input)), RuntimeValue::Number(10.into())],
             &env,
         );
         assert!(
@@ -7428,7 +7439,7 @@ mod tests {
     #[test]
     fn test_date_add_malformed_array_error_prefix() {
         let env = Shared::new(SharedCell::new(Env::default()));
-        let bad_arr = RuntimeValue::Array(vec![RuntimeValue::String("x".into()); 8]);
+        let bad_arr = RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("x".into()); 8]));
         let result = eval_builtin(
             &RuntimeValue::None,
             &Ident::new("date_add"),
@@ -7448,7 +7459,7 @@ mod tests {
     #[test]
     fn test_date_diff_malformed_array_error_prefix() {
         let env = Shared::new(SharedCell::new(Env::default()));
-        let bad_arr = RuntimeValue::Array(vec![RuntimeValue::String("x".into()); 8]);
+        let bad_arr = RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("x".into()); 8]));
         let result = eval_builtin(
             &RuntimeValue::None,
             &Ident::new("date_diff"),
@@ -7722,7 +7733,7 @@ mod tests {
         let result = eval_selector(&node, &Selector::Recursive);
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Markdown(
                     Box::new(Node::Text(mq_markdown::Text {
                         value: "hello".into(),
@@ -7739,7 +7750,7 @@ mod tests {
                     })),
                     None
                 ),
-            ])
+            ]))
         );
     }
 
@@ -7750,7 +7761,7 @@ mod tests {
             position: None,
         });
         let result = eval_selector(&node, &Selector::Recursive);
-        assert_eq!(result, RuntimeValue::Array(vec![]));
+        assert_eq!(result, RuntimeValue::Array(Shared::new(vec![])));
     }
 
     #[test]
@@ -7771,10 +7782,10 @@ mod tests {
         let result = eval_selector(&node, &Selector::Recursive);
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::new_markdown(inner_text),
                 RuntimeValue::new_markdown(heading),
-            ])
+            ]))
         );
     }
 
@@ -7842,10 +7853,10 @@ mod tests {
         let result = eval_builtin(
             &RuntimeValue::None,
             &ident,
-            vec![RuntimeValue::Dict(d1), RuntimeValue::Dict(d2)],
+            vec![RuntimeValue::Dict(Shared::new(d1)), RuntimeValue::Dict(Shared::new(d2))],
             &Shared::new(SharedCell::new(Env::default())),
         );
-        assert_eq!(result, Ok(RuntimeValue::Dict(expected)));
+        assert_eq!(result, Ok(RuntimeValue::Dict(Shared::new(expected))));
     }
 
     #[test]
@@ -7869,18 +7880,18 @@ mod tests {
         let result = eval_builtin(
             &RuntimeValue::None,
             &ident,
-            vec![RuntimeValue::Array(vec![
+            vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("key".into()),
                 RuntimeValue::String("value".into()),
-            ])],
+            ]))],
             &Shared::new(SharedCell::new(Env::default())),
         );
         assert_eq!(
             result,
-            Ok(RuntimeValue::Dict(BTreeMap::from([(
+            Ok(RuntimeValue::Dict(Shared::new(BTreeMap::from([(
                 "key".into(),
                 RuntimeValue::String("value".into())
-            )])))
+            )]))))
         );
     }
 
@@ -8107,7 +8118,7 @@ mod tests {
             args1,
             &Shared::new(SharedCell::new(Env::default())),
         );
-        assert_eq!(result1, Ok(RuntimeValue::Array(vec![])));
+        assert_eq!(result1, Ok(RuntimeValue::Array(Shared::new(vec![]))));
 
         let mut map_data = BTreeMap::default();
         map_data.insert("name".into(), RuntimeValue::String("Jules".into()));
@@ -8124,7 +8135,7 @@ mod tests {
         match result2.unwrap() {
             RuntimeValue::Array(keys_array) => {
                 assert_eq!(keys_array.len(), 2);
-                let keys_str: Vec<String> = keys_array
+                let keys_str: Vec<String> = Shared::unwrap_or_clone(keys_array)
                     .into_iter()
                     .map(|k| match k {
                         RuntimeValue::String(s) => s,
@@ -8175,7 +8186,7 @@ mod tests {
             args1,
             &Shared::new(SharedCell::new(Env::default())),
         );
-        assert_eq!(result1, Ok(RuntimeValue::Array(vec![])));
+        assert_eq!(result1, Ok(RuntimeValue::Array(Shared::new(vec![]))));
 
         let mut map_data = BTreeMap::default();
         map_data.insert("name".into(), RuntimeValue::String("Jules".into()));
@@ -8299,7 +8310,7 @@ mod tests {
         #[case] n: usize,
         #[case] expected_msg: &str,
     ) {
-        let mut value = RuntimeValue::Array(array);
+        let mut value = RuntimeValue::Array(Shared::new(array));
         let result = repeat(&mut value, n);
         assert!(result.is_err());
         if let Err(Error::Runtime(msg)) = result {
@@ -8325,7 +8336,7 @@ mod tests {
         #[case] n: usize,
         #[case] expected_len: usize,
     ) {
-        let mut value = RuntimeValue::Array(array);
+        let mut value = RuntimeValue::Array(Shared::new(array));
         let result = repeat(&mut value, n);
         assert!(result.is_ok());
         if let Ok(RuntimeValue::Array(vec)) = result {
@@ -8364,36 +8375,36 @@ mod tests {
     #[rstest]
     #[case::simple_no_header(
         "a,b,c\n1,2,3\n4,5,6",
-        Ok(RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![
+        Ok(RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
-            ]),
-            RuntimeValue::Array(vec![
+            ])),
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("1".to_string()),
                 RuntimeValue::String("2".to_string()),
                 RuntimeValue::String("3".to_string()),
-            ]),
-            RuntimeValue::Array(vec![
+            ])),
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("4".to_string()),
                 RuntimeValue::String("5".to_string()),
                 RuntimeValue::String("6".to_string()),
-            ]),
-        ]))
+            ])),
+        ])))
     )]
     #[case::single_row_no_header(
         "x,y",
-        Ok(RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![
+        Ok(RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("x".to_string()),
                 RuntimeValue::String("y".to_string()),
-            ]),
-        ]))
+            ])),
+        ])))
     )]
     #[case::empty_no_header(
         "",
-        Ok(RuntimeValue::Array(vec![]))
+        Ok(RuntimeValue::Array(Shared::new(vec![])))
     )]
     fn test_csv_parse_no_header(#[case] csv: &str, #[case] expected: Result<RuntimeValue, Error>) {
         let ident = Ident::new("_csv_parse");
@@ -8416,10 +8427,10 @@ mod tests {
             let mut bob = BTreeMap::new();
             bob.insert(Ident::new("name"), RuntimeValue::String("Bob".to_string()));
             bob.insert(Ident::new("age"), RuntimeValue::String("25".to_string()));
-            Ok(RuntimeValue::Array(vec![
-                RuntimeValue::Dict(alice),
-                RuntimeValue::Dict(bob),
-            ]))
+            Ok(RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Dict(Shared::new(alice)),
+                RuntimeValue::Dict(Shared::new(bob)),
+            ])))
         }
     )]
     #[case::single_row_with_header(
@@ -8428,7 +8439,7 @@ mod tests {
             let mut row = BTreeMap::new();
             row.insert(Ident::new("id"), RuntimeValue::String("1".to_string()));
             row.insert(Ident::new("value"), RuntimeValue::String("hello".to_string()));
-            Ok(RuntimeValue::Array(vec![RuntimeValue::Dict(row)]))
+            Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(row))])))
         }
     )]
     #[case::quoted_fields_with_header(
@@ -8437,7 +8448,7 @@ mod tests {
             let mut row = BTreeMap::new();
             row.insert(Ident::new("name"), RuntimeValue::String("Doe, Jane".to_string()));
             row.insert(Ident::new("note"), RuntimeValue::String("says \"hi\"".to_string()));
-            Ok(RuntimeValue::Array(vec![RuntimeValue::Dict(row)]))
+            Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(row))])))
         }
     )]
     fn test_csv_parse_with_header(#[case] csv: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8460,18 +8471,18 @@ mod tests {
         "a\tb\tc\n1\t2\t3",
         "\t",
         false,
-        Ok(RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![
+        Ok(RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("a".to_string()),
                 RuntimeValue::String("b".to_string()),
                 RuntimeValue::String("c".to_string()),
-            ]),
-            RuntimeValue::Array(vec![
+            ])),
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("1".to_string()),
                 RuntimeValue::String("2".to_string()),
                 RuntimeValue::String("3".to_string()),
-            ]),
-        ]))
+            ])),
+        ])))
     )]
     #[case::tsv_with_header(
         "name\tage\nAlice\t30",
@@ -8481,7 +8492,7 @@ mod tests {
             let mut row = BTreeMap::new();
             row.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
             row.insert(Ident::new("age"), RuntimeValue::String("30".to_string()));
-            Ok(RuntimeValue::Array(vec![RuntimeValue::Dict(row)]))
+            Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(row))])))
         }
     )]
     fn test_csv_parse_custom_delimiter(
@@ -8524,29 +8535,29 @@ mod tests {
         {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("key"), RuntimeValue::String("value".to_string()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::array(
         r#"[1, 2, 3]"#,
-        Ok(RuntimeValue::Array(vec![
+        Ok(RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ]))
+        ])))
     )]
     #[case::nested(
         r#"{"a": [true, null], "b": {"c": 1.2}}"#,
         {
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("a"), RuntimeValue::Array(vec![
+            map.insert(Ident::new("a"), RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Boolean(true),
                 RuntimeValue::NONE,
-            ]));
+            ])));
             let mut inner = BTreeMap::new();
             inner.insert(Ident::new("c"), RuntimeValue::Number(1.2.into()));
-            map.insert(Ident::new("b"), RuntimeValue::Dict(inner));
-            Ok(RuntimeValue::Dict(map))
+            map.insert(Ident::new("b"), RuntimeValue::Dict(Shared::new(inner)));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::string(r#""hello""#, Ok(RuntimeValue::String("hello".to_string())))]
@@ -8588,16 +8599,16 @@ mod tests {
         {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("key"), RuntimeValue::String("value".to_string()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::sequence(
         "- 1\n- 2\n- 3",
-        Ok(RuntimeValue::Array(vec![
+        Ok(RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ]))
+        ])))
     )]
     #[case::nested(
         "a:\n  b: 42",
@@ -8605,8 +8616,8 @@ mod tests {
             let mut inner = BTreeMap::new();
             inner.insert(Ident::new("b"), RuntimeValue::Number(42.into()));
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("a"), RuntimeValue::Dict(inner));
-            Ok(RuntimeValue::Dict(map))
+            map.insert(Ident::new("a"), RuntimeValue::Dict(Shared::new(inner)));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::boolean(
@@ -8614,7 +8625,7 @@ mod tests {
         {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("flag"), RuntimeValue::Boolean(true));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::null(
@@ -8622,7 +8633,7 @@ mod tests {
         {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("value"), RuntimeValue::NONE);
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::float(
@@ -8630,7 +8641,7 @@ mod tests {
         {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("ratio"), RuntimeValue::Number(1.5.into()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     fn test_yaml_parse(#[case] yaml: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8668,7 +8679,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("a"), RuntimeValue::Number(1.into()));
             map.insert(Ident::new("b"), RuntimeValue::Number(2.into()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::nested_indent(
@@ -8677,8 +8688,8 @@ mod tests {
             let mut child_map = BTreeMap::new();
             child_map.insert(Ident::new("child"), RuntimeValue::String("value".to_string()));
             let mut parent_map = BTreeMap::new();
-            parent_map.insert(Ident::new("parent"), RuntimeValue::Dict(child_map));
-            Ok(RuntimeValue::Dict(parent_map))
+            parent_map.insert(Ident::new("parent"), RuntimeValue::Dict(Shared::new(child_map)));
+            Ok(RuntimeValue::Dict(Shared::new(parent_map)))
         }
     )]
     #[case::tabular_data(
@@ -8691,31 +8702,31 @@ mod tests {
             row2.insert(Ident::new("id"), RuntimeValue::Number(2.into()));
             row2.insert(Ident::new("name"), RuntimeValue::String("Ridge Trail".to_string()));
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("hikes"), RuntimeValue::Array(vec![RuntimeValue::Dict(row1), RuntimeValue::Dict(row2)]));
-            Ok(RuntimeValue::Dict(map))
+            map.insert(Ident::new("hikes"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(row1)), RuntimeValue::Dict(Shared::new(row2))])));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::inline_array(
         "items[3]: 1, 2, 3",
         {
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("items"), RuntimeValue::Array(vec![
+            map.insert(Ident::new("items"), RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Number(2.into()),
                 RuntimeValue::Number(3.into()),
-            ]));
-            Ok(RuntimeValue::Dict(map))
+            ])));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::expanded_array(
         "items[2]:\n  - 1\n  - 2",
         {
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("items"), RuntimeValue::Array(vec![
+            map.insert(Ident::new("items"), RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(1.into()),
                 RuntimeValue::Number(2.into()),
-            ]));
-            Ok(RuntimeValue::Dict(map))
+            ])));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::primitives(
@@ -8726,7 +8737,7 @@ mod tests {
             map.insert(Ident::new("b"), RuntimeValue::TRUE);
             map.insert(Ident::new("n"), RuntimeValue::NONE);
             map.insert(Ident::new("f"), RuntimeValue::FALSE);
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     fn test_toon_parse(#[case] toon: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8747,7 +8758,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
             map.insert(Ident::new("age"), RuntimeValue::Number(30.into()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::boolean(
@@ -8756,7 +8767,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("enabled"), RuntimeValue::Boolean(true));
             map.insert(Ident::new("disabled"), RuntimeValue::Boolean(false));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::nested_table(
@@ -8766,19 +8777,19 @@ mod tests {
             inner.insert(Ident::new("host"), RuntimeValue::String("localhost".to_string()));
             inner.insert(Ident::new("port"), RuntimeValue::Number(8080.into()));
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("server"), RuntimeValue::Dict(inner));
-            Ok(RuntimeValue::Dict(map))
+            map.insert(Ident::new("server"), RuntimeValue::Dict(Shared::new(inner)));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     #[case::array(
         "tags = [\"rust\", \"toml\"]",
         {
             let mut map = BTreeMap::new();
-            map.insert(Ident::new("tags"), RuntimeValue::Array(vec![
+            map.insert(Ident::new("tags"), RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("rust".to_string()),
                 RuntimeValue::String("toml".to_string()),
-            ]));
-            Ok(RuntimeValue::Dict(map))
+            ])));
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     fn test_toml_parse(#[case] toml: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8826,7 +8837,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
             map.insert(Ident::new("age"), RuntimeValue::Number(30.into()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     fn test_cbor_parse(#[case] input: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8875,7 +8886,7 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
             map.insert(Ident::new("age"), RuntimeValue::Number(30.into()));
-            Ok(RuntimeValue::Dict(map))
+            Ok(RuntimeValue::Dict(Shared::new(map)))
         }
     )]
     fn test_cbor_stringify_roundtrip(#[case] base64_input: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -8915,7 +8926,7 @@ mod tests {
         assert!(result.is_ok());
         let mut expected = BTreeMap::new();
         expected.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
-        assert_eq!(result.unwrap(), RuntimeValue::Dict(expected));
+        assert_eq!(result.unwrap(), RuntimeValue::Dict(Shared::new(expected)));
     }
 
     #[test]
@@ -8945,11 +8956,11 @@ mod tests {
         Ok(RuntimeValue::Bytes(vec![0xe3, 0x81, 0x82]))
     )]
     #[case::array_of_numbers(
-        RuntimeValue::Array(vec![
+        RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(0.into()),
             RuntimeValue::Number(255.into()),
             RuntimeValue::Number(128.into()),
-        ]),
+        ])),
         Ok(RuntimeValue::Bytes(vec![0, 255, 128]))
     )]
     #[case::bytes_identity(
@@ -8969,12 +8980,12 @@ mod tests {
 
     #[rstest]
     #[case::number(RuntimeValue::Number(42.into()))]
-    #[case::array_with_non_number(RuntimeValue::Array(vec![RuntimeValue::String("x".to_string())]))]
-    #[case::array_with_negative(RuntimeValue::Array(vec![RuntimeValue::Number((-1i64).into())]))]
-    #[case::array_with_256(RuntimeValue::Array(vec![RuntimeValue::Number(256i64.into())]))]
-    #[case::array_with_fractional(RuntimeValue::Array(vec![RuntimeValue::Number(1.5f64.into())]))]
-    #[case::array_with_nan(RuntimeValue::Array(vec![RuntimeValue::Number(f64::NAN.into())]))]
-    #[case::array_with_infinity(RuntimeValue::Array(vec![RuntimeValue::Number(f64::INFINITY.into())]))]
+    #[case::array_with_non_number(RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("x".to_string())])))]
+    #[case::array_with_negative(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number((-1i64).into())])))]
+    #[case::array_with_256(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(256i64.into())])))]
+    #[case::array_with_fractional(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.5f64.into())])))]
+    #[case::array_with_nan(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(f64::NAN.into())])))]
+    #[case::array_with_infinity(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(f64::INFINITY.into())])))]
     fn test_to_bytes_invalid(#[case] input: RuntimeValue) {
         let ident = Ident::new("to_bytes");
         let result = eval_builtin(
@@ -9250,9 +9261,9 @@ mod tests {
             let mut root = BTreeMap::new();
             root.insert(Ident::new("tag"), RuntimeValue::String("root".to_string()));
             root.insert(Ident::new("attributes"), RuntimeValue::new_dict());
-            root.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+            root.insert(Ident::new("children"), RuntimeValue::empty_array());
             root.insert(Ident::new("text"), RuntimeValue::String("hello".to_string()));
-            Ok(RuntimeValue::Dict(root))
+            Ok(RuntimeValue::Dict(Shared::new(root)))
         }
     )]
     #[case::with_attributes(
@@ -9263,10 +9274,10 @@ mod tests {
             attrs.insert(Ident::new("id"), RuntimeValue::String("1".to_string()));
             attrs.insert(Ident::new("class"), RuntimeValue::String("main".to_string()));
             root.insert(Ident::new("tag"), RuntimeValue::String("root".to_string()));
-            root.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs));
-            root.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+            root.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs)));
+            root.insert(Ident::new("children"), RuntimeValue::empty_array());
             root.insert(Ident::new("text"), RuntimeValue::String("hello".to_string()));
-            Ok(RuntimeValue::Dict(root))
+            Ok(RuntimeValue::Dict(Shared::new(root)))
         }
     )]
     #[case::nested(
@@ -9277,26 +9288,26 @@ mod tests {
             let mut attrs1 = BTreeMap::new();
             attrs1.insert(Ident::new("id"), RuntimeValue::String("1".to_string()));
             child1.insert(Ident::new("tag"), RuntimeValue::String("child".to_string()));
-            child1.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs1));
-            child1.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+            child1.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs1)));
+            child1.insert(Ident::new("children"), RuntimeValue::empty_array());
             child1.insert(Ident::new("text"), RuntimeValue::String("hello".to_string()));
 
             let mut child2 = BTreeMap::new();
             let mut attrs2 = BTreeMap::new();
             attrs2.insert(Ident::new("id"), RuntimeValue::String("2".to_string()));
             child2.insert(Ident::new("tag"), RuntimeValue::String("child".to_string()));
-            child2.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs2));
-            child2.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+            child2.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs2)));
+            child2.insert(Ident::new("children"), RuntimeValue::empty_array());
             child2.insert(Ident::new("text"), RuntimeValue::String("world".to_string()));
 
             root.insert(Ident::new("tag"), RuntimeValue::String("root".to_string()));
             root.insert(Ident::new("attributes"), RuntimeValue::new_dict());
-            root.insert(Ident::new("children"), RuntimeValue::Array(vec![
-                RuntimeValue::Dict(child1),
-                RuntimeValue::Dict(child2),
-            ]));
+            root.insert(Ident::new("children"), RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Dict(Shared::new(child1)),
+                RuntimeValue::Dict(Shared::new(child2)),
+            ])));
             root.insert(Ident::new("text"), RuntimeValue::NONE);
-            Ok(RuntimeValue::Dict(root))
+            Ok(RuntimeValue::Dict(Shared::new(root)))
         }
     )]
     #[case::self_closing(
@@ -9307,17 +9318,17 @@ mod tests {
             let mut attrs = BTreeMap::new();
             attrs.insert(Ident::new("id"), RuntimeValue::String("1".to_string()));
             child.insert(Ident::new("tag"), RuntimeValue::String("child".to_string()));
-            child.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs));
-            child.insert(Ident::new("children"), RuntimeValue::EMPTY_ARRAY);
+            child.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs)));
+            child.insert(Ident::new("children"), RuntimeValue::empty_array());
             child.insert(Ident::new("text"), RuntimeValue::NONE);
 
             root.insert(Ident::new("tag"), RuntimeValue::String("root".to_string()));
             root.insert(Ident::new("attributes"), RuntimeValue::new_dict());
-            root.insert(Ident::new("children"), RuntimeValue::Array(vec![
-                RuntimeValue::Dict(child),
-            ]));
+            root.insert(Ident::new("children"), RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Dict(Shared::new(child)),
+            ])));
             root.insert(Ident::new("text"), RuntimeValue::NONE);
-            Ok(RuntimeValue::Dict(root))
+            Ok(RuntimeValue::Dict(Shared::new(root)))
         }
     )]
     fn test_xml_parse(#[case] xml: &str, #[case] expected: Result<RuntimeValue, Error>) {
@@ -9382,8 +9393,8 @@ mod tests {
             &RuntimeValue::None,
             &ident,
             vec![
-                RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]),
-                RuntimeValue::Array(vec![RuntimeValue::Number(2.into())]),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())])),
+                RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into())])),
             ],
             &Shared::new(SharedCell::new(Env::default())),
         );
@@ -9414,7 +9425,7 @@ mod tests {
     #[rstest]
     #[case::single_number(vec![RuntimeValue::Number(1.into())], vec![1u8])]
     #[case::multiple_numbers(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())], vec![1u8, 2u8])]
-    #[case::number_array(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])], vec![1u8, 2u8])]
+    #[case::number_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))], vec![1u8, 2u8])]
     #[case::empty(vec![], vec![])]
     #[case::ignores_strings(vec![RuntimeValue::String("x".into())], vec![])]
     fn test_collect_depth_values(#[case] args: Vec<RuntimeValue>, #[case] expected: Vec<u8>) {
@@ -9424,7 +9435,7 @@ mod tests {
     #[rstest]
     #[case::single_string(vec![RuntimeValue::String("rust".into())], vec!["rust".to_string()])]
     #[case::multiple_strings(vec![RuntimeValue::String("rust".into()), RuntimeValue::String("go".into())], vec!["rust".to_string(), "go".to_string()])]
-    #[case::string_array(vec![RuntimeValue::Array(vec![RuntimeValue::String("rust".into()), RuntimeValue::String("go".into())])], vec!["rust".to_string(), "go".to_string()])]
+    #[case::string_array(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("rust".into()), RuntimeValue::String("go".into())]))], vec!["rust".to_string(), "go".to_string()])]
     #[case::empty(vec![], vec![])]
     #[case::ignores_numbers(vec![RuntimeValue::Number(1.into())], vec![])]
     fn test_collect_string_values(#[case] args: Vec<RuntimeValue>, #[case] expected: Vec<String>) {
@@ -10203,7 +10214,10 @@ mod tests {
             assert_eq!(get(&entries[0], "title"), RuntimeValue::String("World".into()));
             let mut toml_frontmatter = BTreeMap::new();
             toml_frontmatter.insert(Ident::new("title"), RuntimeValue::String("World".into()));
-            assert_eq!(get(&entries[0], "frontmatter"), RuntimeValue::Dict(toml_frontmatter));
+            assert_eq!(
+                get(&entries[0], "frontmatter"),
+                RuntimeValue::Dict(Shared::new(toml_frontmatter))
+            );
 
             assert_eq!(get(&entries[1], "title"), RuntimeValue::String("Hello".into()));
             match get(&entries[1], "frontmatter") {
@@ -10211,7 +10225,9 @@ mod tests {
                     assert_eq!(d.get(&Ident::new("title")), Some(&RuntimeValue::String("Hello".into())));
                     assert_eq!(
                         d.get(&Ident::new("tags")),
-                        Some(&RuntimeValue::Array(vec![RuntimeValue::String("rust".into())]))
+                        Some(&RuntimeValue::Array(Shared::new(vec![RuntimeValue::String(
+                            "rust".into()
+                        )])))
                     );
                 }
                 other => panic!("expected Dict, got {other:?}"),

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -287,7 +287,7 @@ pub(super) fn to_number(value: &mut RuntimeValue) -> Result<RuntimeValue, Error>
             .map(|n| RuntimeValue::Number(n.into()))
             .map_err(|e| Error::Runtime(format!("{}", e))),
         RuntimeValue::Array(array) => {
-            let result_value: Result<Vec<RuntimeValue>, Error> = std::mem::take(array)
+            let result_value: Result<Vec<RuntimeValue>, Error> = crate::Shared::unwrap_or_clone(std::mem::take(array))
                 .into_iter()
                 .map(|o| match o {
                     node @ RuntimeValue::Markdown(_, _) => node
@@ -309,7 +309,7 @@ pub(super) fn to_number(value: &mut RuntimeValue) -> Result<RuntimeValue, Error>
                 })
                 .collect();
 
-            result_value.map(RuntimeValue::Array)
+            result_value.map(|v| RuntimeValue::Array(crate::Shared::new(v)))
         }
         RuntimeValue::Boolean(true) => Ok(RuntimeValue::Number(1.into())),
         RuntimeValue::Boolean(false) => Ok(RuntimeValue::Number(0.into())),
@@ -335,14 +335,14 @@ pub(super) fn to_boolean(value: &RuntimeValue) -> Result<RuntimeValue, Error> {
 pub(super) fn to_array(value: &mut RuntimeValue) -> Result<RuntimeValue, Error> {
     match value {
         RuntimeValue::Array(array) => Ok(RuntimeValue::Array(std::mem::take(array))),
-        RuntimeValue::String(s) => Ok(RuntimeValue::Array(
+        RuntimeValue::String(s) => Ok(RuntimeValue::Array(crate::Shared::new(
             s.chars().map(|c| RuntimeValue::String(c.to_string())).collect(),
-        )),
-        RuntimeValue::Bytes(bytes) => Ok(RuntimeValue::Array(
+        ))),
+        RuntimeValue::Bytes(bytes) => Ok(RuntimeValue::Array(crate::Shared::new(
             bytes.iter().map(|b| RuntimeValue::Number((*b).into())).collect(),
-        )),
-        RuntimeValue::None => Ok(RuntimeValue::Array(Vec::new())),
-        value => Ok(RuntimeValue::Array(vec![std::mem::take(value)])),
+        ))),
+        RuntimeValue::None => Ok(RuntimeValue::empty_array()),
+        value => Ok(RuntimeValue::Array(crate::Shared::new(vec![std::mem::take(value)]))),
     }
 }
 
@@ -615,7 +615,7 @@ pub(super) fn flatten(args: Vec<RuntimeValue>) -> Vec<RuntimeValue> {
     let mut result = Vec::new();
     for arg in args {
         match arg {
-            RuntimeValue::Array(arr) => result.extend(flatten(arr)),
+            RuntimeValue::Array(arr) => result.extend(flatten(crate::Shared::unwrap_or_clone(arr))),
             other => result.push(other),
         }
     }
@@ -893,10 +893,10 @@ mod tests {
 
     #[test]
     fn test_to_number_array() {
-        let mut input = RuntimeValue::Array(vec![
+        let mut input = RuntimeValue::Array(crate::Shared::new(vec![
             RuntimeValue::String("42".to_string()),
             RuntimeValue::Boolean(true),
-        ]);
+        ]));
         let result = to_number(&mut input).unwrap();
         match result {
             RuntimeValue::Array(arr) => {
@@ -924,16 +924,22 @@ mod tests {
     #[case::boolean_false(RuntimeValue::Boolean(false), vec![RuntimeValue::Boolean(false)])]
     fn test_to_array(#[case] mut input: RuntimeValue, #[case] expected: Vec<RuntimeValue>) {
         let result = to_array(&mut input).unwrap();
-        assert_eq!(result, RuntimeValue::Array(expected));
+        assert_eq!(result, RuntimeValue::Array(crate::Shared::new(expected)));
     }
 
     #[test]
     fn test_to_array_already_array() {
-        let mut input = RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]);
+        let mut input = RuntimeValue::Array(crate::Shared::new(vec![
+            RuntimeValue::Number(1.into()),
+            RuntimeValue::Number(2.into()),
+        ]));
         let result = to_array(&mut input).unwrap();
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()),])
+            RuntimeValue::Array(crate::Shared::new(vec![
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::Number(2.into()),
+            ]))
         );
     }
 
@@ -943,22 +949,22 @@ mod tests {
     #[case::number(RuntimeValue::Number(42.into()), "42")]
     #[case::none(RuntimeValue::None, "")]
     #[case::array(
-        RuntimeValue::Array(vec![
+        RuntimeValue::Array(crate::Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ]),
+        ])),
         "a,b,c"
     )]
     #[case::array_with_none(
-        RuntimeValue::Array(vec![
+        RuntimeValue::Array(crate::Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::None,
             RuntimeValue::String("c".to_string()),
-        ]),
+        ])),
         "a,,c"
     )]
-    #[case::empty_array(RuntimeValue::Array(vec![]), "")]
+    #[case::empty_array(RuntimeValue::Array(crate::Shared::new(vec![])), "")]
     fn test_to_text(#[case] input: RuntimeValue, #[case] expected: &str) {
         let result = to_text(&input).unwrap();
         match result {
@@ -998,9 +1004,9 @@ mod tests {
     )]
     #[case::nested_array(
         vec![
-            RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]),
+            RuntimeValue::Array(crate::Shared::new(vec![RuntimeValue::Number(1.into())])),
             RuntimeValue::Number(2.into()),
-            RuntimeValue::Array(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]),
+            RuntimeValue::Array(crate::Shared::new(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])),
         ],
         vec![
             RuntimeValue::Number(1.into()),
@@ -1011,10 +1017,10 @@ mod tests {
     )]
     #[case::deeply_nested(
         vec![
-            RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]),
+            RuntimeValue::Array(crate::Shared::new(vec![
+                RuntimeValue::Array(crate::Shared::new(vec![RuntimeValue::Number(1.into())])),
                 RuntimeValue::Number(2.into()),
-            ]),
+            ])),
         ],
         vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]
     )]
@@ -1027,9 +1033,9 @@ mod tests {
     #[test]
     fn test_flatten_with_empty_nested() {
         let input = vec![
-            RuntimeValue::Array(vec![]),
+            RuntimeValue::Array(crate::Shared::new(vec![])),
             RuntimeValue::Number(1.into()),
-            RuntimeValue::Array(vec![]),
+            RuntimeValue::Array(crate::Shared::new(vec![])),
         ];
         let result = flatten(input);
         assert_eq!(result, vec![RuntimeValue::Number(1.into())]);

--- a/crates/mq-lang/src/eval/builtin/regex.rs
+++ b/crates/mq-lang/src/eval/builtin/regex.rs
@@ -1,4 +1,5 @@
 use crate::Ident;
+use crate::Shared;
 use crate::eval::runtime_value::RuntimeValue;
 use regex_lite::{Regex, RegexBuilder};
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -16,7 +17,7 @@ pub(super) fn match_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error
             .find_iter(input)
             .map(|m| RuntimeValue::String(m.as_str().to_string()))
             .collect();
-        return Ok(RuntimeValue::Array(matches));
+        return Ok(RuntimeValue::Array(Shared::new(matches)));
     }
     let re = RegexBuilder::new(pattern)
         .size_limit(1 << 20)
@@ -27,7 +28,7 @@ pub(super) fn match_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error
         .find_iter(input)
         .map(|m| RuntimeValue::String(m.as_str().to_string()))
         .collect();
-    Ok(RuntimeValue::Array(matches))
+    Ok(RuntimeValue::Array(Shared::new(matches)))
 }
 
 pub(super) fn is_match_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error> {
@@ -51,7 +52,7 @@ pub(super) fn capture_re_inner(re: &Regex, input: &str) -> Result<RuntimeValue, 
                     result.insert(Ident::new(name), RuntimeValue::String(m.as_str().to_string()));
                 }
             }
-            Ok(RuntimeValue::Dict(result))
+            Ok(RuntimeValue::Dict(Shared::new(result)))
         }
         _ => Ok(RuntimeValue::new_dict()),
     }
@@ -87,7 +88,7 @@ fn scan_re_inner(re: &Regex, input: &str) -> RuntimeValue {
         .captures_iter(input)
         .map(|caps| {
             if has_groups {
-                RuntimeValue::Array(
+                RuntimeValue::Array(Shared::new(
                     caps.iter()
                         .skip(1)
                         .map(|m| {
@@ -95,13 +96,13 @@ fn scan_re_inner(re: &Regex, input: &str) -> RuntimeValue {
                                 .unwrap_or(RuntimeValue::NONE)
                         })
                         .collect(),
-                )
+                ))
             } else {
                 RuntimeValue::String(caps.get(0).map(|m| m.as_str().to_string()).unwrap_or_default())
             }
         })
         .collect();
-    RuntimeValue::Array(matches)
+    RuntimeValue::Array(Shared::new(matches))
 }
 
 pub(super) fn scan_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error> {
@@ -119,15 +120,15 @@ pub(super) fn scan_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error>
 #[inline(always)]
 pub(super) fn split_re(input: &str, pattern: &str) -> Result<RuntimeValue, Error> {
     if let Some(re) = REGEX_CACHE.read().unwrap().get(pattern).cloned() {
-        return Ok(RuntimeValue::Array(
+        return Ok(RuntimeValue::Array(Shared::new(
             re.split(input).map(|s| s.to_owned().into()).collect::<Vec<_>>(),
-        ));
+        )));
     }
     let re = Regex::new(pattern).map_err(|_| Error::InvalidRegularExpression(pattern.to_string()))?;
     REGEX_CACHE.write().unwrap().insert(pattern.to_string(), re.clone());
-    Ok(RuntimeValue::Array(
+    Ok(RuntimeValue::Array(Shared::new(
         re.split(input).map(|s| s.to_owned().into()).collect::<Vec<_>>(),
-    ))
+    )))
 }
 
 #[cfg(test)]
@@ -136,7 +137,9 @@ mod tests {
     use rstest::rstest;
 
     fn strings(v: Vec<&str>) -> RuntimeValue {
-        RuntimeValue::Array(v.into_iter().map(|s| RuntimeValue::String(s.to_string())).collect())
+        RuntimeValue::Array(Shared::new(
+            v.into_iter().map(|s| RuntimeValue::String(s.to_string())).collect(),
+        ))
     }
 
     #[rstest]
@@ -258,23 +261,23 @@ mod tests {
         let result = scan_re("2024-06 2025-07", r"(\d{4})-(\d{2})").unwrap();
         assert_eq!(
             result,
-            RuntimeValue::Array(vec![
-                RuntimeValue::Array(vec![
+            RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("2024".to_string()),
                     RuntimeValue::String("06".to_string()),
-                ]),
-                RuntimeValue::Array(vec![
+                ])),
+                RuntimeValue::Array(Shared::new(vec![
                     RuntimeValue::String("2025".to_string()),
                     RuntimeValue::String("07".to_string()),
-                ]),
-            ])
+                ])),
+            ]))
         );
     }
 
     #[test]
     fn test_scan_re_no_match() {
         let result = scan_re("no digits here", r"\d+").unwrap();
-        assert_eq!(result, RuntimeValue::Array(vec![]));
+        assert_eq!(result, RuntimeValue::Array(Shared::new(vec![])));
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/runtime_value.rs
+++ b/crates/mq-lang/src/eval/runtime_value.rs
@@ -88,7 +88,10 @@ pub enum RuntimeValue {
     /// A symbol (interned identifier).
     Symbol(Ident),
     /// An array of runtime values.
-    Array(Vec<RuntimeValue>),
+    ///
+    /// Behind [`Shared`] for clone-on-write: cloning is an O(1) refcount bump; mutating
+    /// builtins must go through [`array_mut`] instead of mutating directly.
+    Array(Shared<Vec<RuntimeValue>>),
     /// A markdown node with an optional selector for indexing.
     Markdown(Box<Node>, Option<Selector>),
     /// A user-defined function with parameters, body (program), and captured environment.
@@ -96,7 +99,9 @@ pub enum RuntimeValue {
     /// A built-in native function identified by name.
     NativeFunction(Ident),
     /// A dictionary mapping identifiers to runtime values.
-    Dict(BTreeMap<Ident, RuntimeValue>),
+    ///
+    /// Same clone-on-write scheme as [`RuntimeValue::Array`]; see [`dict_mut`].
+    Dict(Shared<BTreeMap<Ident, RuntimeValue>>),
     /// A module with its exports.
     Module(ModuleEnv),
     /// An AST node (quoted expression).
@@ -180,23 +185,23 @@ impl From<usize> for RuntimeValue {
 
 impl From<Vec<RuntimeValue>> for RuntimeValue {
     fn from(arr: Vec<RuntimeValue>) -> Self {
-        RuntimeValue::Array(arr)
+        RuntimeValue::Array(Shared::new(arr))
     }
 }
 
 impl From<BTreeMap<Ident, RuntimeValue>> for RuntimeValue {
     fn from(map: BTreeMap<Ident, RuntimeValue>) -> Self {
-        RuntimeValue::Dict(map)
+        RuntimeValue::Dict(Shared::new(map))
     }
 }
 
 impl From<Vec<(String, Number)>> for RuntimeValue {
     fn from(v: Vec<(String, Number)>) -> Self {
-        RuntimeValue::Dict(
+        RuntimeValue::Dict(Shared::new(
             v.into_iter()
                 .map(|(k, v)| (Ident::new(&k), RuntimeValue::Number(v)))
                 .collect::<BTreeMap<Ident, RuntimeValue>>(),
-        )
+        ))
     }
 }
 
@@ -208,7 +213,7 @@ impl From<mq_markdown::AttrValue> for RuntimeValue {
             mq_markdown::AttrValue::Integer(n) => RuntimeValue::Number(n.into()),
             mq_markdown::AttrValue::Boolean(b) => RuntimeValue::Boolean(b),
             mq_markdown::AttrValue::Array(arr) => {
-                RuntimeValue::Array(arr.into_iter().map(RuntimeValue::from).collect())
+                RuntimeValue::Array(Shared::new(arr.into_iter().map(RuntimeValue::from).collect()))
             }
             mq_markdown::AttrValue::Null => RuntimeValue::NONE,
         }
@@ -226,7 +231,9 @@ impl From<yaml_rust2::Yaml> for RuntimeValue {
                 .map(|f| RuntimeValue::Number(f.into()))
                 .unwrap_or(RuntimeValue::NONE),
             yaml_rust2::Yaml::String(s) => RuntimeValue::String(s),
-            yaml_rust2::Yaml::Array(arr) => RuntimeValue::Array(arr.into_iter().map(RuntimeValue::from).collect()),
+            yaml_rust2::Yaml::Array(arr) => {
+                RuntimeValue::Array(Shared::new(arr.into_iter().map(RuntimeValue::from).collect()))
+            }
             yaml_rust2::Yaml::Hash(map) => {
                 let mut btree = BTreeMap::new();
                 for (k, v) in map {
@@ -236,7 +243,7 @@ impl From<yaml_rust2::Yaml> for RuntimeValue {
                     };
                     btree.insert(Ident::new(&key), RuntimeValue::from(v));
                 }
-                RuntimeValue::Dict(btree)
+                RuntimeValue::Dict(Shared::new(btree))
             }
             yaml_rust2::Yaml::Alias(_) => RuntimeValue::NONE,
         }
@@ -256,13 +263,15 @@ impl From<serde_json::Value> for RuntimeValue {
                 }
             }
             serde_json::Value::String(s) => RuntimeValue::String(s),
-            serde_json::Value::Array(arr) => RuntimeValue::Array(arr.into_iter().map(RuntimeValue::from).collect()),
+            serde_json::Value::Array(arr) => {
+                RuntimeValue::Array(Shared::new(arr.into_iter().map(RuntimeValue::from).collect()))
+            }
             serde_json::Value::Object(obj) => {
                 let mut map = BTreeMap::new();
                 for (k, v) in obj {
                     map.insert(Ident::new(&k), RuntimeValue::from(v));
                 }
-                RuntimeValue::Dict(map)
+                RuntimeValue::Dict(Shared::new(map))
             }
         }
     }
@@ -282,7 +291,7 @@ impl From<ciborium::Value> for RuntimeValue {
             ciborium::Value::Bytes(b) => RuntimeValue::Bytes(b),
             ciborium::Value::Array(arr) => {
                 let items = arr.into_iter().map(Into::into).collect();
-                RuntimeValue::Array(items)
+                RuntimeValue::Array(Shared::new(items))
             }
             ciborium::Value::Map(pairs) => {
                 let mut map = BTreeMap::new();
@@ -293,7 +302,7 @@ impl From<ciborium::Value> for RuntimeValue {
                     };
                     map.insert(key, v.into());
                 }
-                RuntimeValue::Dict(map)
+                RuntimeValue::Dict(Shared::new(map))
             }
             ciborium::Value::Tag(_, inner) => (*inner).into(),
             _ => RuntimeValue::NONE,
@@ -373,9 +382,22 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
     })
 }
 
+/// Clone-on-write access to an array's elements.
+///
+/// Bare `Shared::make_mut` is ambiguous (it also matches the `Rc<[T]>`/`Arc<[T]>` slice
+/// specialization), so this pins the type down.
+#[inline(always)]
+pub(crate) fn array_mut(array: &mut Shared<Vec<RuntimeValue>>) -> &mut Vec<RuntimeValue> {
+    Shared::<Vec<RuntimeValue>>::make_mut(array)
+}
+
+/// Clone-on-write access to a dict's entries; see [`array_mut`].
+#[inline(always)]
+pub(crate) fn dict_mut(map: &mut Shared<BTreeMap<Ident, RuntimeValue>>) -> &mut BTreeMap<Ident, RuntimeValue> {
+    Shared::<BTreeMap<Ident, RuntimeValue>>::make_mut(map)
+}
+
 impl RuntimeValue {
-    /// An empty array constant.
-    pub const EMPTY_ARRAY: RuntimeValue = Self::Array(Vec::new());
     /// The boolean `false` value.
     pub const FALSE: RuntimeValue = Self::Boolean(false);
     /// The `None` (null) value.
@@ -383,10 +405,18 @@ impl RuntimeValue {
     /// The boolean `true` value.
     pub const TRUE: RuntimeValue = Self::Boolean(true);
 
+    /// Returns a new empty array.
+    ///
+    /// Not a `const` because `Shared::new` (`Rc`/`Arc::new`) isn't const-evaluable.
+    #[inline(always)]
+    pub fn empty_array() -> RuntimeValue {
+        RuntimeValue::Array(Shared::new(Vec::new()))
+    }
+
     /// Creates a new empty dictionary.
     #[inline(always)]
     pub fn new_dict() -> RuntimeValue {
-        RuntimeValue::Dict(BTreeMap::new())
+        RuntimeValue::Dict(Shared::new(BTreeMap::new()))
     }
 
     /// Creates a new markdown runtime value from the given node.
@@ -607,9 +637,14 @@ impl RuntimeValue {
                 .unwrap_or(serde_json::Value::Null),
             RuntimeValue::String(s) => serde_json::Value::String(s),
             RuntimeValue::Symbol(i) => serde_json::Value::String(i.to_string()),
-            RuntimeValue::Array(arr) => serde_json::Value::Array(arr.into_iter().map(Self::to_json_value).collect()),
+            RuntimeValue::Array(arr) => serde_json::Value::Array(
+                Shared::unwrap_or_clone(arr)
+                    .into_iter()
+                    .map(Self::to_json_value)
+                    .collect(),
+            ),
             RuntimeValue::Dict(map) => {
-                let obj: serde_json::Map<String, serde_json::Value> = map
+                let obj: serde_json::Map<String, serde_json::Value> = Shared::unwrap_or_clone(map)
                     .into_iter()
                     .map(|(k, v)| (k.to_string(), v.to_json_value()))
                     .collect();
@@ -629,9 +664,15 @@ impl RuntimeValue {
             RuntimeValue::String(s) => ciborium::Value::Text(s),
             RuntimeValue::Symbol(i) => ciborium::Value::Text(i.to_string()),
             RuntimeValue::Bytes(b) => ciborium::Value::Bytes(b),
-            RuntimeValue::Array(arr) => ciborium::Value::Array(arr.into_iter().map(Self::to_cbor_value).collect()),
+            RuntimeValue::Array(arr) => ciborium::Value::Array(
+                Shared::unwrap_or_clone(arr)
+                    .into_iter()
+                    .map(Self::to_cbor_value)
+                    .collect(),
+            ),
             RuntimeValue::Dict(map) => ciborium::Value::Map(
-                map.into_iter()
+                Shared::unwrap_or_clone(map)
+                    .into_iter()
                     .map(|(k, v)| (ciborium::Value::Text(k.to_string()), v.to_cbor_value()))
                     .collect(),
             ),
@@ -737,7 +778,7 @@ impl RuntimeValues {
                         RuntimeValue::Symbol(i) => RuntimeValue::new_markdown(node.with_value(&i.as_str())),
                         RuntimeValue::Boolean(b) => RuntimeValue::new_markdown(node.with_value(b.to_string().as_str())),
                         RuntimeValue::Number(n) => RuntimeValue::new_markdown(node.with_value(n.to_string().as_str())),
-                        RuntimeValue::Array(array) => RuntimeValue::Array(
+                        RuntimeValue::Array(array) => RuntimeValue::Array(Shared::new(
                             array
                                 .iter()
                                 .filter_map(|o| {
@@ -751,11 +792,11 @@ impl RuntimeValues {
                                     }
                                 })
                                 .collect::<Vec<_>>(),
-                        ),
+                        )),
                         RuntimeValue::Bytes(b) => RuntimeValue::new_markdown(node.with_value(bytes_to_hex(b).as_str())),
                         RuntimeValue::Dict(map) => {
                             let mut new_dict = BTreeMap::new();
-                            for (k, v) in map {
+                            for (k, v) in map.iter() {
                                 if !v.is_none() && !v.is_empty() {
                                     new_dict.insert(
                                         *k,
@@ -763,7 +804,7 @@ impl RuntimeValues {
                                     );
                                 }
                             }
-                            RuntimeValue::Dict(new_dict)
+                            RuntimeValue::Dict(Shared::new(new_dict))
                         }
                     }
                 } else {
@@ -803,15 +844,15 @@ mod tests {
     #[case(RuntimeValue::Boolean(false), "false")]
     #[case(RuntimeValue::String("hello".to_string()), r#""hello""#)]
     #[case(RuntimeValue::None, "")]
-    #[case(RuntimeValue::Array(vec![
+    #[case(RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(Number::from(1.0)),
             RuntimeValue::String("test".to_string())
-        ]), r#"[1, "test"]"#)]
+        ])), r#"[1, "test"]"#)]
     #[case(RuntimeValue::Dict({
             let mut map = BTreeMap::new();
             map.insert(Ident::new("key1"), RuntimeValue::String("value1".to_string()));
             map.insert(Ident::new("key2"), RuntimeValue::Number(Number::from(42.0)));
-            map
+            Shared::new(map)
         }), r#"{"key1": "value1", "key2": 42}"#)]
     fn test_string_method(#[case] value: RuntimeValue, #[case] expected: &str) {
         assert_eq!(value.string(), expected);
@@ -823,7 +864,7 @@ mod tests {
         assert_eq!(format!("{}", RuntimeValue::Number(Number::from(42.0))), "42");
         assert_eq!(format!("{}", RuntimeValue::String(String::from("test"))), "test");
         assert_eq!(format!("{}", RuntimeValue::None), "");
-        let map_val = RuntimeValue::Dict(BTreeMap::default());
+        let map_val = RuntimeValue::Dict(Shared::new(BTreeMap::default()));
         assert_eq!(format!("{}", map_val), "{}");
     }
 
@@ -837,7 +878,7 @@ mod tests {
         let mut map = BTreeMap::default();
         map.insert(Ident::new("name"), RuntimeValue::String("MQ".to_string()));
         map.insert(Ident::new("version"), RuntimeValue::Number(Number::from(1.0)));
-        let map_val = RuntimeValue::Dict(map);
+        let map_val = RuntimeValue::Dict(Shared::new(map));
         let debug_str = format!("{:?}", map_val);
         assert!(debug_str == r#"{"name": "MQ", "version": 1}"# || debug_str == r#"{"version": 1, "name": "MQ"}"#);
     }
@@ -872,7 +913,7 @@ mod tests {
             .name(),
             "markdown"
         );
-        assert_eq!(RuntimeValue::Dict(BTreeMap::default()).name(), "dict");
+        assert_eq!(RuntimeValue::Dict(Shared::new(BTreeMap::default())).name(), "dict");
     }
 
     #[test]
@@ -883,8 +924,8 @@ mod tests {
         assert!(!RuntimeValue::Number(Number::from(0.0)).is_truthy());
         assert!(RuntimeValue::String(String::from("test")).is_truthy());
         assert!(!RuntimeValue::String(String::from("")).is_truthy());
-        assert!(RuntimeValue::Array(vec!["".to_string().into()]).is_truthy());
-        assert!(!RuntimeValue::Array(Vec::new()).is_truthy());
+        assert!(RuntimeValue::Array(Shared::new(vec!["".to_string().into()])).is_truthy());
+        assert!(!RuntimeValue::Array(Shared::new(Vec::new())).is_truthy());
         assert!(
             RuntimeValue::Markdown(
                 Box::new(mq_markdown::Node::Text(mq_markdown::Text {
@@ -905,7 +946,7 @@ mod tests {
             )
             .is_truthy()
         );
-        assert!(!RuntimeValue::Array(Vec::new()).is_truthy());
+        assert!(!RuntimeValue::Array(Shared::new(Vec::new())).is_truthy());
         assert!(!RuntimeValue::None.is_truthy());
         assert!(RuntimeValue::NativeFunction(Ident::new("name")).is_truthy());
         assert!(
@@ -916,14 +957,17 @@ mod tests {
             )
             .is_truthy()
         );
-        assert!(RuntimeValue::Dict(BTreeMap::default()).is_truthy());
+        assert!(RuntimeValue::Dict(Shared::new(BTreeMap::default())).is_truthy());
     }
 
     #[test]
     fn test_runtime_value_partial_ord() {
         assert!(RuntimeValue::Number(Number::from(1.0)) < RuntimeValue::Number(Number::from(2.0)));
         assert!(RuntimeValue::String(String::from("a")) < RuntimeValue::String(String::from("b")));
-        assert!(RuntimeValue::Array(Vec::new()) < RuntimeValue::Array(vec!["a".to_string().into()]));
+        assert!(
+            RuntimeValue::Array(Shared::new(Vec::new()))
+                < RuntimeValue::Array(Shared::new(vec!["a".to_string().into()]))
+        );
         assert!(
             RuntimeValue::Markdown(
                 Box::new(mq_markdown::Node::Text(mq_markdown::Text {
@@ -958,7 +1002,7 @@ mod tests {
         assert_eq!(RuntimeValue::Number(Number::from(42.0)).len(), 42);
         assert_eq!(RuntimeValue::String(String::from("test")).len(), 4);
         assert_eq!(RuntimeValue::Boolean(true).len(), 1);
-        assert_eq!(RuntimeValue::Array(vec![RuntimeValue::None]).len(), 1);
+        assert_eq!(RuntimeValue::Array(Shared::new(vec![RuntimeValue::None])).len(), 1);
         assert_eq!(
             RuntimeValue::Markdown(
                 Box::new(mq_markdown::Node::Text(mq_markdown::Text {
@@ -973,7 +1017,7 @@ mod tests {
         let mut map = BTreeMap::default();
         map.insert(Ident::new("a"), RuntimeValue::String("alpha".to_string()));
         map.insert(Ident::new("b"), RuntimeValue::String("beta".to_string()));
-        assert_eq!(RuntimeValue::Dict(map).len(), 2);
+        assert_eq!(RuntimeValue::Dict(Shared::new(map)).len(), 2);
     }
 
     #[test]
@@ -988,10 +1032,10 @@ mod tests {
 
     #[test]
     fn test_runtime_value_debug_output() {
-        let array = RuntimeValue::Array(vec![
+        let array = RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(Number::from(1.0)),
             RuntimeValue::String("hello".to_string()),
-        ]);
+        ]));
         assert_eq!(format!("{:?}", array), r#"[1, "hello"]"#);
 
         let node = mq_markdown::Node::Text(mq_markdown::Text {
@@ -1013,7 +1057,7 @@ mod tests {
 
         let mut map = BTreeMap::default();
         map.insert(Ident::new("a"), RuntimeValue::String("alpha".to_string()));
-        let map_val = RuntimeValue::Dict(map);
+        let map_val = RuntimeValue::Dict(Shared::new(map));
         assert_eq!(format!("{:?}", map_val), r#"{"a": "alpha"}"#);
     }
 
@@ -1086,17 +1130,17 @@ mod tests {
         let mut map1_data = BTreeMap::default();
         map1_data.insert(Ident::new("a"), RuntimeValue::Number(Number::from(1.0)));
         map1_data.insert(Ident::new("b"), RuntimeValue::String("hello".to_string()));
-        let map1 = RuntimeValue::Dict(map1_data);
+        let map1 = RuntimeValue::Dict(Shared::new(map1_data));
 
         let mut map2_data = BTreeMap::default();
         map2_data.insert(Ident::new("a"), RuntimeValue::Number(Number::from(1.0)));
         map2_data.insert(Ident::new("b"), RuntimeValue::String("hello".to_string()));
-        let map2 = RuntimeValue::Dict(map2_data);
+        let map2 = RuntimeValue::Dict(Shared::new(map2_data));
 
         let mut map3_data = BTreeMap::default();
         map3_data.insert(Ident::new("a"), RuntimeValue::Number(Number::from(1.0)));
         map3_data.insert(Ident::new("c"), RuntimeValue::String("world".to_string()));
-        let map3 = RuntimeValue::Dict(map3_data);
+        let map3 = RuntimeValue::Dict(Shared::new(map3_data));
 
         assert_eq!(map1, map2);
         assert_ne!(map1, map3);
@@ -1104,12 +1148,12 @@ mod tests {
 
     #[test]
     fn test_runtime_value_map_is_empty() {
-        let empty_map = RuntimeValue::Dict(BTreeMap::default());
+        let empty_map = RuntimeValue::Dict(Shared::new(BTreeMap::default()));
         assert!(empty_map.is_empty());
 
         let mut map_data = BTreeMap::default();
         map_data.insert(Ident::new("a"), RuntimeValue::Number(Number::from(1.0)));
-        let non_empty_map = RuntimeValue::Dict(map_data);
+        let non_empty_map = RuntimeValue::Dict(Shared::new(map_data));
         assert!(!non_empty_map.is_empty());
     }
 
@@ -1117,11 +1161,11 @@ mod tests {
     fn test_runtime_value_map_partial_ord() {
         let mut map1_data = BTreeMap::default();
         map1_data.insert(Ident::new("a"), RuntimeValue::Number(Number::from(1.0)));
-        let map1 = RuntimeValue::Dict(map1_data);
+        let map1 = RuntimeValue::Dict(Shared::new(map1_data));
 
         let mut map2_data = BTreeMap::default();
         map2_data.insert(Ident::new("b"), RuntimeValue::Number(Number::from(2.0)));
-        let map2 = RuntimeValue::Dict(map2_data);
+        let map2 = RuntimeValue::Dict(Shared::new(map2_data));
 
         assert_eq!(map1.partial_cmp(&map2), None);
         assert_eq!(map2.partial_cmp(&map1), None);
@@ -1205,7 +1249,10 @@ mod tests {
 
     #[test]
     fn test_to_json_value_array() {
-        let arr = RuntimeValue::Array(vec![RuntimeValue::Boolean(true), RuntimeValue::String("x".to_string())]);
+        let arr = RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Boolean(true),
+            RuntimeValue::String("x".to_string()),
+        ]));
         match arr.to_json_value() {
             serde_json::Value::Array(items) => {
                 assert_eq!(items[0], serde_json::Value::Bool(true));
@@ -1219,7 +1266,7 @@ mod tests {
     fn test_to_json_value_dict() {
         let mut map = BTreeMap::new();
         map.insert(Ident::new("k"), RuntimeValue::Boolean(false));
-        let obj = RuntimeValue::Dict(map).to_json_value();
+        let obj = RuntimeValue::Dict(Shared::new(map)).to_json_value();
         match obj {
             serde_json::Value::Object(m) => {
                 assert_eq!(m["k"], serde_json::Value::Bool(false));
@@ -1256,7 +1303,7 @@ mod tests {
             value: "hi".to_string(),
             position: None,
         });
-        let arr = RuntimeValue::Array(vec![RuntimeValue::Markdown(Box::new(node), None)]);
+        let arr = RuntimeValue::Array(Shared::new(vec![RuntimeValue::Markdown(Box::new(node), None)]));
         match arr.to_json_value() {
             serde_json::Value::Array(items) => {
                 assert_ne!(items[0], serde_json::Value::Null);
@@ -1270,8 +1317,8 @@ mod tests {
     #[case(RuntimeValue::None, true)]
     #[case(RuntimeValue::Boolean(true), false)]
     #[case(RuntimeValue::String("".to_string()), true)]
-    #[case(RuntimeValue::Array(vec![]), true)]
-    #[case(RuntimeValue::Dict(BTreeMap::new()), true)]
+    #[case(RuntimeValue::Array(Shared::new(vec![])), true)]
+    #[case(RuntimeValue::Dict(Shared::new(BTreeMap::new())), true)]
     #[case(RuntimeValue::Bytes(vec![]), true)]
     #[case(RuntimeValue::Bytes(vec![1]), false)]
     fn test_is_empty(#[case] value: RuntimeValue, #[case] expected: bool) {
@@ -1284,8 +1331,8 @@ mod tests {
     #[case(RuntimeValue::Boolean(false), false)]
     #[case(RuntimeValue::String("hi".to_string()), true)]
     #[case(RuntimeValue::String("".to_string()), false)]
-    #[case(RuntimeValue::Array(vec![RuntimeValue::None]), true)]
-    #[case(RuntimeValue::Array(vec![]), false)]
+    #[case(RuntimeValue::Array(Shared::new(vec![RuntimeValue::None])), true)]
+    #[case(RuntimeValue::Array(Shared::new(vec![])), false)]
     #[case(RuntimeValue::Symbol(Ident::new("s")), true)]
     #[case(RuntimeValue::NativeFunction(Ident::new("f")), true)]
     fn test_is_truthy_variants(#[case] value: RuntimeValue, #[case] expected: bool) {
@@ -1315,9 +1362,9 @@ mod tests {
 
     #[test]
     fn test_is_array_dict() {
-        assert!(RuntimeValue::Array(vec![]).is_array());
+        assert!(RuntimeValue::Array(Shared::new(vec![])).is_array());
         assert!(!RuntimeValue::None.is_array());
-        assert!(RuntimeValue::Dict(BTreeMap::new()).is_dict());
+        assert!(RuntimeValue::Dict(Shared::new(BTreeMap::new())).is_dict());
         assert!(!RuntimeValue::None.is_dict());
     }
 
@@ -1413,7 +1460,7 @@ mod tests {
 
     #[test]
     fn test_negated_array_returns_self() {
-        let arr = RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]);
+        let arr = RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())]));
         assert_eq!(arr.clone().negated(), arr);
     }
 
@@ -1455,7 +1502,7 @@ mod tests {
 
     #[test]
     fn test_to_cbor_value_array() {
-        let arr = RuntimeValue::Array(vec![RuntimeValue::Boolean(false)]);
+        let arr = RuntimeValue::Array(Shared::new(vec![RuntimeValue::Boolean(false)]));
         match arr.to_cbor_value() {
             ciborium::Value::Array(items) => {
                 assert_eq!(items[0], ciborium::Value::Bool(false));
@@ -1468,7 +1515,7 @@ mod tests {
     fn test_to_cbor_value_dict() {
         let mut map = BTreeMap::new();
         map.insert(Ident::new("k"), RuntimeValue::Boolean(true));
-        let obj = RuntimeValue::Dict(map).to_cbor_value();
+        let obj = RuntimeValue::Dict(Shared::new(map)).to_cbor_value();
         match obj {
             ciborium::Value::Map(pairs) => {
                 assert_eq!(pairs[0].0, ciborium::Value::Text("k".to_string()));
@@ -1674,11 +1721,11 @@ mod tests {
     #[test]
     fn test_update_with_markdown_to_array_with_none_filtered() {
         let orig: RuntimeValues = vec![md("item")].into();
-        let updated: RuntimeValues = vec![RuntimeValue::Array(vec![
+        let updated: RuntimeValues = vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::None,
             RuntimeValue::String("b".to_string()),
-        ])]
+        ]))]
         .into();
         let result = orig.update_with(updated);
         if let RuntimeValue::Array(items) = &result[0] {
@@ -1694,7 +1741,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(Ident::new("a"), RuntimeValue::String("val".to_string()));
         map.insert(Ident::new("b"), RuntimeValue::None);
-        let updated: RuntimeValues = vec![RuntimeValue::Dict(map)].into();
+        let updated: RuntimeValues = vec![RuntimeValue::Dict(Shared::new(map))].into();
         let result = orig.update_with(updated);
         if let RuntimeValue::Dict(m) = &result[0] {
             assert!(m.contains_key(&Ident::new("a")));

--- a/crates/mq-lang/src/macro_expand.rs
+++ b/crates/mq-lang/src/macro_expand.rs
@@ -1418,11 +1418,11 @@ mod tests {
     )]
     #[case::foreach_collection(
         "macro make_value(x): x * 2 | foreach(item, [1, 2, 3]): make_value(item);",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(4.into()),
             RuntimeValue::Number(6.into())
-        ])],
+        ]))],
     )]
     #[case::match_value(
         "macro get_val(x): x | match(get_val(5)): | 1: 10 | _: 20 end",
@@ -1621,11 +1621,11 @@ mod tests {
     )]
     #[case::unquote_in_foreach(
         "macro test(arr): quote: foreach(item, unquote(arr)): item * 2; | test([1, 2, 3])",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(4.into()),
             RuntimeValue::Number(6.into())
-        ])],
+        ]))],
     )]
     #[case::unquote_in_let(
         "macro test(x): quote do let y = unquote(x) | y * 2; | test(10)",
@@ -2372,11 +2372,11 @@ mod tests {
         let result = eval_program(&expanded).expect("Failed to eval");
         assert_eq!(
             result,
-            vec![RuntimeValue::Array(vec![
+            vec![RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::Number(10.into()),
                 RuntimeValue::Number(20.into()),
                 RuntimeValue::Number(30.into())
-            ])]
+            ]))]
         );
     }
 

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use mq_lang::{DefaultEngine, Engine, Ident, MqResult, RuntimeValue};
+use mq_lang::{DefaultEngine, Engine, Ident, MqResult, RuntimeValue, Shared};
 use rstest::{fixture, rstest};
 
 #[fixture]
@@ -32,7 +32,7 @@ fn engine() -> DefaultEngine {
       add(x, 1);
     ",
       vec![RuntimeValue::Number(10.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))].into()))]
 #[case::while_break("
     var x = 0 |
     while(x < 10):
@@ -74,7 +74,7 @@ fn engine() -> DefaultEngine {
         x + 10;
     ",
       vec![RuntimeValue::Number(0.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into())])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into())]))].into()))]
 #[case::foreach_break_with_value("
     foreach(x, array(1, 2, 3, 4, 5)):
       if(x == 3):
@@ -92,7 +92,7 @@ fn engine() -> DefaultEngine {
         x + 10;
     ",
       vec![RuntimeValue::Number(0.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into()), RuntimeValue::Number(14.into()), RuntimeValue::Number(15.into())])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into()), RuntimeValue::Number(14.into()), RuntimeValue::Number(15.into())]))].into()))]
 #[case::while_do_end("
     var x = 5 |
     while (x > 0) do
@@ -107,7 +107,7 @@ fn engine() -> DefaultEngine {
     end
     ",
       vec![RuntimeValue::Number(10.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))].into()))]
 #[case::while_do_end_break("
     var x = 0 |
     while(x < 10) do
@@ -131,7 +131,7 @@ fn engine() -> DefaultEngine {
     end
     ",
       vec![RuntimeValue::Number(0.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into()), RuntimeValue::Number(14.into()), RuntimeValue::Number(15.into())])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(11.into()), RuntimeValue::Number(12.into()), RuntimeValue::Number(14.into()), RuntimeValue::Number(15.into())]))].into()))]
 #[case::loop_break_with_value("
     loop:
       break: 42;
@@ -165,7 +165,7 @@ fn engine() -> DefaultEngine {
     end
     ",
       vec![RuntimeValue::Number(0.into())],
-      Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into())]), RuntimeValue::Array(vec![RuntimeValue::Number(6.into()), RuntimeValue::Number(8.into())])])].into()))]
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into())])), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(6.into()), RuntimeValue::Number(8.into())]))]))].into()))]
 #[case::match_do_end("
     match (2) do
       | 1: \"one\"
@@ -460,19 +460,19 @@ fn engine() -> DefaultEngine {
       vec![RuntimeValue::String("String".to_string())],
       Ok(vec![RuntimeValue::FALSE].into()))]
 #[case::is_array("is_array()",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::TRUE].into()))]
 #[case::is_array("is_array(array(\"test\"))",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::TRUE].into()))]
 #[case::is_array("is_string(array(\"test\"))",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::FALSE].into()))]
 #[case::is_dict_true("is_dict()",
       vec![RuntimeValue::new_dict()],
       Ok(vec![RuntimeValue::TRUE].into()))]
 #[case::is_dict_false("is_dict()",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::FALSE].into()))]
 #[case::is_none_true("is_none(None)",
       vec!["text".into()],
@@ -520,16 +520,16 @@ fn engine() -> DefaultEngine {
       vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "hello world".to_string(), position: None}))],
       Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::Text(mq_markdown::Text{value: "hello world".to_string(), position: None}))].into()))]
 #[case::first("first(array(1, 2, 3))",
-      vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
+      vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
       Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::first("first(array())",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::None].into()))]
 #[case::last("last(array(1, 2, 3))",
-      vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
+      vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
       Ok(vec![RuntimeValue::Number(3.into())].into()))]
 #[case::last("last(array())",
-      vec![RuntimeValue::Array(Vec::new())],
+      vec![RuntimeValue::Array(Shared::new(Vec::new()))],
       Ok(vec![RuntimeValue::None].into()))]
 #[case::select("select(contains(\"hello\"))",
       vec![RuntimeValue::String("hello world".to_string())],
@@ -553,22 +553,22 @@ fn engine() -> DefaultEngine {
         vec![RuntimeValue::Number(10.into())],
         Ok(vec![RuntimeValue::Number(15.into())].into()))]
 #[case::map("def test(x): add(x, 1); | map(array(1, 2, 3), test)",
-            vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
-            Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])].into()))]
+            vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
+            Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))].into()))]
 #[case::filter("
             def is_even(x):
               eq(mod(x, 2), 0);
             | filter(array(1, 2, 3, 4, 5, 6), is_even)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())])],
-                    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])].into()))]
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())]))],
+                    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())]))].into()))]
 #[case::filter("
             def is_odd(x):
               eq(mod(x, 2), 1);
             | filter(array(1, 2, 3, 4, 5, 6), is_odd)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())])],
-              Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into())])].into()))]
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())]))],
+              Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into())]))].into()))]
 #[case::func("let func1 = fn(): 1;
       | let func2 = fn(): 2;
       | add(func1(), func2())",
@@ -615,233 +615,233 @@ fn engine() -> DefaultEngine {
       ],
       Ok(vec![RuntimeValue::NONE, RuntimeValue::NONE].into()))]
 #[case::sort_by("sort_by(get_title)",
-      vec![RuntimeValue::Array(vec![
+      vec![RuntimeValue::Array(Shared::new(vec![
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang1".to_string()), title: Some(mq_markdown::Title::new("2".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang2".to_string()), title: Some(mq_markdown::Title::new("1".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
-      ])],
-      Ok(vec![RuntimeValue::Array(vec![
+      ]))],
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang2".to_string()), title: Some(mq_markdown::Title::new("1".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang1".to_string()), title: Some(mq_markdown::Title::new("2".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
-      ])].into()))]
+      ]))].into()))]
 #[case::sort_by("sort_by(get_url)",
-      vec![RuntimeValue::Array(vec![
+      vec![RuntimeValue::Array(Shared::new(vec![
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang2".to_string()), title: Some(mq_markdown::Title::new("1".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang1".to_string()), title: Some(mq_markdown::Title::new("2".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
-      ])],
-      Ok(vec![RuntimeValue::Array(vec![
+      ]))],
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang1".to_string()), title: Some(mq_markdown::Title::new("2".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
           RuntimeValue::new_markdown(mq_markdown::Node::Link(mq_markdown::Link{ url: mq_markdown::Url::new("http://mqlang2".to_string()), title: Some(mq_markdown::Title::new("1".to_string())), values: vec![
             mq_markdown::Node::Text(mq_markdown::Text { value: "text".to_string(), position: None })
           ], position: None })),
-      ])].into()))]
+      ]))].into()))]
 #[case::sort_by(r#"def sort_test(v): if (eq(v, "3")): "1" elif (eq(v, "1")): "3" else: v; sort_by(sort_test)"#,
-      vec![RuntimeValue::Array(vec![
+      vec![RuntimeValue::Array(Shared::new(vec![
          "2".to_string().into(),
          "1".to_string().into(),
          "3".to_string().into(),
-      ])],
-      Ok(vec![RuntimeValue::Array(vec![
+      ]))],
+      Ok(vec![RuntimeValue::Array(Shared::new(vec![
          "3".to_string().into(),
          "2".to_string().into(),
          "1".to_string().into(),
-      ])].into()))]
+      ]))].into()))]
 #[case::find_index("
       def is_even(x):
         eq(mod(x, 2), 0);
       | find_index(array(1, 3, 5, 6, 7), is_even)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())])],
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())]))],
         Ok(vec![RuntimeValue::Number(3.into())].into()))]
 #[case::find_index("
       def is_greater_than_five(x):
         gt(x, 5);
       | find_index(array(1, 3, 5, 6, 7), is_greater_than_five)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())])],
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())]))],
         Ok(vec![RuntimeValue::Number(3.into())].into()))]
 #[case::find_index_no_match("
       def is_negative(x):
         lt(x, 0);
       | find_index(array(1, 3, 5, 6, 7), is_negative)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())])],
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into())]))],
         Ok(vec![RuntimeValue::Number((-1).into())].into()))]
 #[case::find_index_empty_array("
       def is_even(x):
         eq(mod(x, 2), 0);
       | find_index(array(), is_even)
       ",
-        vec![RuntimeValue::Array(vec![])],
+        vec![RuntimeValue::Array(Shared::new(vec![]))],
         Ok(vec![RuntimeValue::Number((-1).into())].into()))]
 #[case::skip("
           skip([1, 2, 3, 4, 5], 2)
           ",
-          vec![RuntimeValue::Array(vec![
+          vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
               RuntimeValue::Number(4.into()),
               RuntimeValue::Number(5.into()),
-          ])],
-          Ok(vec![RuntimeValue::Array(vec![
+          ]))],
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(3.into()),
               RuntimeValue::Number(4.into()),
               RuntimeValue::Number(5.into()),
-          ])].into()))]
+          ]))].into()))]
 #[case::skip_zero("
           skip([1, 2, 3], 0)
           ",
-          vec![RuntimeValue::Array(vec![
+          vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
-          ])],
-          Ok(vec![RuntimeValue::Array(vec![
+          ]))],
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
-          ])].into()))]
+          ]))].into()))]
 #[case::skip_all("
           skip([1, 2, 3], 3)
           ",
-          vec![RuntimeValue::Array(vec![
+          vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
-          ])],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          ]))],
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_more_than_length("
           skip([1, 2, 3], 5)
           ",
-          vec![RuntimeValue::Array(vec![
+          vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
-          ])],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          ]))],
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_empty("
           skip([], 2)
           ",
-          vec![RuntimeValue::Array(vec![])],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          vec![RuntimeValue::Array(Shared::new(vec![]))],
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_while("
       def is_less_than_four(x):
         lt(x, 4);
       | skip_while(array(1, 2, 3, 4, 5, 1, 2), is_less_than_four)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::skip_while_all_match("
       def is_positive(x):
         gt(x, 0);
       | skip_while(array(1, 2, 3), is_positive)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_while_empty_array("
       def is_positive(x):
         gt(x, 0);
       | skip_while(array(), is_positive)
       ",
-        vec![RuntimeValue::Array(vec![])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take("
         take([1, 2, 3, 4, 5], 3)
         ",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
             RuntimeValue::Number(4.into()),
             RuntimeValue::Number(5.into()),
-        ])],
-        Ok(vec![RuntimeValue::Array(vec![
+        ]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])].into()))]
+        ]))].into()))]
 #[case::take_zero("
         take([1, 2, 3], 0)
         ",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        ]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take_all("
         take([1, 2, 3], 3)
         ",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])],
-        Ok(vec![RuntimeValue::Array(vec![
+        ]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])].into()))]
+        ]))].into()))]
 #[case::take_more_than_length("
         take([1, 2, 3], 5)
         ",
-        vec![RuntimeValue::Array(vec![
+        vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])],
-        Ok(vec![RuntimeValue::Array(vec![
+        ]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])].into()))]
+        ]))].into()))]
 #[case::take_empty("
         take([], 2)
         ",
-        vec![RuntimeValue::Array(vec![])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take_while("
       def is_less_than_four(x):
         lt(x, 4);
       | take_while(array(1, 2, 3, 4, 5, 1, 2), is_less_than_four)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::take_while_none_match("
       def is_negative(x):
         lt(x, 0);
       | take_while(array(1, 2, 3), is_negative)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take_while_all_match("
       def is_positive(x):
         gt(x, 0);
       | take_while(array(1, 2, 3), is_positive)
       ",
-        vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
-        Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::take_while_empty_array("
       def is_positive(x):
         gt(x, 0);
       | take_while(array(), is_positive)
       ",
-        vec![RuntimeValue::Array(vec![])],
-        Ok(vec![RuntimeValue::Array(vec![])].into()))]
+        vec![RuntimeValue::Array(Shared::new(vec![]))],
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::anonymous_fn("
         let f = fn(x): add(x, 1);
         | f(10)
@@ -865,23 +865,23 @@ fn engine() -> DefaultEngine {
             Ok(vec![RuntimeValue::Number(10.into())].into()))]
 #[case::array_empty("[]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::array_with_elements("[1, 2, 3]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::array_nested("[[1, 2], [3, 4]]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]),
-            RuntimeValue::Array(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])
-          ])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])),
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))
+          ]))].into()))]
 #[case::array_mixed_types("[1, \"test\", []]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::String("test".to_string()),
-            RuntimeValue::Array(vec![])
-          ])].into()))]
+            RuntimeValue::Array(Shared::new(vec![]))
+          ]))].into()))]
 #[case::array_length("len([])",
           vec![RuntimeValue::Number(0.into())],
           Ok(vec![RuntimeValue::Number(0.into())].into()))]
@@ -890,28 +890,28 @@ fn engine() -> DefaultEngine {
           Ok(vec![RuntimeValue::Number(4.into())].into()))]
 #[case::array_spread_basic("let a = [1, 2, 3] | let b = [4, 5, 6] | [...a, ...b]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()),
             RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()),
-          ])].into()))]
+          ]))].into()))]
 #[case::array_spread_with_surrounding_elements("let a = [1, 2, 3] | [0, ...a, 99]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(0.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()), RuntimeValue::Number(99.into()),
-          ])].into()))]
+          ]))].into()))]
 #[case::array_spread_empty_array("let a = [] | [...a, 1]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())]))].into()))]
 #[case::array_spread_none_contributes_nothing("[...None, 1, 2]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::array_spread_nested("let a = [1, 2] | [...a, ...[3, 4]]",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()),
-          ])].into()))]
+          ]))].into()))]
 #[case::dict_new_empty("dict()",
           vec![RuntimeValue::Number(0.into())],
           Ok(vec![RuntimeValue::new_dict()].into()))]
@@ -923,7 +923,7 @@ fn engine() -> DefaultEngine {
           Ok(vec![RuntimeValue::Number(30.into())].into()))]
 #[case::dict_set_get_array("let m = set(dict(), \"data\", [1, 2, 3]) | get(m, \"data\")",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::dict_set_get_bool("let m = set(dict(), \"active\", true) | get(m, \"active\")",
           vec![RuntimeValue::Number(0.into())],
           Ok(vec![RuntimeValue::Boolean(true)].into()))]
@@ -941,16 +941,16 @@ fn engine() -> DefaultEngine {
           Ok(vec![RuntimeValue::Number(2.into())].into()))]
 #[case::dict_keys_empty("keys(dict())",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::dict_keys_non_empty("let m = set(set(dict(), \"a\", 1), \"b\", 2) | keys(m)",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))].into()))]
 #[case::dict_values_empty("values(dict())",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::dict_values_non_empty("let m = set(set(dict(), \"a\", 1), \"b\", \"hello\") | values(m)",
           vec![RuntimeValue::Number(0.into())],
-          Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::String("hello".to_string())])].into()))]
+          Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::String("hello".to_string())]))].into()))]
 #[case::dict_len_empty("len(dict())",
           vec![RuntimeValue::Number(0.into())],
           Ok(vec![RuntimeValue::Number(0.into())].into()))]
@@ -1078,12 +1078,12 @@ fn engine() -> DefaultEngine {
               mod(x, 3);
             | group_by(array(1, 2, 3, 4, 5, 6, 7, 8, 9), get_remainder)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into()), RuntimeValue::Number(8.into()), RuntimeValue::Number(9.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into()), RuntimeValue::Number(8.into()), RuntimeValue::Number(9.into())]))],
               Ok(vec![{
                 let mut dict = BTreeMap::new();
-                dict.insert(Ident::new("0"), RuntimeValue::Array(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(9.into())]));
-                dict.insert(Ident::new("1"), RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(7.into())]));
-                dict.insert(Ident::new("2"), RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(8.into())]));
+                dict.insert(Ident::new("0"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(9.into())])));
+                dict.insert(Ident::new("1"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(7.into())])));
+                dict.insert(Ident::new("2"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(8.into())])));
                 dict.into()
               }].into()))]
 #[case::group_by_strings(r#"
@@ -1091,12 +1091,12 @@ fn engine() -> DefaultEngine {
               len(s);
             | group_by(array("cat", "dog", "bird", "fish", "elephant"), get_length)
             "#,
-              vec![RuntimeValue::Array(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string()), RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string()), RuntimeValue::String("elephant".to_string())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string()), RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string()), RuntimeValue::String("elephant".to_string())]))],
               Ok(vec![{
                 let mut dict = BTreeMap::new();
-                dict.insert(Ident::new("3"), RuntimeValue::Array(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string())]));
-                dict.insert(Ident::new("4"), RuntimeValue::Array(vec![RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string())]));
-                dict.insert(Ident::new("8"), RuntimeValue::Array(vec![RuntimeValue::String("elephant".to_string())]));
+                dict.insert(Ident::new("3"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string())])));
+                dict.insert(Ident::new("4"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string())])));
+                dict.insert(Ident::new("8"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("elephant".to_string())])));
                 dict.into()
               }].into()))]
 #[case::group_by_empty_array("
@@ -1104,17 +1104,17 @@ fn engine() -> DefaultEngine {
               x;
             | group_by(array(), identity)
             ",
-              vec![RuntimeValue::Array(vec![])],
+              vec![RuntimeValue::Array(Shared::new(vec![]))],
               Ok(vec![RuntimeValue::new_dict()].into()))]
 #[case::group_by_single_element("
             def identity(x):
               x;
             | group_by(array(42), identity)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into())]))],
               Ok(vec![{
                 let mut dict = BTreeMap::new();
-                dict.insert(Ident::new("42"), RuntimeValue::Array(vec![RuntimeValue::Number(42.into())]));
+                dict.insert(Ident::new("42"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into())])));
                 dict.into()
               }].into()))]
 #[case::group_by_all_same_key(r#"
@@ -1122,10 +1122,10 @@ fn engine() -> DefaultEngine {
               "same";
             | group_by(array(1, 2, 3, 4), always_same)
             "#,
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))],
               Ok(vec![{
                 let mut dict = BTreeMap::new();
-                dict.insert(Ident::new("same"), RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]));
+                dict.insert(Ident::new("same"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])));
                 dict.into()
               }].into()))]
 #[case::group_by_boolean_result("
@@ -1133,11 +1133,11 @@ fn engine() -> DefaultEngine {
               eq(mod(x, 2), 0);
             | group_by(array(1, 2, 3, 4, 5, 6), is_even)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into())]))],
               Ok(vec![{
                 let mut dict = BTreeMap::new();
-                dict.insert(Ident::new("false"), RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into())]));
-                dict.insert(Ident::new("true"), RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())]));
+                dict.insert(Ident::new("false"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into())])));
+                dict.insert(Ident::new("true"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])));
                 dict.into()
               }].into()))]
 #[case::is_h_true("is_h()",
@@ -1581,15 +1581,15 @@ fn engine() -> DefaultEngine {
             }))].into()))]
 #[case::any_true("
               any([1, 2, 3], fn(x): x == 2;)",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
               Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::any_false("
               any([1, 2, 3], fn(x): x == 4;)",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))],
               Ok(vec![RuntimeValue::Boolean(false)].into()))]
 #[case::any_empty_array("
               any([], fn(x): x == 1;)",
-              vec![RuntimeValue::Array(vec![])],
+              vec![RuntimeValue::Array(Shared::new(vec![]))],
               Ok(vec![RuntimeValue::Boolean(false)].into()))]
 #[case::any_dict_true(r#"any(dict(["a", 1], ["b", 2]), fn(kv): last(kv) == 2;)"#,
               vec![{
@@ -1609,15 +1609,15 @@ fn engine() -> DefaultEngine {
               Ok(vec![RuntimeValue::Boolean(false)].into()))]
 #[case::all_true("
               all([2, 4, 6], fn(x): mod(x, 2) == 0;)",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())]))],
               Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::all_false("
               all([2, 3, 6], fn(x): mod(x, 2) == 0;)",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into())])],
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into())]))],
               Ok(vec![RuntimeValue::Boolean(false)].into()))]
 #[case::all_empty_array("
               all([], fn(x): x == 1;)",
-              vec![RuntimeValue::Array(vec![])],
+              vec![RuntimeValue::Array(Shared::new(vec![]))],
               Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::all_dict_true(r#"all(dict(["a", 2], ["b", 4]), fn(kv): mod(last(kv), 2) == 0;)"#,
               vec![{
@@ -1658,58 +1658,58 @@ fn engine() -> DefaultEngine {
               add(acc, x);
             | fold([1, 2, 3, 4], 0, sum)
             ",
-            vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])],
+            vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))],
             Ok(vec![RuntimeValue::Number(10.into())].into()))]
 #[case::fold_concat(r#"
             def concat(acc, x):
               add(acc, x);
             | fold(["a", "b", "c"], "", concat)
             "#,
-            vec![RuntimeValue::Array(vec![RuntimeValue::String("a".into()), RuntimeValue::String("b".into()), RuntimeValue::String("c".into())])],
+            vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".into()), RuntimeValue::String("b".into()), RuntimeValue::String("c".into())]))],
             Ok(vec![RuntimeValue::String("abc".into())].into()))]
 #[case::fold_empty("
             def sum(acc, x):
               add(acc, x);
             | fold([], 0, sum)
             ",
-            vec![RuntimeValue::Array(vec![])],
+            vec![RuntimeValue::Array(Shared::new(vec![]))],
             Ok(vec![RuntimeValue::Number(0.into())].into()))]
 #[case::unique_by_numbers("
             def get_remainder(x):
               mod(x, 3);
             | unique_by([1, 2, 3, 4, 5, 6, 7, 8, 9], get_remainder)
             ",
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into()), RuntimeValue::Number(8.into()), RuntimeValue::Number(9.into())])],
-              Ok(vec![RuntimeValue::Array(vec![
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(7.into()), RuntimeValue::Number(8.into()), RuntimeValue::Number(9.into())]))],
+              Ok(vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::Number(1.into()),
               RuntimeValue::Number(2.into()),
               RuntimeValue::Number(3.into()),
-              ])].into()))]
+              ]))].into()))]
 #[case::unique_by_strings(r#"
             def get_length(s):
               len(s);
             | unique_by(["cat", "dog", "bird", "fish", "elephant"], get_length)
             "#,
-              vec![RuntimeValue::Array(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string()), RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string()), RuntimeValue::String("elephant".to_string())])],
-              Ok(vec![RuntimeValue::Array(vec![
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("cat".to_string()), RuntimeValue::String("dog".to_string()), RuntimeValue::String("bird".to_string()), RuntimeValue::String("fish".to_string()), RuntimeValue::String("elephant".to_string())]))],
+              Ok(vec![RuntimeValue::Array(Shared::new(vec![
               RuntimeValue::String("cat".to_string()),
               RuntimeValue::String("bird".to_string()),
               RuntimeValue::String("elephant".to_string()),
-              ])].into()))]
+              ]))].into()))]
 #[case::unique_by_empty_array("
             def identity(x):
               x;
             | unique_by([], identity)
             ",
-              vec![RuntimeValue::Array(vec![])],
-              Ok(vec![RuntimeValue::Array(vec![])].into()))]
+              vec![RuntimeValue::Array(Shared::new(vec![]))],
+              Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::unique_by_all_same_key(r#"
             def always_same(x):
               "same";
             | unique_by([1, 2, 3, 4], always_same)
             "#,
-              vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])],
-              Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into())])].into()))]
+              vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))],
+              Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())]))].into()))]
 #[case::dict_literal_empty("let d = {} | d",
             vec![RuntimeValue::Number(0.into())], // Dummy input
             Ok(vec![RuntimeValue::new_dict()].into()))]
@@ -1930,10 +1930,10 @@ fn engine() -> DefaultEngine {
       Ok(vec![RuntimeValue::String("HELLO WORLD".to_string())].into()))]
 #[case::array_with_comment("[1 # comment\n, 2, 3]",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
           RuntimeValue::Number(1.into()),
           RuntimeValue::Number(2.into()),
-          RuntimeValue::Number(3.into())])].into()))]
+          RuntimeValue::Number(3.into())]))].into()))]
 #[case::dict_literal_with_comment(
   r#"let d = {
     "a": 1, # comment for a
@@ -1955,39 +1955,39 @@ fn engine() -> DefaultEngine {
         Ok(vec![RuntimeValue::Number(0.into())].into()))]
 #[case::array_iter_numbers("[1, 2, 3] | .[]",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])].into()))]
+        ]))].into()))]
 #[case::array_iter_strings(r#"["a", "b", "c"] | .[]"#,
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
             RuntimeValue::String("c".to_string()),
-        ])].into()))]
+        ]))].into()))]
 #[case::dict_iter_values(r#"{"a": 1, "b": 2, "c": 3} | .[]"#,
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
-        ])].into()))]
+        ]))].into()))]
 #[case::array_of_dicts_iter(r#"[{"a": 1}, {"b": 2}] | .[]"#,
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             {
                 let mut d = BTreeMap::new();
                 d.insert(Ident::new("a"), RuntimeValue::Number(1.into()));
-                RuntimeValue::Dict(d)
+                RuntimeValue::Dict(Shared::new(d))
             },
             {
                 let mut d = BTreeMap::new();
                 d.insert(Ident::new("b"), RuntimeValue::Number(2.into()));
-                RuntimeValue::Dict(d)
+                RuntimeValue::Dict(Shared::new(d))
             },
-        ])].into()))]
+        ]))].into()))]
 #[case::array_index_first("[1, 2, 3] | .[0]",
         vec![RuntimeValue::Number(0.into())],
         Ok(vec![RuntimeValue::Number(1.into())].into()))]
@@ -2002,19 +2002,19 @@ fn engine() -> DefaultEngine {
         Ok(vec![RuntimeValue::NONE].into()))]
 #[case::array_mul_decimal("[2,1]*0.2",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(0.4.into()),
             RuntimeValue::Number(0.2.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::array_mul_large_number("[0.4,0.2]*5E9",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(2000000000.0.into()),
             RuntimeValue::Number(1000000000.0.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::array_mul_small_integer("[1,2]*5",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(1.into()),
@@ -2025,7 +2025,7 @@ fn engine() -> DefaultEngine {
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::array_mul_at_boundary("[1,2]*1000",
         vec![RuntimeValue::Number(0.into())],
         Ok(vec![{
@@ -2034,28 +2034,28 @@ fn engine() -> DefaultEngine {
                 arr.push(RuntimeValue::Number(1.into()));
                 arr.push(RuntimeValue::Number(2.into()));
             }
-            RuntimeValue::Array(arr)
+            RuntimeValue::Array(Shared::new(arr))
         }].into()))]
 #[case::array_mul_over_boundary("[1,2]*1001",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1001.into()),
             RuntimeValue::Number(2002.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::range_mul_decimal_large("2..1*.2*5E9",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(2000000000.0.into()),
             RuntimeValue::Number(1000000000.0.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::array_concat_normal("[1,2]+[3,4]",
         vec![RuntimeValue::Number(0.into())],
-        Ok(vec![RuntimeValue::Array(vec![
+        Ok(vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::Number(1.into()),
             RuntimeValue::Number(2.into()),
             RuntimeValue::Number(3.into()),
             RuntimeValue::Number(4.into())
-        ])].into()))]
+        ]))].into()))]
 #[case::get_variable_simple("
           let x = 42
           | get_variable(\"x\")
@@ -2114,7 +2114,7 @@ fn engine() -> DefaultEngine {
         | sum;
     ",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(10.into()), RuntimeValue::Number(15.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(6.into()), RuntimeValue::Number(10.into()), RuntimeValue::Number(15.into())]))].into()))]
 #[case::macro_basic("
     macro double(x) do
       x + x
@@ -2178,7 +2178,7 @@ fn engine() -> DefaultEngine {
     | first_two([1, 2, 3, 4, 5])
     ",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::macro_parameter_shadowing("
     let x = 100 |
     macro use_param(x) do
@@ -2237,7 +2237,7 @@ fn engine() -> DefaultEngine {
     | make_array(1, 2, 3)
     ",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::macro_quote_with_let_outside("
     macro test(x) do
         let y = x + 1 |
@@ -2324,25 +2324,25 @@ fn engine() -> DefaultEngine {
     Ok(vec!["updated".into()].into()))]
 #[case::variadic_all_args("def f(*args): args; | f(1, 2, 3)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::variadic_with_regular_param("def f(a, *rest): rest; | f(1, 2, 3)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::variadic_empty_rest("def f(a, *rest): rest; | f(1)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::variadic_no_args("def f(*args): args; | f()",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::variadic_with_pipe("def f(a, *rest): [a, rest]; | 10 | f(20, 30)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(20.into()), RuntimeValue::Array(vec![RuntimeValue::Number(30.into())])])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(20.into()), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(30.into())]))]))].into()))]
 #[case::variadic_with_two_regular_params("def f(a, b, *rest): [a, b, rest]; | f(1, 2, 3, 4)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Array(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))]))].into()))]
 #[case::variadic_fn_syntax("let g = fn(*args): args; | g(1, 2)",
     vec![RuntimeValue::Number(0.into())],
-    Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::is_regex_match_match(r#"is_regex_match("test1", "[a-z0-9]+")"#,
     vec![RuntimeValue::None],
     Ok(vec![true.into()].into()))]
@@ -2518,76 +2518,76 @@ fn engine() -> DefaultEngine {
     }))].into()))]
 #[case::skip_while_basic("skip_while([1,2,3,4,5], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(3.into()),
         RuntimeValue::Number(4.into()),
         RuntimeValue::Number(5.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::skip_while_all_match("skip_while([1,2,3], fn(x): x < 10;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_while_none_match("skip_while([1,2,3], fn(x): x > 10;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
         RuntimeValue::Number(2.into()),
         RuntimeValue::Number(3.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::skip_while_empty_array("skip_while([], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::skip_while_stops_at_first_non_match("skip_while([1,3,2,4], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(3.into()),
         RuntimeValue::Number(2.into()),
         RuntimeValue::Number(4.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::take_while_basic("take_while([1,2,3,4,5], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
         RuntimeValue::Number(2.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::take_while_all_match("take_while([1,2,3], fn(x): x < 10;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
         RuntimeValue::Number(2.into()),
         RuntimeValue::Number(3.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::take_while_none_match("take_while([1,2,3], fn(x): x > 10;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take_while_empty_array("take_while([], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::take_while_stops_at_first_non_match("take_while([1,3,2,4], fn(x): x < 3;)",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::slice_end_only("let x = [1, 2, 3] | x[:2]",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
         RuntimeValue::Number(2.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::slice_end_only_single("let x = [1, 2, 3] | x[:1]",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::slice_end_only_empty("let x = [1, 2, 3] | x[:0]",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::slice_full_colon("let x = [1, 2, 3] | x[:]",
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![
         RuntimeValue::Number(1.into()),
         RuntimeValue::Number(2.into()),
         RuntimeValue::Number(3.into()),
-    ])].into()))]
+    ]))].into()))]
 #[case::dict_symbol_access_unchanged("let d = {type: :section} | d[:type]",
     vec![RuntimeValue::None],
     Ok(vec![RuntimeValue::Symbol(Ident::new("section"))].into()))]
@@ -2691,7 +2691,7 @@ fn engine() -> DefaultEngine {
 #[case::from_html_empty(
     r#""" | from_html()"#,
     vec![RuntimeValue::None],
-    Ok(vec![RuntimeValue::Array(vec![])].into()))]
+    Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::pow_integer("pow(2, 3)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()),)]
 #[case::pow_zero_exp("pow(5, 0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()),)]
 #[case::pow_negative_exp("pow(2, -1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.5f64.into())].into()),)]
@@ -2709,33 +2709,33 @@ fn engine() -> DefaultEngine {
 #[case::gte_simple("gte(2, 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::lte_simple("lte(1, 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::ne_simple("ne(1, 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
-#[case::csv_parse_simple(r##"_csv_parse("a,b\n1,2", ",", true)"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
-    RuntimeValue::Dict(BTreeMap::from([
+#[case::csv_parse_simple(r##"_csv_parse("a,b\n1,2", ",", true)"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![
+    RuntimeValue::Dict(Shared::new(BTreeMap::from([
         (Ident::new("a"), RuntimeValue::String("1".to_string())),
         (Ident::new("b"), RuntimeValue::String("2".to_string())),
-    ]))
-])].into()))]
-#[case::json_parse_simple(r##"_json_parse("{\"a\": 1}")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
-    (Ident::new("a"), RuntimeValue::Number(1.into())),
+    ])))
 ]))].into()))]
-#[case::yaml_parse_simple(r##"_yaml_parse("a: 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+#[case::json_parse_simple(r##"_json_parse("{\"a\": 1}")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("a"), RuntimeValue::Number(1.into())),
-]))].into()))]
-#[case::toml_parse_simple(r##"_toml_parse("a = 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+])))].into()))]
+#[case::yaml_parse_simple(r##"_yaml_parse("a: 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("a"), RuntimeValue::Number(1.into())),
-]))].into()))]
-#[case::xml_parse_simple(r##"_xml_parse("<root>text</root>")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+])))].into()))]
+#[case::toml_parse_simple(r##"_toml_parse("a = 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
+    (Ident::new("a"), RuntimeValue::Number(1.into())),
+])))].into()))]
+#[case::xml_parse_simple(r##"_xml_parse("<root>text</root>")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("tag"), RuntimeValue::String("root".to_string())),
     (Ident::new("attributes"), RuntimeValue::new_dict()),
-    (Ident::new("children"), RuntimeValue::Array(vec![])),
+    (Ident::new("children"), RuntimeValue::Array(Shared::new(vec![]))),
     (Ident::new("text"), RuntimeValue::String("text".to_string())),
-]))].into()))]
+])))].into()))]
 #[case::and_builtin("and(true, false)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(false)].into()))]
 #[case::or_builtin("or(false, true)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::coalesce_simple("coalesce(None, 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
-#[case::compact_array("compact([1, None, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
-#[case::uniq_array("uniq([1, 2, 1])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
-#[case::sort_array("sort([3, 1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
+#[case::compact_array("compact([1, None, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
+#[case::uniq_array("uniq([1, 2, 1])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
+#[case::sort_array("sort([3, 1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::utf8bytelen_simple(r##"utf8bytelen("あ")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(3.into())].into()))]
 #[case::rindex_simple(r##"rindex("banana", "a")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 #[case::token_count_empty(r#"token_count("", "gpt-4")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
@@ -2746,7 +2746,7 @@ fn engine() -> DefaultEngine {
 #[case::token_count_no_model_simple(r#"token_count("Hello, world!")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(4.into())].into()))]
 #[case::token_count_no_model_markdown(r#"to_md_text("Hello, world!") | token_count()"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(4.into())].into()))]
 #[case::token_count_no_model_none(r#"token_count(None)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
-#[case::explode_simple(r##"explode("abc")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(97.into()), RuntimeValue::Number(98.into()), RuntimeValue::Number(99.into())])].into()))]
+#[case::explode_simple(r##"explode("abc")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(97.into()), RuntimeValue::Number(98.into()), RuntimeValue::Number(99.into())]))].into()))]
 #[case::implode_simple(r##"implode([97, 98, 99])"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("abc".to_string())].into()))]
 #[case::intern_simple(r##"intern("foo")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("foo".to_string())].into()))]
 #[case::nan_builtin("nan() | is_nan()", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
@@ -2763,12 +2763,12 @@ fn engine() -> DefaultEngine {
 #[case::set_list_ordered_simple(r##"to_markdown("- item") | first() | set_list_ordered(true) | .list.ordered"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::diff_simple(r##"_diff("abc", "abd") | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 #[case::get_markdown_position_simple(r##"to_markdown("# title") | first() | _get_markdown_position() | get("start_line")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
-#[case::toon_parse_simple(r##"_toon_parse("a: 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+#[case::toon_parse_simple(r##"_toon_parse("a: 1")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("a"), RuntimeValue::Number(1.into())),
-]))].into()))]
-#[case::capture_simple(r##"capture("abc123def", "(?P<num>\\d+)")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+])))].into()))]
+#[case::capture_simple(r##"capture("abc123def", "(?P<num>\\d+)")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("num"), RuntimeValue::String("123".to_string())),
-]))].into()))]
+])))].into()))]
 #[case::is_debug_mode_simple("is_debug_mode()", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(cfg!(feature = "debugger"))].into()))]
 #[case::set_check_simple(r##"to_markdown("- [ ] task") | first() | set_check(true) | .list.checked"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Boolean(true)].into()))]
 #[case::set_children_simple(r##"to_markdown("# heading") | first() | set_children(["new"]) | to_text()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("new".to_string())].into()))]
@@ -2785,8 +2785,8 @@ fn engine() -> DefaultEngine {
 ], position: None}))].into()))]
 #[case::to_md_table_cell_simple(r##"to_md_table_cell("val", 1, 2)"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::new_markdown(mq_markdown::Node::TableCell(mq_markdown::TableCell{row: 1, column: 2, values: vec!["val".to_string().into()], position: None}))].into()))]
 #[case::to_md_name_simple(r##"to_markdown("# title") | first() | to_md_name()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("h1".to_string())].into()))]
-#[case::entries_simple(r##"entries({"a": 1})"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::Number(1.into())])])].into()))]
-#[case::del_array_simple("del([1, 2, 3], 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into())])].into()))]
+#[case::entries_simple(r##"entries({"a": 1})"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::Number(1.into())]))]))].into()))]
+#[case::del_array_simple("del([1, 2, 3], 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into())]))].into()))]
 #[case::index_string_simple(r##"index("hello", "e")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::set_ref_simple(r##"to_markdown("[link][id]\n\n[id]: url") | first() | set_ref("newlabel") | .link_ref.label"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("newlabel".to_string())].into()))]
 #[case::downcase_simple(r##"downcase("ABC")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("abc".to_string())].into()))]
@@ -2801,17 +2801,17 @@ fn engine() -> DefaultEngine {
 // ascii_upcase only folds ASCII letters: "à" is left untouched, unlike upcase above
 #[case::ascii_upcase_non_ascii(r##"ascii_upcase("abcà")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ABCà".to_string())].into()))]
 #[case::gsub_simple(r##"gsub("a1b2", "\\d", "x")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("axbx".to_string())].into()))]
-#[case::regex_match_simple(r##"regex_match("a1b2", "\\d")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("1".to_string()), RuntimeValue::String("2".to_string())])].into()))]
-#[case::scan_no_groups(r##"scan("a1b2", "\\d")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("1".to_string()), RuntimeValue::String("2".to_string())])].into()))]
-#[case::scan_with_groups(r##"scan("2024-06 2025-07", "(\\d{4})-(\\d{2})")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
-    RuntimeValue::Array(vec![RuntimeValue::String("2024".to_string()), RuntimeValue::String("06".to_string())]),
-    RuntimeValue::Array(vec![RuntimeValue::String("2025".to_string()), RuntimeValue::String("07".to_string())]),
-])].into()))]
+#[case::regex_match_simple(r##"regex_match("a1b2", "\\d")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("1".to_string()), RuntimeValue::String("2".to_string())]))].into()))]
+#[case::scan_no_groups(r##"scan("a1b2", "\\d")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("1".to_string()), RuntimeValue::String("2".to_string())]))].into()))]
+#[case::scan_with_groups(r##"scan("2024-06 2025-07", "(\\d{4})-(\\d{2})")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![
+    RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("2024".to_string()), RuntimeValue::String("06".to_string())])),
+    RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("2025".to_string()), RuntimeValue::String("07".to_string())])),
+]))].into()))]
 #[case::slice_simple(r##"slice("abcdef", 1, 4)"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("bcd".to_string())].into()))]
-#[case::sort_by_impl_simple(r##"_sort_by_impl([[2, "b"], [1, "a"]])"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
-    RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::String("a".to_string())]),
-    RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::String("b".to_string())]),
-])].into()))]
+#[case::sort_by_impl_simple(r##"_sort_by_impl([[2, "b"], [1, "a"]])"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![
+    RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::String("a".to_string())])),
+    RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::String("b".to_string())])),
+]))].into()))]
 #[case::selector_task(r##"to_markdown("- [ ] todo\n- [x] done") | .task | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 #[case::selector_todo(r##"to_markdown("- [ ] todo\n- [x] done") | .todo | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::selector_done(r##"to_markdown("- [ ] todo\n- [x] done") | .done | compact() | len()"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
@@ -2875,27 +2875,27 @@ fn engine() -> DefaultEngine {
 // partial: 2-param function can be partially applied — the scenario that triggered the redesign
 #[case::partial_two_param("def plus(a, b): a + b; | let plus10 = partial(plus, 10) | plus10(5)", vec![RuntimeValue::Number(0.into())], Ok(vec![RuntimeValue::Number(15.into())].into()))]
 // property selector: quoted form (."key") is the only way to access dict keys
-#[case::property_selector_quoted_h1(r#"."h1""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("h1"), RuntimeValue::String("title".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("title".to_string())].into()))]
-#[case::property_selector_quoted_url(r#"."url""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("url"), RuntimeValue::String("https://example.com".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("https://example.com".to_string())].into()))]
-#[case::property_selector_quoted_text(r#"."text""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("text"), RuntimeValue::String("hello".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
+#[case::property_selector_quoted_h1(r#"."h1""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("h1"), RuntimeValue::String("title".to_string())); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("title".to_string())].into()))]
+#[case::property_selector_quoted_url(r#"."url""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("url"), RuntimeValue::String("https://example.com".to_string())); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("https://example.com".to_string())].into()))]
+#[case::property_selector_quoted_text(r#"."text""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("text"), RuntimeValue::String("hello".to_string())); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
 // property selector: quoted form with spaces in key
-#[case::property_selector_quoted_space(r#"."my key""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("my key"), RuntimeValue::String("val".to_string())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("val".to_string())].into()))]
+#[case::property_selector_quoted_space(r#"."my key""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("my key"), RuntimeValue::String("val".to_string())); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("val".to_string())].into()))]
 // property selector: missing key returns None
-#[case::property_selector_quoted_missing(r#"."h1""#, vec![{let d = std::collections::BTreeMap::new(); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
+#[case::property_selector_quoted_missing(r#"."h1""#, vec![{let d = std::collections::BTreeMap::new(); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::None].into()))]
 // nested property selector: ."a"."b" accesses {"a": {"b": 1}}
-#[case::property_selector_nested(r#"."a"."b""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Number(1.into())); outer.insert(Ident::new("a"), RuntimeValue::Dict(inner)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+#[case::property_selector_nested(r#"."a"."b""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Number(1.into())); outer.insert(Ident::new("a"), RuntimeValue::Dict(Shared::new(inner))); RuntimeValue::Dict(Shared::new(outer))}], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 // nested property selector: ."a"."b"."c" accesses three levels deep
-#[case::property_selector_nested_three(r#"."a"."b"."c""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut mid = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("c"), RuntimeValue::Number(42.into())); mid.insert(Ident::new("b"), RuntimeValue::Dict(inner)); outer.insert(Ident::new("a"), RuntimeValue::Dict(mid)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
+#[case::property_selector_nested_three(r#"."a"."b"."c""#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut mid = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("c"), RuntimeValue::Number(42.into())); mid.insert(Ident::new("b"), RuntimeValue::Dict(Shared::new(inner))); outer.insert(Ident::new("a"), RuntimeValue::Dict(Shared::new(mid))); RuntimeValue::Dict(Shared::new(outer))}], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // nested property selector: missing intermediate key returns None
-#[case::property_selector_nested_missing(r#"."a"."b""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("a"), RuntimeValue::Number(1.into())); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::None].into()))]
+#[case::property_selector_nested_missing(r#"."a"."b""#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("a"), RuntimeValue::Number(1.into())); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::None].into()))]
 // property iterator: ."items"[] iterates all elements of the array stored at the key
-#[case::property_selector_iterator(r#"."items"[]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])].into()))]
+#[case::property_selector_iterator(r#"."items"[]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())]))); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())]))].into()))]
 // property iterator with index: ."items"[0] accesses the first element of the array
-#[case::property_selector_iterator_index(r#"."items"[0]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("a".to_string())].into()))]
+#[case::property_selector_iterator_index(r#"."items"[0]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("a".to_string())].into()))]
 // property iterator with index: ."items"[1] accesses the second element
-#[case::property_selector_iterator_index_1(r#"."items"[1]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])); RuntimeValue::Dict(d)}], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
+#[case::property_selector_iterator_index_1(r#"."items"[1]"#, vec![{let mut d = std::collections::BTreeMap::new(); d.insert(Ident::new("items"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))); RuntimeValue::Dict(Shared::new(d))}], Ok(vec![RuntimeValue::String("b".to_string())].into()))]
 // chained property iterator: ."a"."b"[] iterates all elements of a nested array
-#[case::property_selector_nested_iterator(r#"."a"."b"[]"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])); outer.insert(Ident::new("a"), RuntimeValue::Dict(inner)); RuntimeValue::Dict(outer)}], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+#[case::property_selector_nested_iterator(r#"."a"."b"[]"#, vec![{let mut outer = std::collections::BTreeMap::new(); let mut inner = std::collections::BTreeMap::new(); inner.insert(Ident::new("b"), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))); outer.insert(Ident::new("a"), RuntimeValue::Dict(Shared::new(inner))); RuntimeValue::Dict(Shared::new(outer))}], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 // paren-free calls: 0-arg user-defined function called without parentheses
 #[case::paren_free_zero_arg_user_fn("def greet(): \"Hello!\"; | greet", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("Hello!".to_string())].into()))]
 // paren-free calls: 1-arg user-defined function called without parentheses uses current value
@@ -2923,11 +2923,11 @@ fn engine() -> DefaultEngine {
 // paren-free calls: variable access still works correctly (not auto-called)
 #[case::paren_free_variable_not_called("let x = 42 | x", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // paren-free calls: passing function as value to map still works (no spurious auto-call)
-#[case::paren_free_fn_as_value_preserved("map([\"a\", \"b\"], upcase)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())])].into()))]
+#[case::paren_free_fn_as_value_preserved("map([\"a\", \"b\"], upcase)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())]))].into()))]
 // paren-free calls: passing user-defined function as value to map (no spurious auto-call)
-#[case::paren_free_user_fn_as_value_preserved("def double(x): x * 2; | map([1, 2, 3], double)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])].into()))]
+#[case::paren_free_user_fn_as_value_preserved("def double(x): x * 2; | map([1, 2, 3], double)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())]))].into()))]
 // pipeline expressions inside function arguments are treated like implicit do...end blocks
-#[case::pipeline_expr_as_function_arg(r#"array("a" | upcase(), "b" | upcase())"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())])].into()))]
+#[case::pipeline_expr_as_function_arg(r#"array("a" | upcase(), "b" | upcase())"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("A".to_string()), RuntimeValue::String("B".to_string())]))].into()))]
 // shadowing builtin: user-defined function with same name as builtin calls the native builtin inside its body
 #[case::shadow_builtin_upcase("def upcase: upcase() | ltrimstr(\"HELLO\"); | \"hello\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
 // shadowing builtin: user function wraps builtin and adds extra transformation
@@ -2935,7 +2935,7 @@ fn engine() -> DefaultEngine {
 // shadowing builtin: outer scope sees user-defined function
 #[case::shadow_builtin_outer_scope("def upcase: upcase(); | \"world\" | upcase", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("WORLD".to_string())].into()))]
 // gmtime: Unix epoch → UTC broken-down array [year, mon(0-11), mday, hour, min, sec, wday(0=Sun), yday(0-365)]
-#[case::gmtime_epoch("gmtime(0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
+#[case::gmtime_epoch("gmtime(0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![
     RuntimeValue::Number(1970.into()), // year
     RuntimeValue::Number(0.into()),    // mon (Jan=0)
     RuntimeValue::Number(1.into()),    // mday
@@ -2944,8 +2944,8 @@ fn engine() -> DefaultEngine {
     RuntimeValue::Number(0.into()),    // sec
     RuntimeValue::Number(4.into()),    // wday (Thu=4)
     RuntimeValue::Number(0.into()),    // yday
-])].into()))]
-#[case::gmtime_known("gmtime(1704067200)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![
+]))].into()))]
+#[case::gmtime_known("gmtime(1704067200)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![
     RuntimeValue::Number(2024.into()), // year
     RuntimeValue::Number(0.into()),    // mon (Jan=0)
     RuntimeValue::Number(1.into()),    // mday
@@ -2954,7 +2954,7 @@ fn engine() -> DefaultEngine {
     RuntimeValue::Number(0.into()),    // sec
     RuntimeValue::Number(1.into()),    // wday (Mon=1)
     RuntimeValue::Number(0.into()),    // yday
-])].into()))]
+]))].into()))]
 // mktime: broken-down UTC array → Unix timestamp (seconds)
 #[case::mktime_epoch("mktime(array(1970, 0, 1, 0, 0, 0, 4, 0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
 #[case::mktime_known("mktime(array(2024, 0, 1, 0, 0, 0, 1, 0))", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704067200_i64.into())].into()))]
@@ -3027,19 +3027,19 @@ fn engine() -> DefaultEngine {
 // try/catch(e): error binder is bound to a dict with the failure message
 #[case::try_catch_binder(r#"try: error("boom") catch(e): e["message"]"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("boom".to_string())].into()))]
 // try/catch(e): the full error dict is accessible when bound directly
-#[case::try_catch_binder_dict(r#"try: error("boom") catch(e): e"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(BTreeMap::from([
+#[case::try_catch_binder_dict(r#"try: error("boom") catch(e): e"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict(Shared::new(BTreeMap::from([
     (Ident::new("message"), RuntimeValue::String("boom".to_string())),
-]))].into()))]
+])))].into()))]
 // try/catch(e): the binder is unused when the try expression succeeds
 #[case::try_catch_binder_unused_on_success("try: 42 catch(e): 0", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // try/catch(e): binder name does not leak outside the catch expression
 #[case::try_catch_binder_scoped(r#"try: error("boom") catch(e): e["message"] | try: e catch: "e is undefined outside catch""#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("e is undefined outside catch".to_string())].into()))]
 // foreach over string: iterates each character
-#[case::foreach_string("foreach(c, \"abc\"): c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())])].into()))]
+#[case::foreach_string("foreach(c, \"abc\"): c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string()), RuntimeValue::String("c".to_string())]))].into()))]
 // foreach over string with break
-#[case::foreach_string_break("foreach(c, \"abcde\"): if(c == \"c\"): break else: c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])].into()))]
+#[case::foreach_string_break("foreach(c, \"abcde\"): if(c == \"c\"): break else: c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))].into()))]
 // foreach over string with continue
-#[case::foreach_string_continue("foreach(c, \"abc\"): if(c == \"b\"): continue else: c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("c".to_string())])].into()))]
+#[case::foreach_string_continue("foreach(c, \"abc\"): if(c == \"b\"): continue else: c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("c".to_string())]))].into()))]
 // foreach over string: break with value
 #[case::foreach_string_break_value("foreach(c, \"abc\"): if(c == \"b\"): break: \"found\" else: c;", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("found".to_string())].into()))]
 // pattern destructuring in let: array pattern
@@ -3065,9 +3065,9 @@ fn engine() -> DefaultEngine {
 // repeat: string repeated N times
 #[case::repeat_string("\"ab\" * 3", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ababab".to_string())].into()))]
 // repeat: array repeated N times
-#[case::repeat_array("[1, 2] * 3", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+#[case::repeat_array("[1, 2] * 3", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 // repeat: array * 0 returns empty
-#[case::repeat_array_zero("[1, 2] * 0", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![])].into()))]
+#[case::repeat_array_zero("[1, 2] * 0", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 // intern: non-string arg (number)
 #[case::intern_non_string("intern(42)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("42".to_string())].into()))]
 // is_nan: non-number returns false
@@ -3126,11 +3126,11 @@ fn engine() -> DefaultEngine {
 #[case::min_with_none("min(None, 5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 #[case::max_with_none("max(None, 5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 // to_array conversions
-#[case::to_array_string(r#"to_array("ab")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())])].into()))]
-#[case::to_array_number("to_array(42)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(42.into())])].into()))]
-#[case::to_array_bytes(r#"to_array(b"ab")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(97.into()), RuntimeValue::Number(98.into())])].into()))]
-#[case::to_array_none("to_array(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![])].into()))]
-#[case::to_array_already_array("to_array([1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+#[case::to_array_string(r#"to_array("ab")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String("a".to_string()), RuntimeValue::String("b".to_string())]))].into()))]
+#[case::to_array_number("to_array(42)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(42.into())]))].into()))]
+#[case::to_array_bytes(r#"to_array(b"ab")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(97.into()), RuntimeValue::Number(98.into())]))].into()))]
+#[case::to_array_none("to_array(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
+#[case::to_array_already_array("to_array([1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 // to_bytes conversions
 #[case::to_bytes_string(r#"to_bytes("hi") | len"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 #[case::to_bytes_bytes(r#"to_bytes(b"hi") | len"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
@@ -3176,7 +3176,7 @@ fn engine() -> DefaultEngine {
 // del: None returns None
 #[case::del_none("del(None, 0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // del: remove key from dict by string
-#[case::del_dict_string(r#"del({"a": 1, "b": 2}, "a")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict({let mut m = std::collections::BTreeMap::new(); m.insert(mq_lang::Ident::new("b"), RuntimeValue::Number(2.into())); m})].into()))]
+#[case::del_dict_string(r#"del({"a": 1, "b": 2}, "a")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Dict({let mut m = std::collections::BTreeMap::new(); m.insert(mq_lang::Ident::new("b"), RuntimeValue::Number(2.into())); Shared::new(m)})].into()))]
 // index: bytes haystack
 #[case::index_bytes(r#"index(b"hello", b"ll")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 // index: bytes not found
@@ -3194,9 +3194,9 @@ fn engine() -> DefaultEngine {
 // rindex: None returns -1
 #[case::rindex_none(r#"rindex(None, "a")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number((-1).into())].into()))]
 // slice: array with positive indices
-#[case::slice_array("slice([1, 2, 3, 4, 5], 1, 4)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])].into()))]
+#[case::slice_array("slice([1, 2, 3, 4, 5], 1, 4)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))].into()))]
 // slice: array with out-of-bounds → empty
-#[case::slice_array_empty("slice([1, 2, 3], 5, 10)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![])].into()))]
+#[case::slice_array_empty("slice([1, 2, 3], 5, 10)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 // slice: string with negative indices
 #[case::slice_string_negative(r#"slice("hello", -3, -1)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ll".to_string())].into()))]
 // slice: bytes
@@ -3232,9 +3232,9 @@ fn engine() -> DefaultEngine {
 #[case::abs_positive("abs(5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 #[case::abs_negative("abs(-5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 // split: array split
-#[case::split_array("split([1, 2, 3, 2, 4], 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into())]), RuntimeValue::Array(vec![RuntimeValue::Number(3.into())]), RuntimeValue::Array(vec![RuntimeValue::Number(4.into())])  ])].into()))]
-#[case::split_array_no_match("split([1, 2, 3], 99)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])])].into()))]
-#[case::split_array_empty("split([], 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Array(vec![])])].into()))]
+#[case::split_array("split([1, 2, 3, 2, 4], 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into())])), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(3.into())])), RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(4.into())]))  ]))].into()))]
+#[case::split_array_no_match("split([1, 2, 3], 99)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))]))].into()))]
+#[case::split_array_empty("split([], 1)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Array(Shared::new(vec![]))]))].into()))]
 // negate: negate a number
 #[case::negate_positive("negate(5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number((-5).into())].into()))]
 #[case::negate_negative("negate(-5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
@@ -3244,19 +3244,19 @@ fn engine() -> DefaultEngine {
 #[case::join_single(r#"join(["only"], "-")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("only".to_string())].into()))]
 #[case::join_empty_sep(r#"join(["a", "b"], "")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("ab".to_string())].into()))]
 // reverse: reverse array, string, bytes
-#[case::reverse_array("reverse([1, 2, 3])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into())])].into()))]
+#[case::reverse_array("reverse([1, 2, 3])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(3.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(1.into())]))].into()))]
 #[case::reverse_string(r#"reverse("abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("cba".to_string())].into()))]
 #[case::reverse_string_empty(r#"reverse("")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
 #[case::reverse_bytes(r#"reverse(b"\x01\x02\x03") | len"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(3.into())].into()))]
-#[case::reverse_array_empty("reverse([])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![])].into()))]
+#[case::reverse_array_empty("reverse([])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 // flatten: flatten nested arrays
-#[case::flatten_basic("flatten([1, [2, 3], 4])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())])].into()))]
-#[case::flatten_already_flat("flatten([1, 2, 3])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
-#[case::flatten_empty("flatten([])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![])].into()))]
+#[case::flatten_basic("flatten([1, [2, 3], 4])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(4.into())]))].into()))]
+#[case::flatten_already_flat("flatten([1, 2, 3])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
+#[case::flatten_empty("flatten([])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::flatten_non_array("flatten(42)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(42.into())].into()))]
 // insert: insert into array, string, dict
-#[case::insert_array_middle("insert([1, 2, 3], 1, 99)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(99.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
-#[case::insert_array_begin("insert([1, 2], 0, 0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(0.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+#[case::insert_array_middle("insert([1, 2, 3], 1, 99)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(99.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
+#[case::insert_array_begin("insert([1, 2], 0, 0)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(0.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::insert_string(r#"insert("hllo", 1, "e")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello".to_string())].into()))]
 #[case::insert_dict(r#"insert({"a": 1}, "b", 2) | get("b")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
 // basename, dirname, extname, stem, path_join: path utilities
@@ -3277,8 +3277,8 @@ fn engine() -> DefaultEngine {
 // add: various type combinations
 #[case::add_string_number(r#"add("hello", 42)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("hello42".to_string())].into()))]
 #[case::add_number_string(r#"add(42, "!")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("!42".to_string())].into()))]
-#[case::add_array_value("add([1, 2], 3)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())])].into()))]
-#[case::add_value_array("add(0, [1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(0.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())])].into()))]
+#[case::add_array_value("add([1, 2], 3)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into()), RuntimeValue::Number(3.into())]))].into()))]
+#[case::add_value_array("add(0, [1, 2])", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(0.into()), RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())]))].into()))]
 #[case::add_none_number("add(None, 5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 #[case::add_number_none("add(5, None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
 #[case::add_bytes(r#"add(b"\x01", b"\x02") | len"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
@@ -3319,11 +3319,11 @@ fn engine() -> DefaultEngine {
 #[case::match_string(r#"match("hello") do | "hello": 1 | _: 0 end"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 #[case::match_no_arm_returns_none(r#"match(99) do | 1: "one" | 2: "two" end"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // foreach: iteration produces array of results
-#[case::foreach_sum("foreach(x, [1, 2, 3]): x * 2", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())])].into()))]
+#[case::foreach_sum("foreach(x, [1, 2, 3]): x * 2", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(2.into()), RuntimeValue::Number(4.into()), RuntimeValue::Number(6.into())]))].into()))]
 // qualified access to module members
 #[case::module_access("module m: def double(x): x * 2; end | m::double(5)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(10.into())].into()))]
 // function passed as first-class value
-#[case::fn_as_value("def sq(x): x * x; | map([2, 3, 4], sq)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(4.into()), RuntimeValue::Number(9.into()), RuntimeValue::Number(16.into())])].into()))]
+#[case::fn_as_value("def sq(x): x * x; | map([2, 3, 4], sq)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(4.into()), RuntimeValue::Number(9.into()), RuntimeValue::Number(16.into())]))].into()))]
 // try-catch: catches runtime errors
 #[case::try_catch_on_error("try: error(\"e\") catch: \"caught\"", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("caught".to_string())].into()))]
 // optimizer: while loop variant with reassignment
@@ -3333,7 +3333,7 @@ fn engine() -> DefaultEngine {
 // to_string: None
 #[case::to_string_none("to_string(None)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("".to_string())].into()))]
 // range: 3-arg numeric (start, end, step) - end is inclusive
-#[case::range_3_arg("range(1, 8, 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(7.into())])].into()))]
+#[case::range_3_arg("range(1, 8, 2)", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(3.into()), RuntimeValue::Number(5.into()), RuntimeValue::Number(7.into())]))].into()))]
 #[case::range_3_arg_zero("range(0, 6, 3) | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(3.into())].into()))]
 // range: single-char string range (end inclusive)
 #[case::range_char("range(\"a\", \"e\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(5.into())].into()))]
@@ -3373,7 +3373,7 @@ fn engine() -> DefaultEngine {
 // replace: None input → None
 #[case::replace_none(r#"replace(None, "x", "y")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::None].into()))]
 // split: None input → empty array
-#[case::split_none(r#"split(None, " ")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::EMPTY_ARRAY].into()))]
+#[case::split_none(r#"split(None, " ")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::empty_array()].into()))]
 // to_link: empty title → link with no title
 #[case::to_link_empty_title(r##"to_link("url", "text", "") | type"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("markdown".to_string())].into()))]
 // get_title: link with no title → None

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 use miette::IntoDiagnostic;
 use miette::miette;
 use mq_lang::DefaultEngine;
+use mq_lang::Shared;
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::io::BufRead;
@@ -864,7 +865,9 @@ impl Cli {
                         .into_iter::<serde_json::Value>()
                         .collect::<Result<_, _>>()
                         .into_diagnostic()?;
-                    let runtime_value = mq_lang::RuntimeValue::Array(json_values.into_iter().map(Into::into).collect());
+                    let runtime_value = mq_lang::RuntimeValue::Array(mq_lang::Shared::new(
+                        json_values.into_iter().map(Into::into).collect(),
+                    ));
                     engine.define_value(&v[0], runtime_value.clone());
                     named.insert(mq_lang::Ident::new(&v[0]), runtime_value);
                 }
@@ -880,13 +883,16 @@ impl Cli {
             let args_map: BTreeMap<mq_lang::Ident, mq_lang::RuntimeValue> = [
                 (
                     mq_lang::Ident::new("positional"),
-                    mq_lang::RuntimeValue::Array(positional),
+                    mq_lang::RuntimeValue::Array(Shared::new(positional)),
                 ),
-                (mq_lang::Ident::new("named"), mq_lang::RuntimeValue::Dict(named)),
+                (
+                    mq_lang::Ident::new("named"),
+                    mq_lang::RuntimeValue::Dict(Shared::new(named)),
+                ),
             ]
             .into_iter()
             .collect();
-            engine.define_value("ARGS", mq_lang::RuntimeValue::Dict(args_map));
+            engine.define_value("ARGS", mq_lang::RuntimeValue::Dict(Shared::new(args_map)));
         }
 
         if let Some(raw_file) = &self.input.raw_file {
@@ -1420,7 +1426,7 @@ impl Cli {
         match value {
             mq_lang::RuntimeValue::Markdown(node, _) => nodes.push((**node).clone()),
             mq_lang::RuntimeValue::Array(items) => {
-                for item in items {
+                for item in items.iter() {
                     Self::collect_markdown_nodes(item, nodes);
                 }
             }

--- a/crates/mq-run/src/grep.rs
+++ b/crates/mq-run/src/grep.rs
@@ -7,6 +7,8 @@
 
 use miette::IntoDiagnostic;
 use miette::miette;
+#[cfg(test)]
+use mq_lang::Shared;
 use std::collections::HashSet;
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
@@ -251,25 +253,25 @@ mod tests {
         vec![]
     )]
     #[case::empty_array(
-        mq_lang::RuntimeValue::Array(vec![]),
+        mq_lang::RuntimeValue::Array(Shared::new(vec![])),
         vec![]
     )]
     #[case::flat_array(
-        mq_lang::RuntimeValue::Array(vec![
+        mq_lang::RuntimeValue::Array(Shared::new(vec![
             mq_lang::RuntimeValue::String("x".to_string()),
             mq_lang::RuntimeValue::String("y".to_string()),
-        ]),
+        ])),
         vec![
             ("[0]".to_string(), mq_lang::RuntimeValue::String("x".to_string())),
             ("[1]".to_string(), mq_lang::RuntimeValue::String("y".to_string())),
         ]
     )]
     #[case::nested_array(
-        mq_lang::RuntimeValue::Array(vec![
-            mq_lang::RuntimeValue::Array(vec![
+        mq_lang::RuntimeValue::Array(Shared::new(vec![
+            mq_lang::RuntimeValue::Array(Shared::new(vec![
                 mq_lang::RuntimeValue::String("nested".to_string()),
-            ]),
-        ]),
+            ])),
+        ])),
         vec![("[0][0]".to_string(), mq_lang::RuntimeValue::String("nested".to_string()))]
     )]
     fn test_flatten(#[case] input: mq_lang::RuntimeValue, #[case] expected: Vec<(String, mq_lang::RuntimeValue)>) {
@@ -284,7 +286,7 @@ mod tests {
             mq_lang::RuntimeValue::String("val".to_string()),
         );
         assert_eq!(
-            flatten(&mq_lang::RuntimeValue::Dict(m)),
+            flatten(&mq_lang::RuntimeValue::Dict(Shared::new(m))),
             vec![("key".to_string(), mq_lang::RuntimeValue::String("val".to_string()))]
         );
     }
@@ -297,9 +299,12 @@ mod tests {
             mq_lang::RuntimeValue::String("deep".to_string()),
         );
         let mut outer = BTreeMap::new();
-        outer.insert(mq_lang::Ident::new("a"), mq_lang::RuntimeValue::Dict(inner));
+        outer.insert(
+            mq_lang::Ident::new("a"),
+            mq_lang::RuntimeValue::Dict(Shared::new(inner)),
+        );
         assert_eq!(
-            flatten(&mq_lang::RuntimeValue::Dict(outer)),
+            flatten(&mq_lang::RuntimeValue::Dict(Shared::new(outer))),
             vec![("a.b".to_string(), mq_lang::RuntimeValue::String("deep".to_string()))]
         );
     }
@@ -310,10 +315,10 @@ mod tests {
         let mut m = BTreeMap::new();
         m.insert(
             mq_lang::Ident::new("key"),
-            mq_lang::RuntimeValue::Array(vec![mq_lang::RuntimeValue::String("val".to_string())]),
+            mq_lang::RuntimeValue::Array(Shared::new(vec![mq_lang::RuntimeValue::String("val".to_string())])),
         );
         assert_eq!(
-            flatten(&mq_lang::RuntimeValue::Dict(m)),
+            flatten(&mq_lang::RuntimeValue::Dict(Shared::new(m))),
             vec![("key[0]".to_string(), mq_lang::RuntimeValue::String("val".to_string()))]
         );
     }
@@ -326,7 +331,7 @@ mod tests {
             mq_lang::Ident::new("b"),
             mq_lang::RuntimeValue::String("val".to_string()),
         );
-        let input = mq_lang::RuntimeValue::Array(vec![mq_lang::RuntimeValue::Dict(m)]);
+        let input = mq_lang::RuntimeValue::Array(Shared::new(vec![mq_lang::RuntimeValue::Dict(Shared::new(m))]));
         assert_eq!(
             flatten(&input),
             vec![("[0].b".to_string(), mq_lang::RuntimeValue::String("val".to_string()))]
@@ -343,14 +348,14 @@ mod tests {
         vec!["true".to_string()]
     )]
     #[case::empty_array(
-        mq_lang::RuntimeValue::Array(vec![]),
+        mq_lang::RuntimeValue::Array(Shared::new(vec![])),
         vec![]
     )]
     #[case::flat_array(
-        mq_lang::RuntimeValue::Array(vec![
+        mq_lang::RuntimeValue::Array(Shared::new(vec![
             mq_lang::RuntimeValue::String("x".to_string()),
             mq_lang::RuntimeValue::String("y".to_string()),
-        ]),
+        ])),
         vec!["[0]: x".to_string(), "[1]: y".to_string()]
     )]
     fn test_to_nodes(#[case] input: mq_lang::RuntimeValue, #[case] expected: Vec<String>) {
@@ -365,7 +370,7 @@ mod tests {
             mq_lang::Ident::new("key"),
             mq_lang::RuntimeValue::String("val".to_string()),
         );
-        let actual: Vec<String> = to_nodes(&mq_lang::RuntimeValue::Dict(m))
+        let actual: Vec<String> = to_nodes(&mq_lang::RuntimeValue::Dict(Shared::new(m)))
             .into_iter()
             .map(|n| n.to_string())
             .collect();

--- a/crates/mq-run/src/output/csv.rs
+++ b/crates/mq-run/src/output/csv.rs
@@ -7,6 +7,8 @@
 
 use miette::miette;
 use mq_lang::RuntimeValue;
+#[cfg(test)]
+use mq_lang::Shared;
 use std::collections::BTreeSet;
 
 fn cell_value(value: &RuntimeValue) -> String {
@@ -93,10 +95,10 @@ mod tests {
         let mut m2 = std::collections::BTreeMap::new();
         m2.insert(mq_lang::Ident::new("name"), RuntimeValue::String("Bob".to_string()));
         m2.insert(mq_lang::Ident::new("age"), RuntimeValue::String("25".to_string()));
-        let values = vec![RuntimeValue::Array(vec![
-            RuntimeValue::Dict(m1),
-            RuntimeValue::Dict(m2),
-        ])];
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Dict(Shared::new(m1)),
+            RuntimeValue::Dict(Shared::new(m2)),
+        ]))];
         let result = runtime_values_to_csv(&values).unwrap();
         assert_eq!(result, "age,name\n30,Alice\n25,Bob\n");
     }
@@ -105,7 +107,7 @@ mod tests {
     fn test_single_dict() {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("a"), RuntimeValue::String("1".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_csv(&values).unwrap();
         assert_eq!(result, "a\n1\n");
     }
@@ -114,7 +116,7 @@ mod tests {
     fn test_needs_quoting() {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("a"), RuntimeValue::String("has,comma".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_csv(&values).unwrap();
         assert_eq!(result, "a\n\"has,comma\"\n");
     }
@@ -136,26 +138,26 @@ mod tests {
         m1.insert(mq_lang::Ident::new("b"), RuntimeValue::String("2".to_string()));
         let mut m2 = std::collections::BTreeMap::new();
         m2.insert(mq_lang::Ident::new("a"), RuntimeValue::String("3".to_string()));
-        let values = vec![RuntimeValue::Array(vec![
-            RuntimeValue::Dict(m1),
-            RuntimeValue::Dict(m2),
-        ])];
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Dict(Shared::new(m1)),
+            RuntimeValue::Dict(Shared::new(m2)),
+        ]))];
         let result = runtime_values_to_csv(&values).unwrap();
         assert_eq!(result, "a,b\n1,2\n3,\n");
     }
 
     #[test]
     fn test_array_of_arrays() {
-        let values = vec![RuntimeValue::Array(vec![
-            RuntimeValue::Array(vec![
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("h1".to_string()),
                 RuntimeValue::String("h2".to_string()),
-            ]),
-            RuntimeValue::Array(vec![
+            ])),
+            RuntimeValue::Array(Shared::new(vec![
                 RuntimeValue::String("v1".to_string()),
                 RuntimeValue::String("v2".to_string()),
-            ]),
-        ])];
+            ])),
+        ]))];
         let result = runtime_values_to_csv(&values).unwrap();
         assert_eq!(result, "h1,h2\nv1,v2\n");
     }

--- a/crates/mq-run/src/output/json.rs
+++ b/crates/mq-run/src/output/json.rs
@@ -4,6 +4,8 @@
 //! Supports optional ANSI color output using the [`mq_markdown::ColorTheme`].
 
 use miette::miette;
+#[cfg(test)]
+use mq_lang::Shared;
 use mq_markdown::ColorTheme;
 
 fn json_quote(s: &str) -> String {
@@ -179,7 +181,7 @@ mod tests {
     #[test]
     fn test_colorize_array_empty() {
         let theme = plain_theme();
-        let values = vec![RuntimeValue::Array(vec![])];
+        let values = vec![RuntimeValue::Array(Shared::new(vec![]))];
         let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
         assert_eq!(result, "[]");
     }
@@ -187,10 +189,10 @@ mod tests {
     #[test]
     fn test_colorize_array_non_empty() {
         let theme = plain_theme();
-        let values = vec![RuntimeValue::Array(vec![
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("x".to_string()),
             RuntimeValue::String("y".to_string()),
-        ])];
+        ]))];
         let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
         assert!(result.contains('[') && result.contains(']'));
         assert!(result.contains("\"x\"") && result.contains("\"y\""));
@@ -199,7 +201,7 @@ mod tests {
     #[test]
     fn test_colorize_object_empty() {
         let theme = plain_theme();
-        let values = vec![RuntimeValue::Dict(std::collections::BTreeMap::new())];
+        let values = vec![RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::new()))];
         let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
         assert_eq!(result, "{}");
     }
@@ -209,7 +211,7 @@ mod tests {
         let theme = plain_theme();
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("key"), RuntimeValue::String("val".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
         assert!(result.contains("key") && result.contains("val"));
     }

--- a/crates/mq-run/src/output/table.rs
+++ b/crates/mq-run/src/output/table.rs
@@ -7,6 +7,7 @@
 //! Markdown nodes with children are displayed with a nested children table.
 
 use mq_lang::RuntimeValue;
+use mq_lang::Shared;
 use mq_markdown::ColorTheme;
 use std::collections::{BTreeMap, BTreeSet};
 use tabled::Table;
@@ -90,9 +91,9 @@ pub(crate) fn runtime_values_to_table<'a>(runtime_values: &[RuntimeValue], theme
                     end_map.insert(mq_lang::Ident::new("column"), pos.end.column.to_string().into());
 
                     let mut pos_map = BTreeMap::new();
-                    pos_map.insert(mq_lang::Ident::new("start"), RuntimeValue::Dict(start_map));
-                    pos_map.insert(mq_lang::Ident::new("end"), RuntimeValue::Dict(end_map));
-                    let pos_str = format_cell_value(&RuntimeValue::Dict(pos_map), theme);
+                    pos_map.insert(mq_lang::Ident::new("start"), RuntimeValue::Dict(Shared::new(start_map)));
+                    pos_map.insert(mq_lang::Ident::new("end"), RuntimeValue::Dict(Shared::new(end_map)));
+                    let pos_str = format_cell_value(&RuntimeValue::Dict(Shared::new(pos_map)), theme);
                     rows.push(vec!["position".to_string(), pos_str]);
                 }
                 builder.push_record([build_nested_table(&rows, theme)]);
@@ -212,7 +213,7 @@ fn format_cell_value<'a>(value: &RuntimeValue, theme: Option<&'a ColorTheme<'a>>
             let all_dicts = items.iter().all(|v| matches!(v, RuntimeValue::Dict(_)));
             if all_dicts {
                 let mut header_set: BTreeSet<String> = BTreeSet::new();
-                for item in items {
+                for item in items.iter() {
                     if let RuntimeValue::Dict(map) = item {
                         for key in map.keys() {
                             header_set.insert(key.to_string());
@@ -221,7 +222,7 @@ fn format_cell_value<'a>(value: &RuntimeValue, theme: Option<&'a ColorTheme<'a>>
                 }
                 let headers: Vec<String> = header_set.into_iter().collect();
                 let mut table_rows = vec![headers.clone()];
-                for item in items {
+                for item in items.iter() {
                     if let RuntimeValue::Dict(map) = item {
                         let row: Vec<String> = headers
                             .iter()
@@ -281,7 +282,7 @@ mod tests {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("name"), RuntimeValue::String("Alice".to_string()));
         map.insert(mq_lang::Ident::new("age"), RuntimeValue::String("30".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains("name") && s.contains("age"));
@@ -295,7 +296,7 @@ mod tests {
             map.insert(mq_lang::Ident::new("key"), RuntimeValue::String(val.to_string()));
             let mut outer = std::collections::BTreeMap::new();
             outer.insert(mq_lang::Ident::new("name"), RuntimeValue::String(name.to_string()));
-            RuntimeValue::Dict(outer)
+            RuntimeValue::Dict(Shared::new(outer))
         };
         let values = vec![make_dict("Alice", "a"), make_dict("Bob", "b")];
         let table = runtime_values_to_table(&values, None);
@@ -308,7 +309,7 @@ mod tests {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("x"), RuntimeValue::Boolean(true));
         map.insert(mq_lang::Ident::new("y"), RuntimeValue::Boolean(false));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let theme = plain();
         let table = runtime_values_to_table(&values, Some(&theme));
         let s = table.to_string();
@@ -321,10 +322,10 @@ mod tests {
         m1.insert(mq_lang::Ident::new("a"), RuntimeValue::String("1".to_string()));
         let mut m2 = std::collections::BTreeMap::new();
         m2.insert(mq_lang::Ident::new("a"), RuntimeValue::String("2".to_string()));
-        let values = vec![RuntimeValue::Array(vec![
-            RuntimeValue::Dict(m1),
-            RuntimeValue::Dict(m2),
-        ])];
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Dict(Shared::new(m1)),
+            RuntimeValue::Dict(Shared::new(m2)),
+        ]))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains('1') && s.contains('2'));
@@ -332,10 +333,10 @@ mod tests {
 
     #[test]
     fn test_table_array_of_non_dicts() {
-        let values = vec![RuntimeValue::Array(vec![
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("x".to_string()),
             RuntimeValue::String("y".to_string()),
-        ])];
+        ]))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains('x') && s.contains('y'));
@@ -346,8 +347,8 @@ mod tests {
         let mut inner = std::collections::BTreeMap::new();
         inner.insert(mq_lang::Ident::new("sub"), RuntimeValue::String("val".to_string()));
         let mut outer = std::collections::BTreeMap::new();
-        outer.insert(mq_lang::Ident::new("nested"), RuntimeValue::Dict(inner));
-        let values = vec![RuntimeValue::Dict(outer)];
+        outer.insert(mq_lang::Ident::new("nested"), RuntimeValue::Dict(Shared::new(inner)));
+        let values = vec![RuntimeValue::Dict(Shared::new(outer))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains("sub") && s.contains("val"));
@@ -367,8 +368,8 @@ mod tests {
     #[test]
     fn test_table_empty_array_in_cell() {
         let mut map = std::collections::BTreeMap::new();
-        map.insert(mq_lang::Ident::new("arr"), RuntimeValue::Array(vec![]));
-        let values = vec![RuntimeValue::Dict(map)];
+        map.insert(mq_lang::Ident::new("arr"), RuntimeValue::Array(Shared::new(vec![])));
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let table = runtime_values_to_table(&values, None);
         assert!(!table.to_string().is_empty());
     }
@@ -454,9 +455,12 @@ mod tests {
         let mut outer = std::collections::BTreeMap::new();
         outer.insert(
             mq_lang::Ident::new("items"),
-            RuntimeValue::Array(vec![RuntimeValue::Dict(inner1), RuntimeValue::Dict(inner2)]),
+            RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Dict(Shared::new(inner1)),
+                RuntimeValue::Dict(Shared::new(inner2)),
+            ])),
         );
-        let values = vec![RuntimeValue::Dict(outer)];
+        let values = vec![RuntimeValue::Dict(Shared::new(outer))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains("v1") || s.contains("v2") || s.contains("items"));
@@ -470,7 +474,7 @@ mod tests {
         });
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("md"), RuntimeValue::Markdown(Box::new(node), None));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains("node_value") || s.contains("md"));
@@ -479,7 +483,7 @@ mod tests {
     #[test]
     fn test_table_empty_dict() {
         let map = std::collections::BTreeMap::new();
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let table = runtime_values_to_table(&values, None);
         assert!(!table.to_string().is_empty());
     }
@@ -492,7 +496,7 @@ mod tests {
         let mut m2 = std::collections::BTreeMap::new();
         m2.insert(mq_lang::Ident::new("a"), RuntimeValue::String("3".to_string()));
         // m2 is missing key "b" — format_cell_value should return ""
-        let values = vec![RuntimeValue::Dict(m1), RuntimeValue::Dict(m2)];
+        let values = vec![RuntimeValue::Dict(Shared::new(m1)), RuntimeValue::Dict(Shared::new(m2))];
         let table = runtime_values_to_table(&values, None);
         let s = table.to_string();
         assert!(s.contains('1') && s.contains('3'));

--- a/crates/mq-run/src/output/toml.rs
+++ b/crates/mq-run/src/output/toml.rs
@@ -7,6 +7,8 @@
 //! a dict (JSON object); anything else is a descriptive error rather than a panic.
 
 use miette::miette;
+#[cfg(test)]
+use mq_lang::Shared;
 
 /// Converts a list of [`mq_lang::RuntimeValue`]s into a TOML string.
 pub(crate) fn runtime_values_to_toml(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
@@ -31,7 +33,7 @@ mod tests {
     fn test_dict_value() {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("name"), RuntimeValue::String("Alice".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_toml(&values).unwrap();
         assert!(result.contains("name = \"Alice\""));
     }
@@ -41,8 +43,8 @@ mod tests {
         let mut inner = std::collections::BTreeMap::new();
         inner.insert(mq_lang::Ident::new("city"), RuntimeValue::String("NYC".to_string()));
         let mut outer = std::collections::BTreeMap::new();
-        outer.insert(mq_lang::Ident::new("address"), RuntimeValue::Dict(inner));
-        let values = vec![RuntimeValue::Dict(outer)];
+        outer.insert(mq_lang::Ident::new("address"), RuntimeValue::Dict(Shared::new(inner)));
+        let values = vec![RuntimeValue::Dict(Shared::new(outer))];
         let result = runtime_values_to_toml(&values).unwrap();
         assert!(result.contains("[address]"));
         assert!(result.contains("city = \"NYC\""));
@@ -57,7 +59,9 @@ mod tests {
 
     #[test]
     fn test_array_top_level_errors() {
-        let values = vec![RuntimeValue::Array(vec![RuntimeValue::String("a".to_string())])];
+        let values = vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::String(
+            "a".to_string(),
+        )]))];
         let result = runtime_values_to_toml(&values);
         assert!(result.is_err());
     }

--- a/crates/mq-run/src/output/xml.rs
+++ b/crates/mq-run/src/output/xml.rs
@@ -8,6 +8,8 @@
 //! arrays becoming repeated `<item>` elements.
 
 use miette::miette;
+#[cfg(test)]
+use mq_lang::Shared;
 use mq_lang::{Ident, RuntimeValue};
 use quick_xml::Writer;
 use quick_xml::escape::escape;
@@ -32,7 +34,7 @@ fn write_element(writer: &mut Writer<&mut Vec<u8>>, map: &BTreeMap<Ident, Runtim
 
     let mut start = BytesStart::new(tag.as_str());
     if let Some(RuntimeValue::Dict(attrs)) = map.get(&Ident::new("attributes")) {
-        for (k, v) in attrs {
+        for (k, v) in attrs.iter() {
             start.push_attribute((k.to_string().as_str(), escape(v.to_string()).as_ref()));
         }
     }
@@ -141,11 +143,11 @@ mod tests {
         attrs.insert(Ident::new("id"), RuntimeValue::String("1".to_string()));
         let mut map = BTreeMap::new();
         map.insert(Ident::new("tag"), RuntimeValue::String("root".to_string()));
-        map.insert(Ident::new("attributes"), RuntimeValue::Dict(attrs));
-        map.insert(Ident::new("children"), RuntimeValue::Array(vec![]));
+        map.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attrs)));
+        map.insert(Ident::new("children"), RuntimeValue::Array(Shared::new(vec![])));
         map.insert(Ident::new("text"), RuntimeValue::String("hello".to_string()));
 
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_xml(&values).unwrap();
         assert!(result.contains("<root id=\"1\">hello</root>"));
     }
@@ -154,7 +156,7 @@ mod tests {
     fn test_generic_dict() {
         let mut map = BTreeMap::new();
         map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_xml(&values).unwrap();
         assert!(result.contains("<root>"));
         assert!(result.contains("<name>Alice</name>"));
@@ -162,10 +164,10 @@ mod tests {
 
     #[test]
     fn test_generic_array_becomes_items() {
-        let values = vec![RuntimeValue::Array(vec![
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])];
+        ]))];
         let result = runtime_values_to_xml(&values).unwrap();
         assert!(result.contains("<item>a</item>"));
         assert!(result.contains("<item>b</item>"));
@@ -180,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_empty_dict() {
-        let values = vec![RuntimeValue::Dict(BTreeMap::new())];
+        let values = vec![RuntimeValue::Dict(Shared::new(BTreeMap::new()))];
         let result = runtime_values_to_xml(&values).unwrap();
         assert!(result.contains("<root/>"));
     }

--- a/crates/mq-run/src/output/yaml.rs
+++ b/crates/mq-run/src/output/yaml.rs
@@ -4,6 +4,8 @@
 //! [`serde_json::Value`] (see [`crate::json`]) and serializing that with `serde_yaml`.
 
 use miette::miette;
+#[cfg(test)]
+use mq_lang::Shared;
 
 /// Converts a list of [`mq_lang::RuntimeValue`]s into a YAML string.
 pub(crate) fn runtime_values_to_yaml(runtime_values: &[mq_lang::RuntimeValue]) -> miette::Result<String> {
@@ -27,17 +29,17 @@ mod tests {
     fn test_dict_value() {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("name"), RuntimeValue::String("Alice".to_string()));
-        let values = vec![RuntimeValue::Dict(map)];
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
         let result = runtime_values_to_yaml(&values).unwrap();
         assert!(result.contains("name: Alice"));
     }
 
     #[test]
     fn test_array_value() {
-        let values = vec![RuntimeValue::Array(vec![
+        let values = vec![RuntimeValue::Array(Shared::new(vec![
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
-        ])];
+        ]))];
         let result = runtime_values_to_yaml(&values).unwrap();
         assert!(result.contains("- a"));
         assert!(result.contains("- b"));

--- a/crates/mq-web-api/src/api.rs
+++ b/crates/mq-web-api/src/api.rs
@@ -502,7 +502,7 @@ fn collect_markdown_nodes(value: &mq_lang::RuntimeValue, nodes: &mut Vec<mq_mark
     match value {
         mq_lang::RuntimeValue::Markdown(node, _) => nodes.push((**node).clone()),
         mq_lang::RuntimeValue::Array(items) => {
-            for item in items {
+            for item in items.iter() {
                 collect_markdown_nodes(item, nodes);
             }
         }


### PR DESCRIPTION
## Summary

Wrap the Vec/BTreeMap payload of RuntimeValue::Array and ::Dict in Shared<..> (Rc/Arc) so that reading a let-bound array/dict or passing it as a function argument is an O(1) refcount bump instead of a deep clone, matching the sharing already used for Function/Ast. Builtins that mutate in place (sort, reverse, uniq, push, insert, set, del, ...) go through new array_mut/dict_mut helpers backed by Rc::make_mut, cloning only when the value is still shared.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
