### PR TITLE
✨ feat(mq-lsp): validate rename target via textDocument/prepareRename

### DIFF
--- a/crates/mq-lsp/src/capabilities.rs
+++ b/crates/mq-lsp/src/capabilities.rs
@@ -62,7 +62,7 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
             ..Default::default()
         })),
         rename_provider: Some(OneOf::Right(RenameOptions {
-            prepare_provider: Some(false),
+            prepare_provider: Some(true),
             work_done_progress_options: Default::default(),
         })),
         semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(

--- a/crates/mq-lsp/src/rename.rs
+++ b/crates/mq-lsp/src/rename.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bimap::BiMap;
-use tower_lsp_server::ls_types::{self, Position, Range, TextEdit, WorkspaceEdit};
+use tower_lsp_server::ls_types::{self, Position, PrepareRenameResponse, Range, TextEdit, WorkspaceEdit};
 use url::Url;
 
 fn to_range(text_range: mq_lang::Range) -> Range {
@@ -13,6 +13,48 @@ fn to_range(text_range: mq_lang::Range) -> Range {
         Position::new(text_range.start.line - 1, (text_range.start.column - 1) as u32),
         Position::new(text_range.end.line - 1, (text_range.end.column - 1) as u32),
     )
+}
+
+/// Validates that the symbol at `position` can be renamed, without performing the rename itself.
+///
+/// Returns the range of the identifier under the cursor together with its current text as a
+/// placeholder, so clients can reject the rename (or seed their input box) before the user commits
+/// to a new name. Mirrors the eligibility checks in [`response`]: no symbol at the position,
+/// builtin symbols, and unresolved references are all rejected here.
+pub(crate) fn prepare(hir: Arc<RwLock<mq_hir::Hir>>, url: Url, position: Position) -> Option<PrepareRenameResponse> {
+    let hir_guard = hir.read().unwrap();
+    let source = hir_guard.source_by_url(&url)?;
+
+    let (symbol_id, symbol) = hir_guard.find_symbol_in_position(
+        source,
+        mq_lang::Position::new(position.line + 1, (position.character + 1) as usize),
+    )?;
+
+    if hir_guard.is_builtin_symbol(&symbol) {
+        return None;
+    }
+
+    let def_id = match symbol.kind {
+        mq_hir::SymbolKind::Call
+        | mq_hir::SymbolKind::Ref
+        | mq_hir::SymbolKind::CallDynamic
+        | mq_hir::SymbolKind::Argument
+        | mq_hir::SymbolKind::QualifiedAccess => hir_guard.resolve_reference_symbol(symbol_id)?,
+        _ => symbol_id,
+    };
+
+    let def_symbol = hir_guard.symbol(def_id)?;
+    if hir_guard.is_builtin_symbol(def_symbol) {
+        return None;
+    }
+
+    let text_range = symbol.source.text_range?;
+    let placeholder = symbol.value.map(|v| v.to_string()).unwrap_or_default();
+
+    Some(PrepareRenameResponse::RangeWithPlaceholder {
+        range: to_range(text_range),
+        placeholder,
+    })
 }
 
 /// Renames the symbol at `position` and all of its references, across every
@@ -256,6 +298,47 @@ mod tests {
             assert_eq!(edits.len(), 1);
             assert_eq!(edits[0].new_text, "csv_load");
         }
+    }
+
+    #[test]
+    fn test_prepare_rename_returns_range_and_placeholder() {
+        let code = "def func1(): 1; | func1()";
+        let (hir, url, _) = setup(code);
+
+        let result = prepare(hir, url, Position::new(0, 5));
+
+        match result {
+            Some(PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. }) => {
+                assert_eq!(placeholder, "func1");
+            }
+            other => panic!("expected RangeWithPlaceholder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_prepare_rename_rejects_builtin() {
+        let code = "\"hello\" | len";
+        let (hir, url, _) = setup(code);
+
+        let result = prepare(hir, url, Position::new(0, 11));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_prepare_rename_rejects_no_symbol_at_position() {
+        let (hir, url, _) = setup("let x = 1");
+
+        let result = prepare(hir, url, Position::new(5, 5));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_prepare_rename_rejects_unresolved_call() {
+        let code = "totally_unknown_fn()";
+        let (hir, url, _) = setup(code);
+
+        let result = prepare(hir, url, Position::new(0, 5));
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/mq-lsp/src/server.rs
+++ b/crates/mq-lsp/src/server.rs
@@ -285,6 +285,14 @@ impl LanguageServer for Backend {
         ))
     }
 
+    async fn prepare_rename(
+        &self,
+        params: ls_types::TextDocumentPositionParams,
+    ) -> jsonrpc::Result<Option<ls_types::PrepareRenameResponse>> {
+        let url = to_url(&params.text_document.uri);
+        Ok(rename::prepare(Arc::clone(&self.hir), url, params.position))
+    }
+
     async fn formatting(
         &self,
         params: ls_types::DocumentFormattingParams,
@@ -1191,7 +1199,7 @@ mod tests {
 
         match capabilities.rename_provider {
             Some(ls_types::OneOf::Right(options)) => {
-                assert_eq!(options.prepare_provider, Some(false));
+                assert_eq!(options.prepare_provider, Some(true));
             }
             other => panic!("expected rename_provider OneOf::Right(RenameOptions), got {other:?}"),
         }
@@ -1234,6 +1242,75 @@ mod tests {
         let edits = edit.changes.unwrap().into_values().next().unwrap();
         assert_eq!(edits.len(), 2);
         assert!(edits.iter().all(|e| e.new_text == "renamed_func"));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_rename_valid_symbol() {
+        let (service, _) = LspService::new(|client| Backend {
+            client,
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
+            source_map: RwLock::new(BiMap::new()),
+            type_env_map: DashMap::new(),
+            error_map: DashMap::new(),
+            text_map: DashMap::new(),
+            config: LspConfig::default(),
+        });
+
+        let backend = service.inner();
+        let uri = Url::parse("file:///test.mq").unwrap();
+
+        let code = "def test_func(): 1;\ndef main(): test_func();";
+        let (nodes, _) = mq_lang::parse_recovery(code);
+        let (source_id, _) = backend.hir.write().unwrap().add_nodes(uri.clone(), &nodes);
+
+        backend.source_map.write().unwrap().insert(uri.to_string(), source_id);
+
+        let result = backend
+            .prepare_rename(ls_types::TextDocumentPositionParams {
+                text_document: ls_types::TextDocumentIdentifier { uri: to_uri(&uri) },
+                position: ls_types::Position::new(0, 6),
+            })
+            .await;
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Some(ls_types::PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. }) => {
+                assert_eq!(placeholder, "test_func");
+            }
+            other => panic!("expected PrepareRenameResponse::RangeWithPlaceholder, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_prepare_rename_rejects_builtin() {
+        let (service, _) = LspService::new(|client| Backend {
+            client,
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
+            source_map: RwLock::new(BiMap::new()),
+            type_env_map: DashMap::new(),
+            error_map: DashMap::new(),
+            text_map: DashMap::new(),
+            config: LspConfig::default(),
+        });
+
+        let backend = service.inner();
+        let uri = Url::parse("file:///test.mq").unwrap();
+
+        let code = "\"hello\" | len";
+        let (nodes, _) = mq_lang::parse_recovery(code);
+        let (source_id, _) = backend.hir.write().unwrap().add_nodes(uri.clone(), &nodes);
+
+        backend.source_map.write().unwrap().insert(uri.to_string(), source_id);
+
+        let result = backend
+            .prepare_rename(ls_types::TextDocumentPositionParams {
+                text_document: ls_types::TextDocumentIdentifier { uri: to_uri(&uri) },
+                position: ls_types::Position::new(0, 11),
+            })
+            .await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Advertise prepare_provider and implement prepare_rename so clients can check renameability (builtin symbols, unresolved references, no symbol at cursor) before submitting a textDocument/rename request.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
