### PR TITLE
✨ feat(mq-formatter): support stdin/stdout mode via -

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ dependencies = [
 name = "mq-formatter"
 version = "0.7.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "codspeed-divan-compat",
  "glob",

--- a/crates/mq-formatter/Cargo.toml
+++ b/crates/mq-formatter/Cargo.toml
@@ -18,6 +18,7 @@ miette = {workspace = true, features = ["fancy"]}
 mq-lang = {workspace = true, features = ["cst"]}
 
 [dev-dependencies]
+assert_cmd = {workspace = true}
 divan = {workspace = true}
 rstest = {workspace = true}
 

--- a/crates/mq-formatter/README.md
+++ b/crates/mq-formatter/README.md
@@ -56,6 +56,12 @@ mq-fmt --sort-imports --sort-functions file.mq
 
 # Wrap long `|`-chained pipelines at 80 columns
 mq-fmt --max-width 80 file.mq
+
+# Read from stdin and write the formatted result to stdout
+cat file.mq | mq-fmt -
+
+# Check formatting of stdin without writing anything (exits with non-zero if unformatted)
+cat file.mq | mq-fmt --check -
 ```
 
 ### Via mq

--- a/crates/mq-formatter/README.md
+++ b/crates/mq-formatter/README.md
@@ -11,7 +11,7 @@ curl -sSL https://mqlang.org/install_fmt.sh | bash
 ```
 
 The installer will:
-- Download the latest `mq-crawl` binary for your platform
+- Download the latest `mq-fmt` binary for your platform
 - Install it to `~/.local/bin/`
 - Verify the checksum of the downloaded binary
 - Update your shell profile to add `mq-fmt` to your PATH

--- a/crates/mq-formatter/src/main.rs
+++ b/crates/mq-formatter/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use glob::glob;
 use miette::IntoDiagnostic;
 use miette::miette;
+use std::io::{Read, Write};
 use std::{fs, path::PathBuf};
 
 #[derive(Parser, Debug)]
@@ -43,7 +44,8 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     sort_fields: bool,
 
-    /// Path to the mq file(s) to format
+    /// Path to the mq file(s) to format. Pass `-` to read from stdin and write
+    /// the formatted result to stdout instead of modifying files on disk.
     files: Option<Vec<PathBuf>>,
 }
 
@@ -57,6 +59,26 @@ fn main() -> miette::Result<()> {
         sort_functions: cli.sort_functions,
         max_width: cli.max_width,
     }));
+
+    if let Some(files) = &cli.files
+        && files.len() == 1
+        && files[0].as_os_str() == "-"
+    {
+        let mut content = String::new();
+        std::io::stdin().read_to_string(&mut content).into_diagnostic()?;
+
+        let formatted = formatter.format(&content).map_err(|e| miette!("<stdin>: {e}"))?;
+
+        if cli.check {
+            return if formatted != content {
+                Err(miette!("The input is not formatted: <stdin>"))
+            } else {
+                Ok(())
+            };
+        }
+
+        return std::io::stdout().write_all(formatted.as_bytes()).into_diagnostic();
+    }
 
     let files = match cli.files {
         Some(f) => f,

--- a/crates/mq-formatter/tests/integration_tests.rs
+++ b/crates/mq-formatter/tests/integration_tests.rs
@@ -1,0 +1,42 @@
+use assert_cmd::cargo;
+
+#[test]
+fn test_stdin_stdout_formats_and_prints_to_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq-fmt");
+
+    cmd.arg("-")
+        .write_stdin("def foo():1;")
+        .assert()
+        .success()
+        .stdout("def foo(): 1;");
+
+    Ok(())
+}
+
+#[test]
+fn test_stdin_check_passes_when_already_formatted() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq-fmt");
+
+    cmd.arg("--check")
+        .arg("-")
+        .write_stdin("def foo(): 1;\n")
+        .assert()
+        .success()
+        .stdout("");
+
+    Ok(())
+}
+
+#[test]
+fn test_stdin_check_fails_when_not_formatted() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq-fmt");
+
+    cmd.arg("--check")
+        .arg("-")
+        .write_stdin("def foo():1;")
+        .assert()
+        .failure()
+        .code(1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Passing `-` as the sole file argument reads the query from stdin and
writes the formatted result to stdout instead of requiring a file
path on disk, matching tools like rustfmt's stdin mode. `--check -`
validates stdin without writing anything. Since `mq fmt` dispatches
to `mq-fmt` as an external subcommand with inherited stdio, this also
works transparently via `mq fmt -`.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
