### PR TITLE
✨ feat(mq-dap): support "Uncaught Exceptions" breakpoint filter

### DIFF
--- a/crates/mq-dap/README.md
+++ b/crates/mq-dap/README.md
@@ -24,11 +24,12 @@ Once connected to a DAP client:
 2. **Conditional Breakpoints**: Only stop when an mq expression evaluates truthy, e.g. `x > 3`
 3. **Hit Count Breakpoints**: Only stop once the hit count condition is met. A bare number, e.g. `3`, is shorthand for `hit_count >= 3`; otherwise it's evaluated as an mq expression with `hit_count` bound to the current hit count, e.g. `hit_count >= 3 && x == 1`
 4. **Logpoints**: Log a message instead of stopping; uses mq's own `${expr}` string interpolation syntax, e.g. `x is ${x}`. `${self}` yields the current pipeline value and `${$VAR}` reads the environment variable `VAR`
-5. **Start Debugging**: Launch the debugger with your query file
-6. **Step Through Code**: Use step over, step in, and step out commands
-7. **Inspect Variables**: Hover over variables or view them in the variables pane
-8. **Watch Expressions**: Add mq expressions to your editor's watch pane to re-evaluate them against the current scope every time execution stops
-9. **View Call Stack**: See the current execution stack in the call stack pane
+5. **Exception Breakpoints**: Enable "Uncaught Exceptions" in your editor's breakpoints pane to automatically pause when a query raises an error that isn't caught by `try`/`catch`
+6. **Start Debugging**: Launch the debugger with your query file
+7. **Step Through Code**: Use step over, step in, and step out commands
+8. **Inspect Variables**: Hover over variables or view them in the variables pane
+9. **Watch Expressions**: Add mq expressions to your editor's watch pane to re-evaluate them against the current scope every time execution stops
+10. **View Call Stack**: See the current execution stack in the call stack pane
 
 ### Example Debug Session
 

--- a/crates/mq-dap/src/adapter.rs
+++ b/crates/mq-dap/src/adapter.rs
@@ -9,6 +9,8 @@ use mq_lang::Shared;
 use std::borrow::Cow;
 use std::io;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 use std::thread;
 use tracing::{debug, error};
 
@@ -19,6 +21,11 @@ use crate::protocol::{DapCommand, DebuggerMessage, LaunchArgs};
 
 type DynResult<T> = miette::Result<T, Box<dyn std::error::Error>>;
 
+/// The `filter` ID for the "Uncaught Exceptions" exception breakpoint filter advertised in
+/// `Initialize`'s `exceptionBreakpointFilters` capability (see [`crate::server::start`]) and
+/// checked in [`MqAdapter::handle_request`]'s handling of `setExceptionBreakpoints`.
+pub const UNCAUGHT_EXCEPTIONS_FILTER: &str = "uncaught";
+
 /// Main DAP adapter for mq debugger
 pub struct MqAdapter {
     engine: mq_lang::DefaultEngine,
@@ -27,6 +34,7 @@ pub struct MqAdapter {
     debugger_message_tx: Option<Sender<DebuggerMessage>>,
     dap_command_tx: Option<Sender<DapCommand>>,
     current_debug_context: Option<mq_lang::DebugContext>,
+    exception_breakpoints_enabled: Arc<AtomicBool>,
 }
 
 impl Default for MqAdapter {
@@ -40,13 +48,18 @@ impl MqAdapter {
         // Create channels for communication between DAP server and debugger handler
         let (message_tx, message_rx) = crossbeam_channel::unbounded::<DebuggerMessage>();
         let (command_tx, command_rx) = crossbeam_channel::unbounded::<DapCommand>();
+        let exception_breakpoints_enabled = Arc::new(AtomicBool::new(false));
 
         let dap_handler = DapDebuggerHandler::new(message_tx.clone());
         let mut engine = mq_lang::DefaultEngine::default();
 
         // Set up the debugger handler
         {
-            let handler_boxed = Box::new(DapHandlerWrapper::new(dap_handler, command_rx));
+            let handler_boxed = Box::new(DapHandlerWrapper::new(
+                dap_handler,
+                command_rx,
+                Arc::clone(&exception_breakpoints_enabled),
+            ));
             engine.set_debugger_handler(handler_boxed);
         }
 
@@ -57,6 +70,7 @@ impl MqAdapter {
             dap_command_tx: Some(command_tx),
             query_file: None,
             current_debug_context: None,
+            exception_breakpoints_enabled,
         }
     }
 
@@ -209,6 +223,26 @@ impl MqAdapter {
                 debug!(message = %message, "Sending output event for logpoint");
                 self.send_log_output(&message, server)?;
             }
+            DebuggerMessage::ExceptionPaused {
+                thread_id,
+                message,
+                context,
+            } => {
+                // Store the current debug context for variable inspection
+                self.current_debug_context = Some(context);
+                debug!(message = %message, "Sending stopped event for exception");
+
+                let event = Event::Stopped(events::StoppedEventBody {
+                    reason: types::StoppedEventReason::Exception,
+                    description: Some("Paused on error".to_string()),
+                    thread_id: Some(thread_id),
+                    preserve_focus_hint: None,
+                    text: Some(message),
+                    all_threads_stopped: None,
+                    hit_breakpoint_ids: None,
+                });
+                server.send_event(event)?;
+            }
             DebuggerMessage::Terminated => {
                 debug!("Sending terminated event");
 
@@ -320,8 +354,12 @@ impl MqAdapter {
                 let rsp = req.success(ResponseBody::Launch);
                 server.respond(rsp)?;
             }
-            Command::SetExceptionBreakpoints(_) => {
-                debug!("Received SetExceptionBreakpoints request");
+            Command::SetExceptionBreakpoints(args) => {
+                debug!(?args, "Received SetExceptionBreakpoints request");
+
+                let enabled = args.filters.iter().any(|filter| filter == UNCAUGHT_EXCEPTIONS_FILTER);
+                self.exception_breakpoints_enabled.store(enabled, SeqCst);
+
                 let rsp = req.success(ResponseBody::SetExceptionBreakpoints(SetExceptionBreakpointsResponse {
                     breakpoints: None,
                 }));
@@ -773,6 +811,24 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_debugger_message_exception_paused() {
+        let mut adapter = MqAdapter::new();
+        let input = BufReader::new(Cursor::new(Vec::new()));
+        let output = BufWriter::new(Cursor::new(Vec::new()));
+        let mut server = Server::new(input, output);
+
+        let message = DebuggerMessage::ExceptionPaused {
+            thread_id: 1,
+            message: "boom".to_string(),
+            context: mq_lang::DebugContext::default(),
+        };
+
+        let result = adapter.handle_debugger_message(message, &mut server);
+        assert!(result.is_ok());
+        assert!(adapter.current_debug_context.is_some());
+    }
+
+    #[test]
     fn test_handle_debugger_message_step_completed() {
         let mut adapter = MqAdapter::new();
         let input = BufReader::new(Cursor::new(Vec::new()));
@@ -1126,6 +1182,49 @@ mod tests {
         assert_eq!(stored[0].condition.as_deref(), Some("x > 1"));
         assert_eq!(stored[0].hit_condition.as_deref(), Some(">= 2"));
         assert_eq!(stored[0].log_message.as_deref(), Some("x is {x}"));
+    }
+
+    #[test]
+    fn test_handle_request_set_exception_breakpoints_enables_uncaught_filter() {
+        let mut adapter = MqAdapter::new();
+        let input = BufReader::new(Cursor::new(Vec::new()));
+        let output = BufWriter::new(Cursor::new(Vec::new()));
+        let mut server = Server::new(input, output);
+
+        let req = Request {
+            seq: 1,
+            command: Command::SetExceptionBreakpoints(dap::requests::SetExceptionBreakpointsArguments {
+                filters: vec![UNCAUGHT_EXCEPTIONS_FILTER.to_string()],
+                filter_options: None,
+                exception_options: None,
+            }),
+        };
+
+        let result = adapter.handle_request(req, &mut server);
+        assert!(result.is_ok());
+        assert!(adapter.exception_breakpoints_enabled.load(SeqCst));
+    }
+
+    #[test]
+    fn test_handle_request_set_exception_breakpoints_disables_when_filter_absent() {
+        let mut adapter = MqAdapter::new();
+        adapter.exception_breakpoints_enabled.store(true, SeqCst);
+        let input = BufReader::new(Cursor::new(Vec::new()));
+        let output = BufWriter::new(Cursor::new(Vec::new()));
+        let mut server = Server::new(input, output);
+
+        let req = Request {
+            seq: 1,
+            command: Command::SetExceptionBreakpoints(dap::requests::SetExceptionBreakpointsArguments {
+                filters: vec![],
+                filter_options: None,
+                exception_options: None,
+            }),
+        };
+
+        let result = adapter.handle_request(req, &mut server);
+        assert!(result.is_ok());
+        assert!(!adapter.exception_breakpoints_enabled.load(SeqCst));
     }
 
     #[test]

--- a/crates/mq-dap/src/handler.rs
+++ b/crates/mq-dap/src/handler.rs
@@ -43,14 +43,20 @@ pub struct DapHandlerWrapper {
     handler: DapDebuggerHandler,
     command_rx: Receiver<DapCommand>,
     pause_requested: Arc<AtomicBool>,
+    exception_breakpoints_enabled: Arc<AtomicBool>,
 }
 
 impl DapHandlerWrapper {
-    pub fn new(handler: DapDebuggerHandler, command_rx: Receiver<DapCommand>) -> Self {
+    pub fn new(
+        handler: DapDebuggerHandler,
+        command_rx: Receiver<DapCommand>,
+        exception_breakpoints_enabled: Arc<AtomicBool>,
+    ) -> Self {
         Self {
             handler,
             command_rx,
             pause_requested: Arc::new(AtomicBool::new(false)),
+            exception_breakpoints_enabled,
         }
     }
 
@@ -146,6 +152,32 @@ impl mq_lang::DebuggerHandler for DapHandlerWrapper {
             }
         }
     }
+
+    fn on_error(&self, message: &str, context: &mq_lang::DebugContext) {
+        if !self.exception_breakpoints_enabled.load(SeqCst) {
+            return;
+        }
+
+        debug!(message = %message, "Uncaught error, exception breakpoints enabled");
+
+        let dap_message = DebuggerMessage::ExceptionPaused {
+            thread_id: self.handler.thread_id,
+            message: message.to_string(),
+            context: context.clone(),
+        };
+
+        if let Err(e) = self.handler.message_tx.send(dap_message) {
+            error!(error = %e, "Failed to send exception message to DAP server");
+            return;
+        }
+
+        // Block until the client resumes (e.g. via continue/next), mirroring on_breakpoint_hit.
+        // The error propagates regardless of which command is received; this wait only gives
+        // the client a chance to inspect state before that happens.
+        if let Err(e) = self.command_rx.recv() {
+            error!(error = %e, "Failed to receive command from DAP server");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -178,7 +210,7 @@ mod tests {
         let (_command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let debug_str = format!("{:?}", wrapper);
         assert!(debug_str.contains("DapHandlerWrapper"));
@@ -190,7 +222,7 @@ mod tests {
         let (_command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -218,7 +250,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -255,7 +287,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -279,7 +311,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -303,7 +335,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -327,7 +359,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -351,7 +383,7 @@ mod tests {
         let (_command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let breakpoint = mq_lang::Breakpoint {
             id: 1,
@@ -376,7 +408,7 @@ mod tests {
         let (command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let context = mq_lang::DebugContext::default();
 
@@ -411,7 +443,7 @@ mod tests {
             let (command_tx, command_rx) = unbounded::<DapCommand>();
 
             let handler = DapDebuggerHandler::new(message_tx);
-            let wrapper = DapHandlerWrapper::new(handler, command_rx);
+            let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
             let context = mq_lang::DebugContext::default();
 
@@ -430,7 +462,7 @@ mod tests {
         let (_command_tx, command_rx) = unbounded::<DapCommand>();
 
         let handler = DapDebuggerHandler::new(message_tx);
-        let wrapper = DapHandlerWrapper::new(handler, command_rx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
 
         let context = mq_lang::DebugContext::default();
 
@@ -439,5 +471,65 @@ mod tests {
 
         let action = wrapper.on_step(&context);
         assert!(matches!(action, mq_lang::DebuggerAction::Continue));
+    }
+
+    #[test]
+    fn test_on_error_does_not_send_or_block_when_exception_breakpoints_disabled() {
+        let (message_tx, message_rx) = unbounded::<DebuggerMessage>();
+        let (_command_tx, command_rx) = unbounded::<DapCommand>();
+
+        let handler = DapDebuggerHandler::new(message_tx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(false)));
+
+        let context = mq_lang::DebugContext::default();
+
+        // Drop the command sender: if on_error tried to block on command_rx.recv(), this call
+        // would still return (recv fails), but we additionally assert nothing was sent at all.
+        drop(_command_tx);
+
+        wrapper.on_error("boom", &context);
+
+        assert!(message_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_on_error_sends_exception_paused_and_blocks_when_enabled() {
+        let (message_tx, message_rx) = unbounded::<DebuggerMessage>();
+        let (command_tx, command_rx) = unbounded::<DapCommand>();
+
+        let handler = DapDebuggerHandler::new(message_tx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(true)));
+
+        let context = mq_lang::DebugContext::default();
+
+        // Unblock on_error's wait immediately.
+        command_tx.send(DapCommand::Continue).unwrap();
+
+        wrapper.on_error("boom", &context);
+
+        let received_message = message_rx.try_recv().unwrap();
+        match received_message {
+            DebuggerMessage::ExceptionPaused { thread_id, message, .. } => {
+                assert_eq!(thread_id, 1);
+                assert_eq!(message, "boom");
+            }
+            _ => panic!("Expected ExceptionPaused message"),
+        }
+    }
+
+    #[test]
+    fn test_on_error_recv_error_does_not_panic() {
+        let (message_tx, _message_rx) = unbounded::<DebuggerMessage>();
+        let (command_tx, command_rx) = unbounded::<DapCommand>();
+
+        let handler = DapDebuggerHandler::new(message_tx);
+        let wrapper = DapHandlerWrapper::new(handler, command_rx, Arc::new(AtomicBool::new(true)));
+
+        let context = mq_lang::DebugContext::default();
+
+        // Don't send any command, so recv will fail once command_tx is dropped.
+        drop(command_tx);
+
+        wrapper.on_error("boom", &context);
     }
 }

--- a/crates/mq-dap/src/protocol.rs
+++ b/crates/mq-dap/src/protocol.rs
@@ -24,6 +24,13 @@ pub enum DebuggerMessage {
     },
     /// A logpoint breakpoint fired; should send an output event without stopping execution.
     LogPoint { message: String },
+    /// An uncaught error was raised while the "Uncaught Exceptions" filter is enabled,
+    /// should send a stopped event with reason `exception`.
+    ExceptionPaused {
+        thread_id: i64,
+        message: String,
+        context: mq_lang::DebugContext,
+    },
     /// Program has terminated
     Terminated,
 }

--- a/crates/mq-dap/src/server.rs
+++ b/crates/mq-dap/src/server.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use std::io::{self, BufReader, BufWriter};
 use tracing::{debug, error, info};
 
-use crate::adapter::MqAdapter;
+use crate::adapter::{MqAdapter, UNCAUGHT_EXCEPTIONS_FILTER};
 use crate::error::MqAdapterError;
 use crate::log::DebugConsoleWriter;
 
@@ -49,6 +49,14 @@ pub fn start() -> DynResult<()> {
             supports_conditional_breakpoints: Some(true),
             supports_hit_conditional_breakpoints: Some(true),
             supports_log_points: Some(true),
+            exception_breakpoint_filters: Some(vec![types::ExceptionBreakpointsFilter {
+                filter: UNCAUGHT_EXCEPTIONS_FILTER.to_string(),
+                label: "Uncaught Exceptions".to_string(),
+                description: Some("Break when a query raises an error that isn't caught by a try/catch.".to_string()),
+                default: Some(true),
+                supports_condition: None,
+                condition_description: None,
+            }]),
             ..Default::default()
         };
         let rsp = req.success(ResponseBody::Initialize(capabilities));

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -309,6 +309,61 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
     where
         I: Iterator<Item = RuntimeValue>,
     {
+        let result = self.eval_body(program, input);
+
+        #[cfg(feature = "debugger")]
+        if let Err(ref e) = result {
+            self.notify_uncaught_error(e);
+        }
+
+        result
+    }
+
+    /// Notifies the debugger handler of an error that propagated all the way out of
+    /// [`Self::eval`], i.e. one not caught by any `try`/`catch` in the query. A no-op unless
+    /// the debugger is active.
+    #[cfg(feature = "debugger")]
+    fn notify_uncaught_error(&mut self, error: &InnerError) {
+        if !self.debugger.read().unwrap().is_active() {
+            return;
+        }
+
+        let token = match error.token() {
+            Some(token) => Shared::new(token.clone()),
+            None => Shared::new(Token {
+                kind: TokenKind::Eof,
+                range: crate::Range::default(),
+                module_id: Module::TOP_LEVEL_MODULE_ID,
+            }),
+        };
+        let context = DebugContext {
+            token: Shared::clone(&token),
+            call_stack: self.debugger.read().unwrap().current_call_stack(),
+            env: Shared::clone(&self.env),
+            source: Source {
+                name: if token.module_id == Module::TOP_LEVEL_MODULE_ID {
+                    None
+                } else {
+                    Some(self.module_loader.module_name(token.module_id).to_string())
+                },
+                code: self
+                    .module_loader
+                    .get_source_code_for_debug(token.module_id)
+                    .unwrap_or_default(),
+            },
+            ..Default::default()
+        };
+
+        self.debugger_handler
+            .read()
+            .unwrap()
+            .on_error(&error.to_string(), &context);
+    }
+
+    fn eval_body<I>(&mut self, program: &Program, input: I) -> Result<Vec<RuntimeValue>, InnerError>
+    where
+        I: Iterator<Item = RuntimeValue>,
+    {
         let _io_guard = io_context::scoped(Shared::clone(&self.io) as Shared<dyn Io>);
         self.deadline = self.options.timeout.map(|timeout| Instant::now() + timeout);
         self.timeout_step = 0;
@@ -8331,6 +8386,7 @@ mod debugger_tests {
     struct RecordingDebuggerHandler {
         breakpoint_hits: Shared<SharedCell<Vec<String>>>,
         log_points: Shared<SharedCell<Vec<String>>>,
+        errors: Shared<SharedCell<Vec<String>>>,
     }
 
     impl DebuggerHandler for RecordingDebuggerHandler {
@@ -8354,6 +8410,10 @@ mod debugger_tests {
         ) {
             self.log_points.write().unwrap().push(message.to_string());
         }
+
+        fn on_error(&self, message: &str, _context: &DebugContext) {
+            self.errors.write().unwrap().push(message.to_string());
+        }
     }
 
     #[test]
@@ -8363,6 +8423,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::clone(&breakpoint_hits),
             log_points: Shared::default(),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
         engine.debugger().write().unwrap().add_breakpoint_with_options(
@@ -8387,6 +8448,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::clone(&breakpoint_hits),
             log_points: Shared::default(),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
         engine.debugger().write().unwrap().add_breakpoint_with_options(
@@ -8411,6 +8473,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::clone(&breakpoint_hits),
             log_points: Shared::default(),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
         engine.debugger().write().unwrap().add_breakpoint_with_options(
@@ -8435,6 +8498,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::clone(&breakpoint_hits),
             log_points: Shared::default(),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
         engine.debugger().write().unwrap().add_breakpoint_with_options(
@@ -8460,6 +8524,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::clone(&breakpoint_hits),
             log_points: Shared::clone(&log_points),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
         engine.debugger().write().unwrap().add_breakpoint_with_options(
@@ -8492,6 +8557,7 @@ mod debugger_tests {
         engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
             breakpoint_hits: Shared::default(),
             log_points: Shared::clone(&log_points),
+            errors: Shared::default(),
         }));
         engine.debugger().write().unwrap().activate();
 
@@ -8533,5 +8599,57 @@ mod debugger_tests {
 
         let query = "foreach (x, array(1)):\n  x\nend";
         assert!(engine.eval(query, crate::null_input().into_iter()).is_err());
+    }
+
+    #[test]
+    fn test_uncaught_error_notifies_debugger_handler() {
+        let mut engine = crate::DefaultEngine::default();
+        let errors = Shared::new(SharedCell::new(Vec::new()));
+        engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
+            errors: Shared::clone(&errors),
+            ..Default::default()
+        }));
+        engine.debugger().write().unwrap().activate();
+
+        let query = r#"error("boom")"#;
+        let result = engine.eval(query, crate::null_input().into_iter());
+
+        assert!(result.is_err());
+        assert_eq!(errors.read().unwrap().len(), 1);
+        assert!(errors.read().unwrap()[0].contains("boom"));
+    }
+
+    #[test]
+    fn test_error_caught_by_try_catch_does_not_notify_debugger_handler() {
+        let mut engine = crate::DefaultEngine::default();
+        let errors = Shared::new(SharedCell::new(Vec::new()));
+        engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
+            errors: Shared::clone(&errors),
+            ..Default::default()
+        }));
+        engine.debugger().write().unwrap().activate();
+
+        let query = r#"try: error("boom") catch: "caught""#;
+        let result = engine.eval(query, crate::null_input().into_iter());
+
+        assert_eq!(result.unwrap(), vec![RuntimeValue::String("caught".to_string())].into());
+        assert!(errors.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_uncaught_error_does_not_notify_when_debugger_inactive() {
+        let mut engine = crate::DefaultEngine::default();
+        let errors = Shared::new(SharedCell::new(Vec::new()));
+        engine.set_debugger_handler(Box::new(RecordingDebuggerHandler {
+            errors: Shared::clone(&errors),
+            ..Default::default()
+        }));
+        // Debugger left inactive (default state).
+
+        let query = r#"error("boom")"#;
+        let result = engine.eval(query, crate::null_input().into_iter());
+
+        assert!(result.is_err());
+        assert!(errors.read().unwrap().is_empty());
     }
 }

--- a/crates/mq-lang/src/eval/debugger.rs
+++ b/crates/mq-lang/src/eval/debugger.rs
@@ -467,6 +467,14 @@ pub trait DebuggerHandler: std::fmt::Debug + Send + Sync {
     /// log text. Logpoints never pause execution, so unlike [`Self::on_breakpoint_hit`] this
     /// does not return a [`DebuggerAction`].
     fn on_log_point(&self, _breakpoint: &Breakpoint, _message: &str, _context: &DebugContext) {}
+
+    /// Called when a runtime error propagates out of the top-level `eval()` call while the
+    /// debugger is active, i.e. one not caught by any `try`/`catch` in the query. `message` is
+    /// the error's display text; `context.token` locates where the error is attributed.
+    /// Like [`Self::on_log_point`] this never blocks on its own; implementors that want an
+    /// "uncaught exceptions" style pause should wait for a debugger command themselves,
+    /// mirroring [`Self::on_breakpoint_hit`]. The default is a no-op.
+    fn on_error(&self, _message: &str, _context: &DebugContext) {}
 }
 
 #[derive(Debug, Default)]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -98,6 +98,11 @@ pub struct Cli {
     /// No timeout by default.
     #[arg(long, value_name = "SECONDS")]
     timeout: Option<f64>,
+
+    /// Enter the interactive debugger when an uncaught error occurs (mq-dbg only).
+    #[cfg(feature = "debugger")]
+    #[arg(long = "stop-on-error", default_value_t = false)]
+    stop_on_error: bool,
 }
 
 #[cfg(unix)]
@@ -947,7 +952,7 @@ impl Cli {
         #[cfg(feature = "debugger")]
         {
             use crate::debugger::DebuggerHandler;
-            let handler = DebuggerHandler::new(engine.clone());
+            let handler = DebuggerHandler::new(engine.clone(), self.stop_on_error);
             engine.set_debugger_handler(Box::new(handler));
             engine.debugger().write().unwrap().activate();
         }

--- a/crates/mq-run/src/debugger.rs
+++ b/crates/mq-run/src/debugger.rs
@@ -118,6 +118,7 @@ impl From<String> for Command {
 #[derive(Debug)]
 pub struct DebuggerHandler {
     engine: mq_lang::DefaultEngine,
+    stop_on_error: bool,
 }
 
 #[cfg(feature = "debugger")]
@@ -135,6 +136,16 @@ impl mq_lang::DebuggerHandler for DebuggerHandler {
     fn on_step(&self, context: &mq_lang::DebugContext) -> mq_lang::DebuggerAction {
         self.run_debug(context).unwrap_or(mq_lang::DebuggerAction::Continue)
     }
+
+    /// No-op unless `--stop-on-error` was passed.
+    fn on_error(&self, message: &str, context: &mq_lang::DebugContext) {
+        if !self.stop_on_error {
+            return;
+        }
+
+        eprintln!("{}", format!("Uncaught error: {}", message).red().bold());
+        let _ = self.run_debug(context);
+    }
 }
 
 pub fn config_dir() -> Option<std::path::PathBuf> {
@@ -144,8 +155,8 @@ pub fn config_dir() -> Option<std::path::PathBuf> {
 }
 
 impl DebuggerHandler {
-    pub fn new(engine: mq_lang::DefaultEngine) -> Self {
-        Self { engine }
+    pub fn new(engine: mq_lang::DefaultEngine, stop_on_error: bool) -> Self {
+        Self { engine, stop_on_error }
     }
 
     pub fn run_debug(&self, context: &mq_lang::DebugContext) -> miette::Result<mq_lang::DebuggerAction> {
@@ -646,7 +657,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let handler = DebuggerHandler::new(mq_lang::DefaultEngine::default());
+        let handler = DebuggerHandler::new(mq_lang::DefaultEngine::default(), false);
         let (start, snippet) = handler.get_source_code_with_context(&context, 4, 2);
         assert_eq!(start, 2);
         assert_eq!(
@@ -663,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_get_source_code_with_context_edge_cases() {
-        let handler = DebuggerHandler::new(mq_lang::DefaultEngine::default());
+        let handler = DebuggerHandler::new(mq_lang::DefaultEngine::default(), false);
 
         // Empty source code
         let empty_context = DebugContext {
@@ -715,9 +726,18 @@ mod tests {
     #[test]
     fn test_debugger_handler_new() {
         let engine = mq_lang::DefaultEngine::default();
-        let handler = DebuggerHandler::new(engine);
+        let handler = DebuggerHandler::new(engine, false);
         // Just verify it constructs without panic
         assert!(std::mem::size_of_val(&handler) > 0);
+    }
+
+    #[test]
+    fn test_on_error_ignored_when_stop_on_error_disabled() {
+        let handler = DebuggerHandler::new(mq_lang::DefaultEngine::default(), false);
+        let context = DebugContext::default();
+
+        // Should return immediately without prompting, since stop_on_error is disabled.
+        mq_lang::DebuggerHandler::on_error(&handler, "boom", &context);
     }
 
     #[test]

--- a/docs/books/src/start/debugger.md
+++ b/docs/books/src/start/debugger.md
@@ -119,3 +119,13 @@ def process_data(items) {
 When the debugger encounters a `breakpoint()` function call during execution, it will automatically pause and enter interactive debugging mode.
 
 **Note**: The `breakpoint()` function only has an effect when running under the debugger (`mq-dbg`). In normal execution (`mq`), it is ignored and has no impact on performance.
+
+## Stopping on Errors
+
+Pass `--stop-on-error` to drop into the debugger prompt whenever an error propagates uncaught (i.e. not caught by `try`/`catch`), instead of only stopping at breakpoints:
+
+```bash
+mq-dbg --stop-on-error -f your-script.mq input.md
+```
+
+The error is still reported and evaluation still stops afterward; `--stop-on-error` just gives you a chance to inspect the call stack and variables (via `backtrace`, `info`, etc.) before that happens.


### PR DESCRIPTION
## Summary

Wire up setExceptionBreakpoints/exceptionBreakpointFilters, which were previously advertised as unsupported and handled as a no-op. Adds a new DebuggerHandler::on_error hook in mq-lang that fires once per query error that escapes eval() uncaught by try/catch, letting mq-dap pause with a Stopped(exception) event when the filter is enabled.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
