### PR TITLE
✨ feat(mq-crawler): add --max-pages limit and checkpoint/resume support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5223,6 +5223,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/mq-crawler/Cargo.toml
+++ b/crates/mq-crawler/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter"]}
-url = {workspace = true}
+url = {workspace = true, features = ["serde"]}
 tempfile = {workspace = true}
 
 [[bin]]

--- a/crates/mq-crawler/README.md
+++ b/crates/mq-crawler/README.md
@@ -27,6 +27,8 @@ Make web scraping and content extraction effortless with intelligent Markdown co
 - **WebDriver Support**: Use Selenium WebDriver for browser-based crawling
 - **Domain Filtering**: Restrict crawling to specific domains
 - **Sitemap Ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
+- **Max Pages Limit**: Cap the total number of pages visited to bound resource usage
+- **Checkpoint & Resume**: Periodically snapshot crawl progress and resume an interrupted crawl later
 - **Retry with Backoff**: Automatically retries failed requests (network errors, 429, 5xx) with exponential backoff
 - **Custom Headers & Cookies**: Send custom HTTP headers and cookies with every request
 - **Authentication**: Basic and bearer-token authentication for protected sites
@@ -111,6 +113,28 @@ mq-crawl -c 3 https://example.com
 # High-speed crawling with 10 workers
 mq-crawl -c 10 -d 0.1 https://example.com
 ```
+
+### Limiting Crawl Size
+
+```bash
+# Stop after visiting 500 pages, regardless of depth
+mq-crawl --max-pages 500 https://example.com
+```
+
+### Checkpoint & Resume
+
+```bash
+# Save a checkpoint every 20 pages (default) to crawl-state.json
+mq-crawl --checkpoint-path crawl-state.json https://example.com
+
+# Save more frequently
+mq-crawl --checkpoint-path crawl-state.json --checkpoint-interval-pages 5 https://example.com
+
+# Resume an interrupted crawl from the last checkpoint
+mq-crawl --resume-from crawl-state.json --checkpoint-path crawl-state.json https://example.com
+```
+
+A checkpoint is also written once the crawl stops for any reason (queue exhausted, `--max-pages` reached), so `--resume-from` reflects the true end state of the previous run.
 
 ### Sitemap Ingestion
 
@@ -244,58 +268,71 @@ Arguments:
 
 Options:
   -d, --crawl-delay <CRAWL_DELAY>
-          Delay (in seconds) between crawl requests [default: 1]
+          Delay (in seconds) between crawl requests to avoid overloading servers [default: 1]
   -c, --concurrency <CONCURRENCY>
-          Number of concurrent workers [default: 1]
+          Number of concurrent workers for parallel processing [default: 1]
       --depth <DEPTH>
-          Maximum crawl depth (0 = only start URL, 1 = start URL + direct links)
+          Maximum crawl depth. 0 means only the specified URL, 1 means specified URL and its direct links, etc. If not specified, crawling depth is unlimited
+      --max-pages <MAX_PAGES>
+          Maximum total number of pages to visit (queued, in-flight, or crawled) before stopping. If not specified, crawling continues until the frontier is exhausted or --depth is reached
+      --checkpoint-path <PATH>
+          Path to write periodic crawl checkpoints to (JSON). Enables resuming an interrupted crawl later with --resume-from. A checkpoint is written every --checkpoint-interval-pages pages, and once more when the crawl stops
+      --checkpoint-interval-pages <CHECKPOINT_INTERVAL_PAGES>
+          Number of successfully crawled pages between checkpoint saves. Only used when --checkpoint-path is set [default: 20]
+      --resume-from <PATH>
+          Resume a previous crawl from a checkpoint file written via --checkpoint-path. The visited set and pending frontier are restored; the URL argument is only used to determine crawl configuration such as the allowed domain
       --implicit-timeout <IMPLICIT_TIMEOUT>
-          Timeout for element finding (WebDriver only) [default: 5]
+          Timeout (in seconds) for implicit waits (element finding) [default: 5]
   -q, --mq-query <MQ_QUERY>
-          Optional mq query to process the crawled Markdown
+          Optional mq_lang query to process the crawled Markdown content
       --page-load-timeout <PAGE_LOAD_TIMEOUT>
-          Timeout for loading a page [default: 30]
+          Timeout (in seconds) for loading a single page [default: 30]
   -o, --output <OUTPUT>
-          Output directory for markdown files (stdout if not provided)
+          Optional path to an output DIRECTORY where markdown files will be saved. If not provided, output is printed to stdout
       --robots-path <ROBOTS_PATH>
-          Path to custom robots.txt file
+          Optional path to a custom robots.txt file. If not provided, robots.txt will be fetched from the site
       --script-timeout <SCRIPT_TIMEOUT>
-          Timeout for executing scripts (WebDriver only) [default: 10]
-      --allowed-domains <DOMAIN>
-          Comma-separated list of extra domains to crawl; the start URL's domain is always included
-          Example: --allowed-domains docs.example.com,blog.example.com
-      --headless
-          Use built-in headless Chrome (Chrome/Chromium must be installed; cannot be used with --webdriver-url)
-      --chrome-path <PATH>
-          Path to Chrome/Chromium executable (only used with --headless)
+          Timeout (in seconds) for executing scripts on the page [default: 10]
   -U, --webdriver-url <WEBDRIVER_URL>
-          WebDriver URL for browser-based crawling (e.g., http://localhost:4444)
+          Optional WebDriver URL for browser-based crawling (e.g., http://localhost:4444). When specified, uses a headless browser to render JavaScript before extracting content
+      --headless
+          Use a built-in headless Chrome to render JavaScript without an external WebDriver server. Requires Chrome or Chromium to be installed on the system. Cannot be used together with --webdriver-url
+      --chrome-path <PATH>
+          Path to the Chrome/Chromium executable for headless crawling. If not specified, Chrome is auto-detected from standard installation paths. Only used when --headless is set
+      --headless-wait <HEADLESS_WAIT>
+          Wait time (in seconds) after page load in headless mode. When --headless-network-idle or --headless-wait-for-selector is used, this value also acts as the maximum timeout for those strategies (default 30 s). Only used when --headless is set [default: 0]
+      --headless-network-idle
+          Wait for the browser's networkIdle CDP lifecycle event after page load. Effective for SPAs that issue XHR/fetch requests after the load event. The wait is bounded by --headless-wait (or 30 s if not set). Only used when --headless is set
+      --headless-wait-for-selector <SELECTOR>
+          Wait until the given CSS selector is present in the DOM after page load. Useful when the page's content is injected by JavaScript. Example: --headless-wait-for-selector "main" The wait is bounded by --headless-wait (or 30 s if not set). Only used when --headless is set
+      --allowed-domains <DOMAIN>
+          Comma-separated list of domains to crawl in addition to the start URL's domain. If not specified, only the start URL's domain is crawled. If specified, the start URL's domain is always included automatically. Example: --allowed-domains example.com,docs.example.com
   -f, --format <FORMAT>
-          Output format: text or json [default: text]
+          Output format for results and statistics [default: text] [possible values: text, json]
       --sitemap <SITEMAP_URL>
-          URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from
+          Optional URL of a sitemap.xml (or sitemap index) to enumerate additional seed URLs from. Discovered URLs are added to the crawl frontier alongside the start URL and are still subject to robots.txt, domain filtering, and depth limits
       --max-retries <MAX_RETRIES>
-          Maximum retry attempts for failed requests (network errors, 429, 5xx) [default: 3]
+          Max retry attempts on network error, 429, or 5xx [default: 3]
       --retry-initial-backoff <RETRY_INITIAL_BACKOFF>
-          Delay in seconds before the first retry [default: 0.5]
+          Delay (seconds) before the first retry [default: 0.5]
       --retry-max-backoff <RETRY_MAX_BACKOFF>
-          Maximum delay in seconds between retries [default: 10]
+          Max delay (seconds) between retries [default: 10]
       --retry-backoff-multiplier <RETRY_BACKOFF_MULTIPLIER>
-          Multiplier applied to the retry delay after each failed attempt [default: 2]
+          Retry delay multiplier per failed attempt [default: 2]
       --header <KEY: VALUE>
-          Custom HTTP header to send with every request (repeatable); non-browser crawling only
+          Custom header ("Key: Value"), repeatable. Non-browser crawling only
       --cookie <NAME=VALUE>
-          Cookie to send with every request (repeatable); non-browser crawling only
+          Cookie ("name=value"), repeatable, combined into one Cookie header. Non-browser crawling only
       --basic-auth <USER:PASS>
-          HTTP Basic authentication credentials; non-browser crawling only
+          HTTP Basic auth ("username:password"). Non-browser crawling only
       --bearer-token <TOKEN>
-          Bearer token for Authorization header; non-browser crawling only
+          Bearer token for "Authorization: Bearer <token>". Non-browser crawling only
       --extract-scripts-as-code-blocks
           Extract <script> tags as code blocks in Markdown
       --generate-front-matter
           Generate YAML front matter from page metadata
       --use-title-as-h1
-          Use the HTML <title> as the first H1 heading
+          Use the HTML <title> as the first H1 in Markdown
   -h, --help
           Print help
   -V, --version

--- a/crates/mq-crawler/src/crawler.rs
+++ b/crates/mq-crawler/src/crawler.rs
@@ -35,7 +35,7 @@ pub struct CrawlResult {
     pub total_pages_visited: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CrawlResultStats {
     pub pages_crawled: usize,
     pub pages_skipped_robots: usize,
@@ -93,6 +93,26 @@ impl CrawlResult {
     }
 }
 
+/// A snapshot of crawl progress that can be written to disk and later
+/// reloaded to resume an interrupted crawl via `--resume-from`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CrawlCheckpoint {
+    /// URLs that have already been visited (queued, in-flight, or completed).
+    pub visited: Vec<Url>,
+    /// URLs still pending, paired with their crawl depth.
+    pub frontier: Vec<(Url, usize)>,
+    /// Cumulative statistics from the crawl(s) that produced this checkpoint.
+    pub stats: CrawlResultStats,
+}
+
+impl CrawlCheckpoint {
+    /// Loads a checkpoint previously written by [`Crawler::save_checkpoint`].
+    pub fn load(path: &str) -> Result<Self, String> {
+        let data = fs::read_to_string(path).map_err(|e| format!("Failed to read checkpoint file '{}': {}", path, e))?;
+        serde_json::from_str(&data).map_err(|e| format!("Failed to parse checkpoint file '{}': {}", path, e))
+    }
+}
+
 // Helper function to sanitize filename components
 fn sanitize_filename_component(component: &str, max_len: usize) -> String {
     let mut sanitized: String = component
@@ -146,6 +166,8 @@ fn extract_links(html_content: &str, base_url: &Url) -> Vec<Url> {
 #[derive(Debug, Clone)]
 pub struct Crawler {
     allowed_domains: Option<Vec<String>>,
+    checkpoint_interval_pages: usize,
+    checkpoint_path: Option<String>,
     conversion_options: mq_markdown::ConversionOptions,
     crawl_delay: Duration,
     custom_robots_path: Option<String>,
@@ -155,6 +177,7 @@ pub struct Crawler {
     format: OutputFormat,
     http_client: HttpClient,
     initial_domain: String,
+    max_pages: Option<usize>,
     mq_query: String,
     output_path: Option<String>,
     result: Arc<RwLock<CrawlResult>>,
@@ -180,6 +203,10 @@ impl Crawler {
         depth_limit: Option<usize>,
         allowed_domains: Option<Vec<String>>,
         additional_seed_urls: Vec<Url>,
+        max_pages: Option<usize>,
+        checkpoint_path: Option<String>,
+        checkpoint_interval_pages: usize,
+        resume_checkpoint: Option<CrawlCheckpoint>,
     ) -> Result<Self, String> {
         let initial_domain = start_url
             .domain()
@@ -188,25 +215,49 @@ impl Crawler {
         let user_agent = format!("mq crawler/0.1 ({})", env!("CARGO_PKG_HOMEPAGE"));
 
         let to_visit = SegQueue::new();
-        to_visit.push((start_url.clone(), 0));
-        for seed_url in additional_seed_urls {
-            to_visit.push((seed_url, 0));
+        let visited = DashSet::new();
+        let mut initial_result = CrawlResult::default();
+
+        if let Some(checkpoint) = resume_checkpoint {
+            tracing::info!(
+                "Resuming crawl from checkpoint: {} visited, {} queued.",
+                checkpoint.visited.len(),
+                checkpoint.frontier.len()
+            );
+            for url in checkpoint.visited {
+                visited.insert(url);
+            }
+            for (url, depth) in checkpoint.frontier {
+                to_visit.push((url, depth));
+            }
+            initial_result.pages_crawled = checkpoint.stats.pages_crawled;
+            initial_result.pages_skipped_robots = checkpoint.stats.pages_skipped_robots;
+            initial_result.pages_failed = checkpoint.stats.pages_failed;
+            initial_result.links_discovered = checkpoint.stats.links_discovered;
+        } else {
+            to_visit.push((start_url.clone(), 0));
+            for seed_url in additional_seed_urls {
+                to_visit.push((seed_url, 0));
+            }
         }
 
         Ok(Self {
             allowed_domains,
+            checkpoint_interval_pages: checkpoint_interval_pages.max(1),
+            checkpoint_path,
             http_client,
             to_visit: Arc::new(to_visit),
-            visited: Arc::new(DashSet::new()),
+            visited: Arc::new(visited),
             robots_cache: Arc::new(DashMap::new()),
             crawl_delay: Duration::from_secs_f64(crawl_delay_secs),
             domain_last_request: Arc::new(DashMap::new()),
+            max_pages,
             mq_query: mq_query.unwrap_or("identity()".to_string()),
             user_agent,
             output_path,
             initial_domain,
             custom_robots_path,
-            result: Arc::new(RwLock::new(CrawlResult::default())),
+            result: Arc::new(RwLock::new(initial_result)),
             notify: Arc::new(Notify::new()),
             concurrency: concurrency.max(1),
             format,
@@ -278,10 +329,14 @@ impl Crawler {
     async fn run_parallel(&mut self) -> Result<(), String> {
         let semaphore = Arc::new(Semaphore::new(self.concurrency));
         let active_tasks = Arc::new(AtomicUsize::new(0));
+        let mut pages_at_last_checkpoint = self.result.read().await.pages_crawled;
 
         loop {
-            // Termination condition: queue empty AND no tasks in flight
-            if self.to_visit.is_empty() && active_tasks.load(Ordering::SeqCst) == 0 {
+            let max_pages_reached = self.max_pages.is_some_and(|max| self.visited.len() >= max);
+
+            // Termination condition: no tasks in flight, and either the queue is
+            // empty or we have hit the --max-pages limit.
+            if (self.to_visit.is_empty() || max_pages_reached) && active_tasks.load(Ordering::SeqCst) == 0 {
                 break;
             }
 
@@ -290,26 +345,38 @@ impl Crawler {
             let notified = self.notify.notified();
 
             // Drain the queue, spawning tasks up to the semaphore limit
-            while let Some((url, depth)) = self.to_visit.pop() {
-                if self.should_skip_url_without_visited_check(&url) || !self.visited.insert(url.clone()) {
-                    continue;
+            if !max_pages_reached {
+                while let Some((url, depth)) = self.to_visit.pop() {
+                    if self.should_skip_url_without_visited_check(&url) || !self.visited.insert(url.clone()) {
+                        continue;
+                    }
+
+                    let permit = semaphore.clone().acquire_owned().await.expect("Semaphore closed");
+                    active_tasks.fetch_add(1, Ordering::SeqCst);
+
+                    let crawler = self.clone();
+                    let active_tasks_clone = active_tasks.clone();
+                    let notify_clone = self.notify.clone();
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        crawler.process_url_with_rate_limit(url, depth).await;
+                        active_tasks_clone.fetch_sub(1, Ordering::SeqCst);
+                        // Wake the main loop so it can either spawn new tasks or
+                        // detect the termination condition.
+                        notify_clone.notify_one();
+                    });
+
+                    if self.max_pages.is_some_and(|max| self.visited.len() >= max) {
+                        tracing::info!(
+                            "Reached --max-pages limit ({}); no further URLs will be queued.",
+                            self.max_pages.expect("checked by is_some_and above")
+                        );
+                        break;
+                    }
                 }
-
-                let permit = semaphore.clone().acquire_owned().await.expect("Semaphore closed");
-                active_tasks.fetch_add(1, Ordering::SeqCst);
-
-                let crawler = self.clone();
-                let active_tasks_clone = active_tasks.clone();
-                let notify_clone = self.notify.clone();
-                tokio::spawn(async move {
-                    let _permit = permit;
-                    crawler.process_url_with_rate_limit(url, depth).await;
-                    active_tasks_clone.fetch_sub(1, Ordering::SeqCst);
-                    // Wake the main loop so it can either spawn new tasks or
-                    // detect the termination condition.
-                    notify_clone.notify_one();
-                });
             }
+
+            self.maybe_save_checkpoint(&mut pages_at_last_checkpoint).await;
 
             // Block until a task finishes or a new URL is enqueued.
             // If notify_one() was already called since we created `notified`
@@ -317,8 +384,83 @@ impl Crawler {
             notified.await;
         }
 
+        if self.checkpoint_path.is_some()
+            && let Err(e) = self.save_checkpoint().await
+        {
+            tracing::warn!("Failed to save final checkpoint: {}", e);
+        }
+
         self.finalize_crawl().await;
         Ok(())
+    }
+
+    /// Saves a checkpoint if `--checkpoint-path` is set and at least
+    /// `checkpoint_interval_pages` pages have been crawled since the last save.
+    async fn maybe_save_checkpoint(&self, pages_at_last_checkpoint: &mut usize) {
+        if self.checkpoint_path.is_none() {
+            return;
+        }
+
+        let pages_crawled = self.result.read().await.pages_crawled;
+        if pages_crawled < pages_at_last_checkpoint.saturating_add(self.checkpoint_interval_pages) {
+            return;
+        }
+
+        *pages_at_last_checkpoint = pages_crawled;
+        if let Err(e) = self.save_checkpoint().await {
+            tracing::warn!("Failed to save checkpoint: {}", e);
+        }
+    }
+
+    /// Snapshots the current visited set and pending frontier to
+    /// `checkpoint_path`, so the crawl can later be resumed with `--resume-from`.
+    /// The write is atomic (temp file + rename) so a crash mid-write cannot
+    /// leave behind a corrupt checkpoint.
+    async fn save_checkpoint(&self) -> Result<(), String> {
+        let Some(path) = self.checkpoint_path.clone() else {
+            return Ok(());
+        };
+
+        let visited: Vec<Url> = self.visited.iter().map(|entry| entry.clone()).collect();
+        let frontier = self.snapshot_frontier();
+        let stats = self.result.read().await.to_stats();
+        let visited_len = visited.len();
+        let frontier_len = frontier.len();
+
+        let checkpoint = CrawlCheckpoint {
+            visited,
+            frontier,
+            stats,
+        };
+        let json =
+            serde_json::to_string_pretty(&checkpoint).map_err(|e| format!("Failed to serialize checkpoint: {}", e))?;
+
+        let tmp_path = format!("{}.tmp", path);
+        fs::write(&tmp_path, json).map_err(|e| format!("Failed to write checkpoint to '{}': {}", tmp_path, e))?;
+        fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to finalize checkpoint file '{}': {}", path, e))?;
+
+        tracing::info!(
+            "Checkpoint saved to '{}' ({} visited, {} queued).",
+            path,
+            visited_len,
+            frontier_len
+        );
+        Ok(())
+    }
+
+    /// Drains `to_visit` and pushes every item back, returning a snapshot of
+    /// its contents. Safe to call concurrently with producers pushing new
+    /// items; items pushed during the drain may be missing from the snapshot
+    /// but are never lost from the queue itself.
+    fn snapshot_frontier(&self) -> Vec<(Url, usize)> {
+        let mut items = Vec::new();
+        while let Some(item) = self.to_visit.pop() {
+            items.push(item);
+        }
+        for item in &items {
+            self.to_visit.push(item.clone());
+        }
+        items
     }
 
     fn should_skip_url_without_visited_check(&self, url: &Url) -> bool {
@@ -558,6 +700,7 @@ impl Crawler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::{Method::GET, MockServer};
     use rstest::rstest;
     use url::Url;
 
@@ -709,6 +852,10 @@ mod tests {
             depth_limit,
             allowed_domains,
             Vec::new(),
+            None,
+            None,
+            1,
+            None,
         )
         .await
         .unwrap()
@@ -773,6 +920,10 @@ mod tests {
             Some(2),
             None,
             Vec::new(),
+            None,
+            None,
+            1,
+            None,
         )
         .await
         .unwrap();
@@ -797,6 +948,10 @@ mod tests {
             None,
             None,
             Vec::new(),
+            None,
+            None,
+            1,
+            None,
         )
         .await
         .unwrap();
@@ -825,6 +980,10 @@ mod tests {
             None,
             None,
             seed_urls.clone(),
+            None,
+            None,
+            1,
+            None,
         )
         .await
         .unwrap();
@@ -839,5 +998,169 @@ mod tests {
         for seed_url in seed_urls {
             assert!(queued.contains(&(seed_url, 0)));
         }
+    }
+
+    #[tokio::test]
+    async fn test_max_pages_limits_total_visited() {
+        let server = MockServer::start_async().await;
+        let port = server.address().port();
+
+        let index_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/");
+                then.status(200).body(
+                    r#"<html><body>
+                        <a href="/page1">1</a>
+                        <a href="/page2">2</a>
+                        <a href="/page3">3</a>
+                        <a href="/page4">4</a>
+                        <a href="/page5">5</a>
+                    </body></html>"#,
+                );
+            })
+            .await;
+        let page1_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/page1");
+                then.status(200).body("<html><body>Page 1</body></html>");
+            })
+            .await;
+
+        let start_url = Url::parse(&format!("http://localhost:{}/", port)).unwrap();
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+
+        let mut crawler = Crawler::new(
+            http_client,
+            start_url,
+            0.0,
+            None,
+            None,
+            None,
+            1,
+            OutputFormat::Text,
+            mq_markdown::ConversionOptions::default(),
+            None,
+            None,
+            Vec::new(),
+            Some(2),
+            None,
+            1,
+            None,
+        )
+        .await
+        .unwrap();
+
+        crawler.run().await.unwrap();
+
+        assert_eq!(crawler.visited.len(), 2);
+        assert!(!crawler.to_visit.is_empty(), "unvisited URLs should remain queued");
+        index_mock.assert_async().await;
+        page1_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_save_checkpoint_captures_visited_and_frontier() {
+        let start_url = Url::parse("http://start.invalid/").unwrap();
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+        let checkpoint_file = tempfile::NamedTempFile::new().unwrap();
+        let checkpoint_path = checkpoint_file.path().to_string_lossy().to_string();
+
+        let crawler = Crawler::new(
+            http_client,
+            start_url.clone(),
+            0.0,
+            None,
+            None,
+            None,
+            1,
+            OutputFormat::Text,
+            mq_markdown::ConversionOptions::default(),
+            None,
+            None,
+            Vec::new(),
+            None,
+            Some(checkpoint_path.clone()),
+            1,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Drain the default seeded start URL so the frontier reflects only
+        // the mid-crawl state set up below.
+        while crawler.to_visit.pop().is_some() {}
+
+        // Simulate mid-crawl state: one page visited, one still queued.
+        crawler.visited.insert(start_url.clone());
+        let queued_url = Url::parse("http://start.invalid/page1").unwrap();
+        crawler.to_visit.push((queued_url.clone(), 1));
+
+        crawler.save_checkpoint().await.unwrap();
+
+        let loaded = CrawlCheckpoint::load(&checkpoint_path).unwrap();
+        assert_eq!(loaded.visited, vec![start_url]);
+        assert_eq!(loaded.frontier, vec![(queued_url, 1)]);
+
+        // The frontier snapshot must not have drained the live queue.
+        assert!(!crawler.to_visit.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_resume_from_checkpoint_restores_state() {
+        let start_url = Url::parse("http://start.invalid/").unwrap();
+        let http_client = HttpClient::new_reqwest(30.0).unwrap();
+
+        let visited_url = Url::parse("http://start.invalid/already-visited").unwrap();
+        let queued_url = Url::parse("http://start.invalid/still-queued").unwrap();
+        let checkpoint = CrawlCheckpoint {
+            visited: vec![visited_url.clone()],
+            frontier: vec![(queued_url.clone(), 3)],
+            stats: CrawlResultStats {
+                pages_crawled: 5,
+                pages_skipped_robots: 1,
+                pages_failed: 2,
+                links_discovered: 7,
+                total_pages_visited: 1,
+                duration_secs: None,
+            },
+        };
+
+        let crawler = Crawler::new(
+            http_client,
+            start_url.clone(),
+            0.0,
+            None,
+            None,
+            None,
+            1,
+            OutputFormat::Text,
+            mq_markdown::ConversionOptions::default(),
+            None,
+            None,
+            Vec::new(),
+            None,
+            None,
+            1,
+            Some(checkpoint),
+        )
+        .await
+        .unwrap();
+
+        // The checkpoint's visited set is restored, and the start URL is not
+        // re-queued alongside it.
+        assert!(crawler.visited.contains(&visited_url));
+        assert_eq!(crawler.visited.len(), 1);
+
+        let mut queued = Vec::new();
+        while let Some(item) = crawler.to_visit.pop() {
+            queued.push(item);
+        }
+        assert_eq!(queued, vec![(queued_url, 3)]);
+
+        let result = crawler.result.read().await;
+        assert_eq!(result.pages_crawled, 5);
+        assert_eq!(result.pages_skipped_robots, 1);
+        assert_eq!(result.pages_failed, 2);
+        assert_eq!(result.links_discovered, 7);
     }
 }

--- a/crates/mq-crawler/src/main.rs
+++ b/crates/mq-crawler/src/main.rs
@@ -34,6 +34,24 @@ struct CliArgs {
     /// If not specified, crawling depth is unlimited.
     #[clap(long)]
     depth: Option<usize>,
+    /// Maximum total number of pages to visit (queued, in-flight, or crawled) before stopping.
+    /// If not specified, crawling continues until the frontier is exhausted or --depth is reached.
+    #[clap(long)]
+    max_pages: Option<usize>,
+    /// Path to write periodic crawl checkpoints to (JSON). Enables resuming an
+    /// interrupted crawl later with --resume-from. A checkpoint is written every
+    /// --checkpoint-interval-pages pages, and once more when the crawl stops.
+    #[clap(long, value_name = "PATH")]
+    checkpoint_path: Option<String>,
+    /// Number of successfully crawled pages between checkpoint saves.
+    /// Only used when --checkpoint-path is set.
+    #[clap(long, default_value_t = 20, requires = "checkpoint_path")]
+    checkpoint_interval_pages: usize,
+    /// Resume a previous crawl from a checkpoint file written via --checkpoint-path.
+    /// The visited set and pending frontier are restored; the URL argument is only
+    /// used to determine crawl configuration such as the allowed domain.
+    #[clap(long, value_name = "PATH")]
+    resume_from: Option<String>,
     /// Timeout (in seconds) for implicit waits (element finding).
     #[clap(long, default_value_t = 5.0)]
     implicit_timeout: f64,
@@ -342,6 +360,18 @@ async fn main() {
         Vec::new()
     };
 
+    let resume_checkpoint = if let Some(ref resume_path) = args.resume_from {
+        match mq_crawler::crawler::CrawlCheckpoint::load(resume_path) {
+            Ok(checkpoint) => Some(checkpoint),
+            Err(e) => {
+                tracing::error!("Failed to load checkpoint '{}': {}", resume_path, e);
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
     match Crawler::new(
         client,
         args.url.clone(),
@@ -359,6 +389,10 @@ async fn main() {
         args.depth,
         effective_allowed,
         sitemap_seed_urls,
+        args.max_pages,
+        args.checkpoint_path,
+        args.checkpoint_interval_pages,
+        resume_checkpoint,
     )
     .await
     {

--- a/docs/books/src/start/crawler.md
+++ b/docs/books/src/start/crawler.md
@@ -13,6 +13,8 @@ mq-crawler is a web crawler that fetches HTML content from websites, converts it
 - **WebDriver support**: Browser-based crawling via Selenium WebDriver
 - **Domain filtering**: Restrict crawling to specific domains
 - **Sitemap ingestion**: Seed the crawl frontier from a `sitemap.xml` (or sitemap index) up front
+- **Max pages limit**: Cap the total number of pages visited to bound resource usage
+- **Checkpoint & resume**: Periodically snapshot crawl progress and resume an interrupted crawl later
 - **Retry with backoff**: Automatically retries failed requests (network errors, 429, 5xx) with exponential backoff
 - **Custom headers & cookies**: Send custom HTTP headers and cookies with every request
 - **Authentication**: Basic and bearer-token authentication for protected sites
@@ -67,6 +69,10 @@ mq-crawl [OPTIONS] <URL>
 | `-d, --crawl-delay <SECONDS>` | Delay between requests in seconds | `1` |
 | `-c, --concurrency <N>` | Number of concurrent workers | `1` |
 | `--depth <DEPTH>` | Maximum crawl depth (0 = start URL only) | unlimited |
+| `--max-pages <N>` | Maximum total number of pages to visit before stopping | unlimited |
+| `--checkpoint-path <PATH>` | File to periodically save crawl progress to (JSON), enabling `--resume-from` | — |
+| `--checkpoint-interval-pages <N>` | Pages crawled between checkpoint saves (requires `--checkpoint-path`) | `20` |
+| `--resume-from <PATH>` | Resume a crawl from a checkpoint file written via `--checkpoint-path` | — |
 | `-q, --mq-query <QUERY>` | mq-lang query for processing content | — |
 | `--robots-path <PATH>` | Custom robots.txt file path | — |
 | `--allowed-domains <DOMAINS>` | Comma-separated list of extra domains to crawl; the start URL's domain is always included | start domain only |
@@ -130,6 +136,32 @@ mq-crawl --sitemap https://example.com/sitemap.xml https://example.com
 # without following any links.
 mq-crawl --depth 0 --sitemap https://example.com/sitemap.xml https://example.com
 ```
+
+### Limiting Crawl Size
+
+Use `--max-pages` to cap the total number of pages visited (queued, in-flight, or crawled), independent of `--depth`. This is useful as a safety valve on deep or link-heavy sites:
+
+```bash
+# Stop after visiting 500 pages, regardless of depth
+mq-crawl --max-pages 500 https://example.com
+```
+
+### Checkpoint & Resume
+
+For large crawls that may be interrupted (network loss, process restart, `--max-pages` cutoff), use `--checkpoint-path` to periodically save the visited set and pending frontier to a JSON file, and `--resume-from` to continue from it later:
+
+```bash
+# Save a checkpoint every 20 pages (default) to crawl-state.json
+mq-crawl --checkpoint-path crawl-state.json https://example.com
+
+# Save more frequently
+mq-crawl --checkpoint-path crawl-state.json --checkpoint-interval-pages 5 https://example.com
+
+# Resume an interrupted crawl from the last checkpoint
+mq-crawl --resume-from crawl-state.json --checkpoint-path crawl-state.json https://example.com
+```
+
+A checkpoint is also written once the crawl stops for any reason (queue exhausted, `--max-pages` reached), so `--resume-from` reflects the true end state of the previous run. Pass `--checkpoint-path` alongside `--resume-from` if you want the resumed run to keep checkpointing as it continues.
 
 ### Retry & Backoff
 


### PR DESCRIPTION
## Summary

Add --max-pages to cap total visited pages as a safety valve on deep or link-heavy sites, and --checkpoint-path/--checkpoint-interval-pages/ --resume-from to periodically snapshot crawl progress (visited set, pending frontier, stats) to JSON and resume an interrupted crawl later. Checkpoint writes are atomic (temp file + rename).

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
