### PR TITLE
🐛 fix(mq-lang): preserve integer formatting in JSON/YAML/TOML/XML output

### DIFF
--- a/crates/mq-lang/src/eval/runtime_value.rs
+++ b/crates/mq-lang/src/eval/runtime_value.rs
@@ -632,9 +632,15 @@ impl RuntimeValue {
         match self {
             RuntimeValue::None => serde_json::Value::Null,
             RuntimeValue::Boolean(b) => serde_json::Value::Bool(b),
-            RuntimeValue::Number(n) => serde_json::Number::from_f64(n.value())
-                .map(serde_json::Value::Number)
-                .unwrap_or(serde_json::Value::Null),
+            RuntimeValue::Number(n) => {
+                if n.is_int() {
+                    serde_json::Value::Number(serde_json::Number::from(n.to_int()))
+                } else {
+                    serde_json::Number::from_f64(n.value())
+                        .map(serde_json::Value::Number)
+                        .unwrap_or(serde_json::Value::Null)
+                }
+            }
             RuntimeValue::String(s) => serde_json::Value::String(s),
             RuntimeValue::Symbol(i) => serde_json::Value::String(i.to_string()),
             RuntimeValue::Array(arr) => serde_json::Value::Array(
@@ -1243,6 +1249,12 @@ mod tests {
     #[case(RuntimeValue::String("hi".to_string()), serde_json::Value::String("hi".to_string()))]
     #[case(RuntimeValue::Symbol(Ident::new("sym")), serde_json::Value::String("sym".to_string()))]
     #[case(RuntimeValue::NativeFunction(Ident::new("f")), serde_json::Value::Null)]
+    #[case(
+        RuntimeValue::Number(Number::from(42.0)),
+        serde_json::Value::Number(serde_json::Number::from(42))
+    )]
+    #[case(RuntimeValue::Number(Number::from(-7.0)), serde_json::Value::Number(serde_json::Number::from(-7)))]
+    #[case(RuntimeValue::Number(Number::from(1.5)), serde_json::Value::Number(serde_json::Number::from_f64(1.5).unwrap()))]
     fn test_to_json_value_scalars(#[case] value: RuntimeValue, #[case] expected: serde_json::Value) {
         assert_eq!(value.to_json_value(), expected);
     }

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -264,12 +264,12 @@ In {year}, the snowfall was above average.
 #[case::output_format_yaml(
     vec!["--unbuffered", "-I", "json", "-F", "yaml", "self"],
     r#"{"name": "Alice", "age": 30}"#,
-    Some("name: Alice\nage: 30.0\n")
+    Some("name: Alice\nage: 30\n")
 )]
 #[case::output_format_toml(
     vec!["--unbuffered", "-I", "json", "-F", "toml", "self"],
     r#"{"name": "Alice", "age": 30}"#,
-    Some("name = \"Alice\"\nage = 30.0\n")
+    Some("name = \"Alice\"\nage = 30\n")
 )]
 #[case::output_format_csv(
     vec!["--unbuffered", "-I", "json", "-F", "csv", "self"],
@@ -284,7 +284,7 @@ In {year}, the snowfall was above average.
 #[case::output_format_xml_generic(
     vec!["--unbuffered", "-I", "json", "-F", "xml", "self"],
     r#"{"name": "Alice", "age": 30}"#,
-    Some("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n  <name>Alice</name>\n  <age>30.0</age>\n</root>\n")
+    Some("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n  <name>Alice</name>\n  <age>30</age>\n</root>\n")
 )]
 #[case::select_skips_non_matching_wrapped_list_items(
     vec!["--unbuffered", r#"select(.code.lang == "bash") | to_text()"#],


### PR DESCRIPTION
## Summary

RuntimeValue::to_json_value() always converted numbers via serde_json::Number::from_f64(), so integers like 42 were serialized as 42.0 in JSON, YAML, TOML, XML, and CSV output. Use Number::is_int() to emit a proper integer Number when there's no fractional part, matching jq's behavior of preserving integer literals.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
