### PR TITLE
♻️ refactor(mq-lang): resolve $VAR env references through the Io abstraction

### DIFF
--- a/crates/mq-lang/src/ast/parser.rs
+++ b/crates/mq-lang/src/ast/parser.rs
@@ -1,6 +1,7 @@
 use crate::arena::Arena;
 use crate::ast::node::{IdentWithToken, MatchArm, Pattern};
 use crate::error::syntax::SyntaxError;
+use crate::eval::builtin::io_context;
 use crate::lexer::Lexer;
 use crate::lexer::token::{Token, TokenKind};
 use crate::module::ModuleId;
@@ -780,7 +781,8 @@ impl<'a, 'alloc> Parser<'a, 'alloc> {
         match &token.kind {
             TokenKind::Env(s) => Ok(Shared::new(Node {
                 token_id: self.token_arena.alloc(Shared::clone(token)),
-                expr: std::env::var(s)
+                expr: io_context::current()
+                    .env_var(s)
                     .map_err(|_| SyntaxError::EnvNotFound((**token).clone(), SmolStr::new(s)))
                     .map(|s| Shared::new(Expr::Literal(Literal::String(s.to_owned()))))?,
             })),

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -19,6 +19,7 @@ use crate::{
     arena::Arena,
     error::{self},
     eval::Evaluator,
+    eval::builtin::io_context,
     optimizer::{OptimizationLevel, Optimizer},
     parse,
 };
@@ -280,6 +281,8 @@ impl<T: ModuleResolver, IO: Io> Engine<T, IO> {
             return Ok(vec![].into());
         }
 
+        // Scoped before `parse`, not just `evaluator.eval`, so bare `$VAR` resolution sees this engine's `Io`.
+        let _io_guard = io_context::scoped(Shared::clone(&self.evaluator.io) as Shared<dyn Io>);
         let program = parse(code, Shared::clone(&self.token_arena))?;
         let program = Optimizer::with_level(self.optimization_level).optimize(program);
 
@@ -302,6 +305,7 @@ impl<T: ModuleResolver, IO: Io> Engine<T, IO> {
                 program: vec![],
             });
         }
+        let _io_guard = io_context::scoped(Shared::clone(&self.evaluator.io) as Shared<dyn Io>);
         let program = parse(code, Shared::clone(&self.token_arena))?;
         let program = Optimizer::with_level(self.optimization_level).optimize(program);
         Ok(CompiledProgram {

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -1170,7 +1170,7 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
                         acc.push_str(&value.to_string());
                     }
                     ast::StringSegment::Env(env_var) => {
-                        acc.push_str(&std::env::var(env_var).map_err(|_| {
+                        acc.push_str(&io_context::current().env_var(env_var).map_err(|_| {
                             RuntimeError::EnvNotFound(
                                 (*get_token(Shared::clone(&self.token_arena), token_id)).clone(),
                                 env_var.clone(),
@@ -1315,7 +1315,8 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
                             acc.push_str(&runtime_value.to_string());
                         } else if let Some(var) = expr_str.strip_prefix('$') {
                             acc.push_str(
-                                &std::env::var(var)
+                                &io_context::current()
+                                    .env_var(var)
                                     .map_err(|_| RuntimeError::EnvNotFound((**token).clone(), var.into()))?,
                             );
                         } else {


### PR DESCRIPTION
## Summary

Bare $VAR parsing, ${$VAR} string interpolation, and debugger logpoint interpolation now call io_context::current().env_var() instead of std::env::var() directly. Engine::eval/compile also scope the ambient Io around parse(), not just evaluator.eval(), so parse-time $VAR resolution sees the same Io as the rest of evaluation.

This lays the groundwork for a future --allow-env sandbox flag; SandboxedIo::env_var is unchanged and still ungated, so behavior is unaffected today.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
