### PR TITLE
📦 build(mq-check,mq-repl): enable http feature for mq-lang

### DIFF
--- a/crates/mq-check/Cargo.toml
+++ b/crates/mq-check/Cargo.toml
@@ -29,7 +29,7 @@ clap = {workspace = true, features = ["derive"], optional = true}
 colored = {workspace = true, optional = true}
 miette = {workspace = true, features = ["fancy"]}
 mq-hir = {workspace = true}
-mq-lang = {workspace = true, features = ["cst", "file-io"]}
+mq-lang = {workspace = true, features = ["cst", "file-io", "http"]}
 rustc-hash = {workspace = true}
 serde_json = {workspace = true, optional = true}
 slotmap = {workspace = true}

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -16,7 +16,7 @@ colored = {workspace = true}
 dirs = {workspace = true}
 miette = {workspace = true}
 mq-hir = {workspace = true}
-mq-lang = {workspace = true}
+mq-lang = {workspace = true, features = ["http"]}
 mq-markdown = {workspace = true}
 regex-lite = {workspace = true}
 rustyline = {workspace = true, default-features = false, features = ["custom-bindings", "with-file-history"]}


### PR DESCRIPTION
## Summary

Allows mq-check and mq-repl to use mq-lang's HTTP-related builtins.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [x] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
