### PR TITLE
✨ feat(mq-lang,mq-run): add --allow-all flag to grant every sandbox permission

### DIFF
--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -79,6 +79,16 @@ impl<Inner: Io> SandboxedIo<Inner> {
         self
     }
 
+    /// Grants every permission at once (read/write/net/run/env), fully and
+    /// unrestricted, matching `--allow-all`.
+    pub fn allow_all(self) -> Self {
+        self.allow_read(true)
+            .allow_write(true)
+            .allow_net(true)
+            .allow_run(true)
+            .allow_env(true)
+    }
+
     /// Whether any read access is granted (fully or restricted to an allowlist).
     pub fn is_read_allowed(&self) -> bool {
         !self.allow_read.is_denied()
@@ -404,5 +414,15 @@ mod tests {
 
         let io = io.allow_run(true);
         assert_eq!(io.execute("echo", &["hi".to_string()]).unwrap(), "hi");
+    }
+
+    #[test]
+    fn test_allow_all_grants_every_permission() {
+        let io = SandboxedIo::new(MemIo::default()).allow_all();
+        assert!(io.is_read_allowed());
+        assert!(io.is_write_allowed());
+        assert!(io.is_net_allowed());
+        assert!(io.is_run_allowed());
+        assert!(io.is_env_allowed());
     }
 }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -411,6 +411,11 @@ struct InputArgs {
     /// swallowed as a query/file positional instead.
     #[arg(long = "allow-env", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "NAME")]
     allow_env: Option<Vec<String>>,
+
+    /// Grant every sandboxed permission at once (read/write/net/run/env), overriding
+    /// any allowlist given to the individual --allow-* flags. Disabled by default.
+    #[arg(long = "allow-all", default_value_t = false)]
+    allow_all: bool,
 }
 
 #[derive(Clone, Debug, clap::Args, Default)]
@@ -839,15 +844,19 @@ impl Cli {
         // full native access (unchanged from before this Io existed) — --allow-read/
         // write/net/run instead gate what a running query's read_file/write_file/http/
         // system builtins can do at runtime, via the ambient Io set below.
-        let mut engine = mq_lang::DefaultEngine::default();
-        engine.set_io(Shared::new(
-            mq_lang::SandboxedIo::new(mq_lang::NativeIo::default())
+        let sandboxed_io = mq_lang::SandboxedIo::new(mq_lang::NativeIo::default());
+        let sandboxed_io = if self.input.allow_all {
+            sandboxed_io.allow_all()
+        } else {
+            sandboxed_io
                 .allow_read(self.input.allow_read.clone())
                 .allow_write(self.input.allow_write.clone())
                 .allow_net(self.input.allow_net)
                 .allow_run(self.input.allow_run)
-                .allow_env(self.input.allow_env.clone()),
-        ));
+                .allow_env(self.input.allow_env.clone())
+        };
+        let mut engine = mq_lang::DefaultEngine::default();
+        engine.set_io(Shared::new(sandboxed_io));
         engine.load_builtin_module();
         engine.set_optimization_level(self.optimize_level.clone().into());
 
@@ -1833,6 +1842,47 @@ mod tests {
         assert!(
             restricted_cli.run().is_err(),
             "$VAR should be blocked when --allow-env only names other variables"
+        );
+    }
+
+    #[test]
+    fn test_allow_all_flag_grants_every_capability() {
+        // SAFETY: no other threads read/write this env var concurrently in this test.
+        unsafe { std::env::set_var("MQ_ALLOW_ALL_TEST_VAR", "test_value") };
+        defer! {
+            unsafe { std::env::remove_var("MQ_ALLOW_ALL_TEST_VAR") };
+        }
+
+        let base_cli = |query: &str, allow_all: bool| Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                allow_all,
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some(query.to_string()),
+            files: None,
+            ..Cli::default()
+        };
+
+        assert!(
+            base_cli("$MQ_ALLOW_ALL_TEST_VAR", false).run().is_err(),
+            "$VAR should be blocked without --allow-all"
+        );
+        assert!(
+            base_cli("$MQ_ALLOW_ALL_TEST_VAR", true).run().is_ok(),
+            "$VAR should succeed with --allow-all"
+        );
+
+        let system_query = "system(\"echo\", [\"hi\"])";
+        assert!(
+            base_cli(system_query, false).run().is_err(),
+            "system should be blocked without --allow-all"
+        );
+        assert!(
+            base_cli(system_query, true).run().is_ok(),
+            "system should succeed with --allow-all"
         );
     }
 

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -412,9 +412,14 @@ struct InputArgs {
     #[arg(long = "allow-env", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "NAME")]
     allow_env: Option<Vec<String>>,
 
-    /// Grant every sandboxed permission at once (read/write/net/run/env), overriding
-    /// any allowlist given to the individual --allow-* flags. Disabled by default.
-    #[arg(long = "allow-all", default_value_t = false)]
+    /// Grant every sandboxed permission at once (read/write/net/run/env). Disabled by
+    /// default. Cannot be combined with the individual --allow-* flags above.
+    #[arg(
+        short = 'a',
+        long = "allow-all",
+        default_value_t = false,
+        conflicts_with_all = ["allow_net", "allow_read", "allow_write", "allow_run", "allow_env"]
+    )]
     allow_all: bool,
 }
 
@@ -1883,6 +1888,18 @@ mod tests {
         assert!(
             base_cli(system_query, true).run().is_ok(),
             "system should succeed with --allow-all"
+        );
+    }
+
+    #[rstest]
+    #[case(&["mq", "--allow-all", "--allow-read=/tmp", "self"])]
+    #[case(&["mq", "--allow-all", "--allow-write=/tmp", "self"])]
+    #[case(&["mq", "--allow-all", "--allow-run", "self"])]
+    #[case(&["mq", "--allow-all", "--allow-env", "self"])]
+    fn test_allow_all_conflicts_with_individual_allow_flags(#[case] args: &[&str]) {
+        assert!(
+            Cli::try_parse_from(args).is_err(),
+            "--allow-all should conflict with individual --allow-* flags"
         );
     }
 

--- a/docs/books/src/reference/env.md
+++ b/docs/books/src/reference/env.md
@@ -23,6 +23,9 @@ mq --allow-env '$HOME' README.md
 mq --allow-env=HOME '$HOME' README.md
 ```
 
+`--allow-all` grants `--allow-read`/`--allow-write`/`--allow-net`/`--allow-run`/`--allow-env`
+all at once, including `$VAR` access.
+
 ## Color Configuration
 
 ### `NO_COLOR`


### PR DESCRIPTION
## Summary

Add SandboxedIo::allow_all(), a preset that grants read/write/net/run/env
all at once, and wire it to mq-run's --allow-all flag. Deno's -A/--allow-all
shorthand isn't available here (-A is already --aggregate), and none of
the existing --allow-read/write/net/run/env flags have short forms either,
so --allow-all is long-only on purpose given it bypasses all sandboxing.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
