### PR TITLE
✨ feat(mq-lang,mq-run): add domain allowlist to --allow-net

### DIFF
--- a/crates/mq-lang/src/io.rs
+++ b/crates/mq-lang/src/io.rs
@@ -24,7 +24,7 @@ mod sandboxed;
 
 pub use error::IoError;
 pub use native::NativeIo;
-pub use sandboxed::{EnvAccess, PathAccess, SandboxedIo};
+pub use sandboxed::{EnvAccess, NetAccess, PathAccess, SandboxedIo};
 
 /// `pub` here (rather than gated by the `mock-io` feature) would still not leak `MemIo`
 /// externally, since the `io` module itself is private to the crate (see `mod io;` in

--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -3,15 +3,18 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 mod env_access;
+mod net_access;
 mod path_access;
 
 pub use env_access::EnvAccess;
+pub use net_access::NetAccess;
 pub use path_access::PathAccess;
 
 /// Wraps an inner [`Io`] (typically [`NativeIo`]) with instance-owned
 /// read/write/net/run/env permission grants, enforced by every operation. All
-/// five default to fully denied (fail safe); read/write/env may additionally be
-/// restricted to an allowlist via [`PathAccess::AllowedPaths`]/[`EnvAccess::AllowedNames`].
+/// five default to fully denied (fail safe); read/write/net/env may additionally be
+/// restricted to an allowlist via [`PathAccess::AllowedPaths`]/[`NetAccess::AllowedDomains`]/
+/// [`EnvAccess::AllowedNames`].
 ///
 /// Every operation enforces its own permission independently of any external
 /// pre-check, so a caller cannot accidentally bypass sandboxing by forgetting
@@ -21,7 +24,7 @@ pub struct SandboxedIo<Inner: Io = NativeIo> {
     inner: Inner,
     allow_read: PathAccess,
     allow_write: PathAccess,
-    allow_net: bool,
+    allow_net: NetAccess,
     allow_run: bool,
     allow_env: EnvAccess,
 }
@@ -39,7 +42,7 @@ impl<Inner: Io> SandboxedIo<Inner> {
             inner,
             allow_read: PathAccess::Denied,
             allow_write: PathAccess::Denied,
-            allow_net: false,
+            allow_net: NetAccess::Denied,
             allow_run: false,
             allow_env: EnvAccess::Denied,
         }
@@ -60,8 +63,11 @@ impl<Inner: Io> SandboxedIo<Inner> {
         self
     }
 
-    pub fn allow_net(mut self, allow: bool) -> Self {
-        self.allow_net = allow;
+    /// Grants network access, gating `fetch`/`http_request`. See [`Self::allow_read`] for
+    /// the accepted forms; `Vec<String>`/`Option<Vec<String>>` restrict by domain (and any
+    /// path under it) rather than by filesystem path.
+    pub fn allow_net(mut self, allow: impl Into<NetAccess>) -> Self {
+        self.allow_net = allow.into();
         self
     }
 
@@ -99,8 +105,9 @@ impl<Inner: Io> SandboxedIo<Inner> {
         !self.allow_write.is_denied()
     }
 
+    /// Whether any network access is granted (fully or restricted to an allowlist).
     pub fn is_net_allowed(&self) -> bool {
-        self.allow_net
+        !self.allow_net.is_denied()
     }
 
     pub fn is_run_allowed(&self) -> bool {
@@ -127,6 +134,12 @@ fn denied_path(action: &str, path: &Path) -> IoError {
 fn denied_env(name: &str) -> IoError {
     IoError::PermissionDenied(Cow::Owned(format!(
         "access to environment variable `{name}` is not allowed"
+    )))
+}
+
+fn denied_domain(url: &str) -> IoError {
+    IoError::PermissionDenied(Cow::Owned(format!(
+        "network access to {url} is not allowed (outside the allowed domains)"
     )))
 }
 
@@ -208,8 +221,11 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
     }
 
     fn fetch(&self, url: &str) -> Result<String, IoError> {
-        if !self.allow_net {
+        if self.allow_net.is_denied() {
             return Err(denied("network access is disabled"));
+        }
+        if !self.allow_net.permits(url) {
+            return Err(denied_domain(url));
         }
         self.inner.fetch(url)
     }
@@ -221,14 +237,19 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
         body: Option<&str>,
         headers: &[(String, String)],
     ) -> Result<String, IoError> {
-        if !self.allow_net {
+        if self.allow_net.is_denied() {
             return Err(denied("network access is disabled"));
+        }
+        if !self.allow_net.permits(url) {
+            return Err(denied_domain(url));
         }
         self.inner.http_request(method, url, body, headers)
     }
 
+    // Not gated by the domain allowlist: this seeds mock data for the `mock_fetch` builtin
+    // rather than performing a real request, so there's no domain to restrict.
     fn set_fetch_response(&self, url: &str, body: &str) -> Result<(), IoError> {
-        if !self.allow_net {
+        if self.allow_net.is_denied() {
             return Err(denied("network access is disabled"));
         }
         self.inner.set_fetch_response(url, body)
@@ -308,6 +329,34 @@ mod tests {
 
         let io = io.allow_net(true);
         assert_eq!(io.fetch("https://example.com").unwrap(), "body");
+    }
+
+    /// `None` = `allow_net` never called (fail-safe default); `Some(vec![])` = the CLI flag
+    /// passed with no value (fully allowed); `Some(domains)` = the flag restricted to an
+    /// allowlist. Mirrors clap's parse of `--allow-net`.
+    #[rstest]
+    #[case::denied_by_default(None, "https://example.com", false)]
+    #[case::bare_flag_allows_everywhere(Some(vec![]), "https://example.com", true)]
+    #[case::within_allowlisted_domain(Some(vec!["example.com".to_string()]), "https://example.com/path", true)]
+    #[case::outside_allowlisted_domain(Some(vec!["example.com".to_string()]), "https://other.com", false)]
+    #[case::subdomain_prefix_escape_rejected(
+        Some(vec!["example.com".to_string()]),
+        "https://example.com.evil.com",
+        false
+    )]
+    fn test_fetch_allowlist(#[case] allow: Option<Vec<String>>, #[case] target: &str, #[case] expected_ok: bool) {
+        let mut io = SandboxedIo::new(
+            MemIo::default()
+                .with_fetch_response("https://example.com", "body")
+                .with_fetch_response("https://example.com/path", "body")
+                .with_fetch_response("https://other.com", "body")
+                .with_fetch_response("https://example.com.evil.com", "body"),
+        );
+        if let Some(domains) = allow {
+            io = io.allow_net(Some(domains));
+        }
+
+        assert_eq!(io.fetch(target).is_ok(), expected_ok);
     }
 
     #[test]
@@ -402,6 +451,12 @@ mod tests {
     fn test_is_env_allowed_true_for_restricted_allowlist() {
         let io = SandboxedIo::new(MemIo::default()).allow_env(Some(vec!["FOO".to_string()]));
         assert!(io.is_env_allowed());
+    }
+
+    #[test]
+    fn test_is_net_allowed_true_for_restricted_allowlist() {
+        let io = SandboxedIo::new(MemIo::default()).allow_net(Some(vec!["example.com".to_string()]));
+        assert!(io.is_net_allowed());
     }
 
     #[test]

--- a/crates/mq-lang/src/io/sandboxed/net_access.rs
+++ b/crates/mq-lang/src/io/sandboxed/net_access.rs
@@ -1,0 +1,70 @@
+/// Network access granted to [`SandboxedIo`](super::SandboxedIo); same shape as
+/// [`PathAccess`](super::PathAccess)/[`EnvAccess`](super::EnvAccess) but keyed by domain
+/// (e.g. `mq-run`'s `--allow-net`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum NetAccess {
+    /// No network access at all (fail-safe default).
+    #[default]
+    Denied,
+    /// Unrestricted access, matching a bare `--allow-net`.
+    Allowed,
+    /// Access restricted to the given domains (and any path under them).
+    AllowedDomains(Vec<String>),
+}
+
+impl From<bool> for NetAccess {
+    fn from(allow: bool) -> Self {
+        if allow { NetAccess::Allowed } else { NetAccess::Denied }
+    }
+}
+
+impl From<Vec<String>> for NetAccess {
+    fn from(domains: Vec<String>) -> Self {
+        if domains.is_empty() {
+            NetAccess::Allowed
+        } else {
+            NetAccess::AllowedDomains(domains)
+        }
+    }
+}
+
+impl From<Option<Vec<String>>> for NetAccess {
+    fn from(domains: Option<Vec<String>>) -> Self {
+        match domains {
+            None => NetAccess::Denied,
+            Some(domains) => domains.into(),
+        }
+    }
+}
+
+impl NetAccess {
+    pub(super) fn permits(&self, url: &str) -> bool {
+        match self {
+            NetAccess::Denied => false,
+            NetAccess::Allowed => true,
+            NetAccess::AllowedDomains(allowed) => {
+                let without_scheme = url
+                    .strip_prefix("https://")
+                    .or_else(|| url.strip_prefix("http://"))
+                    .unwrap_or(url);
+                allowed.iter().any(|domain| prefix_matches(without_scheme, domain))
+            }
+        }
+    }
+
+    pub(super) fn is_denied(&self) -> bool {
+        matches!(self, NetAccess::Denied)
+    }
+}
+
+/// Returns `true` if `url_without_scheme`'s host/path matches `domain` as a strict prefix.
+///
+/// The match requires that after the prefix the next character is `/`, `?`, `#`, `:`, or
+/// end of string — preventing `example.com.evil.com` from matching `example.com`.
+fn prefix_matches(url_without_scheme: &str, domain: &str) -> bool {
+    let rest = match url_without_scheme.strip_prefix(domain) {
+        Some(r) => r,
+        None => return false,
+    };
+    rest.is_empty() || rest.starts_with('/') || rest.starts_with('?') || rest.starts_with('#') || rest.starts_with(':')
+}

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -88,7 +88,7 @@ pub use eval::runtime_value::{RuntimeValue, RuntimeValues};
 pub use ident::Ident;
 #[cfg(feature = "mock-io")]
 pub use io::MemIo;
-pub use io::{EnvAccess, Io, IoError, NativeIo, PathAccess, SandboxedIo};
+pub use io::{EnvAccess, Io, IoError, NativeIo, NetAccess, PathAccess, SandboxedIo};
 pub use lexer::Options as LexerOptions;
 pub use lexer::token::{StringSegment, Token, TokenKind};
 #[cfg(feature = "http-import")]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -373,12 +373,15 @@ struct InputArgs {
     #[arg(long = "lockfile", value_name = "PATH")]
     lockfile_path: Option<PathBuf>,
 
-    /// Allow the `http` function to make outbound HTTPS requests.
-    /// Disabled by default; requests are HTTPS-only and blocked from reaching
-    /// loopback/private/link-local addresses regardless of this flag.
+    /// Allow the `http` function to make outbound HTTPS requests. Disabled by default;
+    /// requests are HTTPS-only and blocked from reaching loopback/private/link-local
+    /// addresses regardless of this flag. Pass with no value to allow any domain, or
+    /// `--allow-net=DOMAIN` (repeat the flag, or comma-separate, to add more) to restrict
+    /// requests to just those domains (and any path under them). The `=` is required so a
+    /// bare domain after the flag isn't swallowed as a query/file positional instead.
     #[cfg(feature = "http-import")]
-    #[arg(long = "allow-net", default_value_t = false)]
-    allow_net: bool,
+    #[arg(long = "allow-net", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "DOMAIN")]
+    allow_net: Option<Vec<String>>,
 
     /// Allow the `read_file`/`read_file_bytes`/`collection`/`file_exists`/`embed_images`
     /// functions to read from the filesystem. Disabled by default. Pass with no value to
@@ -856,7 +859,7 @@ impl Cli {
             sandboxed_io
                 .allow_read(self.input.allow_read.clone())
                 .allow_write(self.input.allow_write.clone())
-                .allow_net(self.input.allow_net)
+                .allow_net(self.input.allow_net.clone())
                 .allow_run(self.input.allow_run)
                 .allow_env(self.input.allow_env.clone())
         };
@@ -1894,6 +1897,7 @@ mod tests {
     #[rstest]
     #[case(&["mq", "--allow-all", "--allow-read=/tmp", "self"])]
     #[case(&["mq", "--allow-all", "--allow-write=/tmp", "self"])]
+    #[case(&["mq", "--allow-all", "--allow-net=example.com", "self"])]
     #[case(&["mq", "--allow-all", "--allow-run", "self"])]
     #[case(&["mq", "--allow-all", "--allow-env", "self"])]
     fn test_allow_all_conflicts_with_individual_allow_flags(#[case] args: &[&str]) {

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -321,6 +321,17 @@ mq --allow-net 'http_post("https://example.com", "{}", {"Content-Type": "applica
 mq --allow-write 'write_file("out.md", "# Hello")'
 ```
 
+`--allow-net` also accepts a domain allowlist, restricting `http`/`http_*` calls to just those
+domains (and any path under them) instead of granting unrestricted network access:
+
+```sh
+# Restrict to just example.com
+mq --allow-net=example.com 'http_get("https://example.com")'
+
+# Repeat the flag, or comma-separate, to allow more than one domain
+mq --allow-net=example.com,api.example.org 'http_get("https://api.example.org")'
+```
+
 ## Comparison
 
 | Feature  | `module`                          | `import`                          | `include`               |


### PR DESCRIPTION
## Summary

Add NetAccess (Denied/Allowed/AllowedDomains), mirroring PathAccess/ EnvAccess, so --allow-net can restrict http()/http_request to specific domains the same way --allow-read/write/env restrict to paths/names. Bare --allow-net still grants unrestricted access; --allow-net=DOMAIN (repeatable/comma-separated) restricts to just those domains and any path under them.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
