### PR TITLE
✨ feat(mq-lang,mq-run): add command allowlist to --allow-run

### DIFF
--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -5,16 +5,18 @@ use std::path::{Path, PathBuf};
 mod env_access;
 mod net_access;
 mod path_access;
+mod run_access;
 
 pub use env_access::EnvAccess;
 pub use net_access::NetAccess;
 pub use path_access::PathAccess;
+pub use run_access::RunAccess;
 
 /// Wraps an inner [`Io`] (typically [`NativeIo`]) with instance-owned
 /// read/write/net/run/env permission grants, enforced by every operation. All
-/// five default to fully denied (fail safe); read/write/net/env may additionally be
+/// five default to fully denied (fail safe), and may additionally be
 /// restricted to an allowlist via [`PathAccess::AllowedPaths`]/[`NetAccess::AllowedDomains`]/
-/// [`EnvAccess::AllowedNames`].
+/// [`RunAccess::AllowedCommands`]/[`EnvAccess::AllowedNames`].
 ///
 /// Every operation enforces its own permission independently of any external
 /// pre-check, so a caller cannot accidentally bypass sandboxing by forgetting
@@ -25,7 +27,7 @@ pub struct SandboxedIo<Inner: Io = NativeIo> {
     allow_read: PathAccess,
     allow_write: PathAccess,
     allow_net: NetAccess,
-    allow_run: bool,
+    allow_run: RunAccess,
     allow_env: EnvAccess,
 }
 
@@ -43,7 +45,7 @@ impl<Inner: Io> SandboxedIo<Inner> {
             allow_read: PathAccess::Denied,
             allow_write: PathAccess::Denied,
             allow_net: NetAccess::Denied,
-            allow_run: false,
+            allow_run: RunAccess::Denied,
             allow_env: EnvAccess::Denied,
         }
     }
@@ -72,9 +74,10 @@ impl<Inner: Io> SandboxedIo<Inner> {
     }
 
     /// Gates [`Io::execute`], the primitive backing the `system()` builtin — external process
-    /// execution, akin to Deno's `--allow-run`.
-    pub fn allow_run(mut self, allow: bool) -> Self {
-        self.allow_run = allow;
+    /// execution. See [`Self::allow_read`] for the accepted forms; `Vec<String>`/
+    /// `Option<Vec<String>>` restrict by command name.
+    pub fn allow_run(mut self, allow: impl Into<RunAccess>) -> Self {
+        self.allow_run = allow.into();
         self
     }
 
@@ -110,8 +113,9 @@ impl<Inner: Io> SandboxedIo<Inner> {
         !self.allow_net.is_denied()
     }
 
+    /// Whether any process-execution access is granted (fully or restricted to an allowlist).
     pub fn is_run_allowed(&self) -> bool {
-        self.allow_run
+        !self.allow_run.is_denied()
     }
 
     /// Whether any environment-variable access is granted (fully or restricted to an allowlist).
@@ -140,6 +144,12 @@ fn denied_env(name: &str) -> IoError {
 fn denied_domain(url: &str) -> IoError {
     IoError::PermissionDenied(Cow::Owned(format!(
         "network access to {url} is not allowed (outside the allowed domains)"
+    )))
+}
+
+fn denied_command(command: &str) -> IoError {
+    IoError::PermissionDenied(Cow::Owned(format!(
+        "execution of {command} is not allowed (outside the allowed commands)"
     )))
 }
 
@@ -256,8 +266,11 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
     }
 
     fn execute(&self, command: &str, args: &[String]) -> Result<String, IoError> {
-        if !self.allow_run {
+        if self.allow_run.is_denied() {
             return Err(denied("process execution is disabled"));
+        }
+        if !self.allow_run.permits(command) {
+            return Err(denied_command(command));
         }
         self.inner.execute(command, args)
     }
@@ -469,6 +482,33 @@ mod tests {
 
         let io = io.allow_run(true);
         assert_eq!(io.execute("echo", &["hi".to_string()]).unwrap(), "hi");
+    }
+
+    /// `None` = `allow_run` never called (fail-safe default); `Some(vec![])` = the CLI flag
+    /// passed with no value (fully allowed); `Some(commands)` = the flag restricted to an
+    /// allowlist. Mirrors clap's parse of `--allow-run`.
+    #[rstest]
+    #[case::denied_by_default(None, "echo", false)]
+    #[case::bare_flag_allows_everywhere(Some(vec![]), "echo", true)]
+    #[case::within_allowlist(Some(vec!["echo".to_string()]), "echo", true)]
+    #[case::outside_allowlist(Some(vec!["echo".to_string()]), "rm", false)]
+    fn test_execute_allowlist(#[case] allow: Option<Vec<String>>, #[case] command: &str, #[case] expected_ok: bool) {
+        let mut io = SandboxedIo::new(
+            MemIo::default()
+                .with_command_response("echo", &["hi".to_string()], "hi")
+                .with_command_response("rm", &["hi".to_string()], "hi"),
+        );
+        if let Some(commands) = allow {
+            io = io.allow_run(Some(commands));
+        }
+
+        assert_eq!(io.execute(command, &["hi".to_string()]).is_ok(), expected_ok);
+    }
+
+    #[test]
+    fn test_is_run_allowed_true_for_restricted_allowlist() {
+        let io = SandboxedIo::new(MemIo::default()).allow_run(Some(vec!["echo".to_string()]));
+        assert!(io.is_run_allowed());
     }
 
     #[test]

--- a/crates/mq-lang/src/io/sandboxed/run_access.rs
+++ b/crates/mq-lang/src/io/sandboxed/run_access.rs
@@ -1,0 +1,52 @@
+/// Process-execution access granted to [`SandboxedIo`](super::SandboxedIo); same shape as
+/// [`PathAccess`](super::PathAccess)/[`EnvAccess`](super::EnvAccess) but keyed by command name
+/// (e.g. `mq-run`'s `--allow-run`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RunAccess {
+    /// No process execution at all (fail-safe default).
+    #[default]
+    Denied,
+    /// Unrestricted access, matching a bare `--allow-run`.
+    Allowed,
+    /// Execution restricted to the given command names.
+    AllowedCommands(Vec<String>),
+}
+
+impl From<bool> for RunAccess {
+    fn from(allow: bool) -> Self {
+        if allow { RunAccess::Allowed } else { RunAccess::Denied }
+    }
+}
+
+impl From<Vec<String>> for RunAccess {
+    fn from(commands: Vec<String>) -> Self {
+        if commands.is_empty() {
+            RunAccess::Allowed
+        } else {
+            RunAccess::AllowedCommands(commands)
+        }
+    }
+}
+
+impl From<Option<Vec<String>>> for RunAccess {
+    fn from(commands: Option<Vec<String>>) -> Self {
+        match commands {
+            None => RunAccess::Denied,
+            Some(commands) => commands.into(),
+        }
+    }
+}
+
+impl RunAccess {
+    pub(super) fn permits(&self, command: &str) -> bool {
+        match self {
+            RunAccess::Denied => false,
+            RunAccess::Allowed => true,
+            RunAccess::AllowedCommands(allowed) => allowed.iter().any(|allowed_command| allowed_command == command),
+        }
+    }
+
+    pub(super) fn is_denied(&self) -> bool {
+        matches!(self, RunAccess::Denied)
+    }
+}

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -401,11 +401,14 @@ struct InputArgs {
     #[arg(short = 'W', long = "allow-write", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "PATH")]
     allow_write: Option<Vec<PathBuf>>,
 
-    /// Allow the `system` function to execute external commands.
-    /// Disabled by default. Commands run directly (never through a shell), so shell
-    /// metacharacters in arguments are never interpreted.
-    #[arg(long = "allow-run", default_value_t = false)]
-    allow_run: bool,
+    /// Allow the `system` function to execute external commands. Disabled by default.
+    /// Commands run directly (never through a shell), so shell metacharacters in arguments
+    /// are never interpreted. Pass with no value to allow any command, or
+    /// `--allow-run=COMMAND` (repeat the flag, or comma-separate, to add more) to restrict
+    /// execution to just those commands. The `=` is required so a bare command after the
+    /// flag isn't swallowed as a query/file positional instead.
+    #[arg(long = "allow-run", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "COMMAND")]
+    allow_run: Option<Vec<String>>,
 
     /// Allow `$VAR`/`${$VAR}` interpolation and debugger logpoints to read environment
     /// variables. Disabled by default. Pass with no value to allow reading any variable, or
@@ -860,7 +863,7 @@ impl Cli {
                 .allow_read(self.input.allow_read.clone())
                 .allow_write(self.input.allow_write.clone())
                 .allow_net(self.input.allow_net.clone())
-                .allow_run(self.input.allow_run)
+                .allow_run(self.input.allow_run.clone())
                 .allow_env(self.input.allow_env.clone())
         };
         let mut engine = mq_lang::DefaultEngine::default();
@@ -1786,7 +1789,7 @@ mod tests {
         let allowed_cli = Cli {
             input: InputArgs {
                 input_format: Some(InputFormat::Null),
-                allow_run: true,
+                allow_run: Some(vec![]),
                 ..Default::default()
             },
             output: OutputArgs::default(),
@@ -1796,6 +1799,23 @@ mod tests {
             ..Cli::default()
         };
         assert!(allowed_cli.run().is_ok(), "system should succeed with --allow-run");
+
+        let restricted_cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                allow_run: Some(vec!["ls".to_string()]),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some(query.to_string()),
+            files: None,
+            ..Cli::default()
+        };
+        assert!(
+            restricted_cli.run().is_err(),
+            "system should be blocked when --allow-run only names other commands"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add RunAccess (Denied/Allowed/AllowedCommands), mirroring PathAccess/ NetAccess/EnvAccess, so --allow-run can restrict system() to specific commands the same way --allow-read/write/env restrict to paths/names. Bare --allow-run still grants unrestricted execution; --allow-run=COMMAND (repeatable/comma-separated) restricts to just those command names.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
