### PR TITLE
🐛 fix(mq-playground): resolve monaco-vim's deep import to monaco-editor

### DIFF
--- a/packages/mq-playground/vite.config.ts
+++ b/packages/mq-playground/vite.config.ts
@@ -1,10 +1,33 @@
+import { createRequire } from "node:module";
+import path from "node:path";
 import { defineConfig } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 
+const require = createRequire(import.meta.url);
+
+// monaco-editor's "exports" map (as of 0.56.0) can't resolve the extensionless
+// "esm/vs/..." deep import monaco-vim's UMD bundle requires, so derive the
+// package root manually and point straight at the file on disk.
+const monacoEditorRoot = path.resolve(
+  path.dirname(require.resolve("monaco-editor")),
+  "../..",
+);
+
 export default defineConfig({
   base: "./",
   plugins: [react(), babel({ presets: [reactCompilerPreset()] })],
+  resolve: {
+    alias: [
+      {
+        find: "monaco-editor/esm/vs/editor/editor.api",
+        replacement: path.join(
+          monacoEditorRoot,
+          "esm/vs/editor/editor.api.js",
+        ),
+      },
+    ],
+  },
   build: {
     outDir: "../../docs",
     rollupOptions: {


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
