### PR TITLE
✨ feat(mq-markdown): pad GFM table columns to consistent widths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smol_str",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -81,13 +81,15 @@ def add_column(table, col):
   else: do
       let header_cell = to_md_table_cell(col[0], 0, len(table[:header]))
       | let new_header = table[:header] + [header_cell]
-      | var i = 0
+      | var i = 1
       | let new_rows = foreach (row, table[:rows]):
-              let cell = to_md_table_cell(col[i], i, len(row) - 1)
+              let first_cell = row[0]
+              | let cell = to_md_table_cell(col[i], first_cell.row, len(row))
               | i += 1
               | row + [cell]
             end
-      | set(table, :header, new_header) | set(table, :rows, new_rows)
+      | let table_with_header = set(table, :header, new_header)
+      | set(table_with_header, :rows, new_rows)
     end
 end
 

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -67,8 +67,19 @@ end
 def test_table_add_column():
   let t = first(table::tables(table_nodes))
   | let t = table::add_column(t, ["Country", "Japan", "Japan"])
-  | assert_eq(len(t[:header]), 3)
+  | let new_header_cell = t[:header][3]
+  | let row0_first_cell = t[:rows][0][0]
+  | let row0_new_cell = t[:rows][0][3]
+  | let row1_first_cell = t[:rows][1][0]
+  | let row1_new_cell = t[:rows][1][3]
+  | assert_eq(len(t[:header]), 4)
   | assert_eq(len(t[:rows][0]), 4)
+  | assert_eq(to_string(new_header_cell), "Country")
+  | assert_eq(new_header_cell.column, 3)
+  | assert_eq(to_string(row0_new_cell), "Japan")
+  | assert_eq(row0_new_cell.row, row0_first_cell.row)
+  | assert_eq(to_string(row1_new_cell), "Japan")
+  | assert_eq(row1_new_cell.row, row1_first_cell.row)
 end
 
 def test_table_remove_row():

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -22,6 +22,7 @@ serde = {workspace = true, features = ["derive"], optional = true}
 serde_json = {workspace = true, optional = true}
 serde_yaml = {workspace = true, optional = true}
 smol_str = {workspace = true}
+unicode-width = {workspace = true}
 
 [dev-dependencies]
 divan = {workspace = true}

--- a/crates/mq-markdown/src/markdown.rs
+++ b/crates/mq-markdown/src/markdown.rs
@@ -2,10 +2,11 @@
 use crate::html_to_markdown;
 #[cfg(feature = "html-to-markdown")]
 use crate::html_to_markdown::ConversionOptions;
-use crate::node::{ColorTheme, Node, Position, RenderOptions, TableAlign, TableCell, render_values};
+use crate::node::{ColorTheme, Node, Position, RenderOptions, TableAlign, TableAlignKind, TableCell, render_values};
 use markdown::{CompileOptions, Constructs, Options, ParseOptions};
 use miette::miette;
 use std::{fmt, str::FromStr};
+use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Clone)]
 pub struct Markdown {
@@ -56,18 +57,31 @@ impl Markdown {
         let mut is_first = true;
         let mut current_table_row: Option<usize> = None;
         let mut in_table = false;
+        let mut current_table: Option<TableLayout> = None;
 
         let mut buffer = String::with_capacity(self.nodes.len() * 50);
 
         for (i, node) in self.nodes.iter().enumerate() {
-            if let Node::TableCell(TableCell { row, values, .. }) = node {
+            if let Node::TableCell(TableCell {
+                row, column, values, ..
+            }) = node
+            {
+                if current_table.as_ref().is_none_or(|t| i >= t.end) {
+                    current_table = Some(TableLayout::compute(&self.nodes, &self.options, i));
+                }
+                let table = current_table.as_ref().unwrap();
+                let align = table.align_for(*column);
+                let width = table.width_for(*column);
+
                 let value = render_values(values, &self.options, theme);
+                let plain_width = table.plain_width_at(*row, *column);
+                let padded = pad_cell(&value, plain_width, width, &align);
 
                 let is_new_row = current_table_row != Some(*row);
 
                 if is_new_row {
                     if current_table_row.is_some() {
-                        buffer.push_str("|\n");
+                        buffer.push_str(" |\n");
                     } else if !in_table && let Some(pos) = node.position() {
                         // Insert newlines before the first row of a table
                         let new_line_count = pre_position
@@ -80,10 +94,12 @@ impl Markdown {
                         }
                     }
                     current_table_row = Some(*row);
+                    buffer.push_str("| ");
+                } else {
+                    buffer.push_str(" | ");
                 }
 
-                buffer.push('|');
-                buffer.push_str(&value);
+                buffer.push_str(&padded);
 
                 let next_node = self.nodes.get(i + 1);
                 let next_is_different_row = next_node.is_none_or(
@@ -91,7 +107,7 @@ impl Markdown {
                 );
 
                 if next_is_different_row {
-                    buffer.push_str("|\n");
+                    buffer.push_str(" |\n");
                     current_table_row = None;
                 }
 
@@ -101,11 +117,13 @@ impl Markdown {
                 continue;
             }
 
-            if let Node::TableAlign(TableAlign { align, .. }) = node {
-                use itertools::Itertools;
-                buffer.push('|');
-                buffer.push_str(&align.iter().map(|a| a.to_string()).join("|"));
-                buffer.push_str("|\n");
+            if let Node::TableAlign(TableAlign { .. }) = node {
+                if current_table.as_ref().is_none_or(|t| i >= t.end) {
+                    current_table = Some(TableLayout::compute(&self.nodes, &self.options, i));
+                }
+                let table = current_table.as_ref().unwrap();
+                buffer.push_str(&table.render_separator());
+                buffer.push('\n');
                 pre_position = node.position();
                 is_first = false;
                 in_table = true;
@@ -113,6 +131,7 @@ impl Markdown {
             }
 
             current_table_row = None;
+            current_table = None;
             in_table = false;
 
             let value = node.render_with_theme(&self.options, theme);
@@ -332,6 +351,137 @@ impl Markdown {
     }
 }
 
+/// Per-column widths and alignment of a single contiguous table, computed by
+/// scanning ahead over its `TableCell`/`TableAlign` nodes before the first
+/// row is emitted, so every row (including the header) pads to the same
+/// column widths.
+struct TableLayout {
+    widths: Vec<usize>,
+    align: Vec<TableAlignKind>,
+    /// Plain (color-free) display width of every cell, keyed by `(row, column)`,
+    /// computed once during the scan so the main render pass never has to
+    /// re-render a cell just to measure it.
+    cell_widths: rustc_hash::FxHashMap<(usize, usize), usize>,
+    /// Index (exclusive) of the node following this table's last node.
+    end: usize,
+}
+
+impl TableLayout {
+    fn compute(nodes: &[Node], options: &RenderOptions, start: usize) -> Self {
+        let mut widths: Vec<usize> = Vec::new();
+        let mut align: Vec<TableAlignKind> = Vec::new();
+        let mut cell_widths = rustc_hash::FxHashMap::default();
+        let mut i = start;
+
+        while let Some(node) = nodes.get(i) {
+            match node {
+                Node::TableCell(TableCell {
+                    row, column, values, ..
+                }) => {
+                    let width = cell_display_width(values, options);
+                    cell_widths.insert((*row, *column), width);
+                    if *column >= widths.len() {
+                        widths.resize(*column + 1, 0);
+                    }
+                    widths[*column] = widths[*column].max(width);
+                    i += 1;
+                }
+                Node::TableAlign(TableAlign { align: a, .. }) => {
+                    align = a.clone();
+                    i += 1;
+                }
+                _ => break,
+            }
+        }
+
+        if widths.len() < align.len() {
+            widths.resize(align.len(), 0);
+        }
+
+        for (idx, width) in widths.iter_mut().enumerate() {
+            let a = align.get(idx).unwrap_or(&TableAlignKind::None);
+            *width = (*width).max(column_min_width(a));
+        }
+
+        Self {
+            widths,
+            align,
+            cell_widths,
+            end: i,
+        }
+    }
+
+    fn align_for(&self, column: usize) -> TableAlignKind {
+        self.align.get(column).cloned().unwrap_or(TableAlignKind::None)
+    }
+
+    fn width_for(&self, column: usize) -> usize {
+        self.widths
+            .get(column)
+            .copied()
+            .unwrap_or(column_min_width(&self.align_for(column)))
+    }
+
+    /// Plain display width of the cell at `(row, column)`, precomputed during `compute`.
+    fn plain_width_at(&self, row: usize, column: usize) -> usize {
+        self.cell_widths.get(&(row, column)).copied().unwrap_or(0)
+    }
+
+    fn render_separator(&self) -> String {
+        let segments = self
+            .widths
+            .iter()
+            .enumerate()
+            .map(|(idx, &width)| {
+                let align = self.align_for(idx);
+                match align {
+                    TableAlignKind::None => "-".repeat(width),
+                    TableAlignKind::Left => format!(":{}", "-".repeat(width - 1)),
+                    TableAlignKind::Right => format!("{}:", "-".repeat(width - 1)),
+                    TableAlignKind::Center => format!(":{}:", "-".repeat(width - 2)),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" | ");
+
+        format!("| {} |", segments)
+    }
+}
+
+/// Minimum width a column must have to render a valid alignment marker
+/// (e.g. `:-:` needs at least 3 characters for the two colons and a dash).
+fn column_min_width(align: &TableAlignKind) -> usize {
+    match align {
+        TableAlignKind::None => 1,
+        TableAlignKind::Left | TableAlignKind::Right => 2,
+        TableAlignKind::Center => 3,
+    }
+}
+
+/// Display width (in terminal columns) of a table cell's plain-rendered
+/// content, ignoring any ANSI color codes so padding stays correct with
+/// `--color` output.
+fn cell_display_width(values: &[Node], options: &RenderOptions) -> usize {
+    UnicodeWidthStr::width(render_values(values, options, &ColorTheme::PLAIN).as_str())
+}
+
+/// Pads an already-rendered (possibly colored) cell value to `width`
+/// columns, using `plain_width` — the color-free display width — to compute
+/// how much padding is needed.
+fn pad_cell(content: &str, plain_width: usize, width: usize, align: &TableAlignKind) -> String {
+    let pad = width.saturating_sub(plain_width);
+
+    match align {
+        TableAlignKind::Right => format!("{}{}", " ".repeat(pad), content),
+        TableAlignKind::Center => {
+            let left = pad / 2;
+            let right = pad - left;
+            format!("{}{}{}", " ".repeat(left), content, " ".repeat(right))
+        }
+        TableAlignKind::Left | TableAlignKind::None => format!("{}{}", content, " ".repeat(pad)),
+    }
+}
+
 /// Returns the shared `Options` used for both `Markdown::to_html` and the
 /// standalone `to_html` helper.  The options mirror the constructs that are
 /// enabled during parsing (see `from_markdown_str`) so that every feature
@@ -435,18 +585,41 @@ mod tests {
     #[case::table(
         "| Column1 | Column2 | Column3 |\n|:--------|:--------:|---------:|\n| Left    | Center  | Right   |\n",
         7,
-        "|Column1|Column2|Column3|\n|:---|:---:|---:|\n|Left|Center|Right|\n"
+        "| Column1 | Column2 | Column3 |\n| :------ | :-----: | ------: |\n| Left    | Center  |   Right |\n"
     )]
     #[case::table_after_paragraph(
         "Paragraph\n\n| A | B |\n|---|---|\n| 1 | 2 |\n",
         6,
-        "Paragraph\n\n|A|B|\n|---|---|\n|1|2|\n"
+        "Paragraph\n\n| A | B |\n| - | - |\n| 1 | 2 |\n"
     )]
     #[case::table_after_heading(
         "# Title\n\n| A | B |\n|---|---|\n| 1 | 2 |\n",
         6,
-        "# Title\n\n|A|B|\n|---|---|\n|1|2|\n"
+        "# Title\n\n| A | B |\n| - | - |\n| 1 | 2 |\n"
     )]
+    #[case::table_column_padding(
+        "| Name | Age |\n|---|---|\n| Alexander | 5 |\n| Bo | 42 |\n",
+        7,
+        "| Name      | Age |\n| --------- | --- |\n| Alexander | 5   |\n| Bo        | 42  |\n"
+    )]
+    #[case::table_column_padding_wide_chars(
+        "| 名前 | 年齢 |\n|---|---|\n| 太郎 | 5 |\n",
+        5,
+        "| 名前 | 年齢 |\n| ---- | ---- |\n| 太郎 | 5    |\n"
+    )]
+    // Content width (1) is below the Left-align floor (2) — the floor, not
+    // the content, must decide the column width.
+    #[case::table_min_width_left("| A |\n|:--|\n| 1 |\n", 3, "| A  |\n| :- |\n| 1  |\n")]
+    // Same, for the Right-align floor (2).
+    #[case::table_min_width_right("| A |\n|--:|\n| 1 |\n", 3, "|  A |\n| -: |\n|  1 |\n")]
+    // Same, for the Center-align floor (3) — must not collapse to the
+    // invalid `::` marker.
+    #[case::table_min_width_center("| A |\n|:-:|\n| 1 |\n", 3, "|  A  |\n| :-: |\n|  1  |\n")]
+    // An empty cell must still pad out to its column's width.
+    #[case::table_empty_cell("| A | |\n|---|---|\n| 1 | 2 |\n", 5, "| A |   |\n| - | - |\n| 1 | 2 |\n")]
+    // A data row with fewer cells than the header must render only the
+    // cells present, without panicking or misaligning later rows.
+    #[case::table_ragged_row("| A | B |\n|---|---|\n| 1 |\n", 4, "| A | B |\n| - | - |\n| 1 |\n")]
     #[case::excessive_blank_lines("# Title\n\n\n\nParagraph", 2, "# Title\n\nParagraph\n")]
     #[case::three_blank_lines("Para 1\n\n\n\n\nPara 2", 2, "Para 1\n\nPara 2\n")]
     // GFM autolink literal: link text is the same URL — must not nest on round-trip
@@ -777,6 +950,20 @@ mod color_tests {
     }
 
     #[test]
+    fn test_colored_table_padding_ignores_ansi_codes_in_width() {
+        // The "**A**" cell is colored (ANSI-wrapped) but only 5 display columns wide,
+        // one short of the "Bolded" header — padding must be computed from the
+        // plain-text width, not the byte length of the ANSI-wrapped string.
+        let md = "| H | Bolded |\n|---|---|\n| x | **A** |\n"
+            .parse::<Markdown>()
+            .unwrap();
+        assert_eq!(
+            md.to_colored_string(),
+            "| H | Bolded |\n| - | ------ |\n| x | \x1b[1m**A**\x1b[0m  |\n"
+        );
+    }
+
+    #[test]
     fn test_colored_output_contains_ansi_codes() {
         let md = "# Hello\n\n**bold** and *italic*".parse::<Markdown>().unwrap();
         let colored = md.to_colored_string();
@@ -918,7 +1105,7 @@ mod json_tests {
     #[case("<blockquote>Quote</blockquote>", 1, "> Quote\n")]
     #[case("<code>inline</code>", 1, "`inline`\n")]
     #[case("<pre><code>block</code></pre>", 1, "```\nblock\n```\n")]
-    #[case("<table><tr><td>A</td><td>B</td></tr></table>", 3, "|A|B|\n|---|---|\n")]
+    #[case("<table><tr><td>A</td><td>B</td></tr></table>", 3, "| A | B |\n| - | - |\n")]
     #[cfg(feature = "html-to-markdown")]
     fn test_markdown_from_html(#[case] input: &str, #[case] expected_nodes: usize, #[case] expected_output: &str) {
         let md = Markdown::from_html_str(input).unwrap();

--- a/crates/mq-markdown/src/markdown.rs
+++ b/crates/mq-markdown/src/markdown.rs
@@ -2,11 +2,13 @@
 use crate::html_to_markdown;
 #[cfg(feature = "html-to-markdown")]
 use crate::html_to_markdown::ConversionOptions;
-use crate::node::{ColorTheme, Node, Position, RenderOptions, TableAlign, TableAlignKind, TableCell, render_values};
+use crate::node::{ColorTheme, Node, Position, RenderOptions, TableAlign, TableCell, render_values};
 use markdown::{CompileOptions, Constructs, Options, ParseOptions};
 use miette::miette;
 use std::{fmt, str::FromStr};
-use unicode_width::UnicodeWidthStr;
+use table_layout::{TableLayout, pad_cell};
+
+mod table_layout;
 
 #[derive(Debug, Clone)]
 pub struct Markdown {
@@ -348,137 +350,6 @@ impl Markdown {
         )
         .map_err(|e| miette::miette!(e.reason))?;
         Ok(Node::from_mdast_node(root))
-    }
-}
-
-/// Per-column widths and alignment of a single contiguous table, computed by
-/// scanning ahead over its `TableCell`/`TableAlign` nodes before the first
-/// row is emitted, so every row (including the header) pads to the same
-/// column widths.
-struct TableLayout {
-    widths: Vec<usize>,
-    align: Vec<TableAlignKind>,
-    /// Plain (color-free) display width of every cell, keyed by `(row, column)`,
-    /// computed once during the scan so the main render pass never has to
-    /// re-render a cell just to measure it.
-    cell_widths: rustc_hash::FxHashMap<(usize, usize), usize>,
-    /// Index (exclusive) of the node following this table's last node.
-    end: usize,
-}
-
-impl TableLayout {
-    fn compute(nodes: &[Node], options: &RenderOptions, start: usize) -> Self {
-        let mut widths: Vec<usize> = Vec::new();
-        let mut align: Vec<TableAlignKind> = Vec::new();
-        let mut cell_widths = rustc_hash::FxHashMap::default();
-        let mut i = start;
-
-        while let Some(node) = nodes.get(i) {
-            match node {
-                Node::TableCell(TableCell {
-                    row, column, values, ..
-                }) => {
-                    let width = cell_display_width(values, options);
-                    cell_widths.insert((*row, *column), width);
-                    if *column >= widths.len() {
-                        widths.resize(*column + 1, 0);
-                    }
-                    widths[*column] = widths[*column].max(width);
-                    i += 1;
-                }
-                Node::TableAlign(TableAlign { align: a, .. }) => {
-                    align = a.clone();
-                    i += 1;
-                }
-                _ => break,
-            }
-        }
-
-        if widths.len() < align.len() {
-            widths.resize(align.len(), 0);
-        }
-
-        for (idx, width) in widths.iter_mut().enumerate() {
-            let a = align.get(idx).unwrap_or(&TableAlignKind::None);
-            *width = (*width).max(column_min_width(a));
-        }
-
-        Self {
-            widths,
-            align,
-            cell_widths,
-            end: i,
-        }
-    }
-
-    fn align_for(&self, column: usize) -> TableAlignKind {
-        self.align.get(column).cloned().unwrap_or(TableAlignKind::None)
-    }
-
-    fn width_for(&self, column: usize) -> usize {
-        self.widths
-            .get(column)
-            .copied()
-            .unwrap_or(column_min_width(&self.align_for(column)))
-    }
-
-    /// Plain display width of the cell at `(row, column)`, precomputed during `compute`.
-    fn plain_width_at(&self, row: usize, column: usize) -> usize {
-        self.cell_widths.get(&(row, column)).copied().unwrap_or(0)
-    }
-
-    fn render_separator(&self) -> String {
-        let segments = self
-            .widths
-            .iter()
-            .enumerate()
-            .map(|(idx, &width)| {
-                let align = self.align_for(idx);
-                match align {
-                    TableAlignKind::None => "-".repeat(width),
-                    TableAlignKind::Left => format!(":{}", "-".repeat(width - 1)),
-                    TableAlignKind::Right => format!("{}:", "-".repeat(width - 1)),
-                    TableAlignKind::Center => format!(":{}:", "-".repeat(width - 2)),
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" | ");
-
-        format!("| {} |", segments)
-    }
-}
-
-/// Minimum width a column must have to render a valid alignment marker
-/// (e.g. `:-:` needs at least 3 characters for the two colons and a dash).
-fn column_min_width(align: &TableAlignKind) -> usize {
-    match align {
-        TableAlignKind::None => 1,
-        TableAlignKind::Left | TableAlignKind::Right => 2,
-        TableAlignKind::Center => 3,
-    }
-}
-
-/// Display width (in terminal columns) of a table cell's plain-rendered
-/// content, ignoring any ANSI color codes so padding stays correct with
-/// `--color` output.
-fn cell_display_width(values: &[Node], options: &RenderOptions) -> usize {
-    UnicodeWidthStr::width(render_values(values, options, &ColorTheme::PLAIN).as_str())
-}
-
-/// Pads an already-rendered (possibly colored) cell value to `width`
-/// columns, using `plain_width` — the color-free display width — to compute
-/// how much padding is needed.
-fn pad_cell(content: &str, plain_width: usize, width: usize, align: &TableAlignKind) -> String {
-    let pad = width.saturating_sub(plain_width);
-
-    match align {
-        TableAlignKind::Right => format!("{}{}", " ".repeat(pad), content),
-        TableAlignKind::Center => {
-            let left = pad / 2;
-            let right = pad - left;
-            format!("{}{}{}", " ".repeat(left), content, " ".repeat(right))
-        }
-        TableAlignKind::Left | TableAlignKind::None => format!("{}{}", content, " ".repeat(pad)),
     }
 }
 

--- a/crates/mq-markdown/src/markdown/table_layout.rs
+++ b/crates/mq-markdown/src/markdown/table_layout.rs
@@ -1,0 +1,133 @@
+use crate::node::{ColorTheme, Node, RenderOptions, TableAlign, TableAlignKind, TableCell, render_values};
+use unicode_width::UnicodeWidthStr;
+
+/// Per-column widths and alignment of a single contiguous table, computed by
+/// scanning ahead over its `TableCell`/`TableAlign` nodes before the first
+/// row is emitted, so every row (including the header) pads to the same
+/// column widths.
+pub(super) struct TableLayout {
+    widths: Vec<usize>,
+    align: Vec<TableAlignKind>,
+    /// Plain (color-free) display width of every cell, keyed by `(row, column)`,
+    /// computed once during the scan so the main render pass never has to
+    /// re-render a cell just to measure it.
+    cell_widths: rustc_hash::FxHashMap<(usize, usize), usize>,
+    /// Index (exclusive) of the node following this table's last node.
+    pub(super) end: usize,
+}
+
+impl TableLayout {
+    pub(super) fn compute(nodes: &[Node], options: &RenderOptions, start: usize) -> Self {
+        let mut widths: Vec<usize> = Vec::new();
+        let mut align: Vec<TableAlignKind> = Vec::new();
+        let mut cell_widths = rustc_hash::FxHashMap::default();
+        let mut i = start;
+
+        while let Some(node) = nodes.get(i) {
+            match node {
+                Node::TableCell(TableCell {
+                    row, column, values, ..
+                }) => {
+                    let width = cell_display_width(values, options);
+                    cell_widths.insert((*row, *column), width);
+                    if *column >= widths.len() {
+                        widths.resize(*column + 1, 0);
+                    }
+                    widths[*column] = widths[*column].max(width);
+                    i += 1;
+                }
+                Node::TableAlign(TableAlign { align: a, .. }) => {
+                    align = a.clone();
+                    i += 1;
+                }
+                _ => break,
+            }
+        }
+
+        if widths.len() < align.len() {
+            widths.resize(align.len(), 0);
+        }
+
+        for (idx, width) in widths.iter_mut().enumerate() {
+            let a = align.get(idx).unwrap_or(&TableAlignKind::None);
+            *width = (*width).max(column_min_width(a));
+        }
+
+        Self {
+            widths,
+            align,
+            cell_widths,
+            end: i,
+        }
+    }
+
+    pub(super) fn align_for(&self, column: usize) -> TableAlignKind {
+        self.align.get(column).cloned().unwrap_or(TableAlignKind::None)
+    }
+
+    pub(super) fn width_for(&self, column: usize) -> usize {
+        self.widths
+            .get(column)
+            .copied()
+            .unwrap_or(column_min_width(&self.align_for(column)))
+    }
+
+    /// Plain display width of the cell at `(row, column)`, precomputed during `compute`.
+    pub(super) fn plain_width_at(&self, row: usize, column: usize) -> usize {
+        self.cell_widths.get(&(row, column)).copied().unwrap_or(0)
+    }
+
+    pub(super) fn render_separator(&self) -> String {
+        let segments = self
+            .widths
+            .iter()
+            .enumerate()
+            .map(|(idx, &width)| {
+                let align = self.align_for(idx);
+                match align {
+                    TableAlignKind::None => "-".repeat(width),
+                    TableAlignKind::Left => format!(":{}", "-".repeat(width - 1)),
+                    TableAlignKind::Right => format!("{}:", "-".repeat(width - 1)),
+                    TableAlignKind::Center => format!(":{}:", "-".repeat(width - 2)),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" | ");
+
+        format!("| {} |", segments)
+    }
+}
+
+/// Minimum width a column must have to render a valid alignment marker
+/// (e.g. `:-:` needs at least 3 characters for the two colons and a dash).
+fn column_min_width(align: &TableAlignKind) -> usize {
+    match align {
+        TableAlignKind::None => 1,
+        TableAlignKind::Left | TableAlignKind::Right => 2,
+        TableAlignKind::Center => 3,
+    }
+}
+
+/// Display width (in terminal columns) of a table cell's plain-rendered
+/// content, ignoring any ANSI color codes so padding stays correct with
+/// `--color` output.
+fn cell_display_width(values: &[Node], options: &RenderOptions) -> usize {
+    UnicodeWidthStr::width(render_values(values, options, &ColorTheme::PLAIN).as_str())
+}
+
+/// Pads an already-rendered (possibly colored) cell value to `width`
+/// columns, using `plain_width` — the color-free display width — to compute
+/// how much padding is needed.
+pub(super) fn pad_cell(content: &str, plain_width: usize, width: usize, align: &TableAlignKind) -> String {
+    let pad = width.saturating_sub(plain_width);
+
+    match align {
+        TableAlignKind::Right => format!("{}{}", " ".repeat(pad), content),
+        TableAlignKind::Center => {
+            let left = pad / 2;
+            let right = pad - left;
+            format!("{}{}{}", " ".repeat(left), content, " ".repeat(right))
+        }
+        TableAlignKind::Left | TableAlignKind::None => format!("{}{}", content, " ".repeat(pad)),
+    }
+}

--- a/crates/mq-markdown/tests/table_render_property_tests.rs
+++ b/crates/mq-markdown/tests/table_render_property_tests.rs
@@ -1,0 +1,106 @@
+//! Property-based regression coverage for GFM table column-width padding.
+//!
+//! `Markdown::to_string()` pads every cell in a table to its column's
+//! computed width (see `TableLayout` in `src/markdown.rs`), so that tables
+//! render the way markdownlint/Prettier/GitHub do. That padding logic must
+//! hold for arbitrary column counts, row counts, and alignments — not just
+//! the hand-picked shapes covered by the `#[rstest]` cases in
+//! `src/markdown.rs`. This file checks the invariants a correct padding
+//! implementation can never violate, regardless of table shape.
+
+use mq_markdown::{Markdown, TableAlignKind};
+use proptest::prelude::*;
+
+fn align_kind() -> impl Strategy<Value = TableAlignKind> {
+    prop_oneof![
+        Just(TableAlignKind::None),
+        Just(TableAlignKind::Left),
+        Just(TableAlignKind::Right),
+        Just(TableAlignKind::Center),
+    ]
+}
+
+// Plain alphanumerics only: keeps unicode-width == char count trivial and
+// avoids characters (`|`, `*`, backslash, newlines) that would change
+// markdown semantics rather than exercise table padding.
+fn cell_text() -> impl Strategy<Value = String> {
+    "[a-zA-Z0-9]{0,8}"
+}
+
+#[derive(Debug)]
+struct TableSpec {
+    aligns: Vec<TableAlignKind>,
+    header: Vec<String>,
+    rows: Vec<Vec<String>>,
+}
+
+fn table_spec() -> impl Strategy<Value = TableSpec> {
+    (1usize..6).prop_flat_map(|cols| {
+        (
+            prop::collection::vec(align_kind(), cols),
+            prop::collection::vec(cell_text(), cols),
+            prop::collection::vec(prop::collection::vec(cell_text(), cols), 0..6),
+        )
+            .prop_map(|(aligns, header, rows)| TableSpec { aligns, header, rows })
+    })
+}
+
+fn render_table_source(spec: &TableSpec) -> String {
+    let mut lines = vec![
+        format!("| {} |", spec.header.join(" | ")),
+        format!(
+            "| {} |",
+            spec.aligns
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(" | ")
+        ),
+    ];
+    for row in &spec.rows {
+        lines.push(format!("| {} |", row.join(" | ")));
+    }
+    lines.join("\n") + "\n"
+}
+
+proptest! {
+    /// Every line of a rendered table — header, separator, and every data
+    /// row — must have identical display width. A regression that drops
+    /// the column-min-width floor or miscomputes a single cell's padding
+    /// would desync the columns.
+    #[test]
+    fn table_rows_have_uniform_width(spec in table_spec()) {
+        let source = render_table_source(&spec);
+        let md: Markdown = source.parse().unwrap();
+        let rendered = md.to_string();
+        let widths: Vec<usize> = rendered.lines().map(|l| l.chars().count()).collect();
+
+        prop_assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "rendered table lines have unequal width {widths:?}:\n{rendered}"
+        );
+    }
+
+    /// Formatting must be a fixed point: rendering already-padded markdown
+    /// must reproduce it exactly, not grow/shrink the padding on each pass.
+    #[test]
+    fn table_rendering_is_idempotent(spec in table_spec()) {
+        let source = render_table_source(&spec);
+        let md: Markdown = source.parse().unwrap();
+        let first = md.to_string();
+        let second: Markdown = first.parse().unwrap();
+
+        prop_assert_eq!(second.to_string(), first);
+    }
+
+    /// Padding must never add or drop rows: header + separator + every
+    /// data row must each become exactly one line of output.
+    #[test]
+    fn table_row_count_is_preserved(spec in table_spec()) {
+        let source = render_table_source(&spec);
+        let md: Markdown = source.parse().unwrap();
+        let rendered = md.to_string();
+
+        prop_assert_eq!(rendered.lines().count(), 2 + spec.rows.len());
+    }
+}

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -159,17 +159,26 @@ In {year}, the snowfall was above average.
 #[case::table_auto_expand(
     vec!["--unbuffered", "-A", r#"import "table" | table::tables()"#],
     "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n| Bob | 25 |\n",
-    Some("|Name|Age|\n|---|---|\n|Alice|30|\n|Bob|25|\n")
+    Some("| Name  | Age |\n| ----- | --- |\n| Alice | 30  |\n| Bob   | 25  |\n")
 )]
 #[case::table_auto_expand_first(
     vec!["--unbuffered", "-A", r#"import "table" | table::tables() | first()"#],
     "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n| Bob | 25 |\n",
-    Some("|Name|Age|\n|---|---|\n|Alice|30|\n|Bob|25|\n")
+    Some("| Name  | Age |\n| ----- | --- |\n| Alice | 30  |\n| Bob   | 25  |\n")
 )]
 #[case::table_auto_expand_add_row(
     vec!["--unbuffered", "-A", r#"import "table" | table::tables() | first() | table::add_row(["Charlie", "35"])"#],
     "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n",
-    Some("|Name|Age|\n|---|---|\n|Alice|30|\n|Charlie|35|\n")
+    Some("| Name    | Age |\n| ------- | --- |\n| Alice   | 30  |\n| Charlie | 35  |\n")
+)]
+#[case::table_auto_expand_add_column(
+    vec![
+        "--unbuffered",
+        "-A",
+        r#"import "table" | table::tables() | first() | table::add_column(["City", "Tokyo", "Osaka"])"#,
+    ],
+    "| Name | Age |\n| ---- | --- |\n| Alice | 30 |\n| Bob | 25 |\n",
+    Some("| Name  | Age | City  |\n| ----- | --- | ----- |\n| Alice | 30  | Tokyo |\n| Bob   | 25  | Osaka |\n")
 )]
 #[case::capture_named_groups(
     vec!["--unbuffered", "-I", "text", r#"capture("(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})")"#],


### PR DESCRIPTION
## Summary

Rendered tables now align column widths the way markdownlint, Prettier, and GitHub do, instead of collapsing to the minimal `|cell|cell|` form with no padding. `TableLayout` computes each column's display width (unicode-width aware, ANSI-color aware) in a pre-scan pass, then pads/aligns every cell and regenerates the `---`/`:--`/`--:`/`:-:` separator row to match.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
