### PR TITLE
✨ feat(mq-lang): add sort_natural for numeric-aware natural sorting

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -455,7 +455,7 @@ fn register_string(ctx: &mut InferenceContext) {
 /// Array functions: flatten, reverse, sort, uniq, compact, len, slice, insert, range, repeat
 fn register_array(ctx: &mut InferenceContext) {
     // Polymorphic array -> array functions
-    for name in ["reverse", "sort", "uniq", "compact", "shuffle"] {
+    for name in ["reverse", "sort", "sort_natural", "uniq", "compact", "shuffle"] {
         let a = ctx.fresh_var();
         register_unary(ctx, name, Type::array(Type::Var(a)), Type::array(Type::Var(a)));
     }
@@ -578,7 +578,10 @@ fn register_array(ctx: &mut InferenceContext) {
     );
 
     // None propagation for array functions
-    register_none_propagation_unary(ctx, &["reverse", "sort", "uniq", "compact", "flatten", "len"]);
+    register_none_propagation_unary(
+        ctx,
+        &["reverse", "sort", "sort_natural", "uniq", "compact", "flatten", "len"],
+    );
     // slice: (none, number, number) -> none
     register_ternary(ctx, "slice", Type::None, Type::Number, Type::Number, Type::None);
     // slice: (none, number) -> none  (open-ended slice)

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -270,6 +270,16 @@ end
 def sort_by(arr, f):
   let decorate_arr = foreach (x, arr): [f(x), x]; | _sort_by_impl(decorate_arr) | map(second);
 
+# Sorts an array in natural order (numeric-aware), so runs of digits embedded in a
+# string are compared as numbers rather than character-by-character, e.g. "file2" sorts
+# before "file10" (unlike a plain lexicographic `sort`).
+def sort_natural(arr):
+  sort_by(arr, fn(x):
+    scan(to_text(x), "[0-9]+|[^0-9]+")
+    | map(fn(seg): if (test(seg, "^[0-9]+$")): lpad(seg, 20, "0") else: seg;)
+    | join("");
+  );
+
 # Returns the count of elements in the array that satisfy the provided function.
 def count_by(arr, f):
   if (!is_array(arr) || is_empty(arr)):

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -320,6 +320,17 @@ def test_fill():
   | assert_eq(result3, [42, 42])
 end
 
+def test_sort_natural():
+  let result1 = sort_natural(["file10", "file2", "file1"])
+  | assert_eq(result1, ["file1", "file2", "file10"])
+
+  | let result2 = sort_natural(["chapter-2.md", "chapter-10.md", "chapter-1.md"])
+  | assert_eq(result2, ["chapter-1.md", "chapter-2.md", "chapter-10.md"])
+
+  | let result3 = sort_natural([])
+  | assert_eq(result3, [])
+end
+
 def test_skip():
   let result1 = skip([1, 2, 3, 4, 5], 2)
   | assert_eq(result1, [3, 4, 5])


### PR DESCRIPTION
## Summary

Sorts arrays so embedded digit runs compare numerically instead of lexicographically (e.g. "file2" before "file10"), similar to GNU sort -V. Implemented in builtin.mq on top of sort_by using scan/lpad, with type-checker registration in mq-check.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
