### PR TITLE
♻ refactor(mq-lang,mq-check,mq-hir,mq-lsp): unify diagnostic hints across CLI/LSP/lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,6 @@ dependencies = [
  "rustc-hash",
  "slotmap",
  "smol_str",
- "strsim",
  "thiserror 2.0.19",
  "url",
 ]

--- a/crates/mq-check/src/constraint.rs
+++ b/crates/mq-check/src/constraint.rs
@@ -1002,7 +1002,12 @@ pub(super) fn generate_symbol_constraints(
                                             found: arg_tys.len(),
                                             span: range.as_ref().map(range_to_span),
                                             location: range,
-                                            context: None,
+                                            context: Some(format!(
+                                                "`{}` expects {} argument(s), but {} were provided. Check the call site or the function's parameter list.",
+                                                func_name,
+                                                param_tys.len(),
+                                                arg_tys.len()
+                                            )),
                                         });
                                     }
                                 } else {

--- a/crates/mq-check/src/unify.rs
+++ b/crates/mq-check/src/unify.rs
@@ -167,7 +167,11 @@ pub fn unify(
                     found: params2.len(),
                     span: range.as_ref().map(range_to_span),
                     location: range,
-                    context: None,
+                    context: Some(format!(
+                        "Expected a function with {} parameter(s), but found one with {}. Check the function signature.",
+                        params1.len(),
+                        params2.len()
+                    )),
                 });
                 return;
             }

--- a/crates/mq-check/tests/type_errors_test.rs
+++ b/crates/mq-check/tests/type_errors_test.rs
@@ -77,6 +77,46 @@ fn test_function_arity_mismatch() {
 }
 
 #[test]
+fn test_function_arity_mismatch_hint_names_function_and_counts() {
+    // `add(1)` here is not the sole expression after a pipe (which would make the
+    // call site ambiguous re: piped-input arity), so this reliably hits the
+    // `TypeError::WrongArity` path in constraint.rs rather than a piped-input-driven
+    // `UnificationError` like `test_function_arity_mismatch` above does.
+    let result = check_types("def add(x, y): x + y; | [add(1)]");
+
+    let has_hint = result.iter().any(|err| {
+        matches!(
+            err,
+            TypeError::WrongArity { context: Some(hint), .. } if hint.contains("add") && hint.contains('2') && hint.contains('1')
+        )
+    });
+    assert!(
+        has_hint,
+        "Expected a WrongArity error with a hint naming the function and arg counts, got: {result:?}"
+    );
+}
+
+#[test]
+fn test_function_type_arity_mismatch_hint_shows_param_counts() {
+    // Unifying two function *types* with different arities (e.g. two branches of an
+    // `if` returning lambdas with different signatures) hits the WrongArity path in
+    // unify.rs, which has no call-site function name available, unlike the
+    // constraint.rs path exercised above.
+    let result = check_types("let f = fn(x): x; | let g = fn(x, y): x; | if (true): f else: g;");
+
+    let has_hint = result.iter().any(|err| {
+        matches!(
+            err,
+            TypeError::WrongArity { context: Some(hint), .. } if hint.contains('1') && hint.contains('2')
+        )
+    });
+    assert!(
+        has_hint,
+        "Expected a WrongArity error with a hint naming the param counts, got: {result:?}"
+    );
+}
+
+#[test]
 fn test_match_pattern_type_mismatch() {
     // Matching a number against a string pattern should produce a type error
     let result = check_types(r#"match (1): | "hello": "matched" end"#);

--- a/crates/mq-hir/Cargo.toml
+++ b/crates/mq-hir/Cargo.toml
@@ -17,7 +17,6 @@ mq-lang = {workspace = true, features = ["cst", "file-io"]}
 rustc-hash = {workspace = true}
 slotmap = {workspace = true}
 smol_str = {workspace = true}
-strsim = {workspace = true}
 thiserror = {workspace = true}
 url = {workspace = true}
 

--- a/crates/mq-hir/src/error.rs
+++ b/crates/mq-hir/src/error.rs
@@ -9,12 +9,12 @@ pub enum HirError {
         "Unresolved symbol: {}",
         similar_name
             .as_ref()
-            .map(|names| format!("{}, these names seem close though: `{}`", symbol, names.join(", ")))
+            .map(|name| format!("{symbol}. A name with a similar spelling exists: `{name}`."))
             .unwrap_or_else(|| symbol.to_string())
     )]
     UnresolvedSymbol {
         symbol: Symbol,
-        similar_name: Option<Vec<SmolStr>>,
+        similar_name: Option<SmolStr>,
     },
     #[error("Included module not found: {module_name}")]
     ModuleNotFound { symbol: Symbol, module_name: SmolStr },
@@ -129,28 +129,27 @@ impl Hir {
             .collect::<Vec<_>>()
     }
 
-    fn find_similar_names(&self, target: &str) -> Option<Vec<SmolStr>> {
-        let similar_names: Vec<SmolStr> = self
+    // Delegates to `mq_lang::suggest::suggest_name` (Damerau-Levenshtein-based, with a
+    // length-scaled edit-distance tolerance) instead of a HIR-local jaro_winkler
+    // implementation, so a typo produces the same suggestion whether it's reported by
+    // the CLI (mq-lang's `RuntimeError::NotDefined`/`UndefinedReference`) or the LSP
+    // (this `HirError::UnresolvedSymbol`).
+    fn find_similar_names(&self, target: &str) -> Option<SmolStr> {
+        let candidates: Vec<&str> = self
             .symbols
             .iter()
             .filter_map(|(_, symbol)| {
                 if (matches!(&symbol.kind, SymbolKind::Function(_)) || matches!(&symbol.kind, SymbolKind::Variable))
                     && symbol.value.as_ref().is_some_and(|name| name != target)
                 {
-                    let name = symbol.value.as_deref().unwrap_or("");
-                    let similarity = strsim::jaro_winkler(target, name);
-                    if similarity > 0.85 { symbol.value.clone() } else { None }
+                    symbol.value.as_deref()
                 } else {
                     None
                 }
             })
-            .collect::<Vec<_>>();
+            .collect();
 
-        if similar_names.is_empty() {
-            None
-        } else {
-            Some(similar_names)
-        }
+        mq_lang::suggest::suggest_name(target, candidates).map(SmolStr::from)
     }
 }
 #[cfg(test)]
@@ -160,14 +159,11 @@ mod tests {
     #[test]
     fn test_find_similar_names() {
         let mut hir = Hir::default();
-        let _ = hir.add_code(None, "let test = 1 | let test2 = 1 | let test3 = 1");
+        hir.builtin.disabled = true;
+        let _ = hir.add_code(None, "let test1 = 1");
 
         let similar = hir.find_similar_names("test");
-        assert!(similar.is_some());
-        let similar_vec = similar.unwrap();
-        assert_eq!(similar_vec.len(), 2);
-        assert!(similar_vec.contains(&"test2".into()));
-        assert!(similar_vec.contains(&"test3".into()));
+        assert_eq!(similar, Some("test1".into()));
 
         let no_similar = hir.find_similar_names("xyz123");
         assert!(no_similar.is_none());

--- a/crates/mq-hir/src/error.rs
+++ b/crates/mq-hir/src/error.rs
@@ -129,11 +129,6 @@ impl Hir {
             .collect::<Vec<_>>()
     }
 
-    // Delegates to `mq_lang::suggest::suggest_name` (Damerau-Levenshtein-based, with a
-    // length-scaled edit-distance tolerance) instead of a HIR-local jaro_winkler
-    // implementation, so a typo produces the same suggestion whether it's reported by
-    // the CLI (mq-lang's `RuntimeError::NotDefined`/`UndefinedReference`) or the LSP
-    // (this `HirError::UnresolvedSymbol`).
     fn find_similar_names(&self, target: &str) -> Option<SmolStr> {
         let candidates: Vec<&str> = self
             .symbols
@@ -149,7 +144,7 @@ impl Hir {
             })
             .collect();
 
-        mq_lang::suggest::suggest_name(target, candidates).map(SmolStr::from)
+        mq_lang::suggest_name(target, candidates).map(SmolStr::from)
     }
 }
 #[cfg(test)]

--- a/crates/mq-hir/src/hir.rs
+++ b/crates/mq-hir/src/hir.rs
@@ -23,16 +23,7 @@ pub struct Hir {
     pub(crate) source_scopes: FxHashMap<SourceId, ScopeId>,
     pub(crate) references: FxHashMap<SymbolId, SymbolId>,
     pub(crate) source_symbols: FxHashMap<SourceId, Vec<SymbolId>>,
-    /// Monotonically-increasing counter assigned to each symbol at insertion time.
-    /// Because `SlotMap` reuses freed slots (LIFO), the slot-based key order no longer
-    /// reflects insertion order after a source is reloaded (e.g. on repeated LSP saves).
-    /// Using an explicit counter guarantees that parent symbols always have a lower order
-    /// value than their children, which is required by the type-checker's constraint-
-    /// generation passes.
     pub(crate) symbol_insertion_counter: u32,
-    /// Reverse index from symbol name → list of SymbolIds that carry that name.
-    /// Populated by `insert_symbol` and pruned by `add_nodes` cleanup.
-    /// Allows name-based lookups in `resolve.rs` to skip an O(n) full-symbol scan.
     pub(crate) name_index: FxHashMap<SmolStr, Vec<SymbolId>>,
 }
 
@@ -108,10 +99,6 @@ impl Hir {
             return;
         }
 
-        // Mark as loaded before processing so that inline `import` expressions
-        // inside builtin.mq (e.g. `do import "yaml" | ...`) do not re-enter
-        // this function when add_expr → add_import_expr → add_code → add_nodes
-        // calls add_builtin() again.
         self.builtin.loaded = true;
 
         let (nodes, _) = mq_lang::parse_recovery(mq_lang::BUILTIN_MODULE_FILE);

--- a/crates/mq-lang/src/cst/error.rs
+++ b/crates/mq-lang/src/cst/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{Shared, Token, selector};
+use crate::{Shared, Token, TokenKind, selector};
 
 #[derive(Error, Debug, PartialEq, Clone, PartialOrd, Eq, Ord)]
 pub enum ParseError {
@@ -16,4 +16,80 @@ pub enum ParseError {
     UnknownSelector(selector::UnknownSelector),
     #[error("Unexpected `end` keyword — no open block to close")]
     UnmatchedEnd(Shared<Token>),
+}
+
+impl ParseError {
+    /// User-facing hint text for this error, mirroring the `help()` text the AST-level
+    /// `SyntaxError` produces for the equivalent case, so CST-based (LSP) and AST-based
+    /// (CLI) diagnostics stay consistent.
+    #[cold]
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            ParseError::UnknownSelector(sel) => Some(crate::error::selector_help(sel).into_owned()),
+            ParseError::UnexpectedToken(token) if token.kind == TokenKind::Eof => Some(
+                "The source could not be fully parsed from this position. Check for unsupported escape sequences (use \\u{XXXX} for Unicode), invalid characters, or unterminated string literals.".to_string(),
+            ),
+            ParseError::UnexpectedToken(_) => Some(
+                "This token is not valid here. Check for typos, missing operators, or misplaced punctuation.".to_string(),
+            ),
+            ParseError::UnexpectedEOFDetected => Some(
+                "Unexpected end of input. Check for missing closing brackets, parentheses, or incomplete expressions.".to_string(),
+            ),
+            ParseError::InsufficientTokens(_) => Some(
+                "Parsing could not continue here. Check for missing arguments, operators, or mismatched delimiters.".to_string(),
+            ),
+            ParseError::ExpectedClosingBracket(_) => Some(
+                "Expected a closing bracket ']'. Check your brackets for balance.".to_string(),
+            ),
+            ParseError::UnmatchedEnd(_) => Some(
+                "This `end` keyword does not match any open block. Note: single-line `if` expressions do not require `end`. Check that each `end` closes a `def`, `fn`, `do`, `while`, `loop`, or `foreach` block.".to_string(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Position, Range, arena::ArenaId};
+    use rstest::rstest;
+
+    fn make_token(kind: TokenKind) -> Shared<Token> {
+        Shared::new(Token {
+            range: Range {
+                start: Position { line: 1, column: 1 },
+                end: Position { line: 1, column: 1 },
+            },
+            kind,
+            module_id: ArenaId::new(0),
+        })
+    }
+
+    #[rstest]
+    #[case::unexpected_token(ParseError::UnexpectedToken(make_token(TokenKind::Comma)), true)]
+    #[case::unexpected_token_eof(ParseError::UnexpectedToken(make_token(TokenKind::Eof)), true)]
+    #[case::unexpected_eof_detected(ParseError::UnexpectedEOFDetected, true)]
+    #[case::insufficient_tokens(ParseError::InsufficientTokens(make_token(TokenKind::Comma)), true)]
+    #[case::expected_closing_bracket(ParseError::ExpectedClosingBracket(make_token(TokenKind::Comma)), true)]
+    #[case::unmatched_end(ParseError::UnmatchedEnd(make_token(TokenKind::End)), true)]
+    fn test_hint_present(#[case] err: ParseError, #[case] has_hint: bool) {
+        assert_eq!(err.hint().is_some(), has_hint);
+    }
+
+    #[test]
+    fn test_unknown_selector_hint_suggests_similar_selector() {
+        let token = Token {
+            range: Range {
+                start: Position { line: 1, column: 1 },
+                end: Position { line: 1, column: 1 },
+            },
+            kind: TokenKind::Selector(smol_str::SmolStr::new(".hedaing")),
+            module_id: ArenaId::new(0),
+        };
+        let err = ParseError::UnknownSelector(selector::UnknownSelector::new(token));
+        assert_eq!(
+            err.hint(),
+            Some("Unknown selector `.hedaing`. A selector with a similar name exists: `.heading`.".to_string())
+        );
+    }
 }

--- a/crates/mq-lang/src/cst/parser.rs
+++ b/crates/mq-lang/src/cst/parser.rs
@@ -93,6 +93,37 @@ impl ErrorReporter {
         !self.errors.is_empty()
     }
 
+    /// Like [`error_ranges`](Self::error_ranges), but keeps each error's hint text
+    /// (e.g. "did you mean" suggestions) instead of discarding it, so consumers
+    /// that render diagnostics to users (e.g. `mq-lsp`) can show the same guidance
+    /// as the CLI's AST-level errors.
+    pub fn diagnostics(&self, text: &str) -> Vec<crate::Diagnostic> {
+        self.to_vec()
+            .iter()
+            .map(|e| crate::Diagnostic {
+                message: e.to_string(),
+                range: Some(match e {
+                    ParseError::UnexpectedToken(token) => token.range,
+                    ParseError::InsufficientTokens(token) => token.range,
+                    ParseError::ExpectedClosingBracket(token) => token.range,
+                    ParseError::UnknownSelector(selector::UnknownSelector(token)) => token.range,
+                    ParseError::UnmatchedEnd(token) => token.range,
+                    ParseError::UnexpectedEOFDetected => Range {
+                        start: Position {
+                            line: text.lines().count() as u32,
+                            column: text.lines().last().map(|line| line.len()).unwrap_or(0),
+                        },
+                        end: Position {
+                            line: text.lines().count() as u32,
+                            column: text.lines().last().map(|line| line.len()).unwrap_or(0),
+                        },
+                    },
+                }),
+                hints: e.hint().into_iter().collect(),
+            })
+            .collect::<Vec<_>>()
+    }
+
     pub fn error_ranges(&self, text: &str) -> Vec<(String, Range)> {
         self.to_vec()
             .iter()
@@ -11405,6 +11436,54 @@ mod tests {
         assert_eq!(ranges[2].1.start.column, 6);
         assert_eq!(ranges[2].1.end.line, 2);
         assert_eq!(ranges[2].1.end.column, 6);
+    }
+
+    #[test]
+    fn test_error_reporter_diagnostics_carries_hints_and_ranges() {
+        let text = "def foo():\n bar()\n";
+
+        let mut reporter = ErrorReporter::new(100);
+
+        let unexpected_token = Shared::new(Token {
+            range: Range {
+                start: Position { line: 1, column: 4 },
+                end: Position { line: 1, column: 7 },
+            },
+            kind: TokenKind::Ident("foo".into()),
+            module_id: 1.into(),
+        });
+        reporter.report(ParseError::UnexpectedToken(Shared::clone(&unexpected_token)));
+        reporter.report(ParseError::UnexpectedEOFDetected);
+
+        let diagnostics = reporter.diagnostics(text);
+
+        assert_eq!(diagnostics.len(), 2);
+
+        assert_eq!(
+            diagnostics[0].message,
+            ParseError::UnexpectedToken(unexpected_token).to_string()
+        );
+        assert_eq!(diagnostics[0].range.unwrap().start.column, 4);
+        assert_eq!(diagnostics[0].hints.len(), 1);
+
+        assert_eq!(diagnostics[1].message, ParseError::UnexpectedEOFDetected.to_string());
+        assert_eq!(diagnostics[1].hints.len(), 1);
+    }
+
+    #[test]
+    fn test_error_reporter_diagnostics_unknown_selector_hint_matches_error_help() {
+        let mut reporter = ErrorReporter::new(100);
+        reporter.report(ParseError::UnknownSelector(selector::UnknownSelector::new(Token {
+            range: Range::default(),
+            kind: TokenKind::Selector(smol_str::SmolStr::new(".hedaing")),
+            module_id: 1.into(),
+        })));
+
+        let diagnostics = reporter.diagnostics("");
+        assert_eq!(
+            diagnostics[0].hints[0],
+            "Unknown selector `.hedaing`. A selector with a similar name exists: `.heading`."
+        );
     }
 
     #[test]

--- a/crates/mq-lang/src/diagnostic.rs
+++ b/crates/mq-lang/src/diagnostic.rs
@@ -1,0 +1,33 @@
+//! A source-agnostic diagnostic shape shared by the CST parser (used for editor/LSP
+//! scenarios that need error recovery) and other error producers. Keeping this separate
+//! from the AST-level `Error`/miette machinery lets consumers that don't want a full
+//! `miette::Diagnostic` (e.g. `mq-lsp`) render consistent messages and hints without
+//! depending on miette's rendering model.
+
+use crate::Range;
+
+/// A single diagnostic: a message, an optional source location, and zero or more
+/// hint strings explaining how to fix the issue.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub message: String,
+    pub range: Option<Range>,
+    pub hints: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diagnostic_holds_message_range_and_hints() {
+        let diagnostic = Diagnostic {
+            message: "unexpected token".to_string(),
+            range: None,
+            hints: vec!["check for a missing operator".to_string()],
+        };
+
+        assert_eq!(diagnostic.message, "unexpected token");
+        assert_eq!(diagnostic.hints.len(), 1);
+    }
+}

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -168,7 +168,7 @@ fn not_defined_help(name: &str, candidates: &[String]) -> Cow<'static, str> {
 
 // help() text for an unknown selector, with a "did you mean" hint when available.
 #[cold]
-fn selector_help(sel: &selector::UnknownSelector) -> Cow<'static, str> {
+pub(crate) fn selector_help(sel: &selector::UnknownSelector) -> Cow<'static, str> {
     let raw = match &sel.0.kind {
         TokenKind::Selector(s) => s.as_str(),
         _ => "",

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -111,6 +111,7 @@ pub use selector::{AttrKind, Selector};
 
 pub type DefaultEngine = Engine<DefaultModuleResolver>;
 pub type DefaultModuleLoader = ModuleLoader<DefaultModuleResolver>;
+pub use suggest::{suggest_name, suggest_selector};
 
 #[cfg(feature = "cst")]
 pub use cst::incremental::{IncrementalParser, TextEdit};

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -43,6 +43,7 @@ mod arena;
 mod ast;
 #[cfg(feature = "cst")]
 mod cst;
+pub mod diagnostic;
 mod engine;
 mod error;
 mod eval;
@@ -55,7 +56,7 @@ mod number;
 mod optimizer;
 mod range;
 mod selector;
-mod suggest;
+pub mod suggest;
 
 use lexer::Lexer;
 #[cfg(not(feature = "sync"))]
@@ -78,6 +79,7 @@ pub use ast::node::Pattern as AstPattern;
 pub use ast::parser::Parser as AstParser;
 #[cfg(feature = "ast-json")]
 pub use ast::{ast_from_json, ast_to_json};
+pub use diagnostic::Diagnostic;
 pub use engine::CompiledProgram;
 pub use engine::Engine;
 pub use error::Error;

--- a/crates/mq-lang/src/suggest.rs
+++ b/crates/mq-lang/src/suggest.rs
@@ -43,7 +43,7 @@ fn is_word_like_selector(selector: &str) -> bool {
 /// Closest name to `name` among builtin functions and the given extra candidates (e.g.
 /// user-defined functions/variables visible in scope when the lookup failed).
 #[cold]
-pub(crate) fn suggest_name<'a>(name: &str, extra_candidates: impl IntoIterator<Item = &'a str>) -> Option<String> {
+pub fn suggest_name<'a>(name: &str, extra_candidates: impl IntoIterator<Item = &'a str>) -> Option<String> {
     closest_match(
         name,
         crate::BUILTIN_FUNCTION_DOC
@@ -56,7 +56,7 @@ pub(crate) fn suggest_name<'a>(name: &str, extra_candidates: impl IntoIterator<I
 
 /// Closest known selector (e.g. `.h1`, `.code`) to `name`, or `None` if nothing is close enough.
 #[cold]
-pub(crate) fn suggest_selector(name: &str) -> Option<&'static str> {
+pub fn suggest_selector(name: &str) -> Option<&'static str> {
     closest_match(
         name,
         crate::BUILTIN_SELECTOR_DOC

--- a/crates/mq-lsp/src/error.rs
+++ b/crates/mq-lsp/src/error.rs
@@ -1,11 +1,9 @@
 use tower_lsp_server::ls_types;
 use tower_lsp_server::ls_types::NumberOrString;
 
-pub type SyntaxError = (std::string::String, mq_lang::Range);
-
 #[derive(Debug, Clone)]
 pub enum LspError {
-    SyntaxError(SyntaxError),
+    SyntaxError(mq_lang::Diagnostic),
     TypeError(mq_check::TypeError),
     LintWarning(mq_lint::Diagnostic),
 }
@@ -35,8 +33,19 @@ fn lint_severity(severity: mq_lint::Severity) -> ls_types::DiagnosticSeverity {
 impl From<&LspError> for ls_types::Diagnostic {
     fn from(error: &LspError) -> Self {
         match error {
-            LspError::SyntaxError((message, range)) => {
-                ls_types::Diagnostic::new_simple(lsp_range(*range), message.to_string())
+            LspError::SyntaxError(diagnostic) => {
+                let range = diagnostic.range.map(lsp_range).unwrap_or_else(|| {
+                    ls_types::Range::new(
+                        ls_types::Position { line: 0, character: 0 },
+                        ls_types::Position { line: 0, character: 1 },
+                    )
+                });
+                let message = if diagnostic.hints.is_empty() {
+                    diagnostic.message.clone()
+                } else {
+                    format!("{} (help: {})", diagnostic.message, diagnostic.hints.join("; "))
+                };
+                ls_types::Diagnostic::new_simple(range, message)
             }
             LspError::TypeError(type_error) => match type_error.location() {
                 Some(range) => ls_types::Diagnostic::new_simple(lsp_range(range), type_error.to_string()),

--- a/crates/mq-lsp/src/server.rs
+++ b/crates/mq-lsp/src/server.rs
@@ -449,9 +449,9 @@ impl Backend {
 
         let uri_string = uri.to_string();
         let mut errors = errors
-            .error_ranges(&text)
+            .diagnostics(&text)
             .into_iter()
-            .map(|(message, range)| LspError::SyntaxError((message, range)))
+            .map(LspError::SyntaxError)
             .collect::<Vec<_>>();
 
         if errors.is_empty() && self.config.enable_type_checking {
@@ -710,9 +710,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(text)
+                .diagnostics(text)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1621,9 +1621,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(text)
+                .diagnostics(text)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1739,9 +1739,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(text)
+                .diagnostics(text)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1772,9 +1772,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(text)
+                .diagnostics(text)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1796,6 +1796,63 @@ mod tests {
         };
 
         assert!(!report.full_document_diagnostic_report.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_pull_diagnostics_syntax_error_includes_did_you_mean_hint() {
+        // Regression test: syntax errors reported over LSP now carry the same
+        // "did you mean" hint text as the CLI's miette-rendered errors, instead of
+        // being flattened to a bare message before hints could be attached.
+        let (service, _) = LspService::new(|client| Backend {
+            client,
+            hir: Arc::new(RwLock::new(mq_hir::Hir::default())),
+            source_map: RwLock::new(BiMap::new()),
+            type_env_map: DashMap::new(),
+            error_map: DashMap::new(),
+            text_map: DashMap::new(),
+            config: LspConfig::default(),
+        });
+
+        let backend = service.inner();
+        let uri = Url::parse("file:///test.mq").unwrap();
+
+        let text = ".hedaing"; // Typo of the `.heading` selector
+        let (_, errors) = mq_lang::parse_recovery(text);
+        backend.text_map.insert(uri.to_string(), text.to_string().into());
+        backend.error_map.insert(
+            uri.to_string(),
+            errors
+                .diagnostics(text)
+                .into_iter()
+                .map(LspError::SyntaxError)
+                .collect(),
+        );
+
+        let result = backend
+            .diagnostic(ls_types::DocumentDiagnosticParams {
+                text_document: ls_types::TextDocumentIdentifier { uri: to_uri(&uri) },
+                identifier: None,
+                previous_result_id: None,
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .await;
+
+        let ls_types::DocumentDiagnosticReportResult::Report(ls_types::DocumentDiagnosticReport::Full(report)) =
+            result.unwrap()
+        else {
+            panic!("Expected a full document diagnostic report");
+        };
+
+        assert!(
+            report
+                .full_document_diagnostic_report
+                .items
+                .iter()
+                .any(|item| item.message.contains("help:") && item.message.contains(".heading")),
+            "Expected a diagnostic with a `.heading` suggestion, got: {:?}",
+            report.full_document_diagnostic_report.items
+        );
     }
 
     #[tokio::test]
@@ -1858,9 +1915,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1908,9 +1965,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1955,9 +2012,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -1985,13 +2042,14 @@ mod tests {
         backend.text_map.insert(uri.to_string(), text.to_string().into());
         backend.error_map.insert(
             uri.to_string(),
-            vec![LspError::SyntaxError((
-                "Syntax error".to_string(),
-                mq_lang::Range {
+            vec![LspError::SyntaxError(mq_lang::Diagnostic {
+                message: "Syntax error".to_string(),
+                range: Some(mq_lang::Range {
                     start: mq_lang::Position { line: 1, column: 10 },
                     end: mq_lang::Position { line: 1, column: 11 },
-                },
-            ))],
+                }),
+                hints: Vec::new(),
+            })],
         );
 
         let result = backend
@@ -2034,9 +2092,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -2156,13 +2214,14 @@ mod tests {
         backend.text_map.insert(uri.to_string(), text.to_string().into());
         backend.error_map.insert(
             uri.to_string(),
-            vec![LspError::SyntaxError((
-                "Syntax error".to_string(),
-                mq_lang::Range {
+            vec![LspError::SyntaxError(mq_lang::Diagnostic {
+                message: "Syntax error".to_string(),
+                range: Some(mq_lang::Range {
                     start: mq_lang::Position { line: 0, column: 0 },
                     end: mq_lang::Position { line: 0, column: 10 },
-                },
-            ))],
+                }),
+                hints: Vec::new(),
+            })],
         );
 
         let params = DocumentRangeFormattingParams {
@@ -2244,9 +2303,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -2286,9 +2345,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -2367,13 +2426,14 @@ mod tests {
         backend.text_map.insert(uri.to_string(), text.to_string().into());
         backend.error_map.insert(
             uri.to_string(),
-            vec![LspError::SyntaxError((
-                "Syntax error".to_string(),
-                mq_lang::Range {
+            vec![LspError::SyntaxError(mq_lang::Diagnostic {
+                message: "Syntax error".to_string(),
+                range: Some(mq_lang::Range {
                     start: mq_lang::Position { line: 1, column: 1 },
                     end: mq_lang::Position { line: 1, column: 5 },
-                },
-            ))],
+                }),
+                hints: Vec::new(),
+            })],
         );
 
         // Parse errors are present, so type checking should be skipped
@@ -2417,9 +2477,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 
@@ -2462,9 +2522,9 @@ mod tests {
         backend.error_map.insert(
             uri.to_string(),
             errors
-                .error_ranges(code)
+                .diagnostics(code)
                 .into_iter()
-                .map(|(message, range)| LspError::SyntaxError((message, range)))
+                .map(LspError::SyntaxError)
                 .collect(),
         );
 


### PR DESCRIPTION
## Summary

Extends the CLI's existing "did you mean" typo suggestions to cover arity and hint plumbing more consistently across error producers:

- mq-lang: expose the suggest module, add hint() to the CST ParseError (error-recovery parser used by the LSP), and introduce a shared Diagnostic { message, range, hints } type plus ErrorReporter::diagnostics() built on top of it.
- mq-check: TypeError::WrongArity now carries an actual hint string instead of always being None, for both the call-site and function-type-unification arity mismatch paths.
- mq-hir: replace the HIR-local jaro_winkler-based typo suggestion with mq-lang's Damerau-Levenshtein suggest_name, so LSP-reported unresolved symbols suggest the same name the CLI would.
- mq-lsp: LspError::SyntaxError now carries the shared Diagnostic instead of a bare (String, Range) tuple, so syntax error hints (e.g. unknown-selector suggestions) reach LSP diagnostics the same way lint hints already do.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
