### PR TITLE
🐛 fix(mq-lang): keep all documents when parsing multi-document YAML

### DIFF
--- a/crates/mq-lang/modules/yaml.mq
+++ b/crates/mq-lang/modules/yaml.mq
@@ -32,6 +32,8 @@ def _yaml_stringify_value(value, indent_level):
 end
 
 # Parses a YAML string and returns the parsed data structure.
+# A single `---`-separated document is returned as-is; if the input contains
+# multiple `---`-separated documents, an array of the parsed documents is returned.
 def yaml_parse(input):
   _yaml_parse(to_string(input))
 end

--- a/crates/mq-lang/modules/yaml_test.mq
+++ b/crates/mq-lang/modules/yaml_test.mq
@@ -10,6 +10,11 @@ def test_yaml_parse():
   | assert_eq(len(keys(result)), 8)
 end
 
+def test_yaml_parse_multi_document():
+  let result = yaml::yaml_parse("a: 1\n---\nb: 2\n")
+  | assert_eq(result, [{"a": 1}, {"b": 2}])
+end
+
 def test_yaml_to_json():
   let result = yaml::yaml_to_json(yaml::yaml_parse(yaml_input))
   | assert_eq(result, "{\"array\": [\"item1\", \"item2\", \"item3\"], \"number\": 42, \"float\": 3.14, \"bool_true\": true, \"bool_false\": false, \"null_value\": null, \"object\": {\"key1\": \"value1\", \"key2\": \"value2\"}, \"nested\": {\"arr\": [\"a\", \"b\"], \"obj\": {\"subkey\": \"subval\"}}}")

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3385,11 +3385,23 @@ fn _json_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
 fn _yaml_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::String(s)] => {
-            let docs = yaml_rust2::YamlLoader::load_from_str(s)
-                .map_err(|e| Error::Runtime(format!("Failed to parse YAML: {}", e)))?;
-            match docs.into_iter().next() {
-                Some(doc) => Ok(doc.into()),
-                None => Ok(RuntimeValue::NONE),
+            let mut docs = yaml_rust2::YamlLoader::load_from_str(s)
+                .map_err(|e| Error::Runtime(format!("Failed to parse YAML: {}", e)))?
+                .into_iter();
+
+            match (docs.next(), docs.next()) {
+                (None, _) => Ok(RuntimeValue::NONE),
+                // A single `---`-separated document parses the same as before.
+                (Some(doc), None) => Ok(doc.into()),
+                // Multiple `---`-separated documents are returned as an array
+                // instead of silently discarding everything past the first one.
+                (Some(first), Some(second)) => Ok(RuntimeValue::Array(Shared::new(
+                    std::iter::once(first)
+                        .chain(std::iter::once(second))
+                        .chain(docs)
+                        .map(RuntimeValue::from)
+                        .collect(),
+                ))),
             }
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
@@ -8896,6 +8908,19 @@ mod tests {
             let mut map = BTreeMap::new();
             map.insert(Ident::new("ratio"), RuntimeValue::Number(1.5.into()));
             Ok(RuntimeValue::Dict(Shared::new(map)))
+        }
+    )]
+    #[case::multi_document(
+        "a: 1\n---\nb: 2\n",
+        {
+            let mut first = BTreeMap::new();
+            first.insert(Ident::new("a"), RuntimeValue::Number(1.into()));
+            let mut second = BTreeMap::new();
+            second.insert(Ident::new("b"), RuntimeValue::Number(2.into()));
+            Ok(RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::Dict(Shared::new(first)),
+                RuntimeValue::Dict(Shared::new(second)),
+            ])))
         }
     )]
     fn test_yaml_parse(#[case] yaml: &str, #[case] expected: Result<RuntimeValue, Error>) {


### PR DESCRIPTION
## Summary

_yaml_parse only returned the first `---`-separated document from yaml_rust2::YamlLoader::load_from_str, silently dropping the rest. Single-document input (including frontmatter) still returns the parsed value directly; multi-document input now returns an array of all parsed documents.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
