### PR TITLE
✨ feat(mq-lang): add file_size, human_bytes, and human_size builtins

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -284,6 +284,10 @@ fn register_math(ctx: &mut InferenceContext) {
     register_nullary(ctx, "infinite", Type::Number);
     register_unary(ctx, "is_nan", Type::Number, Type::Bool);
 
+    // Human-readable byte size formatting: number -> string
+    register_unary(ctx, "human_bytes", Type::Number, Type::String);
+    register_unary(ctx, "human_size", Type::Number, Type::String);
+
     // Randomness
     register_nullary(ctx, "rand", Type::Number);
     register_binary(ctx, "rand_int", Type::Number, Type::Number, Type::Number);
@@ -1277,6 +1281,7 @@ fn register_file_io(ctx: &mut InferenceContext) {
     register_unary(ctx, "read_file", Type::String, Type::String);
     register_unary(ctx, "read_file_bytes", Type::String, Type::Bytes);
     register_unary(ctx, "file_exists", Type::String, Type::Bool);
+    register_unary(ctx, "file_size", Type::String, Type::Number);
 
     // collection: string (dir path) -> [{path, title, frontmatter, content}]
     let (k, v) = (ctx.fresh_var(), ctx.fresh_var());
@@ -1859,6 +1864,7 @@ mod tests {
     #[case::read_file("read_file(\"a.md\")", true)]
     #[case::read_file_bytes("read_file_bytes(\"a.md\")", true)]
     #[case::file_exists("file_exists(\"a.md\")", true)]
+    #[case::file_size("file_size(\"a.md\")", true)]
     #[case::collection("collection(\"docs\")", true)]
     #[case::collection_len("len(collection(\"docs\"))", true)]
     #[case::basename("basename(\"a/b.md\")", true)]
@@ -1888,6 +1894,7 @@ mod tests {
     )]
     #[case::read_file_number("read_file(42)", false)] // Should fail: wrong type
     #[case::file_exists_number("file_exists(42)", false)] // Should fail: wrong type
+    #[case::file_size_number("file_size(42)", false)] // Should fail: wrong type
     #[case::collection_number("collection(42)", false)] // Should fail: wrong type
     #[case::basename_number("basename(42)", false)] // Should fail: wrong type
     #[case::path_join_number("path_join(42, \"b\")", false)] // Should fail: wrong type

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1087,3 +1087,30 @@ def walk(v, f):
   end
 end
 
+# Formats a byte count as a human-readable decimal (SI, 1000-based) string,
+# e.g. `human_bytes(1500)` => "1.5KB". Negative numbers keep their sign.
+def human_bytes(n):
+  let base = 1000
+  | let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB"]
+  | let sign = if (n < 0): "-" else: ""
+  | let abs_n = abs(n)
+  | let exponent = if (abs_n < base): 0 else: min(floor(log10(abs_n) / log10(base)), len(units) - 1)
+  | let value = abs_n / pow(base, exponent)
+  | let rounded = round(value * 10) / 10
+  | sign + to_string(rounded) + units[exponent]
+end
+
+# Formats a byte count as a human-readable binary (IEC, 1024-based) string
+# without the "i" suffix, matching `numfmt --to=iec`, e.g. `human_size(1536)`
+# => "1.5K". Negative numbers keep their sign.
+def human_size(n):
+  let base = 1024
+  | let units = ["B", "K", "M", "G", "T", "P", "E"]
+  | let sign = if (n < 0): "-" else: ""
+  | let abs_n = abs(n)
+  | let exponent = if (abs_n < base): 0 else: min(floor(log10(abs_n) / log10(base)), len(units) - 1)
+  | let value = abs_n / pow(base, exponent)
+  | let rounded = round(value * 10) / 10
+  | sign + to_string(rounded) + units[exponent]
+end
+

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -1170,3 +1170,43 @@ def test_walk():
   | assert_eq(result24, "h2")
 end
 
+def test_human_bytes():
+  let result1 = human_bytes(0)
+  | assert_eq(result1, "0B")
+
+  | let result2 = human_bytes(500)
+  | assert_eq(result2, "500B")
+
+  | let result3 = human_bytes(1500)
+  | assert_eq(result3, "1.5KB")
+
+  | let result4 = human_bytes(1000000)
+  | assert_eq(result4, "1MB")
+
+  | let result5 = human_bytes(1500000000)
+  | assert_eq(result5, "1.5GB")
+
+  | let result6 = human_bytes(-1500)
+  | assert_eq(result6, "-1.5KB")
+end
+
+def test_human_size():
+  let result1 = human_size(0)
+  | assert_eq(result1, "0B")
+
+  | let result2 = human_size(500)
+  | assert_eq(result2, "500B")
+
+  | let result3 = human_size(1536)
+  | assert_eq(result3, "1.5K")
+
+  | let result4 = human_size(1048576)
+  | assert_eq(result4, "1M")
+
+  | let result5 = human_size(1610612736)
+  | assert_eq(result5, "1.5G")
+
+  | let result6 = human_size(-1536)
+  | assert_eq(result6, "-1.5K")
+end
+

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4043,6 +4043,21 @@ fn file_exists_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
     }
 }
 
+/// Returns the size, in bytes, of the file at `path`. Requires the ambient [`Io`]'s read
+/// permission (see [`io_context`]).
+#[cfg(feature = "file-io")]
+#[mq_macros::mq_fn(name = "file_size", params = Fixed(1))]
+fn file_size_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(path)] => io_context::current()
+            .file_size(std::path::Path::new(path.as_str()))
+            .map(|size| RuntimeValue::Number((size as usize).into()))
+            .map_err(|e| Error::Runtime(format!("Failed to get size of {}: {}", path, e))),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("file_size should always receive exactly one argument"),
+    }
+}
+
 /// Reads the contents of `path` as raw bytes. Requires the ambient [`Io`]'s read
 /// permission (see [`io_context`]).
 #[cfg(feature = "file-io")]
@@ -4685,6 +4700,8 @@ mq_macros::builtin_dispatch! {
     READ_FILE,
     #[cfg(feature = "file-io")]
     FILE_EXISTS,
+    #[cfg(feature = "file-io")]
+    FILE_SIZE,
     #[cfg(feature = "file-io")]
     READ_FILE_BYTES,
     #[cfg(feature = "file-io")]
@@ -6281,6 +6298,14 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         SmolStr::new("file_exists"),
         BuiltinFunctionDoc {
             description: "Checks if a file exists at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
+            params: &["path"],
+        },
+    );
+    #[cfg(feature = "file-io")]
+    map.insert(
+        SmolStr::new("file_size"),
+        BuiltinFunctionDoc {
+            description: "Returns the size, in bytes, of the file at the given path. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
             params: &["path"],
         },
     );
@@ -10471,6 +10496,10 @@ mod tests {
             call("file_exists", vec![RuntimeValue::String(text_path.clone())]).is_err(),
             "file_exists should be blocked when read access is not allowed"
         );
+        assert!(
+            call("file_size", vec![RuntimeValue::String(text_path.clone())]).is_err(),
+            "file_size should be blocked when read access is not allowed"
+        );
 
         let _guard = io_context::scoped(Shared::new(SandboxedIo::new(NativeIo::default()).allow_read(true)));
         assert_eq!(
@@ -10506,6 +10535,20 @@ mod tests {
             Ok(RuntimeValue::Boolean(false))
         );
         assert!(call("file_exists", vec![RuntimeValue::Number(42.into())]).is_err());
+
+        assert_eq!(
+            call("file_size", vec![RuntimeValue::String(text_path.clone())]),
+            Ok(RuntimeValue::Number(5.into()))
+        );
+        assert!(
+            call(
+                "file_size",
+                vec![RuntimeValue::String("/nonexistent/path/no_such_file.md".into())]
+            )
+            .is_err(),
+            "file_size should error for a nonexistent file"
+        );
+        assert!(call("file_size", vec![RuntimeValue::Number(42.into())]).is_err());
 
         // Basic collection: YAML/TOML frontmatter, title, content, sorted by path.
         {

--- a/crates/mq-lang/src/io.rs
+++ b/crates/mq-lang/src/io.rs
@@ -68,6 +68,9 @@ pub trait Io: std::fmt::Debug + IoSyncBound + 'static {
     fn write(&self, path: &Path, content: &[u8]) -> Result<(), IoError>;
     fn exists(&self, path: &Path) -> Result<bool, IoError>;
 
+    /// Size of the file at `path`, in bytes.
+    fn file_size(&self, path: &Path) -> Result<u64, IoError>;
+
     /// `(path, is_dir)` pairs for the immediate entries of a directory.
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError>;
 

--- a/crates/mq-lang/src/io/mem.rs
+++ b/crates/mq-lang/src/io/mem.rs
@@ -94,6 +94,15 @@ impl Io for MemIo {
         Ok(self.files.lock().unwrap().contains_key(path))
     }
 
+    fn file_size(&self, path: &Path) -> Result<u64, IoError> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(path)
+            .map(|bytes| bytes.len() as u64)
+            .ok_or_else(|| IoError::NotFound(Cow::Owned(path.display().to_string())))
+    }
+
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
         let files = self.files.lock().unwrap();
         Ok(files

--- a/crates/mq-lang/src/io/native.rs
+++ b/crates/mq-lang/src/io/native.rs
@@ -55,6 +55,10 @@ impl Io for NativeIo {
         Ok(path.exists())
     }
 
+    fn file_size(&self, path: &Path) -> Result<u64, IoError> {
+        std::fs::metadata(path).map(|m| m.len()).map_err(|e| io_err(e, path))
+    }
+
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
         std::fs::read_dir(path)
             .map_err(|e| io_err(e, path))?

--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -194,6 +194,16 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
         self.inner.exists(path)
     }
 
+    fn file_size(&self, path: &Path) -> Result<u64, IoError> {
+        if self.allow_read.is_denied() {
+            return Err(denied("filesystem reads are disabled"));
+        }
+        if !self.allow_read.permits(path) {
+            return Err(denied_path("read", path));
+        }
+        self.inner.file_size(path)
+    }
+
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
         if self.allow_read.is_denied() {
             return Err(denied("filesystem reads are disabled"));


### PR DESCRIPTION
## Summary

Add file_size(path) to the Io trait (NativeIo/SandboxedIo/MemIo) and expose it as a native builtin, filling the gap of no way to read a file's size. Add human_bytes(n) (SI/1000-based) and human_size(n) (IEC/1024-based, numfmt --to=iec-equivalent) as pure-mq formatters in builtin.mq for turning byte counts into human-readable strings, e.g. for collection() directory reports.
<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
