### PR TITLE
✨ feat(mq-lang,mq-run): add gron-style output/input format

### DIFF
--- a/crates/mq-lang/modules/gron.mq
+++ b/crates/mq-lang/modules/gron.mq
@@ -1,0 +1,7 @@
+# gron Implementation in mq
+
+# Parses gron-style `path = value;` assignment statements (as produced by `mq -F gron`)
+# and returns the corresponding data structure.
+def gron_parse(input):
+  _gron_parse(to_string(input))
+end

--- a/crates/mq-lang/modules/gron_test.mq
+++ b/crates/mq-lang/modules/gron_test.mq
@@ -1,0 +1,24 @@
+import "gron"
+| include "test"
+
+# -- gron Tests --
+
+def test_gron_parse_scalar():
+  let result = gron::gron_parse("json = \"hello\";")
+  | assert_eq(result, "hello")
+end
+
+def test_gron_parse_nested():
+  let result = gron::gron_parse("json = {};\njson.a = {};\njson.a.b = \"deep\";")
+  | assert_eq(result["a"]["b"], "deep")
+end
+
+def test_gron_parse_array():
+  let result = gron::gron_parse("json = [];\njson[0] = \"x\";\njson[1] = \"y\";")
+  | assert_eq(result, ["x", "y"])
+end
+
+def test_gron_parse_ignores_redundant_container_decls():
+  let result = gron::gron_parse("json.a.b = \"deep\";")
+  | assert_eq(result["a"]["b"], "deep")
+end

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3,6 +3,7 @@ pub(super) mod convert;
 #[cfg(feature = "css-selector")]
 mod css;
 pub(super) mod date;
+mod gron;
 #[cfg(feature = "http")]
 mod http;
 pub(crate) mod io_context;
@@ -3444,6 +3445,18 @@ fn _toml_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
     }
 }
 
+#[mq_macros::mq_fn(name = "_gron_parse", params = Fixed(1))]
+fn _gron_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s)] => {
+            let value = self::gron::parse(s).map_err(|e| Error::Runtime(format!("Failed to parse gron: {}", e)))?;
+            Ok(value.into())
+        }
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("_gron_parse should always receive exactly one argument"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "_cbor_parse", params = Fixed(1))]
 fn _cbor_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4676,6 +4689,7 @@ mq_macros::builtin_dispatch! {
     _GET_MARKDOWN_POSITION,
     _CSV_PARSE,
     _JSON_PARSE,
+    _GRON_PARSE,
     _YAML_PARSE,
     _TOON_PARSE,
     _TOML_PARSE,
@@ -5168,6 +5182,13 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc
         BuiltinFunctionDoc {
             description: "Parses a TOML string into a data structure.",
             params: &["toml_string"],
+        },
+    );
+    map.insert(
+        SmolStr::new("_gron_parse"),
+        BuiltinFunctionDoc {
+            description: "Parses gron-style `path = value;` assignment statements into a data structure.",
+            params: &["gron_string"],
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/gron.rs
+++ b/crates/mq-lang/src/eval/builtin/gron.rs
@@ -1,0 +1,223 @@
+//! Parser for gron-style assignment statements (`path = value;`), used by
+//! `_gron_parse` to reconstruct a data structure from the flat, greppable
+//! output produced by mq's `-F gron` output format.
+//!
+//! Each line is a path (dot/bracket notation, matching the `gron` tool)
+//! followed by `= <json-value>` and an optional trailing `;`. Intermediate
+//! containers are auto-vivified from the path itself, so lines can be
+//! processed in any order and partial (e.g. `grep`-filtered) input still
+//! reconstructs the paths that remain.
+
+#[derive(Debug)]
+enum Segment {
+    Key(String),
+    Index(usize),
+}
+
+/// Parses gron assignment statements into a [`serde_json::Value`].
+pub(crate) fn parse(input: &str) -> Result<serde_json::Value, String> {
+    let mut root = serde_json::Value::Null;
+
+    for (lineno, raw_line) in input.lines().enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let (path, value_str) = split_path_value(line).map_err(|e| format!("line {}: {}", lineno + 1, e))?;
+        let value_str = value_str.strip_suffix(';').unwrap_or(value_str).trim();
+        let value: serde_json::Value = serde_json::from_str(value_str)
+            .map_err(|e| format!("line {}: invalid value '{}': {}", lineno + 1, value_str, e))?;
+        let segments = parse_path_segments(path).map_err(|e| format!("line {}: {}", lineno + 1, e))?;
+
+        set_path(&mut root, &segments, value);
+    }
+
+    Ok(root)
+}
+
+/// Splits a line into its path and value parts at the top-level `=`
+/// (i.e. one that isn't inside a `[...]` bracket segment of the path).
+fn split_path_value(line: &str) -> Result<(&str, &str), String> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => {
+                i += 1;
+                if i < bytes.len() && (bytes[i] == b'"' || bytes[i] == b'\'') {
+                    let quote = bytes[i];
+                    i += 1;
+                    while i < bytes.len() && bytes[i] != quote {
+                        i += if bytes[i] == b'\\' { 2 } else { 1 };
+                    }
+                    i += 1;
+                }
+                while i < bytes.len() && bytes[i] != b']' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            b'=' => break,
+            _ => i += 1,
+        }
+    }
+
+    if i >= bytes.len() {
+        return Err(format!("expected '=' in '{}'", line));
+    }
+
+    Ok((line[..i].trim_end(), line[i + 1..].trim_start()))
+}
+
+/// Parses a gron path (e.g. `json.a["b c"][0]`) into a list of key/index
+/// segments, skipping the leading root identifier.
+fn parse_path_segments(path: &str) -> Result<Vec<Segment>, String> {
+    let bytes = path.as_bytes();
+    let mut i = 0;
+
+    // Skip the root identifier; its name is not significant.
+    while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+        i += 1;
+    }
+
+    let mut segments = Vec::new();
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'.' => {
+                i += 1;
+                let start = i;
+                while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+                    i += 1;
+                }
+                if start == i {
+                    return Err(format!("empty key in path '{}'", path));
+                }
+                segments.push(Segment::Key(path[start..i].to_string()));
+            }
+            b'[' => {
+                i += 1;
+                if i < bytes.len() && (bytes[i] == b'"' || bytes[i] == b'\'') {
+                    let quote = bytes[i];
+                    let str_start = i;
+                    i += 1;
+                    while i < bytes.len() && bytes[i] != quote {
+                        i += if bytes[i] == b'\\' { 2 } else { 1 };
+                    }
+                    if i >= bytes.len() {
+                        return Err(format!("unterminated quoted key in path '{}'", path));
+                    }
+                    let str_end = i + 1;
+                    i += 1;
+                    let raw = &path[str_start..str_end];
+                    let key = if quote == b'"' {
+                        serde_json::from_str::<String>(raw)
+                            .map_err(|e| format!("invalid quoted key {} in path '{}': {}", raw, path, e))?
+                    } else {
+                        raw[1..raw.len() - 1].replace("\\'", "'")
+                    };
+                    segments.push(Segment::Key(key));
+                } else {
+                    let start = i;
+                    while i < bytes.len() && bytes[i] != b']' {
+                        i += 1;
+                    }
+                    let idx_str = &path[start..i];
+                    let idx: usize = idx_str
+                        .parse()
+                        .map_err(|_| format!("invalid array index '{}' in path '{}'", idx_str, path))?;
+                    segments.push(Segment::Index(idx));
+                }
+                if i >= bytes.len() || bytes[i] != b']' {
+                    return Err(format!("expected ']' in path '{}'", path));
+                }
+                i += 1;
+            }
+            _ => return Err(format!("unexpected character in path '{}'", path)),
+        }
+    }
+
+    Ok(segments)
+}
+
+/// Writes `value` at `segments` within `root`, auto-vivifying intermediate
+/// objects/arrays as needed. A redundant empty-container declaration
+/// (`path = {};` / `path = [];`) for a path that already holds richer data
+/// is ignored rather than overwriting it, so lines may be applied out of order.
+fn set_path(root: &mut serde_json::Value, segments: &[Segment], value: serde_json::Value) {
+    if segments.is_empty() {
+        let is_empty_container = matches!(&value, serde_json::Value::Object(m) if m.is_empty())
+            || matches!(&value, serde_json::Value::Array(a) if a.is_empty());
+        if is_empty_container && !root.is_null() {
+            return;
+        }
+        *root = value;
+        return;
+    }
+
+    match &segments[0] {
+        Segment::Key(key) => {
+            if !root.is_object() {
+                *root = serde_json::Value::Object(serde_json::Map::new());
+            }
+            let entry = root
+                .as_object_mut()
+                .unwrap()
+                .entry(key.clone())
+                .or_insert(serde_json::Value::Null);
+            set_path(entry, &segments[1..], value);
+        }
+        Segment::Index(idx) => {
+            if !root.is_array() {
+                *root = serde_json::Value::Array(Vec::new());
+            }
+            let arr = root.as_array_mut().unwrap();
+            if arr.len() <= *idx {
+                arr.resize(idx + 1, serde_json::Value::Null);
+            }
+            set_path(&mut arr[*idx], &segments[1..], value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[case("json = \"hello\";", json!("hello"))]
+    #[case("json = 3;", json!(3))]
+    #[case("json = true;", json!(true))]
+    #[case("json = null;", serde_json::Value::Null)]
+    #[case("json = {};\njson.a = 1;", json!({"a": 1}))]
+    #[case("json = [];\njson[0] = \"x\";\njson[1] = \"y\";", json!(["x", "y"]))]
+    #[case("json = {};\njson.a = {};\njson.a.b = \"deep\";", json!({"a": {"b": "deep"}}))]
+    #[case("json[\"weird key\"] = \"v\";", json!({"weird key": "v"}))]
+    #[case("json.arr[2] = \"z\";", json!({"arr": [null, null, "z"]}))]
+    // Container decl arriving after its child (e.g. after `sort -r`) must not wipe it.
+    #[case("json.a.b = \"deep\";\njson.a = {};", json!({"a": {"b": "deep"}}))]
+    // Leaf-only input (as if grep-filtered out of a larger dump) still reconstructs.
+    #[case("json.a.b = \"deep\";", json!({"a": {"b": "deep"}}))]
+    fn test_parse(#[case] input: &str, #[case] expected: serde_json::Value) {
+        assert_eq!(parse(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_parse_ignores_blank_lines() {
+        assert_eq!(parse("\njson = 1;\n\n").unwrap(), json!(1));
+    }
+
+    #[rstest]
+    #[case("json.a")]
+    #[case("json.a = ")]
+    #[case("json.a = notjson;")]
+    #[case("json[abc] = 1;")]
+    #[case("json[0 = 1;")]
+    fn test_parse_errors(#[case] input: &str) {
+        assert!(parse(input).is_err());
+    }
+}

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -43,6 +43,7 @@ fn get_module_name(name: &str) -> Cow<'static, str> {
         "cbor" => Cow::Borrowed("cbor.mq"),
         "csv" => Cow::Borrowed("csv.mq"),
         "fuzzy" => Cow::Borrowed("fuzzy.mq"),
+        "gron" => Cow::Borrowed("gron.mq"),
         "json" => Cow::Borrowed("json.mq"),
         "md" => Cow::Borrowed("md.mq"),
         "section" => Cow::Borrowed("section.mq"),
@@ -100,6 +101,7 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
     std_module!(cbor);
     std_module!(csv);
     std_module!(fuzzy);
+    std_module!(gron);
     std_module!(json);
     std_module!(md);
     std_module!(section);

--- a/crates/mq-lang/src/module/resolver.rs
+++ b/crates/mq-lang/src/module/resolver.rs
@@ -213,6 +213,7 @@ mod tests {
 
     #[rstest]
     #[case("csv")]
+    #[case("gron")]
     #[case("json")]
     #[case("yaml")]
     #[case("toml")]

--- a/crates/mq-lang/src/module/resolver/std_resolver.rs
+++ b/crates/mq-lang/src/module/resolver/std_resolver.rs
@@ -36,6 +36,7 @@ mod tests {
 
     #[rstest]
     #[case("csv")]
+    #[case("gron")]
     #[case("json")]
     #[case("yaml")]
     #[case("toml")]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -38,6 +38,7 @@ use crate::reference;
     Use -I <format> to force a specific format:\n\n\
     .cbor / -I cbor  import \"cbor\" | cbor::cbor_parse()  (reads as bytes)\n\
     .csv  / -I csv   import \"csv\"  | csv::csv_parse(true)\n\
+    .gron / -I gron  import \"gron\" | gron::gron_parse()\n\
     .json / -I json  import \"json\" | json::json_parse()\n\
     .psv  / -I psv   import \"csv\"  | csv::psv_parse(true)\n\
     .toml / -I toml  import \"toml\" | toml::toml_parse()\n\
@@ -121,7 +122,7 @@ const UNIX_EXECUTABLE_BITS: u32 = 0o111;
 ///
 /// Module-backed formats (auto-import and parse, sorted alphabetically):
 /// - Cbor: Reads input as raw bytes and parses via the `cbor` module.
-/// - Csv/Json/Psv/Toml/Toon/Tsv/Xml/Yaml: Auto-import the matching module and parse.
+/// - Csv/Gron/Json/Psv/Toml/Toon/Tsv/Xml/Yaml: Auto-import the matching module and parse.
 #[derive(Clone, Debug, Default, clap::ValueEnum, PartialEq)]
 enum InputFormat {
     #[default]
@@ -134,6 +135,7 @@ enum InputFormat {
     Bytes,
     Cbor,
     Csv,
+    Gron,
     Json,
     Psv,
     Toml,
@@ -153,6 +155,7 @@ impl InputFormat {
             "jsonl" | "ndjson" => Self::Text,
             "cbor" => Self::Cbor,
             "csv" => Self::Csv,
+            "gron" => Self::Gron,
             "json" => Self::Json,
             "psv" => Self::Psv,
             "toml" => Self::Toml,
@@ -173,6 +176,7 @@ impl InputFormat {
             // Module-backed formats (alphabetical order)
             Self::Cbor => Some(r#"import "cbor" | cbor::cbor_parse()"#),
             Self::Csv => Some(r#"import "csv" | csv::csv_parse(true)"#),
+            Self::Gron => Some(r#"import "gron" | gron::gron_parse()"#),
             Self::Json => Some(r#"import "json" | json::json_parse()"#),
             Self::Psv => Some(r#"import "csv" | csv::psv_parse(true)"#),
             Self::Toml => Some(r#"import "toml" | toml::toml_parse()"#),
@@ -250,6 +254,7 @@ enum OutputFormat {
     Json,
     Table,
     Grep,
+    Gron,
     Raw,
     Csv,
     Toml,
@@ -1074,6 +1079,7 @@ impl Cli {
                 InputFormat::Cbor => mq_lang::bytes_input(content.as_bytes()),
                 // Module-backed text formats (alphabetical): pass raw string; the module handles parsing.
                 InputFormat::Csv
+                | InputFormat::Gron
                 | InputFormat::Json
                 | InputFormat::Psv
                 | InputFormat::Toml
@@ -1656,6 +1662,10 @@ impl Cli {
                 let markdown = self.build_markdown(runtime_values);
                 Self::write_ignore_pipe(&mut handle, markdown.to_string().as_bytes())?;
             }
+            OutputFormat::Gron => {
+                let gron_str = crate::output::gron::runtime_values_to_gron(runtime_values);
+                Self::write_ignore_pipe(&mut handle, gron_str.as_bytes())?;
+            }
             OutputFormat::Csv => {
                 let csv_str = crate::output::csv::runtime_values_to_csv(runtime_values)?;
                 Self::write_ignore_pipe(&mut handle, csv_str.as_bytes())?;
@@ -2026,6 +2036,7 @@ mod tests {
             OutputFormat::Text,
             OutputFormat::Table,
             OutputFormat::Grep,
+            OutputFormat::Gron,
             OutputFormat::Csv,
             OutputFormat::Xml,
             OutputFormat::Yaml,
@@ -2523,6 +2534,156 @@ mod tests {
             arr[0].get("type").is_none(),
             "Output should not contain Markdown AST fields"
         );
+    }
+
+    #[test]
+    fn test_output_format_gron() {
+        let (_, temp_file_path) = create_file("test_gron_output.md", "# Title\n");
+        let (_, output_file) = create_file("test_gron_output.gron", "");
+        let temp_file_path_clone = temp_file_path.clone();
+        let output_file_clone = output_file.clone();
+
+        defer! {
+            if temp_file_path_clone.exists() {
+                std::fs::remove_file(&temp_file_path_clone).ok();
+            }
+            if output_file_clone.exists() {
+                std::fs::remove_file(&output_file_clone).ok();
+            }
+        }
+
+        let cli = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Gron,
+                output_file: Some(output_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![temp_file_path]),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_ok());
+        let output_content = fs::read_to_string(&output_file).expect("Failed to read output");
+        assert!(output_content.contains("json[0].type = \"Heading\";\n"));
+        assert!(output_content.contains("json[0].depth = 1;\n"));
+    }
+
+    #[test]
+    fn test_input_format_gron_reconstructs_data() {
+        let (_, temp_file_path) = create_file(
+            "test_gron_input.gron",
+            "json = {};\njson.a = {};\njson.a.b = \"deep\";\njson.arr = [];\njson.arr[0] = 1;\njson.arr[1] = 2;\n",
+        );
+        let (_, output_file) = create_file("test_gron_input_output.json", "");
+        let temp_file_path_clone = temp_file_path.clone();
+        let output_file_clone = output_file.clone();
+
+        defer! {
+            if temp_file_path_clone.exists() {
+                std::fs::remove_file(&temp_file_path_clone).ok();
+            }
+            if output_file_clone.exists() {
+                std::fs::remove_file(&output_file_clone).ok();
+            }
+        }
+
+        let cli = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Json,
+                output_file: Some(output_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![temp_file_path]),
+            ..Cli::default()
+        };
+
+        assert!(cli.run().is_ok());
+        let output_content = fs::read_to_string(&output_file).expect("Failed to read output");
+        let parsed: serde_json::Value = serde_json::from_str(&output_content).expect("Output should be valid JSON");
+        assert_eq!(parsed["a"]["b"], "deep");
+        assert_eq!(parsed["arr"][0], 1.0);
+        assert_eq!(parsed["arr"][1], 2.0);
+    }
+
+    #[test]
+    fn test_output_format_gron_then_input_format_gron_round_trip() {
+        let (_, md_file) = create_file("test_gron_roundtrip.md", "# Title\n\nSome *text* here.\n");
+        let (_, gron_file) = create_file("test_gron_roundtrip.gron", "");
+        let (_, json_file) = create_file("test_gron_roundtrip.json", "");
+        let md_file_clone = md_file.clone();
+        let gron_file_clone = gron_file.clone();
+        let json_file_clone = json_file.clone();
+
+        defer! {
+            if md_file_clone.exists() {
+                std::fs::remove_file(&md_file_clone).ok();
+            }
+            if gron_file_clone.exists() {
+                std::fs::remove_file(&gron_file_clone).ok();
+            }
+            if json_file_clone.exists() {
+                std::fs::remove_file(&json_file_clone).ok();
+            }
+        }
+
+        let to_gron = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Gron,
+                output_file: Some(gron_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![md_file.clone()]),
+            ..Cli::default()
+        };
+        assert!(to_gron.run().is_ok());
+
+        let from_gron = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Json,
+                output_file: Some(json_file.clone()),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![gron_file]),
+            ..Cli::default()
+        };
+        assert!(from_gron.run().is_ok());
+
+        let direct_json = Cli {
+            input: InputArgs::default(),
+            output: OutputArgs {
+                output_format: OutputFormat::Json,
+                output_file: Some(json_file.with_extension("direct.json")),
+                ..Default::default()
+            },
+            commands: None,
+            query: Some("self".to_string()),
+            files: Some(vec![md_file]),
+            ..Cli::default()
+        };
+        assert!(direct_json.run().is_ok());
+
+        let roundtrip_content = fs::read_to_string(&json_file).expect("Failed to read roundtrip output");
+        let direct_content =
+            fs::read_to_string(json_file.with_extension("direct.json")).expect("Failed to read direct output");
+        fs::remove_file(json_file.with_extension("direct.json")).ok();
+
+        let roundtrip_value: serde_json::Value =
+            serde_json::from_str(&roundtrip_content).expect("Roundtrip output should be valid JSON");
+        let direct_value: serde_json::Value =
+            serde_json::from_str(&direct_content).expect("Direct output should be valid JSON");
+        assert_eq!(roundtrip_value, direct_value);
     }
 
     #[test]
@@ -3519,6 +3680,7 @@ mod tests {
     #[case("txt", InputFormat::Raw)]
     #[case("log", InputFormat::Raw)]
     #[case("csv", InputFormat::Csv)]
+    #[case("gron", InputFormat::Gron)]
     #[case("psv", InputFormat::Psv)]
     #[case("tsv", InputFormat::Tsv)]
     #[case("json", InputFormat::Json)]
@@ -3536,6 +3698,7 @@ mod tests {
 
     #[rstest]
     #[case("file.json", Some(r#"import "json" | json::json_parse()"#))]
+    #[case("file.gron", Some(r#"import "gron" | gron::gron_parse()"#))]
     #[case("file.yaml", Some(r#"import "yaml" | yaml::yaml_parse()"#))]
     #[case("file.yml", Some(r#"import "yaml" | yaml::yaml_parse()"#))]
     #[case("file.toml", Some(r#"import "toml" | toml::toml_parse()"#))]
@@ -3725,6 +3888,7 @@ mod tests {
     #[rstest]
     #[case(InputFormat::Bytes, None)]
     #[case(InputFormat::Cbor, Some(r#"import "cbor" | cbor::cbor_parse()"#))]
+    #[case(InputFormat::Gron, Some(r#"import "gron" | gron::gron_parse()"#))]
     #[case(InputFormat::Json, Some(r#"import "json" | json::json_parse()"#))]
     #[case(InputFormat::Markdown, None)]
     #[case(InputFormat::Raw, None)]

--- a/crates/mq-run/src/output.rs
+++ b/crates/mq-run/src/output.rs
@@ -4,6 +4,7 @@
 //! module names don't collide with the like-named `csv`/`toml` crates in the extern prelude.
 
 pub(crate) mod csv;
+pub(crate) mod gron;
 pub(crate) mod json;
 pub(crate) mod table;
 pub(crate) mod toml;

--- a/crates/mq-run/src/output/gron.rs
+++ b/crates/mq-run/src/output/gron.rs
@@ -1,0 +1,157 @@
+//! gron-like flat/greppable output rendering for the `-F gron` CLI option.
+//!
+//! Flattens the same normalized JSON tree used by `-F json`
+//! ([`super::json::runtime_values_to_json_value`]) into a sequence of
+//! `path = value;` assignment statements (following the conventions of the
+//! `gron` tool), so a specific AST path can be located with `grep` without
+//! knowing the mq selector syntax. `-I gron` (via the `gron` module) parses
+//! these statements back into a data structure.
+
+use super::json::runtime_values_to_json_value;
+
+/// Converts a list of [`mq_lang::RuntimeValue`]s into gron-style assignment statements.
+pub(crate) fn runtime_values_to_gron(runtime_values: &[mq_lang::RuntimeValue]) -> String {
+    let value = runtime_values_to_json_value(runtime_values);
+    let mut out = String::new();
+    write_gron(&mut out, "json", &value);
+    out
+}
+
+fn write_gron(out: &mut String, path: &str, value: &serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            out.push_str(path);
+            out.push_str(" = {};\n");
+            for (key, child) in map {
+                write_gron(out, &join_key(path, key), child);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            out.push_str(path);
+            out.push_str(" = [];\n");
+            for (i, child) in items.iter().enumerate() {
+                write_gron(out, &format!("{}[{}]", path, i), child);
+            }
+        }
+        scalar => {
+            out.push_str(path);
+            out.push_str(" = ");
+            out.push_str(&scalar.to_string());
+            out.push_str(";\n");
+        }
+    }
+}
+
+/// Joins a gron path with the next key, using dot notation (`path.key`) when
+/// `key` is a valid bare identifier, and bracket notation (`path["key"]`)
+/// otherwise (matching `gron`'s own escaping rules).
+fn join_key(path: &str, key: &str) -> String {
+    if is_bare_ident(key) {
+        format!("{}.{}", path, key)
+    } else {
+        format!("{}[{}]", path, serde_json::to_string(key).unwrap())
+    }
+}
+
+fn is_bare_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lang::Shared;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_join_key_bare_ident() {
+        assert_eq!(join_key("json", "foo"), "json.foo");
+        assert_eq!(join_key("json", "_foo1"), "json._foo1");
+    }
+
+    #[test]
+    fn test_join_key_needs_brackets() {
+        assert_eq!(join_key("json", "foo bar"), "json[\"foo bar\"]");
+        assert_eq!(join_key("json", "1foo"), "json[\"1foo\"]");
+        assert_eq!(join_key("json", ""), "json[\"\"]");
+    }
+
+    #[test]
+    fn test_gron_scalar_root() {
+        let values = vec![mq_lang::RuntimeValue::String("hello".to_string())];
+        assert_eq!(runtime_values_to_gron(&values), "json = \"hello\";\n");
+    }
+
+    #[test]
+    fn test_gron_boolean_and_number() {
+        assert_eq!(
+            runtime_values_to_gron(&[mq_lang::RuntimeValue::Boolean(true)]),
+            "json = true;\n"
+        );
+        assert_eq!(
+            runtime_values_to_gron(&[mq_lang::RuntimeValue::Number(3i64.into())]),
+            "json = 3;\n"
+        );
+    }
+
+    #[test]
+    fn test_gron_none_is_null() {
+        assert_eq!(runtime_values_to_gron(&[mq_lang::RuntimeValue::None]), "json = null;\n");
+    }
+
+    #[test]
+    fn test_gron_flat_array() {
+        let values = vec![mq_lang::RuntimeValue::Array(Shared::new(vec![
+            mq_lang::RuntimeValue::String("x".to_string()),
+            mq_lang::RuntimeValue::String("y".to_string()),
+        ]))];
+        assert_eq!(
+            runtime_values_to_gron(&values),
+            "json = [];\njson[0] = \"x\";\njson[1] = \"y\";\n"
+        );
+    }
+
+    #[test]
+    fn test_gron_empty_array() {
+        let values = vec![mq_lang::RuntimeValue::Array(Shared::new(vec![]))];
+        assert_eq!(runtime_values_to_gron(&values), "json = [];\n");
+    }
+
+    #[test]
+    fn test_gron_nested_dict() {
+        let mut inner = BTreeMap::new();
+        inner.insert(
+            mq_lang::Ident::new("b"),
+            mq_lang::RuntimeValue::String("deep".to_string()),
+        );
+        let mut outer = BTreeMap::new();
+        outer.insert(
+            mq_lang::Ident::new("a"),
+            mq_lang::RuntimeValue::Dict(Shared::new(inner)),
+        );
+        let values = vec![mq_lang::RuntimeValue::Dict(Shared::new(outer))];
+        assert_eq!(
+            runtime_values_to_gron(&values),
+            "json = {};\njson.a = {};\njson.a.b = \"deep\";\n"
+        );
+    }
+
+    #[test]
+    fn test_gron_dict_key_needing_brackets() {
+        let mut m = BTreeMap::new();
+        m.insert(
+            mq_lang::Ident::new("weird key"),
+            mq_lang::RuntimeValue::String("v".to_string()),
+        );
+        let values = vec![mq_lang::RuntimeValue::Dict(Shared::new(m))];
+        assert_eq!(
+            runtime_values_to_gron(&values),
+            "json = {};\njson[\"weird key\"] = \"v\";\n"
+        );
+    }
+}

--- a/crates/mq-run/src/output/gron.rs
+++ b/crates/mq-run/src/output/gron.rs
@@ -66,60 +66,35 @@ fn is_bare_ident(s: &str) -> bool {
 mod tests {
     use super::*;
     use mq_lang::Shared;
+    use rstest::rstest;
     use std::collections::BTreeMap;
 
-    #[test]
-    fn test_join_key_bare_ident() {
-        assert_eq!(join_key("json", "foo"), "json.foo");
-        assert_eq!(join_key("json", "_foo1"), "json._foo1");
+    #[rstest]
+    #[case("json", "foo", "json.foo")]
+    #[case("json", "_foo1", "json._foo1")]
+    #[case("json", "foo bar", "json[\"foo bar\"]")]
+    #[case("json", "1foo", "json[\"1foo\"]")]
+    #[case("json", "", "json[\"\"]")]
+    fn test_join_key(#[case] path: &str, #[case] key: &str, #[case] expected: &str) {
+        assert_eq!(join_key(path, key), expected);
     }
 
-    #[test]
-    fn test_join_key_needs_brackets() {
-        assert_eq!(join_key("json", "foo bar"), "json[\"foo bar\"]");
-        assert_eq!(join_key("json", "1foo"), "json[\"1foo\"]");
-        assert_eq!(join_key("json", ""), "json[\"\"]");
-    }
-
-    #[test]
-    fn test_gron_scalar_root() {
-        let values = vec![mq_lang::RuntimeValue::String("hello".to_string())];
-        assert_eq!(runtime_values_to_gron(&values), "json = \"hello\";\n");
-    }
-
-    #[test]
-    fn test_gron_boolean_and_number() {
-        assert_eq!(
-            runtime_values_to_gron(&[mq_lang::RuntimeValue::Boolean(true)]),
-            "json = true;\n"
-        );
-        assert_eq!(
-            runtime_values_to_gron(&[mq_lang::RuntimeValue::Number(3i64.into())]),
-            "json = 3;\n"
-        );
-    }
-
-    #[test]
-    fn test_gron_none_is_null() {
-        assert_eq!(runtime_values_to_gron(&[mq_lang::RuntimeValue::None]), "json = null;\n");
-    }
-
-    #[test]
-    fn test_gron_flat_array() {
-        let values = vec![mq_lang::RuntimeValue::Array(Shared::new(vec![
+    #[rstest]
+    #[case(vec![mq_lang::RuntimeValue::String("hello".to_string())], "json = \"hello\";\n")]
+    #[case(vec![mq_lang::RuntimeValue::Boolean(true)], "json = true;\n")]
+    #[case(vec![mq_lang::RuntimeValue::Boolean(false)], "json = false;\n")]
+    #[case(vec![mq_lang::RuntimeValue::Number(3i64.into())], "json = 3;\n")]
+    #[case(vec![mq_lang::RuntimeValue::None], "json = null;\n")]
+    #[case(vec![mq_lang::RuntimeValue::Array(Shared::new(vec![]))], "json = [];\n")]
+    #[case(
+        vec![mq_lang::RuntimeValue::Array(Shared::new(vec![
             mq_lang::RuntimeValue::String("x".to_string()),
             mq_lang::RuntimeValue::String("y".to_string()),
-        ]))];
-        assert_eq!(
-            runtime_values_to_gron(&values),
-            "json = [];\njson[0] = \"x\";\njson[1] = \"y\";\n"
-        );
-    }
-
-    #[test]
-    fn test_gron_empty_array() {
-        let values = vec![mq_lang::RuntimeValue::Array(Shared::new(vec![]))];
-        assert_eq!(runtime_values_to_gron(&values), "json = [];\n");
+        ]))],
+        "json = [];\njson[0] = \"x\";\njson[1] = \"y\";\n"
+    )]
+    fn test_runtime_values_to_gron(#[case] values: Vec<mq_lang::RuntimeValue>, #[case] expected: &str) {
+        assert_eq!(runtime_values_to_gron(&values), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `-F gron` to flatten query results (including Markdown AST nodes, via the same normalized tree used by `-F json`) into gron-style `path = value;` assignment statements, so specific AST paths can be located with plain `grep` without knowing mq's selector syntax.

Add `-I gron` (backed by a new `gron` module and native `_gron_parse` builtin) to reconstruct a data structure from those statements. Containers are auto-vivified from the paths themselves, so partial, grep-filtered input still reconstructs correctly.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
