### PR TITLE
✨ feat(mq-lang): add strptime builtin for parsing dates with a custom format

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -959,6 +959,9 @@ fn register_datetime(ctx: &mut InferenceContext) {
     // strftime: (number, string) -> string
     register_binary(ctx, "strftime", Type::Number, Type::String, Type::String);
 
+    // strptime: (string, string) -> number
+    register_binary(ctx, "strptime", Type::String, Type::String, Type::Number);
+
     // date_add: ([number], number, string) -> [number]
     register_ternary(
         ctx,
@@ -1822,6 +1825,7 @@ mod tests {
     #[case::localtime("localtime(0)", true)]
     #[case::mktime("mktime([2024, 0, 1, 0, 0, 0, 1, 0])", true)]
     #[case::strftime("strftime(0, \"%Y-%m-%d\")", true)]
+    #[case::strptime("strptime(\"2024-01-01\", \"%Y-%m-%d\")", true)]
     #[case::date_add("date_add([2024, 0, 1, 0, 0, 0, 1, 0], 1, \"days\")", true)]
     #[case::date_diff(
         "date_diff([2024, 0, 1, 0, 0, 0, 1, 0], [2024, 0, 2, 0, 0, 0, 2, 1], \"days\")",
@@ -1830,6 +1834,7 @@ mod tests {
     #[case::gmtime_string("gmtime(\"x\")", false)] // Should fail: wrong type
     #[case::mktime_string("mktime(\"x\")", false)] // Should fail: wrong type
     #[case::strftime_swapped("strftime(\"x\", 1)", false)] // Should fail: wrong type
+    #[case::strptime_swapped("strptime(1, \"%Y-%m-%d\")", false)] // Should fail: wrong type
     fn test_datetime_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -356,6 +356,32 @@ fn strftime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
     }
 }
 
+/// Parses a date string using the given strptime format and returns a Unix timestamp (seconds, UTC).
+/// Formats without a time component (e.g. "%Y-%m-%d") default the time to midnight.
+#[mq_macros::mq_fn(name = "strptime", params = Fixed(2))]
+fn strptime_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(date_str), RuntimeValue::String(fmt)] => {
+            let date_str = date_str.as_str();
+            let fmt = fmt.as_str();
+
+            chrono::NaiveDateTime::parse_from_str(date_str, fmt)
+                .or_else(|e| {
+                    chrono::NaiveDate::parse_from_str(date_str, fmt)
+                        .map(|d| d.and_time(chrono::NaiveTime::MIN))
+                        .map_err(|_| e)
+                })
+                .map(|dt| RuntimeValue::Number(dt.and_utc().timestamp().into()))
+                .map_err(|e| Error::Runtime(format!("strptime: {}", e)))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("strptime should always receive exactly two arguments"),
+    }
+}
+
 /// Adds n units to a broken-down time array and returns a new broken-down array (UTC).
 /// Input/output format: [year, month (0-11), day, hour, minute, second, weekday, day-of-year]
 /// Units: "seconds", "minutes", "hours", "days", "weeks", "months", "years"
@@ -4522,6 +4548,7 @@ mq_macros::builtin_dispatch! {
     LOCALTIME,
     MKTIME,
     STRFTIME,
+    STRPTIME,
     DATE_ADD,
     DATE_DIFF,
     BASE64,
@@ -5202,7 +5229,7 @@ pub struct BuiltinFunctionDoc {
 }
 
 pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>> = LazyLock::new(|| {
-    let mut map = FxHashMap::with_capacity_and_hasher(110, FxBuildHasher);
+    let mut map = FxHashMap::with_capacity_and_hasher(111, FxBuildHasher);
 
     map.insert(
         SmolStr::new("halt"),
@@ -5328,6 +5355,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Formats a Unix timestamp (seconds) as a date string using the given strftime format (e.g. \"%Y-%m-%d\").",
             params: &["timestamp", "format"],
+        },
+    );
+    map.insert(
+        SmolStr::new("strptime"),
+        BuiltinFunctionDoc {
+            description: "Parses a date string using the given strptime format (e.g. \"%Y-%m-%d\") and returns a Unix timestamp (seconds, UTC).",
+            params: &["date_str", "format"],
         },
     );
     map.insert(
@@ -7578,6 +7612,39 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, RuntimeValue::String(expected.into()));
+    }
+
+    #[rstest]
+    #[case("2024-01-01", "%Y-%m-%d", 1704067200_i64)]
+    #[case("1970-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S", 0_i64)]
+    #[case("01/02/2024", "%m/%d/%Y", 1704153600_i64)]
+    fn test_strptime(#[case] date_str: &str, #[case] fmt: &str, #[case] expected: i64) {
+        let ident = Ident::new("strptime");
+        let args = vec![RuntimeValue::String(date_str.into()), RuntimeValue::String(fmt.into())];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        )
+        .unwrap();
+        assert_eq!(result, RuntimeValue::Number(expected.into()));
+    }
+
+    #[test]
+    fn test_strptime_invalid_format() {
+        let ident = Ident::new("strptime");
+        let args = vec![
+            RuntimeValue::String("not-a-date".into()),
+            RuntimeValue::String("%Y-%m-%d".into()),
+        ];
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            args,
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(result.is_err());
     }
 
     fn gmtime_array(secs: i64) -> RuntimeValue {

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2970,6 +2970,11 @@ fn engine() -> DefaultEngine {
 #[case::strftime_date("strftime(1704067200, \"%Y-%m-%d\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("2024-01-01".to_string())].into()))]
 #[case::strftime_datetime("strftime(0, \"%Y-%m-%dT%H:%M:%S\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("1970-01-01T00:00:00".to_string())].into()))]
 #[case::strftime_year("strftime(1704067200, \"%Y\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("2024".to_string())].into()))]
+// strptime: parse date string with a given format (UTC)
+#[case::strptime_date("strptime(\"2024-01-01\", \"%Y-%m-%d\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704067200_i64.into())].into()))]
+#[case::strptime_datetime("strptime(\"1970-01-01T00:00:00\", \"%Y-%m-%dT%H:%M:%S\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
+// strftime | strptime roundtrip
+#[case::strftime_strptime_roundtrip("strftime(1704067200, \"%Y-%m-%d\") | strptime(\"%Y-%m-%d\")", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1704067200_i64.into())].into()))]
 // now | gmtime / strftime pipeline
 #[case::now_gmtime_len("now | gmtime | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(8.into())].into()))]
 #[case::now_strftime_len("now | strftime(\"%Y-%m-%d\") | len", vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(10.into())].into()))]
@@ -3680,6 +3685,10 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 #[case::mktime_wrong_length("mktime(array(1, 2))", vec![RuntimeValue::None],)]
 // strftime: first arg not a number → type error
 #[case::strftime_non_number(r#"strftime("string", "%Y")"#, vec![RuntimeValue::None],)]
+// strptime: first arg not a string → type error
+#[case::strptime_non_string(r#"strptime(1, "%Y-%m-%d")"#, vec![RuntimeValue::None],)]
+// strptime: date string doesn't match format → runtime error
+#[case::strptime_mismatched_format(r#"strptime("not-a-date", "%Y-%m-%d")"#, vec![RuntimeValue::None],)]
 // date_add: wrong types (number instead of array) → type error
 #[case::date_add_wrong_types(r#"date_add(42, 1, "days")"#, vec![RuntimeValue::None],)]
 // date_diff: wrong types → type error


### PR DESCRIPTION
## Summary

from_date only accepts RFC3339 strings, leaving no way to parse non-ISO date strings (e.g. scraped data, CSV columns, non-RFC3339 frontmatter) into a timestamp. strptime(date_str, format) fills that gap using chrono, falling back to date-only parsing (midnight UTC) when the format has no time component.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
