### PR TITLE
✨ feat(mq-lang): add host function registration API for embedding

### DIFF
--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -206,6 +206,58 @@ impl<T: ModuleResolver, IO: Io> Engine<T, IO> {
         self.evaluator.define_value(name, value);
     }
 
+    /// Registers a native Rust function under `name`, callable from mq code as `name(...)`.
+    ///
+    /// Accepts two forms:
+    ///
+    /// - A raw form taking the already-evaluated call arguments as a slice and returning a
+    ///   single [`RuntimeValue`]: `|args: &[RuntimeValue]| -> HostFnResult { .. }`.
+    /// - A typed form taking up to four plain Rust arguments (any combination of `i64`, `f64`,
+    ///   `String`, `bool`, `RuntimeValue`, `Vec<T>`, or `Option<T>` for a [`ValueAdapter`] `T`),
+    ///   returning `Result<R, HostFunctionError>` for an `R: ValueAdapter`. Argument and return
+    ///   values are converted to/from `RuntimeValue` automatically; a wrong argument count or
+    ///   type is reported as a [`HostFunctionError`] rather than panicking.
+    ///
+    /// Errors and panics raised by the function are caught at the call boundary and surfaced as
+    /// a normal mq runtime error rather than aborting evaluation or unwinding through the
+    /// evaluator; recursion depth and the configured timeout ([`Self::set_timeout`]) are
+    /// enforced around each call exactly as for a user-defined function call.
+    ///
+    /// A registered function only fills in a name that would otherwise be undefined: a `def` of
+    /// the same name always takes precedence, and so does *any* built-in function name, whether
+    /// or not [`Self::load_builtin_module`] was called — name resolution itself falls back to
+    /// the built-in table before host functions are ever consulted. Host functions therefore
+    /// extend the set of callable names rather than override existing ones; pick a name that
+    /// doesn't collide with a builtin.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use mq_lang::{DefaultEngine, HostFunctionError, RuntimeValue};
+    ///
+    /// let mut engine = DefaultEngine::default();
+    /// engine.load_builtin_module();
+    ///
+    /// // Raw form: works with any number of arguments, matched by hand.
+    /// engine.register_fn("shout", |args: &[RuntimeValue]| match args {
+    ///     [RuntimeValue::String(s)] => Ok(RuntimeValue::String(format!("{}!", s.to_uppercase()))),
+    ///     _ => Err(HostFunctionError::new("shout() expects one string argument")),
+    /// });
+    ///
+    /// // Typed form: argument and return conversions are handled for you.
+    /// engine.register_fn("double", |n: i64| Ok(n * 2));
+    ///
+    /// let input = mq_lang::parse_text_input("hello").unwrap();
+    /// let result = engine.eval(r#"shout("hi") + to_string(double(21))"#, input.into_iter());
+    /// assert_eq!(result.unwrap(), vec!["HI!42".to_string().into()].into());
+    /// ```
+    pub fn register_fn<F, Marker>(&self, name: impl Into<crate::Ident>, f: F)
+    where
+        F: crate::eval::host::IntoHostFunction<Marker>,
+    {
+        self.evaluator.register_fn(name, f.into_host_fn());
+    }
+
     /// Load the built-in function modules.
     ///
     /// This must be called to enable access to standard functions
@@ -856,5 +908,215 @@ mod tests {
         let result = engine.get_source_code_for_debug(module_id);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_register_fn_basic() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("greet", |args: &[RuntimeValue]| match args {
+            [RuntimeValue::String(name)] => Ok(RuntimeValue::String(format!("Hello, {name}!"))),
+            _ => Err(crate::HostFunctionError::new("greet() expects one string argument")),
+        });
+
+        let result = engine.eval(r#"greet("World")"#, crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec!["Hello, World!".to_string().into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_receives_evaluated_args() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("identity", |args: &[RuntimeValue]| {
+            Ok(args.first().cloned().unwrap_or(RuntimeValue::NONE))
+        });
+
+        let result = engine.eval("identity(1 + 1)", crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec![2.into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_works_without_builtin_module_loaded() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.register_fn("triple", |args: &[RuntimeValue]| match args {
+            [RuntimeValue::Number(n)] => Ok(RuntimeValue::from(crate::number::Number::from(n.value() * 3.0))),
+            _ => Err(crate::HostFunctionError::new("triple() expects one number")),
+        });
+
+        let result = engine.eval("triple(2)", crate::null_input().into_iter());
+        assert_eq!(
+            result.unwrap(),
+            vec![RuntimeValue::from(crate::number::Number::from(6_i64))].into()
+        );
+    }
+
+    #[test]
+    fn test_register_fn_does_not_override_builtin_name() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.register_fn("len", |_args: &[RuntimeValue]| {
+            Ok(RuntimeValue::from(crate::number::Number::from(-1_i64)))
+        });
+
+        let result = engine.eval(r#"len("hello")"#, crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec![5.into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_shadowed_by_user_def() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("answer", |_args: &[RuntimeValue]| {
+            Ok(RuntimeValue::from(crate::number::Number::from(1)))
+        });
+
+        let result = engine.eval("def answer(): 42; | answer()", crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec![42.into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_overwrite() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("f", |_args: &[RuntimeValue]| Ok(RuntimeValue::Boolean(false)));
+        engine.register_fn("f", |_args: &[RuntimeValue]| Ok(RuntimeValue::Boolean(true)));
+
+        let result = engine.eval("f()", crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec![true.into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_error_propagates() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("boom", |_args: &[RuntimeValue]| {
+            Err(crate::HostFunctionError::new("something went wrong"))
+        });
+
+        let err = engine.eval("boom()", crate::null_input().into_iter()).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("boom"), "{message}");
+        assert!(message.contains("something went wrong"), "{message}");
+        assert!(matches!(
+            err.cause,
+            crate::error::InnerError::Runtime(crate::error::runtime::RuntimeError::HostFunctionError(_, _, _))
+        ));
+    }
+
+    #[test]
+    fn test_register_fn_panic_is_caught() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("crash", |_args: &[RuntimeValue]| -> crate::HostFnResult {
+            panic!("host function bug");
+        });
+
+        let err = engine.eval("crash()", crate::null_input().into_iter()).unwrap_err();
+        assert!(err.to_string().contains("panic"), "{}", err.to_string());
+    }
+
+    #[test]
+    fn test_register_fn_respects_timeout() {
+        use crate::RuntimeValue;
+
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("noop", |_args: &[RuntimeValue]| Ok(RuntimeValue::NONE));
+        // A zero timeout guarantees the deadline has already passed by the first
+        // periodic check inside the host function call, regardless of machine speed.
+        engine.set_timeout(std::time::Duration::ZERO);
+
+        let err = engine
+            .eval("while(true): noop(); ", crate::null_input().into_iter())
+            .unwrap_err();
+        assert!(matches!(
+            err.cause,
+            crate::error::InnerError::Runtime(crate::error::runtime::RuntimeError::Timeout(_))
+        ));
+    }
+
+    #[test]
+    fn test_register_fn_typed_zero_args() {
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("answer", || Ok(42_i64));
+
+        let result = engine.eval("answer()", crate::null_input().into_iter());
+        assert_eq!(
+            result.unwrap(),
+            vec![crate::RuntimeValue::from(crate::number::Number::from(42_i64))].into()
+        );
+    }
+
+    #[test]
+    fn test_register_fn_typed_one_arg() {
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("double", |n: i64| Ok(n * 2));
+
+        let result = engine.eval("double(21)", crate::null_input().into_iter());
+        assert_eq!(
+            result.unwrap(),
+            vec![crate::RuntimeValue::from(crate::number::Number::from(42_i64))].into()
+        );
+    }
+
+    #[test]
+    fn test_register_fn_typed_multiple_args_and_types() {
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("repeat", |s: String, n: i64| Ok(s.repeat(n as usize)));
+
+        let result = engine.eval(r#"repeat("ab", 3)"#, crate::null_input().into_iter());
+        assert_eq!(result.unwrap(), vec!["ababab".to_string().into()].into());
+    }
+
+    #[test]
+    fn test_register_fn_typed_wrong_type_reports_error() {
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("double", |n: i64| Ok(n * 2));
+
+        let err = engine
+            .eval(r#"double("not a number")"#, crate::null_input().into_iter())
+            .unwrap_err();
+        assert!(err.to_string().contains("double"), "{}", err.to_string());
+    }
+
+    #[test]
+    fn test_register_fn_typed_vec_and_option() {
+        let mut engine = DefaultEngine::default();
+        engine.load_builtin_module();
+        engine.register_fn("sum", |xs: Vec<i64>| Ok(xs.into_iter().sum::<i64>()));
+        engine.register_fn("first_or", |xs: Vec<i64>, default: Option<i64>| {
+            Ok(xs.into_iter().next().or(default))
+        });
+
+        let result = engine.eval("sum([1, 2, 3])", crate::null_input().into_iter());
+        assert_eq!(
+            result.unwrap(),
+            vec![crate::RuntimeValue::from(crate::number::Number::from(6_i64))].into()
+        );
+
+        let result = engine.eval("first_or([], 9)", crate::null_input().into_iter());
+        assert_eq!(
+            result.unwrap(),
+            vec![crate::RuntimeValue::from(crate::number::Number::from(9_i64))].into()
+        );
     }
 }

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -212,7 +212,7 @@ impl<T: ModuleResolver, IO: Io> Engine<T, IO> {
     ///
     /// - A raw form taking the already-evaluated call arguments as a slice and returning a
     ///   single [`RuntimeValue`]: `|args: &[RuntimeValue]| -> HostFnResult { .. }`.
-    /// - A typed form taking up to four plain Rust arguments (any combination of `i64`, `f64`,
+    /// - A typed form taking up to eight plain Rust arguments (any combination of `i64`, `f64`,
     ///   `String`, `bool`, `RuntimeValue`, `Vec<T>`, or `Option<T>` for a [`ValueAdapter`] `T`),
     ///   returning `Result<R, HostFunctionError>` for an `R: ValueAdapter`. Argument and return
     ///   values are converted to/from `RuntimeValue` automatically; a wrong argument count or

--- a/crates/mq-lang/src/error.rs
+++ b/crates/mq-lang/src/error.rs
@@ -431,6 +431,9 @@ impl Diagnostic for Error {
             InnerError::Runtime(RuntimeError::DestructuringFailed(_)) => Some(Cow::Borrowed(
                 "Destructuring pattern did not match the value. Check that the pattern structure matches the value.",
             )),
+            InnerError::Runtime(RuntimeError::HostFunctionError(_, name, _)) => Some(Cow::Owned(format!(
+                "The host function '{name}' returned an error, or panicked. Check the host application's implementation of this function."
+            ))),
             #[cfg(feature = "http-import")]
             InnerError::Module(ModuleError::HttpImportNotAllowed(_)) => Some(Cow::Borrowed(
                 "HTTP imports are only allowed at the top level. \

--- a/crates/mq-lang/src/error/runtime.rs
+++ b/crates/mq-lang/src/error/runtime.rs
@@ -92,6 +92,11 @@ pub enum RuntimeError {
     InvalidConvert(Token, String),
     #[error("Destructuring pattern did not match value")]
     DestructuringFailed(Token),
+    // Both extra fields are boxed (rather than `String`) to keep this rarely-populated variant
+    // from growing every `RuntimeError` beyond clippy's `result_large_err` threshold; see the
+    // `NotDefined` comment above for the same tradeoff.
+    #[error("Error in host function \"{1}\": {2}")]
+    HostFunctionError(ErrorToken, Box<str>, Box<str>),
 }
 
 impl RuntimeError {
@@ -128,6 +133,7 @@ impl RuntimeError {
             RuntimeError::InvalidMacroResult(token) => Some(token),
             RuntimeError::InvalidConvert(token, _) => Some(token),
             RuntimeError::DestructuringFailed(token) => Some(token),
+            RuntimeError::HostFunctionError(token, _, _) => Some(token),
         }
     }
 }
@@ -176,6 +182,7 @@ mod tests {
     #[case(RuntimeError::InvalidMacroResult(eof_token()), true)]
     #[case(RuntimeError::InvalidConvert(eof_token(), "msg".to_string()), true)]
     #[case(RuntimeError::DestructuringFailed(eof_token()), true)]
+    #[case(RuntimeError::HostFunctionError(eof_token(), "f".into(), "boom".into()), true)]
     fn test_token_presence(#[case] err: RuntimeError, #[case] has_token: bool) {
         assert_eq!(err.token().is_some(), has_token);
     }
@@ -189,6 +196,10 @@ mod tests {
     #[case(RuntimeError::RecursionLimit, "Maximum macro recursion depth exceeded")]
     #[case(RuntimeError::UndefinedMacro(Ident::new("foo")), "Undefined macro: foo")]
     #[case(RuntimeError::ArityMismatch { macro_name: Ident::new("bar"), expected: 2, got: 1 }, "Macro bar expects 2 arguments, got 1")]
+    #[case(
+        RuntimeError::HostFunctionError(eof_token(), "f".into(), "boom".into()),
+        "Error in host function \"f\": boom"
+    )]
     fn test_error_display(#[case] err: RuntimeError, #[case] expected: &str) {
         assert_eq!(err.to_string(), expected);
     }

--- a/crates/mq-lang/src/eval.rs
+++ b/crates/mq-lang/src/eval.rs
@@ -46,9 +46,11 @@ pub mod builtin;
 #[cfg(feature = "debugger")]
 pub mod debugger;
 pub mod env;
+pub mod host;
 pub mod runtime_value;
 
 use env::Env;
+use host::HostFunctions;
 use runtime_value::RuntimeValue;
 
 /// Number of loop iterations / function calls between wall-clock deadline checks.
@@ -175,6 +177,10 @@ pub struct Evaluator<T: ModuleResolver = DefaultModuleResolver, IO: Io = Sandbox
     /// capability flags used to have. Statically dispatched: `IO` is fixed per `Evaluator`
     /// instantiation rather than a `dyn Io` trait object.
     pub(crate) io: Shared<IO>,
+    /// Host-registered native functions, consulted in [`Self::eval_fn`] when a called
+    /// identifier isn't a local binding, before falling back to the built-in table. Empty by
+    /// default: a host must opt in via [`crate::Engine::register_fn`].
+    pub(crate) host_functions: Shared<SharedCell<HostFunctions>>,
 
     #[cfg(feature = "debugger")]
     debugger: Shared<SharedCell<Debugger>>,
@@ -194,6 +200,7 @@ impl<T: ModuleResolver, IO: Io + Default> Default for Evaluator<T, IO> {
             module_loader: module::ModuleLoader::new(T::default()),
             macro_expander: Macro::new(),
             io: Shared::new(IO::default()),
+            host_functions: Shared::new(SharedCell::new(HostFunctions::default())),
             #[cfg_attr(feature = "sync", allow(clippy::arc_with_non_send_sync))]
             #[cfg(feature = "debugger")]
             debugger: Shared::new(SharedCell::new(Debugger::new())),
@@ -215,6 +222,7 @@ impl<T: ModuleResolver, IO: Io> Clone for Evaluator<T, IO> {
             module_loader: self.module_loader.clone(),
             macro_expander: self.macro_expander.clone(),
             io: Shared::clone(&self.io),
+            host_functions: Shared::clone(&self.host_functions),
             #[cfg(feature = "debugger")]
             debugger: Shared::clone(&self.debugger),
             #[cfg(feature = "debugger")]
@@ -268,6 +276,7 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
             module_loader,
             macro_expander: Macro::new(),
             io,
+            host_functions: Shared::new(SharedCell::new(HostFunctions::default())),
             #[cfg_attr(feature = "sync", allow(clippy::arc_with_non_send_sync))]
             #[cfg(feature = "debugger")]
             debugger: Shared::new(SharedCell::new(Debugger::new())),
@@ -280,6 +289,15 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
     /// duration of `eval()` calls on this evaluator.
     pub(crate) fn set_io(&mut self, io: Shared<IO>) {
         self.io = io;
+    }
+
+    /// Registers a native Rust function under `name`, callable from mq code as `name(...)`.
+    /// See [`crate::Engine::register_fn`].
+    pub(crate) fn register_fn(&self, name: impl Into<Ident>, f: Shared<dyn host::HostFunction>) {
+        #[cfg(not(feature = "sync"))]
+        self.host_functions.borrow_mut().insert_shared(name, f);
+        #[cfg(feature = "sync")]
+        self.host_functions.write().unwrap().insert_shared(name, f);
     }
 
     /// Helper method to temporarily take the macro_expander to avoid borrow conflicts.
@@ -2056,8 +2074,61 @@ impl<T: ModuleResolver, IO: Io> Evaluator<T, IO> {
 
         match resolved {
             Ok(fn_value) => self.call_fn(&fn_value, node, ident, args, runtime_value, env),
-            Err(_) => self.eval_builtin(runtime_value, node, &ident, args, env),
+            // `Env::resolve` itself already falls back to the raw builtin table (see its use of
+            // `get_builtin_functions_by_str`), so reaching here means `ident` is neither a local
+            // binding, a builtin loaded into scope, *nor* a raw builtin — host functions can
+            // therefore only fill in names that don't collide with any builtin, not override one.
+            Err(_) => {
+                #[cfg(not(feature = "sync"))]
+                let host_fn = self.host_functions.borrow().get(&ident);
+                #[cfg(feature = "sync")]
+                let host_fn = self.host_functions.read().unwrap().get(&ident);
+
+                match host_fn {
+                    Some(host_fn) => self.eval_host_fn(host_fn, runtime_value, node, &ident, args, env),
+                    None => self.eval_builtin(runtime_value, node, &ident, args, env),
+                }
+            }
         }
+    }
+
+    /// Evaluates a call to a host-registered native function: marshals args, guards recursion
+    /// depth and the wall-clock timeout the same way a user-defined function call would (see
+    /// [`Self::enter_scope`]), and catches panics at the boundary so a misbehaving host closure
+    /// can't unwind through the evaluator.
+    fn eval_host_fn(
+        &mut self,
+        host_fn: Shared<dyn host::HostFunction>,
+        runtime_value: &RuntimeValue,
+        node: Shared<ast::Node>,
+        ident: &Ident,
+        args: &ast::Args,
+        env: &Shared<SharedCell<Env>>,
+    ) -> EvalResult {
+        self.enter_scope()?;
+        let evaluated = self.eval_call_args(runtime_value, &node, ident, args, env);
+        let result = match evaluated {
+            Ok(evaluated) => std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| host_fn.call(&evaluated)))
+                .unwrap_or_else(|payload| {
+                    Err(host::HostFunctionError::new(format!(
+                        "panic: {}",
+                        host::panic_message(&*payload)
+                    )))
+                }),
+            Err(e) => {
+                self.exit_scope();
+                return Err(e);
+            }
+        };
+        self.exit_scope();
+
+        result.map_err(|e| {
+            EvalError::from(RuntimeError::HostFunctionError(
+                (*get_token(Shared::clone(&self.token_arena), node.token_id)).clone(),
+                ident.to_string().into_boxed_str(),
+                e.message().to_string().into_boxed_str(),
+            ))
+        })
     }
 
     #[inline(always)]

--- a/crates/mq-lang/src/eval/host.rs
+++ b/crates/mq-lang/src/eval/host.rs
@@ -1,0 +1,218 @@
+//! Host-registered native functions: the embedding API that lets a Rust host expose its own
+//! functions to mq code.
+//!
+//! A [`HostFunctions`] registry is owned per [`Engine`](crate::Engine)/[`Evaluator`](crate::eval::Evaluator)
+//! and consulted by the evaluator whenever a called identifier isn't a local binding, right
+//! before falling back to the built-in function table. This lets host functions be called from
+//! mq code without any special syntax, exactly like builtins, while still being shadowable by a
+//! `def` of the same name.
+
+use crate::{Ident, RuntimeValue, Shared};
+use rustc_hash::FxHashMap;
+
+pub mod adapter;
+pub use adapter::{IntoHostFunction, ValueAdapter};
+
+/// Marker trait bounding host function closures to what's safe to store behind [`Shared`].
+/// `Send + Sync` is only required when the `sync` feature (which backs [`Shared`] with `Arc`)
+/// is enabled; under the default `Rc`-backed build, closures may freely capture non-`Send` state.
+#[cfg(feature = "sync")]
+pub trait HostFunctionSyncBound: Send + Sync {}
+#[cfg(feature = "sync")]
+impl<T: Send + Sync> HostFunctionSyncBound for T {}
+
+#[cfg(not(feature = "sync"))]
+pub trait HostFunctionSyncBound {}
+#[cfg(not(feature = "sync"))]
+impl<T> HostFunctionSyncBound for T {}
+
+/// Error returned by a host-registered function, or produced while marshalling arguments and
+/// return values (see the `ValueAdapter` trait). Carries only a message, so it stays
+/// `PartialEq`-comparable and cheap to embed in [`RuntimeError`](crate::error::runtime::RuntimeError).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostFunctionError(String);
+
+impl HostFunctionError {
+    /// Creates a new host function error with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+
+    /// Returns the error message.
+    pub fn message(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for HostFunctionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for HostFunctionError {}
+
+impl From<&str> for HostFunctionError {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for HostFunctionError {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+/// Result type returned by a host function call.
+pub type HostFnResult = Result<RuntimeValue, HostFunctionError>;
+
+/// Extracts a human-readable message from a caught panic payload.
+pub(crate) fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+/// A native Rust function callable from mq code, registered via [`HostFunctions::insert`].
+///
+/// Receives the already-evaluated call arguments and returns a single [`RuntimeValue`]. Blanket-
+/// implemented for any matching closure, so hosts never need to name this trait directly.
+///
+/// Dispatch goes through [`Self::call`] rather than calling `dyn HostFunction` values directly:
+/// the standard library only provides `Fn`-trait impls for `Box<dyn Fn..>`, not for `Rc`/`Arc`
+/// (which back [`Shared`] depending on the `sync` feature), so an explicit method keeps
+/// invocation through `Shared<dyn HostFunction>` unambiguous.
+pub trait HostFunction: HostFunctionSyncBound + 'static {
+    fn call(&self, args: &[RuntimeValue]) -> HostFnResult;
+}
+
+impl<F> HostFunction for F
+where
+    F: Fn(&[RuntimeValue]) -> HostFnResult + HostFunctionSyncBound + 'static,
+{
+    fn call(&self, args: &[RuntimeValue]) -> HostFnResult {
+        (self)(args)
+    }
+}
+
+/// A registry of native Rust functions exposed to mq code under a given name.
+///
+/// Cloning is O(1): registered functions are stored behind [`Shared`], so a clone shares the
+/// same underlying entries (matching how [`Engine`](crate::Engine) itself is `Clone`).
+#[derive(Clone, Default)]
+pub struct HostFunctions(FxHashMap<Ident, Shared<dyn HostFunction>>);
+
+impl std::fmt::Debug for HostFunctions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostFunctions")
+            .field("names", &self.0.keys().map(Ident::to_string).collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl HostFunctions {
+    /// Registers a raw host function under `name`, callable from mq code as `name(...)`.
+    ///
+    /// If a function is already registered under `name`, it is replaced.
+    pub fn insert(&mut self, name: impl Into<Ident>, f: impl HostFunction) {
+        self.0.insert(name.into(), Shared::new(f));
+    }
+
+    /// Like [`Self::insert`], but takes an already-boxed function; used by
+    /// [`crate::Engine::register_fn`]'s typed-argument overload.
+    pub(crate) fn insert_shared(&mut self, name: impl Into<Ident>, f: Shared<dyn HostFunction>) {
+        self.0.insert(name.into(), f);
+    }
+
+    /// Removes the function registered under `name`, if any. Returns whether one was removed.
+    pub fn remove(&mut self, name: impl Into<Ident>) -> bool {
+        self.0.remove(&name.into()).is_some()
+    }
+
+    /// Whether a function is registered under `name`.
+    pub fn contains(&self, name: &Ident) -> bool {
+        self.0.contains_key(name)
+    }
+
+    /// Looks up the function registered under `name`, cloning the [`Shared`] handle.
+    pub(crate) fn get(&self, name: &Ident) -> Option<Shared<dyn HostFunction>> {
+        self.0.get(name).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_and_get() {
+        let mut fns = HostFunctions::default();
+        assert!(!fns.contains(&Ident::new("double")));
+
+        fns.insert("double", |args: &[RuntimeValue]| match args {
+            [RuntimeValue::Number(n)] => Ok(RuntimeValue::from(crate::number::Number::from(n.value() * 2.0))),
+            _ => Err(HostFunctionError::new("expected one number")),
+        });
+
+        assert!(fns.contains(&Ident::new("double")));
+        let f = fns.get(&Ident::new("double")).unwrap();
+        let result = f
+            .call(&[RuntimeValue::from(crate::number::Number::from(21.0))])
+            .unwrap();
+        assert_eq!(result, RuntimeValue::from(crate::number::Number::from(42.0)));
+    }
+
+    #[test]
+    fn test_insert_replaces_existing() {
+        let mut fns = HostFunctions::default();
+        fns.insert("f", |_: &[RuntimeValue]| {
+            Ok(RuntimeValue::from(crate::number::Number::from(1_i64)))
+        });
+        fns.insert("f", |_: &[RuntimeValue]| Ok(RuntimeValue::Boolean(true)));
+
+        let f = fns.get(&Ident::new("f")).unwrap();
+        assert_eq!(f.call(&[]).unwrap(), RuntimeValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut fns = HostFunctions::default();
+        fns.insert("f", |_: &[RuntimeValue]| Ok(RuntimeValue::NONE));
+
+        assert!(fns.remove("f"));
+        assert!(!fns.contains(&Ident::new("f")));
+        assert!(!fns.remove("f"));
+    }
+
+    #[test]
+    fn test_get_missing_returns_none() {
+        let fns = HostFunctions::default();
+        assert!(fns.get(&Ident::new("missing")).is_none());
+    }
+
+    #[test]
+    fn test_host_function_error_display_and_message() {
+        let err = HostFunctionError::new("boom");
+        assert_eq!(err.message(), "boom");
+        assert_eq!(err.to_string(), "boom");
+
+        let err: HostFunctionError = "from str".into();
+        assert_eq!(err.message(), "from str");
+
+        let err: HostFunctionError = String::from("from string").into();
+        assert_eq!(err.message(), "from string");
+    }
+
+    #[test]
+    fn test_debug_lists_names() {
+        let mut fns = HostFunctions::default();
+        fns.insert("alpha", |_: &[RuntimeValue]| Ok(RuntimeValue::NONE));
+        let debug = format!("{:?}", fns);
+        assert!(debug.contains("alpha"));
+    }
+}

--- a/crates/mq-lang/src/eval/host/adapter.rs
+++ b/crates/mq-lang/src/eval/host/adapter.rs
@@ -167,6 +167,10 @@ impl_into_host_fn!(1; A);
 impl_into_host_fn!(2; A, B);
 impl_into_host_fn!(3; A, B, C);
 impl_into_host_fn!(4; A, B, C, D);
+impl_into_host_fn!(5; A, B, C, D, E);
+impl_into_host_fn!(6; A, B, C, D, E, F);
+impl_into_host_fn!(7; A, B, C, D, E, F, G);
+impl_into_host_fn!(8; A, B, C, D, E, F, G, H);
 
 #[cfg(test)]
 mod tests {
@@ -237,6 +241,16 @@ mod tests {
             ])
             .unwrap();
         assert_eq!(result, RuntimeValue::from(Number::from(3_i64)));
+    }
+
+    #[test]
+    fn test_register_typed_eight_arity() {
+        let f = (|a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, g: i64, h: i64| Ok(a + b + c + d + e + f + g + h))
+            .into_host_fn();
+        let result = f
+            .call(&(1..=8).map(|n| RuntimeValue::from(Number::from(n))).collect::<Vec<_>>())
+            .unwrap();
+        assert_eq!(result, RuntimeValue::from(Number::from(36_i64)));
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/host/adapter.rs
+++ b/crates/mq-lang/src/eval/host/adapter.rs
@@ -1,0 +1,267 @@
+//! Ergonomic sugar on top of the raw [`super::HostFunction`] API:
+//! [`ValueAdapter`] converts between [`RuntimeValue`] and plain Rust types, and
+//! [`IntoHostFunction`] lets [`crate::Engine::register_fn`] accept a typed closure like
+//! `|n: i64| Ok(n * 2)` directly, without the host ever touching a `&[RuntimeValue]` slice.
+
+use super::{HostFnResult, HostFunction, HostFunctionError, HostFunctionSyncBound};
+use crate::{RuntimeValue, Shared, number::Number};
+
+/// Converts a Rust type to and from [`RuntimeValue`], powering the typed-argument overload of
+/// [`crate::Engine::register_fn`]. Implemented for the primitive types a host function typically
+/// wants to take or return; implement it for your own types to use them directly as arguments or
+/// return values too.
+pub trait ValueAdapter: Sized {
+    /// Converts a [`RuntimeValue`] argument to `Self`, or fails with a message describing the
+    /// expected type.
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError>;
+
+    /// Converts `self` into the [`RuntimeValue`] returned to mq code.
+    fn into_runtime_value(self) -> RuntimeValue;
+}
+
+fn type_mismatch(expected: &str, value: &RuntimeValue) -> HostFunctionError {
+    HostFunctionError::new(format!("expected {expected}, got {}", value.name()))
+}
+
+impl ValueAdapter for RuntimeValue {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        Ok(value.clone())
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        self
+    }
+}
+
+impl ValueAdapter for i64 {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::Number(n) => Ok(n.to_int()),
+            other => Err(type_mismatch("a number", other)),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        RuntimeValue::from(Number::from(self))
+    }
+}
+
+impl ValueAdapter for f64 {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::Number(n) => Ok(n.value()),
+            other => Err(type_mismatch("a number", other)),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        RuntimeValue::from(Number::from(self))
+    }
+}
+
+impl ValueAdapter for bool {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::Boolean(b) => Ok(*b),
+            other => Err(type_mismatch("a bool", other)),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        RuntimeValue::Boolean(self)
+    }
+}
+
+impl ValueAdapter for String {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::String(s) => Ok(s.clone()),
+            other => Err(type_mismatch("a string", other)),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        RuntimeValue::String(self)
+    }
+}
+
+impl<T: ValueAdapter> ValueAdapter for Vec<T> {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::Array(items) => items.iter().map(T::from_runtime_value).collect(),
+            other => Err(type_mismatch("an array", other)),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        RuntimeValue::Array(Shared::new(self.into_iter().map(T::into_runtime_value).collect()))
+    }
+}
+
+impl<T: ValueAdapter> ValueAdapter for Option<T> {
+    fn from_runtime_value(value: &RuntimeValue) -> Result<Self, HostFunctionError> {
+        match value {
+            RuntimeValue::None => Ok(None),
+            other => T::from_runtime_value(other).map(Some),
+        }
+    }
+
+    fn into_runtime_value(self) -> RuntimeValue {
+        match self {
+            Some(v) => v.into_runtime_value(),
+            None => RuntimeValue::NONE,
+        }
+    }
+}
+
+/// Converts a Rust closure into a boxed [`HostFunction`], as the target of
+/// [`crate::Engine::register_fn`]. `Marker` distinguishes the raw `&[RuntimeValue]` form from
+/// each typed arity below so a single closure can only ever match one implementation — hosts
+/// never need to name `Marker` or this trait themselves.
+pub trait IntoHostFunction<Marker> {
+    fn into_host_fn(self) -> Shared<dyn HostFunction>;
+}
+
+/// Marker for the raw form: `Fn(&[RuntimeValue]) -> HostFnResult`.
+pub struct RawArgs;
+
+impl<F> IntoHostFunction<RawArgs> for F
+where
+    F: Fn(&[RuntimeValue]) -> HostFnResult + HostFunctionSyncBound + 'static,
+{
+    fn into_host_fn(self) -> Shared<dyn HostFunction> {
+        Shared::new(self)
+    }
+}
+
+macro_rules! impl_into_host_fn {
+    ($n:expr; $($T:ident),*) => {
+        impl<Func, R, $($T),*> IntoHostFunction<($($T,)*)> for Func
+        where
+            Func: Fn($($T),*) -> Result<R, HostFunctionError> + HostFunctionSyncBound + 'static,
+            R: ValueAdapter,
+            $($T: ValueAdapter,)*
+        {
+            #[allow(non_snake_case)]
+            fn into_host_fn(self) -> Shared<dyn HostFunction> {
+                Shared::new(move |args: &[RuntimeValue]| -> HostFnResult {
+                    if args.len() != $n {
+                        return Err(HostFunctionError::new(format!(
+                            "expected {} argument(s), got {}",
+                            $n,
+                            args.len()
+                        )));
+                    }
+                    #[allow(unused_mut, unused_variables)]
+                    let mut iter = args.iter();
+                    $(let $T = $T::from_runtime_value(iter.next().unwrap())?;)*
+                    (self)($($T),*).map(ValueAdapter::into_runtime_value)
+                })
+            }
+        }
+    };
+}
+
+impl_into_host_fn!(0;);
+impl_into_host_fn!(1; A);
+impl_into_host_fn!(2; A, B);
+impl_into_host_fn!(3; A, B, C);
+impl_into_host_fn!(4; A, B, C, D);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Erases a `T: ValueAdapter`'s `from_runtime_value` + `into_runtime_value` pair to a
+    /// uniform, comparable fn pointer, so every `ValueAdapter` impl's happy path and error path
+    /// can share one rstest table each despite each case exercising a different Rust type.
+    /// Only sound for non-capturing closures, which every case below is.
+    type RoundTripFn = fn(&RuntimeValue) -> Result<RuntimeValue, HostFunctionError>;
+
+    fn round_trip<T: ValueAdapter>(value: &RuntimeValue) -> Result<RuntimeValue, HostFunctionError> {
+        T::from_runtime_value(value).map(ValueAdapter::into_runtime_value)
+    }
+
+    #[rstest]
+    #[case::runtime_value(round_trip::<RuntimeValue> as RoundTripFn, RuntimeValue::from(Number::from(42_i64)))]
+    #[case::i64(round_trip::<i64> as RoundTripFn, RuntimeValue::from(Number::from(7_i64)))]
+    #[case::f64(round_trip::<f64> as RoundTripFn, RuntimeValue::from(Number::from(1.5)))]
+    #[case::bool(round_trip::<bool> as RoundTripFn, RuntimeValue::Boolean(true))]
+    #[case::string(round_trip::<String> as RoundTripFn, RuntimeValue::String("hi".to_string()))]
+    #[case::vec(
+        round_trip::<Vec<i64>> as RoundTripFn,
+        RuntimeValue::Array(Shared::new(vec![RuntimeValue::from(Number::from(1_i64)), RuntimeValue::from(Number::from(2_i64))]))
+    )]
+    #[case::option_none(round_trip::<Option<i64>> as RoundTripFn, RuntimeValue::NONE)]
+    #[case::option_some(round_trip::<Option<i64>> as RoundTripFn, RuntimeValue::from(Number::from(3_i64)))]
+    fn test_adapter_roundtrip(#[case] convert: RoundTripFn, #[case] value: RuntimeValue) {
+        assert_eq!(convert(&value).unwrap(), value);
+    }
+
+    #[rstest]
+    #[case::i64_wrong_type(round_trip::<i64> as RoundTripFn, RuntimeValue::Boolean(true))]
+    #[case::f64_wrong_type(round_trip::<f64> as RoundTripFn, RuntimeValue::String("x".to_string()))]
+    #[case::bool_wrong_type(round_trip::<bool> as RoundTripFn, RuntimeValue::NONE)]
+    #[case::string_wrong_type(round_trip::<String> as RoundTripFn, RuntimeValue::Boolean(false))]
+    #[case::vec_wrong_type(round_trip::<Vec<i64>> as RoundTripFn, RuntimeValue::Boolean(true))]
+    #[case::vec_wrong_element_type(
+        round_trip::<Vec<i64>> as RoundTripFn,
+        RuntimeValue::Array(Shared::new(vec![RuntimeValue::Boolean(true)]))
+    )]
+    #[case::option_wrong_inner_type(round_trip::<Option<i64>> as RoundTripFn, RuntimeValue::Boolean(true))]
+    fn test_adapter_type_mismatch_errors(#[case] convert: RoundTripFn, #[case] value: RuntimeValue) {
+        assert!(convert(&value).is_err());
+    }
+
+    #[test]
+    fn test_register_typed_zero_arity() {
+        let f = (|| Ok(true)).into_host_fn();
+        assert_eq!(f.call(&[]).unwrap(), RuntimeValue::Boolean(true));
+    }
+
+    #[test]
+    fn test_register_typed_one_arity() {
+        let f = (|n: i64| Ok(n * 2)).into_host_fn();
+        let result = f.call(&[RuntimeValue::from(Number::from(21_i64))]).unwrap();
+        assert_eq!(result, RuntimeValue::from(Number::from(42_i64)));
+    }
+
+    #[test]
+    fn test_register_typed_two_arity() {
+        let f = (|a: i64, b: i64| Ok(a + b)).into_host_fn();
+        let result = f
+            .call(&[
+                RuntimeValue::from(Number::from(1_i64)),
+                RuntimeValue::from(Number::from(2_i64)),
+            ])
+            .unwrap();
+        assert_eq!(result, RuntimeValue::from(Number::from(3_i64)));
+    }
+
+    #[test]
+    fn test_register_typed_wrong_arity_errors() {
+        let f = (|n: i64| Ok(n)).into_host_fn();
+        assert!(f.call(&[]).is_err());
+        assert!(
+            f.call(&[
+                RuntimeValue::from(Number::from(1_i64)),
+                RuntimeValue::from(Number::from(2_i64))
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_register_typed_wrong_type_errors() {
+        let f = (|n: i64| Ok(n)).into_host_fn();
+        assert!(f.call(&[RuntimeValue::Boolean(true)]).is_err());
+    }
+
+    #[test]
+    fn test_raw_args_still_works_via_into_host_fn() {
+        let f = (|args: &[RuntimeValue]| Ok(args[0].clone())).into_host_fn();
+        let result = f.call(&[RuntimeValue::Boolean(true)]).unwrap();
+        assert_eq!(result, RuntimeValue::Boolean(true));
+    }
+}

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -86,6 +86,7 @@ pub use error::Error;
 pub use eval::builtin::{
     BUILTIN_FUNCTION_DOC, BUILTIN_SELECTOR_DOC, BuiltinFunctionDoc, BuiltinSelectorDoc, INTERNAL_FUNCTION_DOC,
 };
+pub use eval::host::{HostFnResult, HostFunction, HostFunctionError, HostFunctions, IntoHostFunction, ValueAdapter};
 pub use eval::runtime_value::{RuntimeValue, RuntimeValues};
 pub use ident::Ident;
 #[cfg(feature = "mock-io")]


### PR DESCRIPTION
## Summary

Engine::register_fn lets a host register native Rust functions callable from mq code, for embedding mq-lang as a safe extension/scripting engine rather than only a Markdown-CLI evaluator (similar to Rhai's register_fn).

- Raw form: |args: &[RuntimeValue]| -> HostFnResult, for full control.
- Typed form: |n: i64| Ok(n * 2), with argument/return conversion handled by a new ValueAdapter trait (i64, f64, bool, String, RuntimeValue, Vec<T>, Option<T>).
- Host functions are resolved as a fallback after local bindings and the builtin table, so they extend the callable namespace rather than override existing builtin names.
- Panics inside a host function are caught at the call boundary and surfaced as a normal RuntimeError::HostFunctionError; recursion depth and the configured timeout are enforced the same as for user-defined function calls.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
