### PR TITLE
✨ feat(mq-lang): add token_compress builtin for token-budget compression

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -482,6 +482,15 @@ fn register_array(ctx: &mut InferenceContext) {
         Type::Number,
         Type::array(Type::Markdown),
     );
+    // token_compress: ([markdown], number, model: string) -> [markdown]
+    register_ternary(
+        ctx,
+        "token_compress",
+        Type::array(Type::Markdown),
+        Type::Number,
+        Type::String,
+        Type::array(Type::Markdown),
+    );
 
     // flatten: [[a]] -> [a]
     let a = ctx.fresh_var();
@@ -1585,6 +1594,7 @@ mod tests {
     #[case::token_count_no_model("token_count(\"hello world\")", true)]
     #[case::token_count_number("token_count(42, \"gpt-4\")", false)] // Should fail: wrong type
     #[case::token_compress("to_markdown(\"# Title\\n\\nBody\") | token_compress(100)", true)]
+    #[case::token_compress_with_model("to_markdown(\"# Title\\n\\nBody\") | token_compress(100, \"gpt-4\")", true)]
     #[case::token_compress_string("token_compress(\"not an array\", 100)", false)] // Should fail: wrong type
     #[case::capture("capture(\"hello 42\", \"(?P<word>\\\\w+)\")", true)]
     #[case::is_regex_match("is_regex_match(\"hello123\", \"[0-9]+\")", true)]

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -474,6 +474,15 @@ fn register_array(ctx: &mut InferenceContext) {
         Type::array(Type::Var(a)),
     );
 
+    // token_compress: ([markdown], number) -> [markdown]
+    register_binary(
+        ctx,
+        "token_compress",
+        Type::array(Type::Markdown),
+        Type::Number,
+        Type::array(Type::Markdown),
+    );
+
     // flatten: [[a]] -> [a]
     let a = ctx.fresh_var();
     register_unary(
@@ -1575,6 +1584,8 @@ mod tests {
     #[case::token_count("token_count(\"hello world\", \"gpt-4\")", true)]
     #[case::token_count_no_model("token_count(\"hello world\")", true)]
     #[case::token_count_number("token_count(42, \"gpt-4\")", false)] // Should fail: wrong type
+    #[case::token_compress("to_markdown(\"# Title\\n\\nBody\") | token_compress(100)", true)]
+    #[case::token_compress_string("token_compress(\"not an array\", 100)", false)] // Should fail: wrong type
     #[case::capture("capture(\"hello 42\", \"(?P<word>\\\\w+)\")", true)]
     #[case::is_regex_match("is_regex_match(\"hello123\", \"[0-9]+\")", true)]
     #[case::is_not_regex_match("is_not_regex_match(\"hello123\", \"[0-9]+\")", true)]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1678,33 +1678,53 @@ fn token_count_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
     }
 }
 
-/// Reduces an array of Markdown nodes to fit within `budget` estimated LLM tokens. See
-/// [`compress`] for the staged algorithm.
-#[mq_macros::mq_fn(name = "token_compress", params = Fixed(2))]
+/// Reduces an array of Markdown nodes to fit within `budget` tokens. See
+/// [`compress::token_compress`] for the staged algorithm; `model` is optional and behaves like
+/// in `token_count`.
+#[mq_macros::mq_fn(name = "token_compress", params = Range(2, 3))]
 fn token_compress_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    match args.as_mut_slice() {
-        [RuntimeValue::Array(nodes), RuntimeValue::Number(budget)] => {
-            let vec = std::mem::take(nodes);
-            let markdown_nodes: Vec<mq_markdown::Node> = Shared::unwrap_or_clone(vec)
-                .into_iter()
-                .filter_map(|v| v.markdown_node())
-                .collect();
-            let budget = budget.value().max(0.0) as usize;
-            let compressed = compress::compress(markdown_nodes, budget);
+    fn compress_nodes(
+        nodes: &mut Shared<Vec<RuntimeValue>>,
+        budget: &number::Number,
+        model: Option<&str>,
+    ) -> Result<RuntimeValue, Error> {
+        let vec = std::mem::take(nodes);
+        let markdown_nodes: Vec<mq_markdown::Node> = Shared::unwrap_or_clone(vec)
+            .into_iter()
+            .filter_map(|v| v.markdown_node())
+            .collect();
+        let budget = budget.value().max(0.0) as usize;
+        let counter = tokenizer::counter(model)?;
+        let compressed = compress::token_compress(markdown_nodes, budget, counter.as_ref());
 
-            Ok(RuntimeValue::Array(Shared::new(
-                compressed
-                    .into_iter()
-                    .map(|node| RuntimeValue::Markdown(Box::new(node), None))
-                    .collect(),
-            )))
-        }
+        Ok(RuntimeValue::Array(Shared::new(
+            compressed
+                .into_iter()
+                .map(|node| RuntimeValue::Markdown(Box::new(node), None))
+                .collect(),
+        )))
+    }
+
+    match args.as_mut_slice() {
+        [RuntimeValue::Array(nodes), RuntimeValue::Number(budget)] => compress_nodes(nodes, budget, None),
+        [
+            RuntimeValue::Array(nodes),
+            RuntimeValue::Number(budget),
+            RuntimeValue::String(model),
+        ] => compress_nodes(nodes, budget, Some(model)),
         [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::Array(Shared::new(Vec::new()))),
+        [RuntimeValue::None, RuntimeValue::Number(_), RuntimeValue::String(_)] => {
+            Ok(RuntimeValue::Array(Shared::new(Vec::new())))
+        }
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
         )),
-        _ => unreachable!("token_compress should always receive exactly two arguments"),
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("token_compress should always receive two or three arguments"),
     }
 }
 
@@ -5931,8 +5951,8 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("token_compress"),
         BuiltinFunctionDoc {
-            description: "Reduces an array of Markdown nodes to fit within `budget` estimated LLM tokens, preserving structure as much as possible: paragraphs are cut to their first sentence, then lists/tables/code blocks are collapsed to a summary, and only as a last resort is the remaining text hard-truncated.",
-            params: &["nodes", "budget"],
+            description: "Reduces an array of Markdown nodes to fit within `budget` LLM tokens, preserving structure as much as possible: paragraphs are cut to their first sentence, then lists/tables/code blocks are collapsed to a summary, and only as a last resort is the remaining text hard-truncated. Uses a lightweight chars-per-token heuristic by default; built with the `tiktoken` Cargo feature, counts exactly via tiktoken-rs instead when `model` (e.g. \"gpt-5\") is given. `model` is optional; without it, the heuristic estimate is always used.",
+            params: &["nodes", "budget", "model?"],
         },
     );
     map.insert(
@@ -7331,6 +7351,20 @@ mod tests {
     #[case(
         "token_compress",
         vec![RuntimeValue::None, RuntimeValue::Number(100.into())],
+        Ok(RuntimeValue::Array(Shared::new(vec![])))
+    )]
+    #[case(
+        "token_compress",
+        vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Markdown(Box::new(Node::from("hi".to_string())), None)])),
+            RuntimeValue::Number(1000.into()),
+            RuntimeValue::String("gpt-4".into()),
+        ],
+        Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Markdown(Box::new(Node::from("hi".to_string())), None)])))
+    )]
+    #[case(
+        "token_compress",
+        vec![RuntimeValue::None, RuntimeValue::Number(100.into()), RuntimeValue::String("gpt-4".into())],
         Ok(RuntimeValue::Array(Shared::new(vec![])))
     )]
     #[case("abs", vec![RuntimeValue::Number((-10).into())], Ok(RuntimeValue::Number(10.into())))]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -1,4 +1,5 @@
 pub(super) mod bytes;
+mod compress;
 pub(super) mod convert;
 #[cfg(feature = "css-selector")]
 mod css;
@@ -1674,6 +1675,36 @@ fn token_count_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedE
             vec![std::mem::take(a), std::mem::take(b)],
         )),
         _ => unreachable!("token_count should always receive one or two arguments"),
+    }
+}
+
+/// Reduces an array of Markdown nodes to fit within `budget` estimated LLM tokens. See
+/// [`compress`] for the staged algorithm.
+#[mq_macros::mq_fn(name = "token_compress", params = Fixed(2))]
+fn token_compress_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Array(nodes), RuntimeValue::Number(budget)] => {
+            let vec = std::mem::take(nodes);
+            let markdown_nodes: Vec<mq_markdown::Node> = Shared::unwrap_or_clone(vec)
+                .into_iter()
+                .filter_map(|v| v.markdown_node())
+                .collect();
+            let budget = budget.value().max(0.0) as usize;
+            let compressed = compress::compress(markdown_nodes, budget);
+
+            Ok(RuntimeValue::Array(Shared::new(
+                compressed
+                    .into_iter()
+                    .map(|node| RuntimeValue::Markdown(Box::new(node), None))
+                    .collect(),
+            )))
+        }
+        [RuntimeValue::None, RuntimeValue::Number(_)] => Ok(RuntimeValue::Array(Shared::new(Vec::new()))),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("token_compress should always receive exactly two arguments"),
     }
 }
 
@@ -4650,6 +4681,7 @@ mq_macros::builtin_dispatch! {
     LEN,
     UTF8BYTELEN,
     TOKEN_COUNT,
+    TOKEN_COMPRESS,
     RINDEX,
     RANGE,
     DEL,
@@ -5271,7 +5303,7 @@ pub struct BuiltinFunctionDoc {
 }
 
 pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>> = LazyLock::new(|| {
-    let mut map = FxHashMap::with_capacity_and_hasher(111, FxBuildHasher);
+    let mut map = FxHashMap::with_capacity_and_hasher(112, FxBuildHasher);
 
     map.insert(
         SmolStr::new("halt"),
@@ -5894,6 +5926,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Estimates how many LLM tokens the given text would consume, for context-window budgeting. Uses a lightweight chars-per-token heuristic by default; built with the `tiktoken` Cargo feature, counts exactly via tiktoken-rs instead when `model` (e.g. \"gpt-5\") is given. `model` is optional; without it, the heuristic estimate is always used.",
             params: &["text", "model?"],
+        },
+    );
+    map.insert(
+        SmolStr::new("token_compress"),
+        BuiltinFunctionDoc {
+            description: "Reduces an array of Markdown nodes to fit within `budget` estimated LLM tokens, preserving structure as much as possible: paragraphs are cut to their first sentence, then lists/tables/code blocks are collapsed to a summary, and only as a last resort is the remaining text hard-truncated.",
+            params: &["nodes", "budget"],
         },
     );
     map.insert(
@@ -7281,6 +7320,19 @@ mod tests {
     #[case("token_count", vec![RuntimeValue::String("".into()), RuntimeValue::String("gpt-4".into())], Ok(RuntimeValue::Number(0.into())))]
     #[case("token_count", vec![RuntimeValue::String("Hello, world!".into())], Ok(RuntimeValue::Number(4.into())))]
     #[case("token_count", vec![RuntimeValue::String("".into())], Ok(RuntimeValue::Number(0.into())))]
+    #[case(
+        "token_compress",
+        vec![
+            RuntimeValue::Array(Shared::new(vec![RuntimeValue::Markdown(Box::new(Node::from("hi".to_string())), None)])),
+            RuntimeValue::Number(1000.into()),
+        ],
+        Ok(RuntimeValue::Array(Shared::new(vec![RuntimeValue::Markdown(Box::new(Node::from("hi".to_string())), None)])))
+    )]
+    #[case(
+        "token_compress",
+        vec![RuntimeValue::None, RuntimeValue::Number(100.into())],
+        Ok(RuntimeValue::Array(Shared::new(vec![])))
+    )]
     #[case("abs", vec![RuntimeValue::Number((-10).into())], Ok(RuntimeValue::Number(10.into())))]
     #[case("ceil", vec![RuntimeValue::Number(3.2.into())], Ok(RuntimeValue::Number(4.0.into())))]
     #[case("floor", vec![RuntimeValue::Number(3.8.into())], Ok(RuntimeValue::Number(3.0.into())))]

--- a/crates/mq-lang/src/eval/builtin/compress.rs
+++ b/crates/mq-lang/src/eval/builtin/compress.rs
@@ -1,0 +1,365 @@
+//! `token_compress` builtin: reduces a Markdown node list to a token budget in stages (ordered
+//! least- to most-destructive) instead of a single blind char-truncate.
+
+use mq_markdown::{Code, Node};
+
+use super::tokenizer::token_count_estimate;
+
+/// Max list items (and table body rows) kept per contiguous run once collection-trimming kicks in.
+const MAX_COLLECTION_ITEMS: usize = 3;
+
+/// Reduces `nodes` to fit within `budget` (estimated LLM tokens), trying progressively more
+/// aggressive stages and stopping as soon as the budget is met.
+pub(super) fn compress(nodes: Vec<Node>, budget: usize) -> Vec<Node> {
+    if total_tokens(&nodes) <= budget {
+        return nodes;
+    }
+
+    let nodes = trim_paragraphs(nodes);
+    if total_tokens(&nodes) <= budget {
+        return nodes;
+    }
+
+    let nodes = collapse_lists(nodes);
+    let nodes = collapse_tables(nodes);
+    let nodes = collapse_code(nodes);
+    if total_tokens(&nodes) <= budget {
+        return nodes;
+    }
+
+    hard_truncate(&nodes, budget)
+}
+
+fn total_tokens(nodes: &[Node]) -> usize {
+    nodes.iter().map(|n| token_count_estimate(&n.value())).sum()
+}
+
+/// mq-markdown has no `Paragraph` node; a paragraph is an unmarked run of inline siblings
+/// between these block markers.
+fn is_block_marker(node: &Node) -> bool {
+    node.is_heading(None)
+        || node.is_list()
+        || matches!(node, Node::Code(_))
+        || matches!(node, Node::TableRow(_))
+        || node.is_table_align()
+        || node.is_blockquote()
+        || node.is_horizontal_rule()
+}
+
+/// Collapses each paragraph run down to its first sentence; leaves runs with no sentence
+/// boundary untouched.
+fn trim_paragraphs(nodes: Vec<Node>) -> Vec<Node> {
+    let mut result = Vec::with_capacity(nodes.len());
+    let mut run: Vec<Node> = Vec::new();
+
+    for node in nodes {
+        if is_block_marker(&node) {
+            flush_paragraph_run(&mut run, &mut result);
+            result.push(node);
+        } else {
+            run.push(node);
+        }
+    }
+    flush_paragraph_run(&mut run, &mut result);
+
+    result
+}
+
+fn flush_paragraph_run(run: &mut Vec<Node>, result: &mut Vec<Node>) {
+    if run.is_empty() {
+        return;
+    }
+
+    let text: String = run.iter().map(|n| n.to_string()).collect();
+    match first_sentence(&text) {
+        Some(sentence) if sentence.len() < text.trim().len() => result.push(Node::from(sentence)),
+        _ => result.append(run),
+    }
+    run.clear();
+}
+
+/// First sentence of `text`, or `None` if no boundary is found. CJK terminators (`。！？`) always
+/// end a sentence (no space follows in CJK prose); Latin `.!?` only count when followed by
+/// whitespace/EOF, so decimals and abbreviations (`3.14`) aren't mistaken for boundaries.
+fn first_sentence(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+
+    for (i, (byte_idx, c)) in chars.iter().enumerate() {
+        let is_boundary = match c {
+            '。' | '！' | '？' => true,
+            '.' | '!' | '?' => chars.get(i + 1).map(|(_, next)| next.is_whitespace()).unwrap_or(true),
+            _ => false,
+        };
+        if is_boundary {
+            return Some(trimmed[..byte_idx + c.len_utf8()].to_string());
+        }
+    }
+
+    None
+}
+
+/// Caps each run of consecutive `List` siblings to [`MAX_COLLECTION_ITEMS`], noting how many
+/// were omitted.
+fn collapse_lists(nodes: Vec<Node>) -> Vec<Node> {
+    let mut result = Vec::with_capacity(nodes.len());
+    let mut run: Vec<Node> = Vec::new();
+
+    for node in nodes {
+        if node.is_list() {
+            run.push(node);
+        } else {
+            flush_capped_run(&mut run, &mut result, MAX_COLLECTION_ITEMS, "list items");
+            result.push(node);
+        }
+    }
+    flush_capped_run(&mut run, &mut result, MAX_COLLECTION_ITEMS, "list items");
+
+    result
+}
+
+/// Caps table body rows to [`MAX_COLLECTION_ITEMS`]; the header row is positional (whatever comes
+/// before `TableAlign` in the run), since `TableRow` itself has no header flag.
+fn collapse_tables(nodes: Vec<Node>) -> Vec<Node> {
+    let mut result = Vec::with_capacity(nodes.len());
+    let mut run: Vec<Node> = Vec::new();
+
+    for node in nodes {
+        if node.is_table_align() || matches!(node, Node::TableRow(_)) {
+            run.push(node);
+        } else {
+            flush_table_run(&mut run, &mut result);
+            result.push(node);
+        }
+    }
+    flush_table_run(&mut run, &mut result);
+
+    result
+}
+
+fn flush_table_run(run: &mut Vec<Node>, result: &mut Vec<Node>) {
+    if run.is_empty() {
+        return;
+    }
+
+    if let Some(align_idx) = run.iter().position(Node::is_table_align) {
+        let body_start = align_idx + 1;
+        let body_len = run.len() - body_start;
+        if body_len > MAX_COLLECTION_ITEMS {
+            let omitted = body_len - MAX_COLLECTION_ITEMS;
+            result.extend(run.drain(..body_start + MAX_COLLECTION_ITEMS));
+            result.push(Node::from(format!("_(+{omitted} more table rows omitted)_")));
+            run.clear();
+            return;
+        }
+    }
+
+    result.append(run);
+}
+
+fn flush_capped_run(run: &mut Vec<Node>, result: &mut Vec<Node>, cap: usize, label: &str) {
+    if run.len() > cap {
+        let omitted = run.len() - cap;
+        result.extend(run.drain(..cap));
+        result.push(Node::from(format!("_(+{omitted} more {label} omitted)_")));
+        run.clear();
+    } else {
+        result.append(run);
+    }
+}
+
+/// Replaces each code block's body with a `lang`/line-count placeholder.
+fn collapse_code(nodes: Vec<Node>) -> Vec<Node> {
+    nodes
+        .into_iter()
+        .map(|node| {
+            if let Node::Code(Code {
+                ref value, ref lang, ..
+            }) = node
+            {
+                let lines = value.lines().count();
+                let lang_label = lang.as_deref().unwrap_or("code");
+                let placeholder = format!("... ({lines} lines of {lang_label} omitted)");
+                node.with_value(&placeholder)
+            } else {
+                node
+            }
+        })
+        .collect()
+}
+
+/// Last resort: truncates the rendered text to the largest prefix fitting `budget`. Unlike the
+/// earlier stages, this can cut off mid-sentence.
+fn hard_truncate(nodes: &[Node], budget: usize) -> Vec<Node> {
+    let text: String = nodes.iter().map(|n| n.to_string()).collect::<Vec<_>>().join("\n\n");
+
+    if token_count_estimate(&text) <= budget {
+        return vec![Node::from(text)];
+    }
+
+    let chars: Vec<char> = text.chars().collect();
+    let (mut lo, mut hi) = (0usize, chars.len());
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        let prefix: String = chars[..mid].iter().collect();
+        if token_count_estimate(&prefix) <= budget {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    let mut truncated: String = chars[..lo].iter().collect();
+    truncated.push_str("...");
+    vec![Node::from(truncated)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_markdown::{Heading, List, TableAlign, TableRow, Text};
+    use rstest::rstest;
+
+    fn text(value: &str) -> Node {
+        Node::Text(Text {
+            value: value.to_string(),
+            position: None,
+        })
+    }
+
+    fn heading(depth: u8, value: &str) -> Node {
+        Node::Heading(Heading {
+            depth,
+            values: vec![text(value)],
+            position: None,
+        })
+    }
+
+    fn list_item(value: &str, index: usize) -> Node {
+        Node::List(List {
+            values: vec![text(value)],
+            index,
+            level: 0,
+            ordered: false,
+            checked: None,
+            position: None,
+        })
+    }
+
+    fn code(value: &str, lang: &str) -> Node {
+        Node::Code(Code {
+            value: value.to_string(),
+            lang: Some(lang.to_string()),
+            position: None,
+            meta: None,
+            fence: true,
+        })
+    }
+
+    #[test]
+    fn already_under_budget_is_untouched() {
+        let nodes = vec![heading(1, "Title"), text("A short paragraph.")];
+        let result = compress(nodes.clone(), 1000);
+        assert_eq!(result, nodes);
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(compress(Vec::new(), 10), Vec::new());
+    }
+
+    #[test]
+    fn paragraph_is_cut_to_first_sentence() {
+        let nodes = vec![
+            heading(1, "Title"),
+            text(
+                "First sentence. Second sentence. Third sentence, much longer, to push the total well past any tiny budget.",
+            ),
+        ];
+        // Big enough that trimming to "Title" + "First sentence." already fits (2 + 4 tokens),
+        // but small enough that the untrimmed paragraph doesn't.
+        let result = compress(nodes, 6);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[1].value(), "First sentence.");
+    }
+
+    #[test]
+    fn paragraph_without_sentence_boundary_is_left_alone() {
+        let nodes = vec![text("no terminal punctuation here at all just words")];
+        let result = trim_paragraphs(nodes.clone());
+        assert_eq!(result, nodes);
+    }
+
+    #[rstest]
+    #[case("Hello world.", Some("Hello world.".to_string()))]
+    #[case("Hi! Bye.", Some("Hi!".to_string()))]
+    #[case("こんにちは。さようなら。", Some("こんにちは。".to_string()))]
+    #[case("no boundary", None)]
+    #[case("3.14 is pi", None)]
+    fn test_first_sentence(#[case] input: &str, #[case] expected: Option<String>) {
+        assert_eq!(first_sentence(input), expected);
+    }
+
+    #[test]
+    fn list_run_is_capped_with_omitted_count() {
+        let nodes: Vec<Node> = (0..6).map(|i| list_item(&format!("item {i}"), i)).collect();
+        let result = collapse_lists(nodes);
+        assert_eq!(result.len(), MAX_COLLECTION_ITEMS + 1);
+        assert!(result.last().unwrap().value().contains("+3 more list items omitted"));
+    }
+
+    #[test]
+    fn short_list_run_is_untouched() {
+        let nodes: Vec<Node> = (0..2).map(|i| list_item(&format!("item {i}"), i)).collect();
+        let result = collapse_lists(nodes.clone());
+        assert_eq!(result, nodes);
+    }
+
+    #[test]
+    fn table_body_rows_are_capped_with_omitted_count() {
+        let header = Node::TableRow(TableRow {
+            values: vec![text("col")],
+            position: None,
+        });
+        let align = Node::TableAlign(TableAlign {
+            align: vec![],
+            position: None,
+        });
+        let mut nodes = vec![header, align];
+        nodes.extend((0..6).map(|i| {
+            Node::TableRow(TableRow {
+                values: vec![text(&format!("row {i}"))],
+                position: None,
+            })
+        }));
+
+        let result = collapse_tables(nodes);
+        // header + align + MAX_COLLECTION_ITEMS body rows + omitted-count marker
+        assert_eq!(result.len(), 2 + MAX_COLLECTION_ITEMS + 1);
+        assert!(result.last().unwrap().value().contains("+3 more table rows omitted"));
+    }
+
+    #[test]
+    fn code_block_is_collapsed_to_placeholder() {
+        let nodes = vec![code("line1\nline2\nline3", "rust")];
+        let result = collapse_code(nodes);
+        assert_eq!(result.len(), 1);
+        let value = result[0].value();
+        assert!(value.contains("3 lines of rust omitted"), "got: {value}");
+    }
+
+    #[test]
+    fn hard_truncate_is_last_resort_and_fits_budget() {
+        let nodes = vec![text("a".repeat(500).as_str())];
+        let result = compress(nodes, 5);
+        assert_eq!(result.len(), 1);
+        assert!(token_count_estimate(&result[0].value()) <= 5 + token_count_estimate("..."));
+    }
+
+    #[test]
+    fn zero_budget_does_not_panic() {
+        let nodes = vec![heading(1, "Title"), text("Some paragraph text here.")];
+        let result = compress(nodes, 0);
+        assert!(total_tokens(&result) <= token_count_estimate("..."));
+    }
+}

--- a/crates/mq-lang/src/eval/builtin/compress.rs
+++ b/crates/mq-lang/src/eval/builtin/compress.rs
@@ -3,35 +3,57 @@
 
 use mq_markdown::{Code, Node};
 
-use super::tokenizer::token_count_estimate;
+const TAIL_SHARE_DIVISOR: usize = 4;
+const HARD_TRUNCATE_SEPARATOR: &str = "\n\n...\n\n";
 
-/// Max list items (and table body rows) kept per contiguous run once collection-trimming kicks in.
-const MAX_COLLECTION_ITEMS: usize = 3;
-
-/// Reduces `nodes` to fit within `budget` (estimated LLM tokens), trying progressively more
-/// aggressive stages and stopping as soon as the budget is met.
-pub(super) fn compress(nodes: Vec<Node>, budget: usize) -> Vec<Node> {
-    if total_tokens(&nodes) <= budget {
+/// Reduces `nodes` to fit within `budget` tokens, trying progressively more aggressive stages
+/// and stopping as soon as the budget is met.
+pub(super) fn token_compress(nodes: Vec<Node>, budget: usize, counter: &dyn Fn(&str) -> usize) -> Vec<Node> {
+    if tokens_of(&nodes, counter) <= budget {
         return nodes;
     }
 
-    let nodes = trim_paragraphs(nodes);
-    if total_tokens(&nodes) <= budget {
+    let nodes = trim_paragraphs(nodes, budget, counter);
+    if tokens_of(&nodes, counter) <= budget {
         return nodes;
     }
 
-    let nodes = collapse_lists(nodes);
-    let nodes = collapse_tables(nodes);
+    let nodes = collapse_lists(nodes, budget, counter);
+    if tokens_of(&nodes, counter) <= budget {
+        return nodes;
+    }
+
+    let nodes = collapse_tables(nodes, budget, counter);
+    if tokens_of(&nodes, counter) <= budget {
+        return nodes;
+    }
+
     let nodes = collapse_code(nodes);
-    if total_tokens(&nodes) <= budget {
+    if tokens_of(&nodes, counter) <= budget {
         return nodes;
     }
 
-    hard_truncate(&nodes, budget)
+    hard_truncate(&nodes, budget, counter)
 }
 
-fn total_tokens(nodes: &[Node]) -> usize {
-    nodes.iter().map(|n| token_count_estimate(&n.value())).sum()
+fn tokens_of(nodes: &[Node], counter: &dyn Fn(&str) -> usize) -> usize {
+    nodes.iter().map(|n| counter(&n.value())).sum()
+}
+
+/// Binary-searches the largest `n` in `0..=len` such that `candidate(n)` stays within `budget`.
+/// Assumes `candidate` is monotonically non-decreasing in `n`; doesn't verify `candidate(0)`
+/// itself fits, so a `budget` too tight for anything can still overshoot slightly.
+fn largest_fit(len: usize, budget: usize, mut candidate: impl FnMut(usize) -> usize) -> usize {
+    let (mut lo, mut hi) = (0usize, len);
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        if candidate(mid) <= budget {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    lo
 }
 
 /// mq-markdown has no `Paragraph` node; a paragraph is an unmarked run of inline siblings
@@ -46,36 +68,85 @@ fn is_block_marker(node: &Node) -> bool {
         || node.is_horizontal_rule()
 }
 
-/// Collapses each paragraph run down to its first sentence; leaves runs with no sentence
-/// boundary untouched.
-fn trim_paragraphs(nodes: Vec<Node>) -> Vec<Node> {
-    let mut result = Vec::with_capacity(nodes.len());
+enum Segment {
+    Marker(Node),
+    Paragraph(Vec<Node>),
+}
+
+fn segment_tokens(segment: &Segment, counter: &dyn Fn(&str) -> usize) -> usize {
+    match segment {
+        Segment::Marker(node) => counter(&node.value()),
+        Segment::Paragraph(nodes) => tokens_of(nodes, counter),
+    }
+}
+
+fn split_into_segments(nodes: Vec<Node>) -> Vec<Segment> {
+    let mut segments = Vec::new();
     let mut run: Vec<Node> = Vec::new();
 
     for node in nodes {
         if is_block_marker(&node) {
-            flush_paragraph_run(&mut run, &mut result);
-            result.push(node);
+            if !run.is_empty() {
+                segments.push(Segment::Paragraph(std::mem::take(&mut run)));
+            }
+            segments.push(Segment::Marker(node));
         } else {
             run.push(node);
         }
     }
-    flush_paragraph_run(&mut run, &mut result);
+    if !run.is_empty() {
+        segments.push(Segment::Paragraph(run));
+    }
 
-    result
+    segments
 }
 
-fn flush_paragraph_run(run: &mut Vec<Node>, result: &mut Vec<Node>) {
-    if run.is_empty() {
-        return;
+/// Collapses paragraph runs down to their first sentence, largest run first, stopping as soon as
+/// `budget` is met so smaller paragraphs can be left fully intact.
+fn trim_paragraphs(nodes: Vec<Node>, budget: usize, counter: &dyn Fn(&str) -> usize) -> Vec<Node> {
+    let mut segments = split_into_segments(nodes);
+    let mut total: usize = segments.iter().map(|s| segment_tokens(s, counter)).sum();
+
+    let mut run_indices: Vec<usize> = segments
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| matches!(s, Segment::Paragraph(_)))
+        .map(|(i, _)| i)
+        .collect();
+    run_indices.sort_by_key(|&i| std::cmp::Reverse(segment_tokens(&segments[i], counter)));
+
+    for i in run_indices {
+        if total <= budget {
+            break;
+        }
+        let Segment::Paragraph(run) = &segments[i] else {
+            continue;
+        };
+        if let Some(sentence) = trimmed_paragraph(run) {
+            let before = segment_tokens(&segments[i], counter);
+            let after = counter(&sentence);
+            if after < before {
+                total -= before - after;
+                segments[i] = Segment::Paragraph(vec![Node::from(sentence)]);
+            }
+        }
     }
 
+    segments
+        .into_iter()
+        .flat_map(|s| match s {
+            Segment::Marker(node) => vec![node],
+            Segment::Paragraph(nodes) => nodes,
+        })
+        .collect()
+}
+
+fn trimmed_paragraph(run: &[Node]) -> Option<String> {
     let text: String = run.iter().map(|n| n.to_string()).collect();
     match first_sentence(&text) {
-        Some(sentence) if sentence.len() < text.trim().len() => result.push(Node::from(sentence)),
-        _ => result.append(run),
+        Some(sentence) if sentence.len() < text.trim().len() => Some(sentence),
+        _ => None,
     }
-    run.clear();
 }
 
 /// First sentence of `text`, or `None` if no boundary is found. CJK terminators (`。！？`) always
@@ -99,9 +170,8 @@ fn first_sentence(text: &str) -> Option<String> {
     None
 }
 
-/// Caps each run of consecutive `List` siblings to [`MAX_COLLECTION_ITEMS`], noting how many
-/// were omitted.
-fn collapse_lists(nodes: Vec<Node>) -> Vec<Node> {
+/// Caps each run of consecutive `List` siblings to whatever fits the remaining budget.
+fn collapse_lists(nodes: Vec<Node>, budget: usize, counter: &dyn Fn(&str) -> usize) -> Vec<Node> {
     let mut result = Vec::with_capacity(nodes.len());
     let mut run: Vec<Node> = Vec::new();
 
@@ -109,18 +179,34 @@ fn collapse_lists(nodes: Vec<Node>) -> Vec<Node> {
         if node.is_list() {
             run.push(node);
         } else {
-            flush_capped_run(&mut run, &mut result, MAX_COLLECTION_ITEMS, "list items");
+            flush_capped_run(&mut run, &mut result, budget, counter, "list items");
             result.push(node);
         }
     }
-    flush_capped_run(&mut run, &mut result, MAX_COLLECTION_ITEMS, "list items");
+    flush_capped_run(&mut run, &mut result, budget, counter, "list items");
 
     result
 }
 
-/// Caps table body rows to [`MAX_COLLECTION_ITEMS`]; the header row is positional (whatever comes
-/// before `TableAlign` in the run), since `TableRow` itself has no header flag.
-fn collapse_tables(nodes: Vec<Node>) -> Vec<Node> {
+fn flush_capped_run(
+    run: &mut Vec<Node>,
+    result: &mut Vec<Node>,
+    budget: usize,
+    counter: &dyn Fn(&str) -> usize,
+    label: &str,
+) {
+    if run.is_empty() {
+        return;
+    }
+
+    let remaining = budget.saturating_sub(tokens_of(result, counter));
+    result.extend(cap_by_budget(run, remaining, counter, label));
+    run.clear();
+}
+
+/// Caps table body rows to whatever fits the remaining budget; the header row is positional
+/// (whatever comes before `TableAlign` in the run), since `TableRow` itself has no header flag.
+fn collapse_tables(nodes: Vec<Node>, budget: usize, counter: &dyn Fn(&str) -> usize) -> Vec<Node> {
     let mut result = Vec::with_capacity(nodes.len());
     let mut run: Vec<Node> = Vec::new();
 
@@ -128,44 +214,64 @@ fn collapse_tables(nodes: Vec<Node>) -> Vec<Node> {
         if node.is_table_align() || matches!(node, Node::TableRow(_)) {
             run.push(node);
         } else {
-            flush_table_run(&mut run, &mut result);
+            flush_table_run(&mut run, &mut result, budget, counter);
             result.push(node);
         }
     }
-    flush_table_run(&mut run, &mut result);
+    flush_table_run(&mut run, &mut result, budget, counter);
 
     result
 }
 
-fn flush_table_run(run: &mut Vec<Node>, result: &mut Vec<Node>) {
+fn flush_table_run(run: &mut Vec<Node>, result: &mut Vec<Node>, budget: usize, counter: &dyn Fn(&str) -> usize) {
     if run.is_empty() {
         return;
     }
 
     if let Some(align_idx) = run.iter().position(Node::is_table_align) {
         let body_start = align_idx + 1;
-        let body_len = run.len() - body_start;
-        if body_len > MAX_COLLECTION_ITEMS {
-            let omitted = body_len - MAX_COLLECTION_ITEMS;
-            result.extend(run.drain(..body_start + MAX_COLLECTION_ITEMS));
-            result.push(Node::from(format!("_(+{omitted} more table rows omitted)_")));
-            run.clear();
-            return;
-        }
+        let header = &run[..body_start];
+        let body = &run[body_start..];
+
+        let remaining = budget
+            .saturating_sub(tokens_of(result, counter))
+            .saturating_sub(tokens_of(header, counter));
+
+        result.extend_from_slice(header);
+        result.extend(cap_by_budget(body, remaining, counter, "table rows"));
+        run.clear();
+        return;
     }
 
     result.append(run);
 }
 
-fn flush_capped_run(run: &mut Vec<Node>, result: &mut Vec<Node>, cap: usize, label: &str) {
-    if run.len() > cap {
-        let omitted = run.len() - cap;
-        result.extend(run.drain(..cap));
-        result.push(Node::from(format!("_(+{omitted} more {label} omitted)_")));
-        run.clear();
-    } else {
-        result.append(run);
+/// Largest prefix of `run` whose tokens, plus an omitted-count marker for the rest, fit within
+/// `remaining`.
+fn cap_by_budget(run: &[Node], remaining: usize, counter: &dyn Fn(&str) -> usize, label: &str) -> Vec<Node> {
+    if tokens_of(run, counter) <= remaining {
+        return run.to_vec();
     }
+
+    let keep = largest_fit(run.len(), remaining, |n| {
+        let omitted = run.len() - n;
+        let marker_tokens = if omitted > 0 {
+            counter(&omitted_marker(omitted, label))
+        } else {
+            0
+        };
+        tokens_of(&run[..n], counter) + marker_tokens
+    });
+
+    let mut result: Vec<Node> = run[..keep].to_vec();
+    if keep < run.len() {
+        result.push(Node::from(omitted_marker(run.len() - keep, label)));
+    }
+    result
+}
+
+fn omitted_marker(omitted: usize, label: &str) -> String {
+    format!("_(+{omitted} more {label} omitted)_")
 }
 
 /// Replaces each code block's body with a `lang`/line-count placeholder.
@@ -188,30 +294,66 @@ fn collapse_code(nodes: Vec<Node>) -> Vec<Node> {
         .collect()
 }
 
-/// Last resort: truncates the rendered text to the largest prefix fitting `budget`. Unlike the
-/// earlier stages, this can cut off mid-sentence.
-fn hard_truncate(nodes: &[Node], budget: usize) -> Vec<Node> {
+/// Last resort: keeps a word-boundary-snapped head and tail of the rendered text, joined by an
+/// ellipsis, so the closing content survives too, not just the opening. Falls back to a
+/// prefix-only truncation when `budget` is too tight to spare anything for a tail.
+fn hard_truncate(nodes: &[Node], budget: usize, counter: &dyn Fn(&str) -> usize) -> Vec<Node> {
     let text: String = nodes.iter().map(|n| n.to_string()).collect::<Vec<_>>().join("\n\n");
-
-    if token_count_estimate(&text) <= budget {
+    if counter(&text) <= budget {
         return vec![Node::from(text)];
     }
-
     let chars: Vec<char> = text.chars().collect();
-    let (mut lo, mut hi) = (0usize, chars.len());
-    while lo < hi {
-        let mid = lo + (hi - lo).div_ceil(2);
-        let prefix: String = chars[..mid].iter().collect();
-        if token_count_estimate(&prefix) <= budget {
-            lo = mid;
-        } else {
-            hi = mid - 1;
-        }
+
+    let separator_tokens = counter(HARD_TRUNCATE_SEPARATOR);
+    let usable = budget.saturating_sub(separator_tokens);
+    let tail_budget = usable / TAIL_SHARE_DIVISOR;
+    let head_budget = usable - tail_budget;
+
+    let tail_len = largest_fit(chars.len(), tail_budget, |n| {
+        counter(&chars[chars.len() - n..].iter().collect::<String>())
+    });
+    if tail_len == 0 {
+        return vec![Node::from(prefix_truncated(&chars, budget, counter))];
     }
 
-    let mut truncated: String = chars[..lo].iter().collect();
+    let head_len = largest_fit(chars.len() - tail_len, head_budget, |n| {
+        counter(&chars[..n].iter().collect::<String>())
+    });
+    let head_end = snap_prefix_boundary(&chars, head_len);
+    let tail_start = snap_suffix_start(&chars, chars.len() - tail_len).max(head_end);
+
+    let head: String = chars[..head_end].iter().collect::<String>().trim_end().to_string();
+    let tail: String = chars[tail_start..].iter().collect::<String>().trim_start().to_string();
+
+    vec![Node::from(format!("{head}{HARD_TRUNCATE_SEPARATOR}{tail}"))]
+}
+
+fn prefix_truncated(chars: &[char], budget: usize, counter: &dyn Fn(&str) -> usize) -> String {
+    let len = largest_fit(chars.len(), budget, |n| counter(&chars[..n].iter().collect::<String>()));
+    let end = snap_prefix_boundary(chars, len);
+    let mut truncated: String = chars[..end].iter().collect::<String>().trim_end().to_string();
     truncated.push_str("...");
-    vec![Node::from(truncated)]
+    truncated
+}
+
+fn snap_prefix_boundary(chars: &[char], end: usize) -> usize {
+    let mut end = end;
+    if end > 0 && end < chars.len() && !chars[end - 1].is_whitespace() && !chars[end].is_whitespace() {
+        while end > 0 && !chars[end - 1].is_whitespace() {
+            end -= 1;
+        }
+    }
+    end
+}
+
+fn snap_suffix_start(chars: &[char], start: usize) -> usize {
+    let mut start = start;
+    if start > 0 && start < chars.len() && !chars[start - 1].is_whitespace() && !chars[start].is_whitespace() {
+        while start < chars.len() && !chars[start].is_whitespace() {
+            start += 1;
+        }
+    }
+    start
 }
 
 #[cfg(test)]
@@ -219,6 +361,8 @@ mod tests {
     use super::*;
     use mq_markdown::{Heading, List, TableAlign, TableRow, Text};
     use rstest::rstest;
+
+    use super::super::tokenizer::token_count_estimate as count;
 
     fn text(value: &str) -> Node {
         Node::Text(Text {
@@ -259,13 +403,13 @@ mod tests {
     #[test]
     fn already_under_budget_is_untouched() {
         let nodes = vec![heading(1, "Title"), text("A short paragraph.")];
-        let result = compress(nodes.clone(), 1000);
+        let result = token_compress(nodes.clone(), 1000, &count);
         assert_eq!(result, nodes);
     }
 
     #[test]
     fn empty_input_stays_empty() {
-        assert_eq!(compress(Vec::new(), 10), Vec::new());
+        assert_eq!(token_compress(Vec::new(), 10, &count), Vec::new());
     }
 
     #[test]
@@ -278,7 +422,7 @@ mod tests {
         ];
         // Big enough that trimming to "Title" + "First sentence." already fits (2 + 4 tokens),
         // but small enough that the untrimmed paragraph doesn't.
-        let result = compress(nodes, 6);
+        let result = token_compress(nodes, 6, &count);
         assert_eq!(result.len(), 2);
         assert_eq!(result[1].value(), "First sentence.");
     }
@@ -286,8 +430,24 @@ mod tests {
     #[test]
     fn paragraph_without_sentence_boundary_is_left_alone() {
         let nodes = vec![text("no terminal punctuation here at all just words")];
-        let result = trim_paragraphs(nodes.clone());
+        let result = trim_paragraphs(nodes.clone(), 0, &count);
         assert_eq!(result, nodes);
+    }
+
+    #[test]
+    fn trim_paragraphs_prioritizes_largest_run_first() {
+        let big = text("First sentence in big paragraph. Second sentence padding padding padding padding.");
+        let small = text("Small one. More.");
+        let nodes = vec![heading(1, "Title"), big.clone(), heading(2, "Sub"), small.clone()];
+
+        let heading_tokens = tokens_of(&[nodes[0].clone(), nodes[2].clone()], &count);
+        let big_trimmed = first_sentence(&big.to_string()).unwrap();
+        let budget = heading_tokens + count(&big_trimmed) + count(&small.to_string());
+
+        let result = trim_paragraphs(nodes, budget, &count);
+
+        assert_eq!(result[1].value(), big_trimmed);
+        assert_eq!(result[3].value(), small.to_string());
     }
 
     #[rstest]
@@ -301,22 +461,29 @@ mod tests {
     }
 
     #[test]
-    fn list_run_is_capped_with_omitted_count() {
+    fn list_run_within_budget_is_kept_in_full() {
         let nodes: Vec<Node> = (0..6).map(|i| list_item(&format!("item {i}"), i)).collect();
-        let result = collapse_lists(nodes);
-        assert_eq!(result.len(), MAX_COLLECTION_ITEMS + 1);
-        assert!(result.last().unwrap().value().contains("+3 more list items omitted"));
-    }
-
-    #[test]
-    fn short_list_run_is_untouched() {
-        let nodes: Vec<Node> = (0..2).map(|i| list_item(&format!("item {i}"), i)).collect();
-        let result = collapse_lists(nodes.clone());
+        let result = collapse_lists(nodes.clone(), 1000, &count);
         assert_eq!(result, nodes);
     }
 
     #[test]
-    fn table_body_rows_are_capped_with_omitted_count() {
+    fn list_run_is_capped_by_remaining_budget() {
+        let nodes: Vec<Node> = (0..6).map(|_| list_item("padding padding padding", 0)).collect();
+        let per_item = count("padding padding padding");
+        let marker = omitted_marker(4, "list items");
+        let budget = per_item * 2 + count(&marker);
+
+        let result = collapse_lists(nodes, budget, &count);
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].value(), "padding padding padding");
+        assert_eq!(result[1].value(), "padding padding padding");
+        assert!(result[2].value().contains("+4 more list items omitted"));
+    }
+
+    #[test]
+    fn table_body_rows_are_capped_by_remaining_budget() {
         let header = Node::TableRow(TableRow {
             values: vec![text("col")],
             position: None,
@@ -325,18 +492,72 @@ mod tests {
             align: vec![],
             position: None,
         });
-        let mut nodes = vec![header, align];
-        nodes.extend((0..6).map(|i| {
-            Node::TableRow(TableRow {
-                values: vec![text(&format!("row {i}"))],
-                position: None,
+        let rows: Vec<Node> = (0..6)
+            .map(|_| {
+                Node::TableRow(TableRow {
+                    values: vec![text("padding padding padding")],
+                    position: None,
+                })
             })
-        }));
+            .collect();
+        let mut nodes = vec![header.clone(), align.clone()];
+        nodes.extend(rows.clone());
 
-        let result = collapse_tables(nodes);
-        // header + align + MAX_COLLECTION_ITEMS body rows + omitted-count marker
-        assert_eq!(result.len(), 2 + MAX_COLLECTION_ITEMS + 1);
-        assert!(result.last().unwrap().value().contains("+3 more table rows omitted"));
+        let header_tokens = tokens_of(&[header, align], &count);
+        let per_row = count("padding padding padding");
+        let marker = omitted_marker(4, "table rows");
+        let budget = header_tokens + per_row * 2 + count(&marker);
+
+        let result = collapse_tables(nodes, budget, &count);
+
+        assert_eq!(result.len(), 2 + 2 + 1);
+        assert!(result.last().unwrap().value().contains("+4 more table rows omitted"));
+    }
+
+    #[test]
+    fn later_stage_is_skipped_once_earlier_stage_meets_budget() {
+        let header = Node::TableRow(TableRow {
+            values: vec![text("col")],
+            position: None,
+        });
+        let align = Node::TableAlign(TableAlign {
+            align: vec![],
+            position: None,
+        });
+        let rows: Vec<Node> = (0..5)
+            .map(|i| {
+                Node::TableRow(TableRow {
+                    values: vec![text(&format!("row {i}"))],
+                    position: None,
+                })
+            })
+            .collect();
+        let list_items: Vec<Node> = (0..20).map(|_| list_item("padding padding padding", 0)).collect();
+
+        let mut nodes = vec![header.clone(), align.clone()];
+        nodes.extend(rows.clone());
+        nodes.extend(list_items.clone());
+
+        let table_tokens = tokens_of(&[header, align], &count) + tokens_of(&rows, &count);
+        let per_item = count("padding padding padding");
+        let marker = omitted_marker(17, "list items");
+        // Enough for the table in full, plus only 3 list items -- forces list capping but should
+        // leave the table alone once collapse_lists already brings the total under budget.
+        let budget = table_tokens + per_item * 3 + count(&marker);
+
+        let result = token_compress(nodes, budget, &count);
+
+        for row in &rows {
+            assert!(
+                result.iter().any(|n| n.value() == row.value()),
+                "table row {:?} should be untouched",
+                row.value()
+            );
+        }
+        assert!(
+            result.iter().any(|n| n.value().contains("more list items omitted")),
+            "list should have been capped"
+        );
     }
 
     #[test]
@@ -351,15 +572,38 @@ mod tests {
     #[test]
     fn hard_truncate_is_last_resort_and_fits_budget() {
         let nodes = vec![text("a".repeat(500).as_str())];
-        let result = compress(nodes, 5);
+        let result = token_compress(nodes, 5, &count);
         assert_eq!(result.len(), 1);
-        assert!(token_count_estimate(&result[0].value()) <= 5 + token_count_estimate("..."));
+        assert!(count(&result[0].value()) <= 5 + count("..."));
+    }
+
+    #[test]
+    fn hard_truncate_keeps_head_and_tail_without_cutting_words() {
+        let words: Vec<String> = (0..80).map(|i| format!("word{i}")).collect();
+        let nodes = vec![text(&words.join(" "))];
+
+        let result = hard_truncate(&nodes, 40, &count);
+
+        assert_eq!(result.len(), 1);
+        let value = result[0].value();
+        assert!(value.contains("..."), "expected an ellipsis marker, got: {value}");
+        assert!(value.starts_with("word0 "), "got: {value}");
+        assert!(value.ends_with("word79"), "got: {value}");
+        for token in value.split_whitespace() {
+            if let Some(rest) = token.strip_prefix("word") {
+                let rest = rest.trim_end_matches('.');
+                assert!(
+                    !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()),
+                    "word cut mid-token: {token}"
+                );
+            }
+        }
     }
 
     #[test]
     fn zero_budget_does_not_panic() {
         let nodes = vec![heading(1, "Title"), text("Some paragraph text here.")];
-        let result = compress(nodes, 0);
-        assert!(total_tokens(&result) <= token_count_estimate("..."));
+        let result = token_compress(nodes, 0, &count);
+        assert!(tokens_of(&result, &count) <= count("..."));
     }
 }

--- a/crates/mq-lang/src/eval/builtin/tokenizer.rs
+++ b/crates/mq-lang/src/eval/builtin/tokenizer.rs
@@ -84,10 +84,33 @@ pub(super) fn token_count(text: &str, model: &str) -> Result<usize, Error> {
     }
 }
 
+pub(super) type Counter = Box<dyn Fn(&str) -> usize>;
+
+/// Like [`token_count`], but resolves the BPE encoder once instead of on every call — for
+/// `token_compress`, which counts tokens in a loop/binary search.
+pub(super) fn counter(model: Option<&str>) -> Result<Counter, Error> {
+    match model {
+        Some(model) => resolve_model_counter(model),
+        None => Ok(Box::new(token_count_estimate)),
+    }
+}
+
+fn resolve_model_counter(model: &str) -> Result<Counter, Error> {
+    #[cfg(feature = "tiktoken")]
+    {
+        let bpe = tiktoken_rs::bpe_for_model(model).map_err(|e| Error::Runtime(format!("token_compress: {e}")))?;
+        Ok(Box::new(move |text: &str| bpe.encode_ordinary(text).len()))
+    }
+    #[cfg(not(feature = "tiktoken"))]
+    {
+        let _ = model;
+        Ok(Box::new(token_count_estimate))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::heuristic::{is_cjk, is_latin, token_count as heuristic_token_count};
-    #[cfg(feature = "tiktoken")]
     use super::*;
     use rstest::rstest;
 
@@ -144,5 +167,31 @@ mod tests {
     #[test]
     fn test_exact_token_count_ignores_special_tokens_in_text() {
         assert!(exact_token_count("<|endoftext|>", "gpt-4").unwrap() > 0);
+    }
+
+    #[test]
+    fn test_counter_no_model_uses_heuristic() {
+        let count = counter(None).unwrap();
+        assert_eq!(count("Hello, world!"), heuristic_token_count("Hello, world!"));
+    }
+
+    #[cfg(feature = "tiktoken")]
+    #[test]
+    fn test_counter_with_model_uses_exact_count() {
+        let count = counter(Some("gpt-4")).unwrap();
+        assert_eq!(count("Hello, world!"), 4);
+    }
+
+    #[cfg(feature = "tiktoken")]
+    #[test]
+    fn test_counter_unknown_model_errors() {
+        assert!(counter(Some("not-a-real-model")).is_err());
+    }
+
+    #[cfg(not(feature = "tiktoken"))]
+    #[test]
+    fn test_counter_with_model_falls_back_to_heuristic_without_feature() {
+        let count = counter(Some("gpt-4")).unwrap();
+        assert_eq!(count("Hello, world!"), heuristic_token_count("Hello, world!"));
     }
 }

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -2746,6 +2746,8 @@ fn engine() -> DefaultEngine {
 #[case::token_count_no_model_simple(r#"token_count("Hello, world!")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(4.into())].into()))]
 #[case::token_count_no_model_markdown(r#"to_md_text("Hello, world!") | token_count()"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(4.into())].into()))]
 #[case::token_count_no_model_none(r#"token_count(None)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
+#[case::token_compress_under_budget(r##"to_markdown("# Title") | token_compress(1000)"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::new_markdown(mq_markdown::Node::Heading(mq_markdown::Heading{depth: 1, values: vec!["Title".to_string().into()], position: None}))]))].into()))]
+#[case::token_compress_none(r#"token_compress(None, 100)"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![]))].into()))]
 #[case::explode_simple(r##"explode("abc")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::Number(97.into()), RuntimeValue::Number(98.into()), RuntimeValue::Number(99.into())]))].into()))]
 #[case::implode_simple(r##"implode([97, 98, 99])"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("abc".to_string())].into()))]
 #[case::intern_simple(r##"intern("foo")"##, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("foo".to_string())].into()))]
@@ -3742,6 +3744,8 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 // token_count: non-string/non-markdown text → type error
 #[case::token_count_non_string(r#"token_count(42, "gpt-4")"#, vec![RuntimeValue::None],)]
 #[case::token_count_no_model_non_string(r#"token_count(42)"#, vec![RuntimeValue::None],)]
+// token_compress: non-array first arg → type error
+#[case::token_compress_non_array(r#"token_compress("not an array", 100)"#, vec![RuntimeValue::None],)]
 // range: multi-char string with step → error
 #[case::range_multichar_with_step(r#"range("aa", "zz", 2)"#, vec![RuntimeValue::None],)]
 // range: invalid type → error


### PR DESCRIPTION
## Summary

Reduces an array of Markdown nodes to fit a token budget in stages (paragraph-to-first-sentence, list/table/code collapse, hard truncate as last resort) instead of a single blind char-truncate, so structure is preserved as long as possible.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
