### PR TITLE
✨ feat(table): add pivot_longer/pivot_wider for wide/long table reshaping

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -370,7 +370,7 @@ def group_by(arr, f):
             | i += 1
             | let key = to_string(f(v))
             | let existing = get(groups, key)
-            | let new_group = if (is_none(existing)): [v] else: existing + v
+            | let new_group = if (is_none(existing)): [v] else: existing + [v]
             | groups = set(groups, key, new_group)
             | groups
           end

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -142,3 +142,87 @@ def to_csv(table, delimiter = ",")
   | csv::csv_stringify([header] + rows, delimiter)
 end
 
+# Reshape a table from wide format to long format (a.k.a. melt/unpivot).
+# `value_columns` is an array of column indices to unpivot; each one becomes
+# a row holding its header name (in the `names_to` column) and its cell
+# value (in the `values_to` column). Columns not listed in `value_columns`
+# are treated as identifier columns and repeated for every unpivoted value.
+def pivot_longer(table, value_columns, names_to = "name", values_to = "value"):
+  let header = table[:header]
+  | let id_columns = filter(range(0, len(header) - 1), fn(i): !in(value_columns, i);)
+  | var col = 0
+  | let id_header_cells = foreach (i, id_columns):
+        let cell = to_md_table_cell(to_string(header[i]), 0, col)
+        | col += 1
+        | cell
+      end
+  | let new_header = id_header_cells + [to_md_table_cell(names_to, 0, col), to_md_table_cell(values_to, 0, col + 1)]
+  | let new_align = to_md_table_align(map(range(0, len(new_header) - 1), fn(_): "none";))
+  | let new_rows = fold(table[:rows], [], fn(acc, row):
+        let base_row = len(acc) + 1
+        | var k = 0
+        | let expanded = foreach (vc, value_columns):
+              let row_num = base_row + k
+              | var c = 0
+              | let id_cells = foreach (i, id_columns):
+                    let cell = to_md_table_cell(to_string(row[i]), row_num, c)
+                    | c += 1
+                    | cell
+                  end
+              | let name_cell = to_md_table_cell(to_string(header[vc]), row_num, c)
+              | let value_cell = to_md_table_cell(to_string(row[vc]), row_num, c + 1)
+              | k += 1
+              | id_cells + [name_cell, value_cell]
+            end
+        | acc + expanded;
+      )
+  | set(set(set(table, :header, new_header), :rows, new_rows), :align, new_align)
+end
+
+# Reshape a table from long format to wide format (a.k.a. pivot/cast).
+# `names_from` is the column index whose distinct values become the headers
+# of new columns; `values_from` is the column index supplying the values
+# for those new columns. Columns other than `names_from` and `values_from`
+# are treated as identifier columns and used to group rows together.
+def pivot_wider(table, names_from, values_from):
+  let header = table[:header]
+  | let id_columns = filter(range(0, len(header) - 1), fn(i): i != names_from && i != values_from;)
+  | let key_of = fn(row): join(map(id_columns, fn(i): to_string(row[i]);), " ");
+  | let groups = group_by(table[:rows], key_of)
+  | let names = unique_by(map(table[:rows], fn(row): to_string(row[names_from]);), identity)
+  | let group_keys = unique_by(map(table[:rows], key_of), identity)
+  | var col = 0
+  | let id_header_cells = foreach (i, id_columns):
+        let cell = to_md_table_cell(to_string(header[i]), 0, col)
+        | col += 1
+        | cell
+      end
+  | let name_header_cells = foreach (name, names):
+        let cell = to_md_table_cell(name, 0, col)
+        | col += 1
+        | cell
+      end
+  | let new_header = id_header_cells + name_header_cells
+  | let new_align = to_md_table_align(map(range(0, len(new_header) - 1), fn(_): "none";))
+  | let new_rows = fold(group_keys, [], fn(acc, key):
+        let rows_for_key = get(groups, key)
+        | let first_row = first(rows_for_key)
+        | let row_num = len(acc) + 1
+        | var c = 0
+        | let id_cells = foreach (i, id_columns):
+              let cell = to_md_table_cell(to_string(first_row[i]), row_num, c)
+              | c += 1
+              | cell
+            end
+        | let value_map = fold(rows_for_key, dict(), fn(m, r): set(m, to_string(r[names_from]), to_string(r[values_from])); )
+        | let name_cells = foreach (name, names):
+              let v = get_or(value_map, name, "")
+              | let cell = to_md_table_cell(v, row_num, c)
+              | c += 1
+              | cell
+            end
+        | acc + [id_cells + name_cells];
+      )
+  | set(set(set(table, :header, new_header), :rows, new_rows), :align, new_align)
+end
+

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -128,3 +128,55 @@ def test_table_sort_rows():
   | let md_result = table::sort_rows(t)
   | assert_eq(to_string(md_result[:rows][0][0]), "Alice")
 end
+
+def test_table_pivot_longer():
+  let t = first(table::tables(table_nodes))
+  | let result = table::pivot_longer(t, [1, 2])
+  | assert_eq(len(result[:header]), 3)
+  | assert_eq(to_string(result[:header][1]), "name")
+  | assert_eq(to_string(result[:header][2]), "value")
+  | assert_eq(len(result[:rows]), 4)
+  | assert_eq(to_string(result[:rows][0][0]), "Alice")
+  | assert_eq(to_string(result[:rows][0][1]), "Age")
+  | assert_eq(to_string(result[:rows][0][2]), "30")
+  | assert_eq(to_string(result[:rows][1][1]), "City")
+  | assert_eq(to_string(result[:rows][1][2]), "Tokyo")
+  | assert_eq(to_string(result[:rows][3][0]), "Bob")
+  | assert_eq(to_string(result[:rows][3][1]), "City")
+  | assert_eq(to_string(result[:rows][3][2]), "Osaka")
+end
+
+def test_table_pivot_longer_custom_names():
+  let t = first(table::tables(table_nodes))
+  | let result = table::pivot_longer(t, [1, 2], "attr", "val")
+  | assert_eq(to_string(result[:header][1]), "attr")
+  | assert_eq(to_string(result[:header][2]), "val")
+end
+
+def test_table_pivot_wider():
+  let t = first(table::tables(table_nodes))
+  | let long = table::pivot_longer(t, [1, 2])
+  | let result = table::pivot_wider(long, 1, 2)
+  | assert_eq(len(result[:header]), 3)
+  | assert_eq(to_string(result[:header][0]), "Name")
+  | assert_eq(to_string(result[:header][1]), "Age")
+  | assert_eq(to_string(result[:header][2]), "City")
+  | assert_eq(len(result[:rows]), 2)
+  | assert_eq(to_string(result[:rows][0][0]), "Alice")
+  | assert_eq(to_string(result[:rows][0][1]), "30")
+  | assert_eq(to_string(result[:rows][0][2]), "Tokyo")
+  | assert_eq(to_string(result[:rows][1][0]), "Bob")
+  | assert_eq(to_string(result[:rows][1][1]), "25")
+  | assert_eq(to_string(result[:rows][1][2]), "Osaka")
+end
+
+def test_table_pivot_wider_missing_combination():
+  let header_row = "| Name | Attr | Val |\n| --- | --- | --- |\n| Alice | Age | 30 |\n| Alice | City | Tokyo |\n| Bob | Age | 25 |\n"
+  | let md_nodes = to_markdown(header_row)
+  | let t = first(table::tables(md_nodes))
+  | let result = table::pivot_wider(t, 1, 2)
+  | assert_eq(len(result[:rows]), 2)
+  | assert_eq(to_string(result[:rows][1][0]), "Bob")
+  | assert_eq(to_string(result[:rows][1][1]), "25")
+  | assert_eq(to_string(result[:rows][1][2]), "")
+end

--- a/docs/books/src/start/example.md
+++ b/docs/books/src/start/example.md
@@ -518,6 +518,66 @@ $ mq -A 'import "table" | table::tables() | first | table::to_csv' README.md
 
 **Output**: Returns the table as a CSV string.
 
+### Reshape a Table: Wide to Long (`pivot_longer`)
+
+Unpivot a set of columns into `name`/`value` row pairs, keeping the remaining columns as identifiers. `value_columns` is an array of column indices; `names_to` and `values_to` (both optional) name the two new columns.
+
+```bash
+$ mq -A 'import "table" | let t = first(table::tables()) | table::pivot_longer(t, [1, 2, 3], "quarter", "score")' README.md
+```
+
+**Input example**:
+
+```markdown
+| Name  | Q1 | Q2 | Q3 |
+| ----- | -- | -- | -- |
+| Alice | 10 | 20 | 30 |
+| Bob   | 5  | 15 | 25 |
+```
+
+**Output**:
+
+```markdown
+| Name  | quarter | score |
+| ----- | ------- | ----- |
+| Alice | Q1      | 10    |
+| Alice | Q2      | 20    |
+| Alice | Q3      | 30    |
+| Bob   | Q1      | 5     |
+| Bob   | Q2      | 15    |
+| Bob   | Q3      | 25    |
+```
+
+### Reshape a Table: Long to Wide (`pivot_wider`)
+
+The inverse of `pivot_longer`: spread a key/value column pair back out into one column per distinct key, grouping rows by the remaining identifier columns. `names_from` is the column index whose distinct values become new headers; `values_from` is the column index supplying the values. Combinations missing from the input become empty cells.
+
+```bash
+$ mq -A 'import "table" | table::tables() | first | table::pivot_wider(1, 2)' README.md
+```
+
+**Input example**:
+
+```markdown
+| Name  | quarter | score |
+| ----- | ------- | ----- |
+| Alice | Q1      | 10    |
+| Alice | Q2      | 20    |
+| Alice | Q3      | 30    |
+| Bob   | Q1      | 5     |
+| Bob   | Q2      | 15    |
+| Bob   | Q3      | 25    |
+```
+
+**Output**:
+
+```markdown
+| Name  | Q1 | Q2 | Q3 |
+| ----- | -- | -- | -- |
+| Alice | 10 | 20 | 30 |
+| Bob   | 5  | 15 | 25 |
+```
+
 ## Custom Functions and Programming
 
 ### Define Custom Function


### PR DESCRIPTION
## Summary

Add table::pivot_longer (wide-to-long/melt) and table::pivot_wider (long-to-wide/cast) to the table module, matching the semantics of Miller's reshape verb. Existing transpose only does a raw matrix transpose without column-name semantics, so it could not cover this case.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
