### PR TITLE
✨ feat(mq-lang): add date_relative builtin for parsing relative date expressions

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -431,6 +431,30 @@ fn date_diff_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
     }
 }
 
+/// Parses a natural-language relative date expression relative to a base Unix timestamp
+/// (seconds) and returns the resulting Unix timestamp (seconds, UTC).
+/// Supported forms: "now", "today", "yesterday", "tomorrow", "<n> <unit> ago",
+/// "in <n> <unit>", "next <weekday>", "last <weekday>".
+/// Units accept singular or plural: "second(s)", "minute(s)", "hour(s)", "day(s)", "week(s)", "month(s)", "year(s)".
+/// The base timestamp comes first (like `to_date`/`strftime`) so it can flow through a pipe:
+/// `now() | date_relative("3 days ago")`.
+#[mq_macros::mq_fn(name = "date_relative", params = Fixed(2))]
+fn date_relative_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Number(base), RuntimeValue::String(s)] => {
+            let base_secs = base.value() as i64;
+            let base_dt = DateTime::from_timestamp(base_secs, 0)
+                .ok_or_else(|| Error::Runtime(format!("date_relative: invalid base timestamp: {}", base_secs)))?;
+            date::parse_relative(s.as_str(), base_dt).map(|dt| RuntimeValue::Number(dt.timestamp().into()))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("date_relative should always receive exactly two arguments"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "base64", params = Fixed(1))]
 fn base64_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4577,6 +4601,7 @@ mq_macros::builtin_dispatch! {
     STRPTIME,
     DATE_ADD,
     DATE_DIFF,
+    DATE_RELATIVE,
     BASE64,
     BASE64D,
     BASE64URL,
@@ -5418,6 +5443,13 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
         BuiltinFunctionDoc {
             description: "Returns the difference (array2 - array1) in the given unit. Units: \"seconds\", \"minutes\", \"hours\", \"days\", \"weeks\".",
             params: &["array1", "array2", "unit"],
+        },
+    );
+    map.insert(
+        SmolStr::new("date_relative"),
+        BuiltinFunctionDoc {
+            description: "Parses a natural-language relative date expression (e.g. \"3 days ago\", \"yesterday\", \"tomorrow\", \"next monday\", \"in 2 weeks\") relative to a base Unix timestamp and returns the resulting Unix timestamp (seconds, UTC).",
+            params: &["base_timestamp", "date_str"],
         },
     );
     map.insert(
@@ -7878,6 +7910,64 @@ mod tests {
             Err(Error::Runtime(msg)) => assert!(msg.starts_with("date_diff:"), "expected date_diff prefix, got: {msg}"),
             other => panic!("expected Runtime error, got: {other:?}"),
         }
+    }
+
+    // date_relative: base is 2024-01-15T00:00:00Z (Monday), 1705276800
+    #[rstest]
+    #[case("now", 1705276800_i64)]
+    #[case("today", 1705276800_i64)]
+    #[case("yesterday", 1705190400_i64)]
+    #[case("tomorrow", 1705363200_i64)]
+    #[case("3 days ago", 1705017600_i64)]
+    #[case("in 2 weeks", 1706486400_i64)]
+    #[case("next monday", 1705881600_i64)]
+    #[case("last friday", 1705017600_i64)]
+    fn test_date_relative(#[case] input: &str, #[case] expected_secs: i64) {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_relative"),
+            vec![
+                RuntimeValue::Number(1705276800_i64.into()),
+                RuntimeValue::String(input.into()),
+            ],
+            &env,
+        )
+        .unwrap();
+        assert_eq!(result, RuntimeValue::Number(expected_secs.into()));
+    }
+
+    #[test]
+    fn test_date_relative_invalid_expression() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_relative"),
+            vec![
+                RuntimeValue::Number(1705276800_i64.into()),
+                RuntimeValue::String("not a relative date".into()),
+            ],
+            &env,
+        );
+        match result {
+            Err(Error::Runtime(msg)) => assert!(
+                msg.starts_with("date_relative:"),
+                "expected date_relative prefix, got: {msg}"
+            ),
+            other => panic!("expected Runtime error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_date_relative_invalid_types() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("date_relative"),
+            vec![RuntimeValue::Number(1.into()), RuntimeValue::Number(2.into())],
+            &env,
+        );
+        assert!(matches!(result, Err(Error::InvalidTypes(_, _))));
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin/date.rs
+++ b/crates/mq-lang/src/eval/builtin/date.rs
@@ -1,5 +1,5 @@
 use super::Error;
-use chrono::{DateTime, Duration, Months, Utc};
+use chrono::{DateTime, Datelike, Duration, Months, NaiveDateTime, Utc, Weekday};
 
 /// Date/time units used by `date_add` and `date_diff`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,6 +90,93 @@ pub(super) fn add(dt: DateTime<Utc>, amount: i64, unit: &str) -> Result<DateTime
 pub(super) fn diff(diff: Duration, unit: &str) -> Result<i64, Error> {
     let unit = DateUnit::try_from(unit)?;
     unit.apply_diff(diff)
+}
+
+/// Like `DateUnit::try_from`, but also accepts singular unit words (e.g. "day"), since
+/// relative-date phrases such as "1 day ago" use the singular form.
+fn parse_relative_unit(word: &str) -> Option<DateUnit> {
+    match word {
+        "second" | "seconds" => Some(DateUnit::Seconds),
+        "minute" | "minutes" => Some(DateUnit::Minutes),
+        "hour" | "hours" => Some(DateUnit::Hours),
+        "day" | "days" => Some(DateUnit::Days),
+        "week" | "weeks" => Some(DateUnit::Weeks),
+        "month" | "months" => Some(DateUnit::Months),
+        "year" | "years" => Some(DateUnit::Years),
+        _ => None,
+    }
+}
+
+fn parse_weekday(word: &str) -> Option<Weekday> {
+    match word {
+        "sunday" => Some(Weekday::Sun),
+        "monday" => Some(Weekday::Mon),
+        "tuesday" => Some(Weekday::Tue),
+        "wednesday" => Some(Weekday::Wed),
+        "thursday" => Some(Weekday::Thu),
+        "friday" => Some(Weekday::Fri),
+        "saturday" => Some(Weekday::Sat),
+        _ => None,
+    }
+}
+
+/// Walks forward (or backward) from `base` a day at a time until `target` weekday is
+/// reached, preserving `base`'s time-of-day. `base`'s own weekday never matches, so this
+/// always lands on the next/previous occurrence, never today.
+fn nearest_weekday(base: DateTime<Utc>, target: Weekday, forward: bool) -> DateTime<Utc> {
+    let time = base.time();
+    let mut date = base.date_naive();
+
+    loop {
+        date = if forward {
+            date.succ_opt().expect("date arithmetic within a week cannot overflow")
+        } else {
+            date.pred_opt().expect("date arithmetic within a week cannot overflow")
+        };
+        if date.weekday() == target {
+            return NaiveDateTime::new(date, time).and_utc();
+        }
+    }
+}
+
+/// Parses a natural-language relative date expression relative to `base` and returns the
+/// resulting UTC datetime.
+///
+/// Supported forms: "now", "today", "yesterday", "tomorrow", "<n> <unit> ago",
+/// "in <n> <unit>", "next <weekday>", "last <weekday>". Units accept singular or plural
+/// ("day"/"days", ...); weekdays use their full English name ("monday", ...).
+pub(super) fn parse_relative(s: &str, base: DateTime<Utc>) -> Result<DateTime<Utc>, Error> {
+    let unrecognized = || Error::Runtime(format!("date_relative: unrecognized relative date expression {:?}", s));
+    let lower = s.trim().to_lowercase();
+
+    match lower.as_str() {
+        "now" | "today" => return Ok(base),
+        "yesterday" => return Ok(base - Duration::days(1)),
+        "tomorrow" => return Ok(base + Duration::days(1)),
+        _ => {}
+    }
+
+    match lower.split_whitespace().collect::<Vec<_>>().as_slice() {
+        [amount, unit_word, "ago"] => {
+            let amount: i64 = amount.parse().map_err(|_| unrecognized())?;
+            let unit = parse_relative_unit(unit_word).ok_or_else(unrecognized)?;
+            unit.apply_add(base, -amount).ok_or_else(unrecognized)
+        }
+        ["in", amount, unit_word] => {
+            let amount: i64 = amount.parse().map_err(|_| unrecognized())?;
+            let unit = parse_relative_unit(unit_word).ok_or_else(unrecognized)?;
+            unit.apply_add(base, amount).ok_or_else(unrecognized)
+        }
+        ["next", weekday_word] => {
+            let weekday = parse_weekday(weekday_word).ok_or_else(unrecognized)?;
+            Ok(nearest_weekday(base, weekday, true))
+        }
+        ["last", weekday_word] => {
+            let weekday = parse_weekday(weekday_word).ok_or_else(unrecognized)?;
+            Ok(nearest_weekday(base, weekday, false))
+        }
+        _ => Err(unrecognized()),
+    }
 }
 
 #[cfg(test)]
@@ -207,5 +294,53 @@ mod tests {
     fn test_diff_wrapper_invalid_unit() {
         let d = Duration::days(30);
         assert!(diff(d, "months").is_err());
+    }
+
+    // --- parse_relative ---
+    // Base is 2024-01-15, a Monday.
+
+    #[rstest]
+    #[case("now", utc(2024, 1, 15))]
+    #[case("today", utc(2024, 1, 15))]
+    #[case("yesterday", utc(2024, 1, 14))]
+    #[case("tomorrow", utc(2024, 1, 16))]
+    #[case("Tomorrow", utc(2024, 1, 16))]
+    #[case("  tomorrow  ", utc(2024, 1, 16))]
+    #[case("1 day ago", utc(2024, 1, 14))]
+    #[case("3 days ago", utc(2024, 1, 12))]
+    #[case("2 weeks ago", utc(2024, 1, 1))]
+    #[case("1 month ago", utc(2023, 12, 15))]
+    #[case("1 year ago", utc(2023, 1, 15))]
+    #[case("in 3 days", utc(2024, 1, 18))]
+    #[case("in 2 weeks", utc(2024, 1, 29))]
+    #[case("in 1 month", utc(2024, 2, 15))]
+    #[case("In 1 Month", utc(2024, 2, 15))]
+    #[case("next monday", utc(2024, 1, 22))]
+    #[case("next friday", utc(2024, 1, 19))]
+    #[case("last monday", utc(2024, 1, 8))]
+    #[case("last friday", utc(2024, 1, 12))]
+    fn test_parse_relative_valid(#[case] input: &str, #[case] expected: DateTime<Utc>) {
+        let base = utc(2024, 1, 15);
+        assert_eq!(parse_relative(input, base).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case("someday")]
+    #[case("3 decades ago")]
+    #[case("in three days")]
+    #[case("next someday")]
+    #[case("last")]
+    #[case("ago 3 days")]
+    fn test_parse_relative_invalid(#[case] input: &str) {
+        let base = utc(2024, 1, 15);
+        assert!(parse_relative(input, base).is_err());
+    }
+
+    #[test]
+    fn test_parse_relative_preserves_time_of_day() {
+        let base = Utc.with_ymd_and_hms(2024, 1, 15, 9, 30, 0).unwrap();
+        let expected = Utc.with_ymd_and_hms(2024, 1, 22, 9, 30, 0).unwrap();
+        assert_eq!(parse_relative("next monday", base).unwrap(), expected);
     }
 }


### PR DESCRIPTION
## Summary

Adds date_relative(base_timestamp, date_str), which parses natural-language relative expressions ("3 days ago", "yesterday", "tomorrow", "next monday", "in 2 weeks", ...) against a base Unix timestamp and returns the resulting timestamp. Implemented on top of the existing chrono primitives already used by date_add/date_diff, so no new dependency is introduced. Argument order matches to_date/strftime (timestamp first) so it composes naturally in a pipe, e.g. now() | date_relative("3 days ago").

Close #2127

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
