### PR TITLE
✨ feat(mq-lang): add assert_type, assert_field, assert_matches to test module

### DIFF
--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -1210,3 +1210,51 @@ def test_human_size():
   | assert_eq(result6, "-1.5K")
 end
 
+def test_assert_type():
+  let node = do "# Title" | to_markdown() | first();
+  | let result1 = assert_type(node, "h1")
+  | assert_eq(result1, node)
+
+  | let result2 = assert_type(node, "h2")
+  | assert_eq(is_dict(result2), true)
+  | assert_eq(result2["error"], true)
+  | assert_eq(result2["range"]["start_line"], 1)
+
+  | let result3 = assert_type("hello", "string")
+  | assert_eq(result3, "hello")
+
+  | let result4 = assert_type(42, "string")
+  | assert_eq(result4["error"], true)
+  | assert_eq(is_none(result4["range"]), true)
+end
+
+def test_assert_field():
+  let record = {"name": "mq", "kind": "cli"}
+  | let result1 = assert_field(record, "name")
+  | assert_eq(result1, record)
+
+  | let result2 = assert_field(record, "missing")
+  | assert_eq(result2["error"], true)
+  | assert_eq(contains(result2["message"], "missing"), true)
+
+  | let result3 = assert_field("not a dict", "name")
+  | assert_eq(result3["error"], true)
+  | assert_eq(contains(result3["message"], "string"), true)
+end
+
+def test_assert_matches():
+  let node = do "let x = 1;" | to_markdown() | first();
+  | let result1 = assert_matches(node, "^let ")
+  | assert_eq(result1, node)
+
+  | let result2 = assert_matches(node, "^fn ")
+  | assert_eq(result2["error"], true)
+  | assert_eq(result2["range"]["start_line"], 1)
+
+  | let result3 = assert_matches("hello world", "^hello")
+  | assert_eq(result3, "hello world")
+
+  | let result4 = assert_matches("hello world", "^bye")
+  | assert_eq(result4["error"], true)
+end
+

--- a/crates/mq-lang/modules/test.mq
+++ b/crates/mq-lang/modules/test.mq
@@ -148,6 +148,38 @@ def assert_not_empty(array):
     {"error": true, "message": "Assertion failed: Expected non-empty array but got empty array"}
 end
 
+# Verifies that a value has the given type.
+#
+# For markdown nodes this checks the node kind (e.g. "h1", "code", "list"),
+# matching `to_md_name`. For every other value it checks the runtime type
+# returned by `type`. On failure the source range of `value` is included
+# so callers (e.g. content-lint rules) can point at the offending node.
+def assert_type(value, expected_type):
+  let actual_type = if (is_markdown(value)): to_md_name(value) else: type(value)
+  | if (actual_type == expected_type):
+      value
+    else:
+      {"error": true, "range": get_location(value), "message": "Assertion failed: expected type \"" + expected_type + "\" but got \"" + actual_type + "\""}
+end
+
+# Verifies that a dict has the given field.
+def assert_field(value, field):
+  if (is_dict(value) && contains(value, field)):
+    value
+  elif (not(is_dict(value))):
+    {"error": true, "range": get_location(value), "message": "Assertion failed: expected a dict but got \"" + type(value) + "\""}
+  else:
+    {"error": true, "range": get_location(value), "message": "Assertion failed: expected field \"" + field + "\" to exist"}
+end
+
+# Verifies that a value's string representation matches the given regular expression pattern.
+def assert_matches(value, pattern):
+  if (test(to_string(value), pattern)):
+    value
+  else:
+    {"error": true, "range": get_location(value), "message": "Assertion failed: expected \"" + to_string(value) + "\" to match pattern \"" + pattern + "\""}
+end
+
 # Test execution helper functions
 
 # Runs a single test function and captures the result


### PR DESCRIPTION
## Summary

Adds a node/domain assertion API to the test module: assert_type checks a markdown node kind (or runtime type for scalars), assert_field checks a required dict key, and assert_matches checks a value's string form against a regex. All three return the value on success or an error dict with a source range and message on failure, so callers can point at the exact node that failed a constraint.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
