### PR TITLE
✨ feat(mq-lang): add native fuzzy-match distance builtins using strsim

### DIFF
--- a/crates/mq-lang/modules/fuzzy.mq
+++ b/crates/mq-lang/modules/fuzzy.mq
@@ -1,132 +1,6 @@
 # Fuzzy Match Implementation in mq
-
-def _levenshtein_distance(s1, s2):
-  let len1 = len(s1)
-  | let len2 = len(s2)
-  | let matrix = []
-  | var i = 0
-  | let matrix = while (i <= len1):
-      var j = 0
-      | let row = []
-      | let row = while (j <= len2):
-              let value = if (i == 0):
-                j
-              elif (j == 0):
-                i
-              else:
-                0
-              | let row = row + [value]
-              | j += 1
-              | row
-            end
-      | let matrix = matrix + [row]
-      | i += 1
-      | matrix
-    end
-  | i = 1
-  | let matrix = while (i <= len1):
-      var j = 1
-      | let matrix = while (j <= len2):
-              let cost = if (s1[i - 1] == s2[j - 1]): 0 else: 1
-              | let deletion = matrix[i - 1][j] + 1
-              | let insertion = matrix[i][j - 1] + 1
-              | let substitution = matrix[i - 1][j - 1] + cost
-              | let min_value = if (deletion <= insertion && deletion <= substitution):
-                              deletion
-                            elif (insertion <= substitution):
-                              insertion
-                            else:
-                              substitution
-              | let row = matrix[i]
-              | let row = set(row, j, min_value)
-              | let matrix = set(matrix, i, row)
-              | j += 1
-              | matrix
-            end
-      | i += 1
-      | matrix
-    end
-  | if (len1 == 0): len2 elif (len2 == 0): len1 elif (is_none(matrix)): 0 else: matrix[len1][len2]
-end
-
-def _calculate_jaro_distance(s1, s2, len1, len2):
-  let match_window = floor(if (len1 > len2): (len1 / 2) - 1 else: (len2 / 2) - 1)
-  | let match_window = if (match_window < 0): 0 else: match_window
-  | let s1_matches = []
-  | let s2_matches = []
-  | let matches = 0
-  | var i = 0
-  | let result = while (i < len1):
-      let start = max(i - match_window, 0)
-      | let end_ = min(len2, i + match_window + 1)
-      | var j = start
-      | var found = false
-      | let result = while (j < end_ && !found):
-              let result = if (s1[i] == s2[j] && !contains(s2_matches, j)):
-                [true, j]
-              else:
-                [false, j + 1]
-              | found = result[0]
-              | j = result[1]
-              | let result = if (found):
-                              [s1_matches + [i], s2_matches + [j], matches + 1]
-                            else:
-                              [s1_matches, s2_matches, matches]
-              | let s1_matches = result[0]
-              | let s2_matches = result[1]
-              | let matches = result[2]
-              | result
-            end
-      | let s1_matches = result[0]
-      | let s2_matches = result[1]
-      | let matches = result[2]
-      | i += 1
-      | [s1_matches, s2_matches, matches]
-    end
-  | let s1_matches = result[0]
-  | let s2_matches = result[1]
-  | let matches = result[2]
-  | if (is_none(matches) || matches == 0):
-      0
-    else:
-      _calculate_jaro_with_transpositions(s1, s2, s1_matches, s2_matches, matches, len1, len2)
-end
-
-def _calculate_jaro_with_transpositions(s1, s2, s1_matches, s2_matches, matches, len1, len2):
-  let transpositions = 0
-  | var i = 0
-  | let s1_matches_len = len(s1_matches)
-  | let transpositions = while (i < s1_matches_len):
-      let transpositions = if (s1_matches[i] != s2_matches[i]):
-        transpositions + 1
-      else:
-        transpositions
-      | i += 1
-      | transpositions
-    end
-  | let transpositions = transpositions / 2
-  | ((matches / len1) + (matches / len2) + ((matches - transpositions) / matches)) / 3
-end
-
-def _jaro_distance(s1, s2):
-  let len1 = len(s1)
-  | let len2 = len(s2)
-  | if (len1 == 0 && len2 == 0):
-      1
-    elif (len1 == 0 || len2 == 0):
-      0
-    else:
-      _calculate_jaro_distance(s1, s2, len1, len2)
-end
-
-def _common_prefix_length(s1, s2):
-  let min_len = if (len(s1) < len(s2)): len(s1) else: len(s2)
-  | var i = 0
-  | while (i < min_len && s1[i] == s2[i]):
-      i += 1
-    end
-  | i
-end
+# Distance calculations (Levenshtein, Jaro, Jaro-Winkler) are implemented natively in
+# Rust for performance; this module wraps them with matching, filtering, and sorting utilities.
 
 def _fuzzy_match_with_algorithm(query, candidates, algorithm):
   map(candidates, fn(candidate):
@@ -135,22 +9,13 @@ def _fuzzy_match_with_algorithm(query, candidates, algorithm):
 end
 
 # Calculates the Levenshtein distance between two strings.
-def levenshtein(s1, s2):
-  _levenshtein_distance(s1, s2)
-end
+def levenshtein(s1, s2): _levenshtein_distance(s1, s2);
 
 # Calculates the Jaro distance between two strings (0.0 to 1.0, where 1.0 is exact match).
-def jaro(s1, s2):
-  _jaro_distance(s1, s2)
-end
+def jaro(s1, s2): _jaro_distance(s1, s2);
 
 # Calculates the Jaro-Winkler distance between two strings.
-def jaro_winkler(s1, s2):
-  let jaro_dist = _jaro_distance(s1, s2)
-  | let prefix_length = _common_prefix_length(s1, s2)
-  | let prefix_length = if (prefix_length > 4): 4 else: prefix_length
-  | jaro_dist + (0.1 * to_number(prefix_length) * (1 - jaro_dist))
-end
+def jaro_winkler(s1, s2): _jaro_winkler_distance(s1, s2);
 
 # Performs fuzzy matching on an array of strings using Jaro-Winkler distance.
 def fuzzy_match(candidates, query):

--- a/crates/mq-lang/modules/fuzzy_test.mq
+++ b/crates/mq-lang/modules/fuzzy_test.mq
@@ -65,7 +65,7 @@ def test_fuzzy_filter():
   | assert_eq(len(result1), 1)
 
   | let result2 = fuzzy::fuzzy_filter(["lawn", "claw"], "lawn", 0.7)
-  | assert_eq(len(result2), 1)
+  | assert_eq(len(result2), 2)
 
   | let result3 = fuzzy::fuzzy_filter(["lawn", "claw"], "flaw", 0.6)
   | assert_eq(len(result3), 2)

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -3478,6 +3478,56 @@ fn _csv_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
     }
 }
 
+#[mq_macros::mq_fn(name = "_levenshtein_distance", params = Fixed(2))]
+fn _levenshtein_distance_impl(
+    ident: &Ident,
+    _: &RuntimeValue,
+    mut args: Args,
+    _: &SharedEnv,
+) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s1), RuntimeValue::String(s2)] => {
+            Ok(RuntimeValue::Number((strsim::levenshtein(s1, s2) as i64).into()))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("_levenshtein_distance should always receive exactly two arguments"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "_jaro_distance", params = Fixed(2))]
+fn _jaro_distance_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s1), RuntimeValue::String(s2)] => Ok(RuntimeValue::Number(strsim::jaro(s1, s2).into())),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("_jaro_distance should always receive exactly two arguments"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "_jaro_winkler_distance", params = Fixed(2))]
+fn _jaro_winkler_distance_impl(
+    ident: &Ident,
+    _: &RuntimeValue,
+    mut args: Args,
+    _: &SharedEnv,
+) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(s1), RuntimeValue::String(s2)] => {
+            Ok(RuntimeValue::Number(strsim::jaro_winkler(s1, s2).into()))
+        }
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("_jaro_winkler_distance should always receive exactly two arguments"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "_json_parse", params = Fixed(1))]
 fn _json_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4805,6 +4855,9 @@ mq_macros::builtin_dispatch! {
     TO_MDX,
     _GET_MARKDOWN_POSITION,
     _CSV_PARSE,
+    _LEVENSHTEIN_DISTANCE,
+    _JARO_DISTANCE,
+    _JARO_WINKLER_DISTANCE,
     _JSON_PARSE,
     _GRON_PARSE,
     _YAML_PARSE,
@@ -5265,6 +5318,27 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc
         BuiltinFunctionDoc {
             description: "Parses a CSV string into an array of arrays, using the specified delimiter and header options.",
             params: &["csv_string", "delimiter", "has_header"],
+        },
+    );
+    map.insert(
+        SmolStr::new("_levenshtein_distance"),
+        BuiltinFunctionDoc {
+            description: "Calculates the Levenshtein edit distance between two strings.",
+            params: &["s1", "s2"],
+        },
+    );
+    map.insert(
+        SmolStr::new("_jaro_distance"),
+        BuiltinFunctionDoc {
+            description: "Calculates the Jaro distance between two strings (0.0 to 1.0, where 1.0 is an exact match).",
+            params: &["s1", "s2"],
+        },
+    );
+    map.insert(
+        SmolStr::new("_jaro_winkler_distance"),
+        BuiltinFunctionDoc {
+            description: "Calculates the Jaro-Winkler distance between two strings, boosting scores for matching prefixes.",
+            params: &["s1", "s2"],
         },
     );
     map.insert(

--- a/crates/mq-lang/tests/integration_tests.rs
+++ b/crates/mq-lang/tests/integration_tests.rs
@@ -3518,6 +3518,16 @@ fn engine() -> DefaultEngine {
 #[case::csv_parse_delimiter(r#"_csv_parse("a;b;c", ";") | first | first"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("a".to_string())].into()))]
 // _csv_parse: with header row
 #[case::csv_parse_header(r#"_csv_parse("name,age\nAlice,30", ",", true) | first | type"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("dict".to_string())].into()))]
+// _levenshtein_distance: edit distance between two strings
+#[case::levenshtein_distance(r#"_levenshtein_distance("flaw", "lawn")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(2.into())].into()))]
+// _levenshtein_distance: identical strings
+#[case::levenshtein_distance_identical(r#"_levenshtein_distance("abc", "abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(0.into())].into()))]
+// _jaro_distance: identical strings
+#[case::jaro_distance_identical(r#"_jaro_distance("abc", "abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+// _jaro_distance: empty strings
+#[case::jaro_distance_empty(r#"_jaro_distance("", "")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
+// _jaro_winkler_distance: identical strings
+#[case::jaro_winkler_distance_identical(r#"_jaro_winkler_distance("abc", "abc")"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::Number(1.into())].into()))]
 // _xml_parse: basic element with text
 #[case::xml_parse_basic(r#"_xml_parse("<root>hello</root>") | type"#, vec![RuntimeValue::None], Ok(vec![RuntimeValue::String("dict".to_string())].into()))]
 // _xml_parse: self-closing element
@@ -3788,6 +3798,12 @@ fn test_eval(mut engine: Engine, #[case] program: &str, #[case] input: Vec<Runti
 #[case::csv_parse_non_string_delim(r#"_csv_parse("a,b", 42)"#, vec![RuntimeValue::None],)]
 // _xml_parse: non-string arg → type error
 #[case::xml_parse_non_string("_xml_parse(42)", vec![RuntimeValue::None],)]
+// _levenshtein_distance: non-string arg → type error
+#[case::levenshtein_distance_non_string(r#"_levenshtein_distance(42, "a")"#, vec![RuntimeValue::None],)]
+// _jaro_distance: non-string arg → type error
+#[case::jaro_distance_non_string(r#"_jaro_distance("a", 42)"#, vec![RuntimeValue::None],)]
+// _jaro_winkler_distance: non-string arg → type error
+#[case::jaro_winkler_distance_non_string(r#"_jaro_winkler_distance(42, 42)"#, vec![RuntimeValue::None],)]
 // get: Markdown + non-number key → type error
 #[case::get_markdown_non_number(r#"get(to_h("hi", 1), "key")"#, vec![RuntimeValue::None],)]
 // mul: negative float * string → type error


### PR DESCRIPTION
## Summary

Replace the pure-mq Levenshtein/Jaro/Jaro-Winkler distance calculations in fuzzy.mq with native Rust builtins (_levenshtein_distance, _jaro_distance, _jaro_winkler_distance) backed by the strsim crate, mirroring the native _csv_parse wrapper pattern for performance.

- fuzzy.mq's levenshtein/jaro/jaro_winkler now delegate to the new builtins; higher-level APIs (fuzzy_match, fuzzy_filter, fuzzy_best_match, etc.) are unchanged
- Fixes a transposition-counting bug in the old pure-mq Jaro distance implementation, updating one fuzzy_test.mq expectation to match the correct standard Jaro-Winkler score
- Add integration test cases covering the new builtins

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
