### PR TITLE
✨ feat(playground,vscode): add many more usage examples

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -48,30 +48,30 @@ import "yaml" | if (.yaml): yaml::yaml_parse() | get(:title)
 
 # Sort by property
 [{"name": "Bob", "age": 30}, {"name": "Alice", "age": 25}]
-| sort_by(self, fn(x): get(x, "age");)
+| sort_by(fn(x): get(x, "age");)
 
 # Group by predicate
 [1, 2, 3, 4, 5, 6, 7, 8]
-| group_by(self, fn(x): if (x % 2 == 0): "even" else: "odd";)
+| group_by(fn(x): if (x % 2 == 0): "even" else: "odd";)
 
 # Sum with fold
 fold([1, 2, 3, 4, 5], 0, fn(acc, x): acc + x;)
 
 # Pick specific dict fields
 {"name": "mq", "version": "0.7.0", "internal_id": 42}
-| pick(self, ["name", "version"])
+| pick(["name", "version"])
 
 # Parse relative dates
-date_relative(now(), "3 days ago") | strftime(self, "%Y-%m-%d")
+date_relative(now(), "3 days ago") | strftime("%Y-%m-%d")
 
 # Compare semantic versions
 include "semver" | semver_gt(semver_parse("2.1.0"), semver_parse("2.0.5"))
 
 # Stringify to TOML
-include "toml" | {"title": "mq", "version": "0.7.0"} | toml_stringify(self)
+include "toml" | {"title": "mq", "version": "0.7.0"} | toml_stringify()
 
 # Uppercase all headings (run with the -U/--update flag to apply in place)
-.h | upcase(self)
+.h | upcase()
 `;
 
 let client: lc.LanguageClient | null = null;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -45,6 +45,33 @@ include "csv" | csv_parse("a,b,c\n1,2,3\n4,5,6", true) | csv_to_markdown_table()
 
 # Extract Front Matter
 import "yaml" | if (.yaml): yaml::yaml_parse() | get(:title)
+
+# Sort by property
+[{"name": "Bob", "age": 30}, {"name": "Alice", "age": 25}]
+| sort_by(self, fn(x): get(x, "age");)
+
+# Group by predicate
+[1, 2, 3, 4, 5, 6, 7, 8]
+| group_by(self, fn(x): if (x % 2 == 0): "even" else: "odd";)
+
+# Sum with fold
+fold([1, 2, 3, 4, 5], 0, fn(acc, x): acc + x;)
+
+# Pick specific dict fields
+{"name": "mq", "version": "0.7.0", "internal_id": 42}
+| pick(self, ["name", "version"])
+
+# Parse relative dates
+date_relative(now(), "3 days ago") | strftime(self, "%Y-%m-%d")
+
+# Compare semantic versions
+include "semver" | semver_gt(semver_parse("2.1.0"), semver_parse("2.0.5"))
+
+# Stringify to TOML
+include "toml" | {"title": "mq", "version": "0.7.0"} | toml_stringify(self)
+
+# Uppercase all headings (run with the -U/--update flag to apply in place)
+.h | upcase(self)
 `;
 
 let client: lc.LanguageClient | null = null;

--- a/packages/mq-playground/src/examples.ts
+++ b/packages/mq-playground/src/examples.ts
@@ -661,6 +661,310 @@ Keyboard, Accessories, $80, 35
       },
     ],
   },
+  {
+    name: "String Functions",
+    examples: [
+      {
+        name: "Trim and normalize case",
+        code: `trim(self) | upcase()`,
+        markdown: `  hello, mq!  `,
+        isUpdate: false,
+        format: "raw",
+      },
+      {
+        name: "Split and join",
+        code: `split(self, ",") | join(self, " | ")`,
+        markdown: `apple,banana,cherry`,
+        isUpdate: false,
+        format: "raw",
+      },
+      {
+        name: "Pad numbers",
+        code: `["7", "42", "123"] | map(self, fn(x): lpad(x, 5, "0");)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Slugify text",
+        code: `slugify(self)`,
+        markdown: `Hello, World! This is mq`,
+        isUpdate: false,
+        format: "raw",
+      },
+    ],
+  },
+  {
+    name: "Array and Collection Functions",
+    examples: [
+      {
+        name: "Sort by property",
+        code: `[{"name": "Bob", "age": 30}, {"name": "Alice", "age": 25}, {"name": "Carol", "age": 35}]
+| sort_by(self, fn(x): get(x, "age");)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Group by predicate",
+        code: `[1, 2, 3, 4, 5, 6, 7, 8]
+| group_by(self, fn(x): if (x % 2 == 0): "even" else: "odd";)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Chunk into groups",
+        code: `[1, 2, 3, 4, 5, 6, 7] | chunks(self, 3)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Zip two arrays",
+        code: `zip(["a", "b", "c"], [1, 2, 3])`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Partition by predicate",
+        code: `[1, 2, 3, 4, 5, 6] | partition(self, fn(x): x % 2 == 0;)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "Functional Programming",
+    examples: [
+      {
+        name: "Sum with fold",
+        code: `[1, 2, 3, 4, 5] | fold(self, 0, fn(acc, x): acc + x;)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Any and all conditions",
+        code: `[1, 2, 3, 4, 5]
+| {"any_gt_4": any(self, fn(x): x > 4;), "all_positive": all(self, fn(x): x > 0;)}`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Filter and convert with compact_map",
+        code: `["1", "abc", "3", "xyz", "5"]
+| compact_map(self, fn(x): if (is_regex_match(x, "^[0-9]+$")): to_number(x);)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "Date and Time",
+    examples: [
+      {
+        name: "Parse relative dates",
+        code: `date_relative(1705276800, "3 days ago") | strftime(self, "%Y-%m-%d")`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Format dates with strftime",
+        code: `from_date("2024-01-15T00:00:00Z") | strftime(self, "%A, %B %d, %Y")`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Add to a date",
+        code: `gmtime(from_date("2024-01-15T00:00:00Z"))
+| date_add(self, 2, "months")
+| mktime(self)
+| strftime(self, "%Y-%m-%d")`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Days between two dates",
+        code: `date_diff(gmtime(from_date("2024-01-01T00:00:00Z")), gmtime(from_date("2024-03-15T00:00:00Z")), "days")`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "Data Format Conversion",
+    examples: [
+      {
+        name: "Parse TOML",
+        code: `include "toml" | toml_parse(self)`,
+        markdown: `title = "mq"
+version = "0.7.0"
+
+[author]
+name = "harehare"
+`,
+        isUpdate: false,
+        format: "raw",
+      },
+      {
+        name: "Parse XML to markdown table",
+        code: `include "xml" | xml_parse(self) | xml_to_markdown_table(self)`,
+        markdown: `<book><title>mq Guide</title><price>20</price></book>`,
+        isUpdate: false,
+        format: "raw",
+      },
+      {
+        name: "Parse gron output",
+        code: `include "gron" | gron_parse(self)`,
+        markdown: `json = {};
+json.name = "mq";
+json.tags = [];
+json.tags[0] = "markdown";
+json.tags[1] = "cli";
+`,
+        isUpdate: false,
+        format: "raw",
+      },
+      {
+        name: "Stringify to TOON",
+        code: `include "toon"
+| {"name": "mq", "version": "0.7.0", "tags": ["cli", "markdown"]}
+| toon_stringify(self)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "Semantic Versioning",
+    examples: [
+      {
+        name: "Compare versions",
+        code: `include "semver" | semver_gt(semver_parse("2.1.0"), semver_parse("2.0.5"))`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Sort version list",
+        code: `include "semver"
+| ["1.2.0", "1.10.0", "1.2.10"]
+| map(self, semver_parse)
+| semver_sort(self)
+| map(self, semver_to_string)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "Markdown Builders",
+    examples: [
+      {
+        name: "Build heading and list",
+        code: `include "md"
+| doc(h("Getting Started", 2), to_md_list(text("Install mq"), 1), to_md_list(text("Run your first query"), 1))`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Build a callout",
+        code: `include "md" | doc(callout(text("Breaking change in 0.7.0"), "warning", "Heads up"))`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Build a link",
+        code: `include "md" | doc(strong(text("Note:")), to_link("https://mqlang.org", "mq documentation", ""))`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
+  {
+    name: "In-place Document Updates",
+    examples: [
+      {
+        name: "Uppercase all headings",
+        code: `.h | upcase(self)`,
+        markdown: `# Introduction
+
+Welcome to the project.
+
+## Installation
+
+Run npm install.
+
+## Usage
+
+Use the tool like this.
+`,
+        isUpdate: true,
+        format: "markdown",
+      },
+      {
+        name: "Promote heading levels",
+        code: `.h | increase_header_depth(self)`,
+        markdown: `# Introduction
+
+Welcome to the project.
+
+## Installation
+
+Run npm install.
+
+## Usage
+
+Use the tool like this.
+`,
+        isUpdate: true,
+        format: "markdown",
+      },
+    ],
+  },
+  {
+    name: "Dictionary and Path Utilities",
+    examples: [
+      {
+        name: "Pick specific fields",
+        code: `{"name": "mq", "version": "0.7.0", "license": "MIT", "internal_id": 42}
+| pick(self, ["name", "version"])`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Get and set nested values",
+        code: `{"author": {"name": "harehare", "location": {"country": "Japan"}}}
+| set_path(self, ["author", "location", "city"], "Tokyo")
+| get_path(self, ["author", "location"])`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+      {
+        name: "Transform dict values",
+        code: `{"a": 1, "b": 2} | with_entries(self, fn(e): [e[0], e[1] * 10];)`,
+        markdown: ``,
+        isUpdate: false,
+        format: "null",
+      },
+    ],
+  },
 ];
 
 // Flatten examples for backward compatibility

--- a/packages/mq-playground/src/examples.ts
+++ b/packages/mq-playground/src/examples.ts
@@ -666,28 +666,28 @@ Keyboard, Accessories, $80, 35
     examples: [
       {
         name: "Trim and normalize case",
-        code: `trim(self) | upcase()`,
+        code: `trim() | upcase()`,
         markdown: `  hello, mq!  `,
         isUpdate: false,
         format: "raw",
       },
       {
         name: "Split and join",
-        code: `split(self, ",") | join(self, " | ")`,
+        code: `split(",") | join(" | ")`,
         markdown: `apple,banana,cherry`,
         isUpdate: false,
         format: "raw",
       },
       {
         name: "Pad numbers",
-        code: `["7", "42", "123"] | map(self, fn(x): lpad(x, 5, "0");)`,
+        code: `["7", "42", "123"] | map(fn(x): lpad(x, 5, "0");)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
       },
       {
         name: "Slugify text",
-        code: `slugify(self)`,
+        code: `slugify()`,
         markdown: `Hello, World! This is mq`,
         isUpdate: false,
         format: "raw",
@@ -700,7 +700,7 @@ Keyboard, Accessories, $80, 35
       {
         name: "Sort by property",
         code: `[{"name": "Bob", "age": 30}, {"name": "Alice", "age": 25}, {"name": "Carol", "age": 35}]
-| sort_by(self, fn(x): get(x, "age");)`,
+| sort_by(fn(x): get(x, "age");)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -708,14 +708,14 @@ Keyboard, Accessories, $80, 35
       {
         name: "Group by predicate",
         code: `[1, 2, 3, 4, 5, 6, 7, 8]
-| group_by(self, fn(x): if (x % 2 == 0): "even" else: "odd";)`,
+| group_by(fn(x): if (x % 2 == 0): "even" else: "odd";)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
       },
       {
         name: "Chunk into groups",
-        code: `[1, 2, 3, 4, 5, 6, 7] | chunks(self, 3)`,
+        code: `[1, 2, 3, 4, 5, 6, 7] | chunks(3)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -729,7 +729,7 @@ Keyboard, Accessories, $80, 35
       },
       {
         name: "Partition by predicate",
-        code: `[1, 2, 3, 4, 5, 6] | partition(self, fn(x): x % 2 == 0;)`,
+        code: `[1, 2, 3, 4, 5, 6] | partition(fn(x): x % 2 == 0;)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -741,7 +741,7 @@ Keyboard, Accessories, $80, 35
     examples: [
       {
         name: "Sum with fold",
-        code: `[1, 2, 3, 4, 5] | fold(self, 0, fn(acc, x): acc + x;)`,
+        code: `[1, 2, 3, 4, 5] | fold(0, fn(acc, x): acc + x;)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -749,7 +749,7 @@ Keyboard, Accessories, $80, 35
       {
         name: "Any and all conditions",
         code: `[1, 2, 3, 4, 5]
-| {"any_gt_4": any(self, fn(x): x > 4;), "all_positive": all(self, fn(x): x > 0;)}`,
+| {"any_gt_4": any(fn(x): x > 4;), "all_positive": all(fn(x): x > 0;)}`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -757,7 +757,7 @@ Keyboard, Accessories, $80, 35
       {
         name: "Filter and convert with compact_map",
         code: `["1", "abc", "3", "xyz", "5"]
-| compact_map(self, fn(x): if (is_regex_match(x, "^[0-9]+$")): to_number(x);)`,
+| compact_map(fn(x): if (is_regex_match(x, "^[0-9]+$")): to_number(x);)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -769,14 +769,14 @@ Keyboard, Accessories, $80, 35
     examples: [
       {
         name: "Parse relative dates",
-        code: `date_relative(1705276800, "3 days ago") | strftime(self, "%Y-%m-%d")`,
+        code: `date_relative(1705276800, "3 days ago") | strftime("%Y-%m-%d")`,
         markdown: ``,
         isUpdate: false,
         format: "null",
       },
       {
         name: "Format dates with strftime",
-        code: `from_date("2024-01-15T00:00:00Z") | strftime(self, "%A, %B %d, %Y")`,
+        code: `from_date("2024-01-15T00:00:00Z") | strftime("%A, %B %d, %Y")`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -784,9 +784,9 @@ Keyboard, Accessories, $80, 35
       {
         name: "Add to a date",
         code: `gmtime(from_date("2024-01-15T00:00:00Z"))
-| date_add(self, 2, "months")
-| mktime(self)
-| strftime(self, "%Y-%m-%d")`,
+| date_add(2, "months")
+| mktime()
+| strftime("%Y-%m-%d")`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -805,7 +805,7 @@ Keyboard, Accessories, $80, 35
     examples: [
       {
         name: "Parse TOML",
-        code: `include "toml" | toml_parse(self)`,
+        code: `include "toml" | toml_parse()`,
         markdown: `title = "mq"
 version = "0.7.0"
 
@@ -817,14 +817,14 @@ name = "harehare"
       },
       {
         name: "Parse XML to markdown table",
-        code: `include "xml" | xml_parse(self) | xml_to_markdown_table(self)`,
+        code: `include "xml" | xml_parse() | xml_to_markdown_table()`,
         markdown: `<book><title>mq Guide</title><price>20</price></book>`,
         isUpdate: false,
         format: "raw",
       },
       {
         name: "Parse gron output",
-        code: `include "gron" | gron_parse(self)`,
+        code: `include "gron" | gron_parse()`,
         markdown: `json = {};
 json.name = "mq";
 json.tags = [];
@@ -838,7 +838,7 @@ json.tags[1] = "cli";
         name: "Stringify to TOON",
         code: `include "toon"
 | {"name": "mq", "version": "0.7.0", "tags": ["cli", "markdown"]}
-| toon_stringify(self)`,
+| toon_stringify()`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -859,9 +859,9 @@ json.tags[1] = "cli";
         name: "Sort version list",
         code: `include "semver"
 | ["1.2.0", "1.10.0", "1.2.10"]
-| map(self, semver_parse)
-| semver_sort(self)
-| map(self, semver_to_string)`,
+| map(semver_parse)
+| semver_sort()
+| map(semver_to_string)`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -900,7 +900,7 @@ json.tags[1] = "cli";
     examples: [
       {
         name: "Uppercase all headings",
-        code: `.h | upcase(self)`,
+        code: `.h | upcase()`,
         markdown: `# Introduction
 
 Welcome to the project.
@@ -918,7 +918,7 @@ Use the tool like this.
       },
       {
         name: "Promote heading levels",
-        code: `.h | increase_header_depth(self)`,
+        code: `.h | increase_header_depth()`,
         markdown: `# Introduction
 
 Welcome to the project.
@@ -942,7 +942,7 @@ Use the tool like this.
       {
         name: "Pick specific fields",
         code: `{"name": "mq", "version": "0.7.0", "license": "MIT", "internal_id": 42}
-| pick(self, ["name", "version"])`,
+| pick(["name", "version"])`,
         markdown: ``,
         isUpdate: false,
         format: "null",
@@ -950,15 +950,15 @@ Use the tool like this.
       {
         name: "Get and set nested values",
         code: `{"author": {"name": "harehare", "location": {"country": "Japan"}}}
-| set_path(self, ["author", "location", "city"], "Tokyo")
-| get_path(self, ["author", "location"])`,
+| set_path(["author", "location", "city"], "Tokyo")
+| get_path(["author", "location"])`,
         markdown: ``,
         isUpdate: false,
         format: "null",
       },
       {
         name: "Transform dict values",
-        code: `{"a": 1, "b": 2} | with_entries(self, fn(e): [e[0], e[1] * 10];)`,
+        code: `{"a": 1, "b": 2} | with_entries(fn(e): [e[0], e[1] * 10];)`,
         markdown: ``,
         isUpdate: false,
         format: "null",


### PR DESCRIPTION
## Summary

Expand the playground's example gallery with 9 new categories (30 examples) covering string/array/functional-programming helpers, date-and-time builtins, TOML/XML/gron/TOON conversion, semver, the md builder module, dictionary/path utilities, and the -U in-place update mode. Add matching entries to the VS Code extension's new-file template so users can try the same features immediately.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
