### PR TITLE
✨feat(mq-lang): add gitignore support to collection(), switch regex-lite to regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2110,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2607,6 +2636,7 @@ dependencies = [
  "getrandom 0.4.3",
  "glob",
  "html-escape",
+ "ignore",
  "itertools 0.15.0",
  "md5",
  "miette",
@@ -2618,7 +2648,7 @@ dependencies = [
  "proptest",
  "quick-xml",
  "rand 0.10.2",
- "regex-lite",
+ "regex",
  "ropey",
  "rstest",
  "rustc-hash",
@@ -2721,7 +2751,7 @@ dependencies = [
  "mq-hir",
  "mq-lang",
  "mq-markdown",
- "regex-lite",
+ "regex",
  "rustyline",
  "scopeguard",
  "strum",
@@ -2748,7 +2778,7 @@ dependencies = [
  "mq-repl",
  "quick-xml",
  "rayon",
- "regex-lite",
+ "regex",
  "rstest",
  "rustyline",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,8 @@ proptest = "1.11"
 quick-xml = "0.41.0"
 rand = "0.10.1"
 rayon = "1.11.0"
-regex-lite = "0.1.9"
+ignore = "0.4.31"
+regex = {version = "1.13", default-features = false, features = ["std", "perf", "unicode-perl"]}
 reqwest = {version = "0.13"}
 robots_txt = "0.7"
 ropey = "1.6"

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -1313,6 +1313,16 @@ fn register_file_io(ctx: &mut InferenceContext) {
         Type::array(Type::dict(Type::Var(k), Type::Var(v))),
     );
 
+    // collection: (string, bool) (dir path, respect_gitignore) -> [{path, title, frontmatter, content}]
+    let (k, v) = (ctx.fresh_var(), ctx.fresh_var());
+    register_binary(
+        ctx,
+        "collection",
+        Type::String,
+        Type::Bool,
+        Type::array(Type::dict(Type::Var(k), Type::Var(v))),
+    );
+
     // Path manipulation: string -> string
     register_many(
         ctx,
@@ -1892,6 +1902,7 @@ mod tests {
     #[case::file_exists("file_exists(\"a.md\")", true)]
     #[case::file_size("file_size(\"a.md\")", true)]
     #[case::collection("collection(\"docs\")", true)]
+    #[case::collection_respect_gitignore("collection(\"docs\", true)", true)]
     #[case::collection_len("len(collection(\"docs\"))", true)]
     #[case::basename("basename(\"a/b.md\")", true)]
     #[case::dirname("dirname(\"a/b.md\")", true)]
@@ -1922,6 +1933,7 @@ mod tests {
     #[case::file_exists_number("file_exists(42)", false)] // Should fail: wrong type
     #[case::file_size_number("file_size(42)", false)] // Should fail: wrong type
     #[case::collection_number("collection(42)", false)] // Should fail: wrong type
+    #[case::collection_respect_gitignore_number("collection(\"docs\", 42)", false)] // Should fail: wrong type
     #[case::basename_number("basename(42)", false)] // Should fail: wrong type
     #[case::path_join_number("path_join(42, \"b\")", false)] // Should fail: wrong type
     #[case::glob_match_number("glob_match(42, \"a.md\")", false)] // Should fail: wrong type

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -22,6 +22,7 @@ sha2 = {workspace = true}
 chrono = {workspace = true}
 dirs = {workspace = true}
 glob = {workspace = true}
+ignore = {workspace = true, optional = true}
 itertools = {workspace = true}
 miette = {workspace = true}
 mq-markdown = {workspace = true, features = ["html-to-markdown", "json", "obsidian"]}
@@ -29,7 +30,7 @@ nom = {workspace = true}
 nom_locate = {workspace = true}
 percent-encoding = {workspace = true}
 rand = {workspace = true}
-regex-lite = {workspace = true}
+regex = {workspace = true}
 ropey = {workspace = true, optional = true}
 rustc-hash = {workspace = true}
 scraper = {workspace = true, optional = true}
@@ -64,7 +65,7 @@ cst = ["dep:ropey"]
 css-selector = ["dep:scraper"]
 debugger = ["sync"]
 default = ["std"]
-file-io = []
+file-io = ["dep:ignore"]
 process-io = []
 std = []
 sync = []

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4600,16 +4600,49 @@ fn collection_record(path: String, raw: &str) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::Dict(Shared::new(record)))
 }
 
+/// Checks matchers closest-directory-first, so a deeper `.gitignore` overrides a shallower one.
+#[cfg(feature = "file-io")]
+fn is_gitignored(stack: &[ignore::gitignore::Gitignore], path: &std::path::Path, is_dir: bool) -> bool {
+    for gi in stack.iter().rev() {
+        match gi.matched(path, is_dir) {
+            ignore::Match::Ignore(_) => return true,
+            ignore::Match::Whitelist(_) => return false,
+            ignore::Match::None => continue,
+        }
+    }
+    false
+}
+
+/// Reads `dir`'s `.gitignore` (if any) through the ambient [`Io`] rather than the real
+/// filesystem, so it stays subject to the same sandboxed read permission as the rest of the walk.
+#[cfg(feature = "file-io")]
+fn load_gitignore(io: &dyn Io, dir: &std::path::Path) -> Option<ignore::gitignore::Gitignore> {
+    let gitignore_path = dir.join(".gitignore");
+    if !io.exists(&gitignore_path).unwrap_or(false) {
+        return None;
+    }
+    let contents = io.read_to_string(&gitignore_path).ok()?;
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
+    for line in contents.lines() {
+        let _ = builder.add_line(None, line);
+    }
+    builder.build().ok()
+}
+
 #[cfg(feature = "file-io")]
 fn collect_markdown_files(
     io: &dyn Io,
     dir: &std::path::Path,
     ancestors: &mut std::collections::HashSet<std::path::PathBuf>,
+    gitignore_stack: &mut Vec<ignore::gitignore::Gitignore>,
+    respect_gitignore: bool,
 ) -> Result<Vec<std::path::PathBuf>, Error> {
     let canonical = io.canonicalize(dir);
     if !ancestors.insert(canonical.clone()) {
         return Ok(Vec::new());
     }
+
+    let pushed_gitignore = respect_gitignore && load_gitignore(io, dir).map(|gi| gitignore_stack.push(gi)).is_some();
 
     let entries = io
         .read_dir(dir)
@@ -4618,8 +4651,24 @@ fn collect_markdown_files(
     let mut paths = Vec::new();
 
     for (path, is_dir) in entries {
+        if respect_gitignore {
+            let is_hidden = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with('.'));
+            if is_hidden || is_gitignored(gitignore_stack, &path, is_dir) {
+                continue;
+            }
+        }
+
         if is_dir {
-            paths.extend(collect_markdown_files(io, &path, ancestors)?);
+            paths.extend(collect_markdown_files(
+                io,
+                &path,
+                ancestors,
+                gitignore_stack,
+                respect_gitignore,
+            )?);
         } else if io.exists(&path).unwrap_or(false)
             && path
                 .extension()
@@ -4630,36 +4679,60 @@ fn collect_markdown_files(
         }
     }
 
+    if pushed_gitignore {
+        gitignore_stack.pop();
+    }
     ancestors.remove(&canonical);
     Ok(paths)
 }
 
+#[cfg(feature = "file-io")]
+fn collection_impl_inner(dir: &str, respect_gitignore: bool) -> Result<RuntimeValue, Error> {
+    let io = io_context::current();
+    let mut ancestors = std::collections::HashSet::new();
+    let mut gitignore_stack = Vec::new();
+    let mut paths = collect_markdown_files(
+        io.as_ref(),
+        std::path::Path::new(dir),
+        &mut ancestors,
+        &mut gitignore_stack,
+        respect_gitignore,
+    )?;
+    paths.sort();
+
+    let records = paths
+        .into_iter()
+        .map(|path| {
+            let raw = io
+                .read_to_string(&path)
+                .map_err(|e| Error::Runtime(format!("Failed to read file {}: {}", path.display(), e)))?;
+            collection_record(path.to_string_lossy().into_owned(), &raw)
+        })
+        .collect::<Result<Vec<RuntimeValue>, Error>>()?;
+
+    Ok(RuntimeValue::Array(Shared::new(records)))
+}
+
 /// Recursively reads every Markdown file under `dir`. Requires the ambient [`Io`]'s read
 /// permission (see [`io_context`]).
+///
+/// `respect_gitignore` (default `false`, keeping prior behavior) skips dotfiles/dot-directories
+/// and any path matched by a `.gitignore` found in `dir` or one of its subdirectories, with
+/// closer `.gitignore` files taking precedence over farther ones, same as `git`.
 #[cfg(feature = "file-io")]
-#[mq_macros::mq_fn(name = "collection", params = Fixed(1))]
+#[mq_macros::mq_fn(name = "collection", params = Range(1, 2))]
 fn collection_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
-        [RuntimeValue::String(dir)] => {
-            let io = io_context::current();
-            let mut ancestors = std::collections::HashSet::new();
-            let mut paths = collect_markdown_files(io.as_ref(), std::path::Path::new(dir.as_str()), &mut ancestors)?;
-            paths.sort();
-
-            let records = paths
-                .into_iter()
-                .map(|path| {
-                    let raw = io
-                        .read_to_string(&path)
-                        .map_err(|e| Error::Runtime(format!("Failed to read file {}: {}", path.display(), e)))?;
-                    collection_record(path.to_string_lossy().into_owned(), &raw)
-                })
-                .collect::<Result<Vec<RuntimeValue>, Error>>()?;
-
-            Ok(RuntimeValue::Array(Shared::new(records)))
+        [RuntimeValue::String(dir)] => collection_impl_inner(dir.as_str(), false),
+        [RuntimeValue::String(dir), RuntimeValue::Boolean(respect_gitignore)] => {
+            collection_impl_inner(dir.as_str(), *respect_gitignore)
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
-        _ => unreachable!("collection should always receive exactly one argument"),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("collection should always receive one or two arguments"),
     }
 }
 
@@ -7898,9 +7971,9 @@ x
     map.insert(
         SmolStr::new("collection"),
         BuiltinFunctionDoc {
-            description: "Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
-            params: &["dir"],
-            param_types: &["string"],
+            description: "Recursively reads every Markdown file in the given directory (including subdirectories and symlinked files/directories) and returns an array of `{path, title, frontmatter, content}` dicts, sorted by path, so they can be filtered, sorted, or aggregated as a single dataset. `content` holds the file's Markdown nodes with frontmatter stripped. Symlink cycles are detected and only visited once. `respect_gitignore` is optional (default `false`); when `true`, dotfiles/dot-directories and any path matched by a `.gitignore` in `dir` or a subdirectory are skipped, with closer `.gitignore` files taking precedence, same as `git`. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
+            params: &["dir", "respect_gitignore?"],
+            param_types: &["string", "boolean"],
             returns: "array",
             examples: &[],
             capability: Some("file-io"),
@@ -12700,6 +12773,87 @@ mod tests {
 
         // Errors for an invalid argument type.
         assert!(call("collection", vec![RuntimeValue::Number(42.into())]).is_err());
+
+        // respect_gitignore defaults to false: prior behavior is unchanged.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            std::fs::write(dir.path().join(".gitignore"), "ignored.md\n").expect("failed to write");
+            std::fs::write(dir.path().join("ignored.md"), "# Ignored\n").expect("failed to write");
+            std::fs::write(dir.path().join("kept.md"), "# Kept\n").expect("failed to write");
+
+            let hidden_dir = dir.path().join(".hidden");
+            std::fs::create_dir(&hidden_dir).expect("failed to create hidden dir");
+            std::fs::write(hidden_dir.join("secret.md"), "# Secret\n").expect("failed to write");
+
+            let entries = as_entries(
+                call(
+                    "collection",
+                    vec![RuntimeValue::String(dir.path().to_string_lossy().into_owned())],
+                )
+                .expect("collection should succeed"),
+            );
+            assert_eq!(
+                entries.len(),
+                3,
+                "ignored.md and .hidden/secret.md should still be collected"
+            );
+        }
+
+        // respect_gitignore = true: skips dotfiles and .gitignore matches; nested .gitignore wins.
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            std::fs::write(dir.path().join(".gitignore"), "*.log.md\nbuild/\n").expect("failed to write");
+            std::fs::write(dir.path().join("kept.md"), "# Kept\n").expect("failed to write");
+            std::fs::write(dir.path().join("debug.log.md"), "# Debug\n").expect("failed to write");
+
+            let hidden_dir = dir.path().join(".hidden");
+            std::fs::create_dir(&hidden_dir).expect("failed to create hidden dir");
+            std::fs::write(hidden_dir.join("secret.md"), "# Secret\n").expect("failed to write");
+
+            let build_dir = dir.path().join("build");
+            std::fs::create_dir(&build_dir).expect("failed to create build dir");
+            std::fs::write(build_dir.join("out.md"), "# Out\n").expect("failed to write");
+
+            // A subdirectory's .gitignore re-allows a file the parent's .gitignore ignores.
+            let sub = dir.path().join("sub");
+            std::fs::create_dir(&sub).expect("failed to create subdir");
+            std::fs::write(sub.join(".gitignore"), "!debug.log.md\n").expect("failed to write");
+            std::fs::write(sub.join("debug.log.md"), "# Sub debug\n").expect("failed to write");
+
+            let entries = as_entries(
+                call(
+                    "collection",
+                    vec![
+                        RuntimeValue::String(dir.path().to_string_lossy().into_owned()),
+                        RuntimeValue::Boolean(true),
+                    ],
+                )
+                .expect("collection should succeed"),
+            );
+            let titles: Vec<_> = entries
+                .iter()
+                .map(|entry| match get(entry, "title") {
+                    RuntimeValue::String(s) => s,
+                    other => panic!("expected String, got {other:?}"),
+                })
+                .collect();
+
+            assert_eq!(entries.len(), 2, "titles: {titles:?}");
+            assert!(titles.contains(&"Kept".to_string()));
+            assert!(titles.contains(&"Sub debug".to_string()));
+        }
+
+        // Errors for an invalid respect_gitignore argument type.
+        assert!(
+            call(
+                "collection",
+                vec![
+                    RuntimeValue::String("/nonexistent/path".into()),
+                    RuntimeValue::Number(1.into())
+                ],
+            )
+            .is_err()
+        );
     }
 
     #[cfg(feature = "file-io")]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4633,7 +4633,7 @@ fn load_gitignore(io: &dyn Io, dir: &std::path::Path) -> Option<ignore::gitignor
 fn collect_markdown_files(
     io: &dyn Io,
     dir: &std::path::Path,
-    ancestors: &mut std::collections::HashSet<std::path::PathBuf>,
+    ancestors: &mut FxHashSet<std::path::PathBuf>,
     gitignore_stack: &mut Vec<ignore::gitignore::Gitignore>,
     respect_gitignore: bool,
 ) -> Result<Vec<std::path::PathBuf>, Error> {
@@ -4689,7 +4689,7 @@ fn collect_markdown_files(
 #[cfg(feature = "file-io")]
 fn collection_impl_inner(dir: &str, respect_gitignore: bool) -> Result<RuntimeValue, Error> {
     let io = io_context::current();
-    let mut ancestors = std::collections::HashSet::new();
+    let mut ancestors = FxHashSet::default();
     let mut gitignore_stack = Vec::new();
     let mut paths = collect_markdown_files(
         io.as_ref(),

--- a/crates/mq-lang/src/eval/builtin/regex.rs
+++ b/crates/mq-lang/src/eval/builtin/regex.rs
@@ -1,7 +1,7 @@
 use crate::Ident;
 use crate::Shared;
 use crate::eval::runtime_value::RuntimeValue;
-use regex_lite::{Regex, RegexBuilder};
+use regex::{Regex, RegexBuilder};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::collections::BTreeMap;
 use std::sync::{LazyLock, RwLock};

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -18,7 +18,7 @@ miette = {workspace = true}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["http"]}
 mq-markdown = {workspace = true}
-regex-lite = {workspace = true}
+regex = {workspace = true}
 rustyline = {workspace = true, default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {workspace = true, features = ["derive"]}
 tempfile = {workspace = true}

--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -23,26 +23,26 @@ fn highlight_mq_syntax(line: &str) -> Cow<'_, str> {
     let mut matches: Vec<(usize, usize, u8, String)> = Vec::new();
 
     let commands_pattern = r"^(/clear|/copy|/edit|/env|/help|/history|/quit|/load|/reset|/vars|/version)\b";
-    if let Ok(re) = regex_lite::Regex::new(commands_pattern) {
+    if let Ok(re) = regex::Regex::new(commands_pattern) {
         for m in re.find_iter(line) {
             matches.push((m.start(), m.end(), 0, m.as_str().bright_green().to_string()));
         }
     }
 
-    if let Ok(re) = regex_lite::Regex::new(r#""([^"\\]|\\.)*""#) {
+    if let Ok(re) = regex::Regex::new(r#""([^"\\]|\\.)*""#) {
         for m in re.find_iter(line) {
             matches.push((m.start(), m.end(), 1, m.as_str().bright_green().to_string()));
         }
     }
 
     let keywords_pattern = r"\b(def|let|if|elif|else|end|while|foreach|self|nodes|fn|break|continue|include|true|false|None|match|import|module|do|var|macro|quote|unquote)\b";
-    if let Ok(re) = regex_lite::Regex::new(keywords_pattern) {
+    if let Ok(re) = regex::Regex::new(keywords_pattern) {
         for m in re.find_iter(line) {
             matches.push((m.start(), m.end(), 2, m.as_str().bright_blue().to_string()));
         }
     }
 
-    if let Ok(re) = regex_lite::Regex::new(r"\b\d+\b") {
+    if let Ok(re) = regex::Regex::new(r"\b\d+\b") {
         for m in re.find_iter(line) {
             matches.push((m.start(), m.end(), 3, m.as_str().bright_magenta().to_string()));
         }
@@ -50,7 +50,7 @@ fn highlight_mq_syntax(line: &str) -> Cow<'_, str> {
 
     let operators_pattern =
         r"(\/\/=|<<|>>|\|\||\?\?|<=|>=|==|!=|=~|&&|\+=|-=|\*=|\/=|\|=|=|\||:|;|\?|!|\+|-|\*|\/|%|<|>|@)";
-    if let Ok(re) = regex_lite::Regex::new(operators_pattern) {
+    if let Ok(re) = regex::Regex::new(operators_pattern) {
         for m in re.find_iter(line) {
             matches.push((m.start(), m.end(), 4, m.as_str().bright_yellow().to_string()));
         }

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "mq"
 
 [features]
 css-selector = ["mq-lang/css-selector"]
-debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex-lite", "mq-dap"]
+debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex", "mq-dap"]
 default = ["std", "use_mimalloc", "http-import", "css-selector"]
 http-import = ["mq-lang/http-import-ureq"]
 std = []
@@ -39,7 +39,7 @@ quick-xml = {workspace = true}
 rayon = {workspace = true}
 serde_json = {workspace = true}
 serde_yaml = {workspace = true}
-regex-lite = {workspace = true, optional = true}
+regex = {workspace = true, optional = true}
 rustyline = {workspace = true, optional = true, default-features = false, features = ["custom-bindings", "with-file-history"]}
 strum = {workspace = true, features = ["derive"], optional = true}
 tabled = {workspace = true}

--- a/crates/mq-run/src/debugger.rs
+++ b/crates/mq-run/src/debugger.rs
@@ -364,7 +364,7 @@ fn collect_spans(
     line: &str,
     color_fn: impl Fn(&str) -> String,
 ) {
-    if let Ok(re) = regex_lite::Regex::new(pattern) {
+    if let Ok(re) = regex::Regex::new(pattern) {
         for m in re.find_iter(line) {
             let (start, end) = (m.start(), m.end());
             let overlaps = spans.iter().any(|(s, e, _)| start < *e && end > *s);


### PR DESCRIPTION
## Summary

collection(dir) gains an optional respect_gitignore bool (default false, prior behavior unchanged): when true, it skips dotfiles/dot-directories and any path matched by a .gitignore in dir or a subdirectory, with closer .gitignore files taking precedence, same as git. Implemented via the ignore crate's Gitignore matcher, fed lines read through the existing Io abstraction rather than the real filesystem, so it stays subject to the same sandboxed read permission as the rest of the walk.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
