### PR TITLE
✨ feat(mq-lang): add merge_with/merge_defaults for deep dict merging

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1994,6 +1994,71 @@ def from_entries(arr):
 # Returns: dict
 def with_entries(d, f): from_entries(map(entries(d), f));
 
+# Deep merges two values, recursing into dicts key by key. Neither input is mutated.
+# When both sides provide a leaf/array value for the same key, the conflict is resolved
+# according to `policy`, one of:
+# - `"replace"`: the second value (`b`) wins.
+# - `"append"`: arrays are concatenated; other conflicting values are collected into `[a, b]`.
+# - `"error"`: raises an error describing the conflict.
+#
+# Example:
+# ```
+# merge_with({"a": 1, "b": {"x": 1}}, {"b": {"y": 2}, "c": 3}, "replace")
+# #=> {"a": 1, "b": {"x": 1, "y": 2}, "c": 3}
+# ```
+#
+# Returns: dynamic
+def merge_with(a, b, policy):
+  if (!in(["replace", "append", "error"], policy)):
+    error("policy must be one of \"replace\", \"append\", or \"error\"")
+  elif (is_dict(a) && is_dict(b)):
+    fold(uniq(keys(a) + keys(b)), dict(), fn(acc, key):
+      if (has(a, key) && has(b, key)):
+        set(acc, key, merge_with(a[key], b[key], policy))
+      elif (has(b, key)):
+        set(acc, key, b[key])
+      else:
+        set(acc, key, a[key])
+    ;)
+  elif (is_array(a) && is_array(b)):
+    if (policy == "append"):
+      a + b
+    elif (policy == "replace"):
+      b
+    else:
+      error("merge conflict on arrays: use \"replace\" or \"append\" instead of \"error\"")
+  elif (is_none(a) && is_none(b)):
+    None
+  elif (is_none(a) || is_none(b)):
+    if (policy == "replace"):
+      b
+    elif (policy == "append"):
+      if (is_none(b)): a else: b
+    else:
+      error("merge conflict on null: use \"replace\" or \"append\" instead of \"error\"")
+  else:
+    if (policy == "replace"):
+      b
+    elif (policy == "append"):
+      [a, b]
+    else:
+      error("merge conflict: cannot merge " + type(a) + " with " + type(b))
+end
+
+# Deep merges `d` over `defaults`, similar to Jsonnet's object inheritance: values present
+# in `d` win (recursively for nested dicts), while keys missing from `d` fall back to the
+# corresponding value in `defaults`. Arrays and scalar conflicts are resolved by letting
+# `d` replace `defaults`. Neither input is mutated.
+#
+# Example:
+# ```
+# merge_defaults({"a": {"x": 1}}, {"a": {"x": 0, "y": 2}, "b": 3})
+# #=> {"a": {"x": 1, "y": 2}, "b": 3}
+# ```
+#
+# Returns: dynamic
+def merge_defaults(d, defaults): merge_with(defaults, d, "replace");
+
 # Parses frontmatter from a markdown node, supporting both YAML and TOML formats.
 #
 # Returns: dynamic

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -1049,6 +1049,49 @@ def test_with_entries():
   | assert_eq(result2, dict())
 end
 
+def test_merge_with():
+  # Nested dicts are merged recursively; non-overlapping keys are kept from both sides
+  let result1 = merge_with({"a": 1, "b": {"x": 1}}, {"b": {"y": 2}, "c": 3}, "replace")
+  | assert_eq(result1, {"a": 1, "b": {"x": 1, "y": 2}, "c": 3})
+
+  # "replace" policy: the second value wins on leaf/array conflicts
+  | let result2 = merge_with({"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "replace")
+  | assert_eq(result2, {"a": [3], "b": 2})
+
+  # "append" policy: arrays are concatenated, scalar conflicts become [a, b]
+  | let result3 = merge_with({"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "append")
+  | assert_eq(result3, {"a": [1, 2, 3], "b": [1, 2]})
+
+  # "error" policy: raises on conflicting leaf values
+  | let result4 = try: merge_with({"a": 1}, {"a": 2}, "error") catch: "error"
+  | assert_eq(result4, "error")
+
+  # Null on either side is not an error; "replace" lets the null win, "append" keeps the non-null value
+  | let result5 = merge_with({"a": 1}, {"a": None}, "replace")
+  | assert_eq(result5, {"a": None})
+
+  | let result6 = merge_with({"a": 1}, {"a": None}, "append")
+  | assert_eq(result6, {"a": 1})
+
+  # An invalid policy is rejected
+  | let result7 = try: merge_with({}, {}, "invalid") catch: "error"
+  | assert_eq(result7, "error")
+end
+
+def test_merge_defaults():
+  # Values from `d` win, missing keys fall back to `defaults`, recursively
+  let result1 = merge_defaults({"a": {"x": 1}}, {"a": {"x": 0, "y": 2}, "b": 3})
+  | assert_eq(result1, {"a": {"x": 1, "y": 2}, "b": 3})
+
+  # `d`'s arrays replace `defaults`'s arrays entirely
+  | let result2 = merge_defaults({"a": [1]}, {"a": [2, 3]})
+  | assert_eq(result2, {"a": [1]})
+
+  # An empty override falls back entirely to defaults
+  | let result3 = merge_defaults({}, {"a": 1, "b": 2})
+  | assert_eq(result3, {"a": 1, "b": 2})
+end
+
 def test_frontmatter():
   # YAML frontmatter is parsed into a dict
   let result1 = do "---\ntitle: Hello\nauthor: World\n---\n\n# Heading" | to_markdown() | first() | frontmatter();

--- a/docs/books/src/builtins.html
+++ b/docs/books/src/builtins.html
@@ -353,8 +353,8 @@
         </div>
         <nav class="sidebar-section">
           <div class="sidebar-section-title">Modules</div>
-<a class="sidebar-link active" href="#" data-module="mod-all"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg></span><span class="sidebar-label">All</span><span class="sidebar-count">426</span></a>
-<a class="sidebar-link" href="#" data-module="mod-0"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">Built-in</span><span class="sidebar-count">329</span></a>
+<a class="sidebar-link active" href="#" data-module="mod-all"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg></span><span class="sidebar-label">All</span><span class="sidebar-count">428</span></a>
+<a class="sidebar-link" href="#" data-module="mod-0"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">Built-in</span><span class="sidebar-count">331</span></a>
 <a class="sidebar-link" href="#" data-module="mod-1"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">ast</span><span class="sidebar-count">2</span></a>
 <a class="sidebar-link" href="#" data-module="mod-2"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">cbor</span><span class="sidebar-count">2</span></a>
 <a class="sidebar-link" href="#" data-module="mod-3"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">csv</span><span class="sidebar-count">8</span></a>
@@ -384,7 +384,7 @@
     <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     <input type="text" class="search-input" placeholder="Filter functions..." />
   </div>
-  <p class="count"><span class="count-num">426</span> functions</p>
+  <p class="count"><span class="count-num">428</span> functions</p>
   <table>
     <thead><tr><th>Function</th><th>Description</th><th>Parameters</th><th>Example</th></tr></thead>
     <tbody>
@@ -1456,6 +1456,26 @@
                   <td> Returns the average (mean) of an array of numbers, or None if the array is empty.</td>
                   <td><code>arr</code></td>
                   <td><code>mean(arr)</code></td>
+                </tr>
+                <tr>
+                  <td><code>merge_defaults</code></td>
+                  <td> Deep merges `d` over `defaults`, similar to Jsonnet's object inheritance: values present
+ in `d` win (recursively for nested dicts), while keys missing from `d` fall back to the
+ corresponding value in `defaults`. Arrays and scalar conflicts are resolved by letting
+ `d` replace `defaults`. Neither input is mutated.</td>
+                  <td><code>d</code>, <code>defaults</code></td>
+                  <td><code>merge_defaults(d, defaults)</code></td>
+                </tr>
+                <tr>
+                  <td><code>merge_with</code></td>
+                  <td> Deep merges two values, recursing into dicts key by key. Neither input is mutated.
+ When both sides provide a leaf/array value for the same key, the conflict is resolved
+ according to `policy`, one of:
+ - `&quot;replace&quot;`: the second value (`b`) wins.
+ - `&quot;append&quot;`: arrays are concatenated; other conflicting values are collected into `[a, b]`.
+ - `&quot;error&quot;`: raises an error describing the conflict.</td>
+                  <td><code>a</code>, <code>b</code>, <code>policy</code></td>
+                  <td><code>merge_with(a, b, policy)</code></td>
                 </tr>
                 <tr>
                   <td><code>min</code></td>
@@ -2997,7 +3017,7 @@
     <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     <input type="text" class="search-input" placeholder="Filter functions..." />
   </div>
-  <p class="count"><span class="count-num">329</span> functions</p>
+  <p class="count"><span class="count-num">331</span> functions</p>
   <table>
     <thead><tr><th>Function</th><th>Description</th><th>Parameters</th><th>Example</th></tr></thead>
     <tbody>
@@ -4069,6 +4089,26 @@
                   <td> Returns the average (mean) of an array of numbers, or None if the array is empty.</td>
                   <td><code>arr</code></td>
                   <td><code>mean(arr)</code></td>
+                </tr>
+                <tr>
+                  <td><code>merge_defaults</code></td>
+                  <td> Deep merges `d` over `defaults`, similar to Jsonnet's object inheritance: values present
+ in `d` win (recursively for nested dicts), while keys missing from `d` fall back to the
+ corresponding value in `defaults`. Arrays and scalar conflicts are resolved by letting
+ `d` replace `defaults`. Neither input is mutated.</td>
+                  <td><code>d</code>, <code>defaults</code></td>
+                  <td><code>merge_defaults(d, defaults)</code></td>
+                </tr>
+                <tr>
+                  <td><code>merge_with</code></td>
+                  <td> Deep merges two values, recursing into dicts key by key. Neither input is mutated.
+ When both sides provide a leaf/array value for the same key, the conflict is resolved
+ according to `policy`, one of:
+ - `&quot;replace&quot;`: the second value (`b`) wins.
+ - `&quot;append&quot;`: arrays are concatenated; other conflicting values are collected into `[a, b]`.
+ - `&quot;error&quot;`: raises an error describing the conflict.</td>
+                  <td><code>a</code>, <code>b</code>, <code>policy</code></td>
+                  <td><code>merge_with(a, b, policy)</code></td>
                 </tr>
                 <tr>
                   <td><code>min</code></td>

--- a/docs/books/src/builtins.html
+++ b/docs/books/src/builtins.html
@@ -353,8 +353,8 @@
         </div>
         <nav class="sidebar-section">
           <div class="sidebar-section-title">Modules</div>
-<a class="sidebar-link active" href="#" data-module="mod-all"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg></span><span class="sidebar-label">All</span><span class="sidebar-count">428</span></a>
-<a class="sidebar-link" href="#" data-module="mod-0"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">Built-in</span><span class="sidebar-count">331</span></a>
+<a class="sidebar-link active" href="#" data-module="mod-all"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg></span><span class="sidebar-label">All</span><span class="sidebar-count">426</span></a>
+<a class="sidebar-link" href="#" data-module="mod-0"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">Built-in</span><span class="sidebar-count">329</span></a>
 <a class="sidebar-link" href="#" data-module="mod-1"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">ast</span><span class="sidebar-count">2</span></a>
 <a class="sidebar-link" href="#" data-module="mod-2"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">cbor</span><span class="sidebar-count">2</span></a>
 <a class="sidebar-link" href="#" data-module="mod-3"><span class="sidebar-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span><span class="sidebar-label">csv</span><span class="sidebar-count">8</span></a>
@@ -384,7 +384,7 @@
     <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     <input type="text" class="search-input" placeholder="Filter functions..." />
   </div>
-  <p class="count"><span class="count-num">428</span> functions</p>
+  <p class="count"><span class="count-num">426</span> functions</p>
   <table>
     <thead><tr><th>Function</th><th>Description</th><th>Parameters</th><th>Example</th></tr></thead>
     <tbody>
@@ -1456,26 +1456,6 @@
                   <td> Returns the average (mean) of an array of numbers, or None if the array is empty.</td>
                   <td><code>arr</code></td>
                   <td><code>mean(arr)</code></td>
-                </tr>
-                <tr>
-                  <td><code>merge_defaults</code></td>
-                  <td> Deep merges `d` over `defaults`, similar to Jsonnet's object inheritance: values present
- in `d` win (recursively for nested dicts), while keys missing from `d` fall back to the
- corresponding value in `defaults`. Arrays and scalar conflicts are resolved by letting
- `d` replace `defaults`. Neither input is mutated.</td>
-                  <td><code>d</code>, <code>defaults</code></td>
-                  <td><code>merge_defaults(d, defaults)</code></td>
-                </tr>
-                <tr>
-                  <td><code>merge_with</code></td>
-                  <td> Deep merges two values, recursing into dicts key by key. Neither input is mutated.
- When both sides provide a leaf/array value for the same key, the conflict is resolved
- according to `policy`, one of:
- - `&quot;replace&quot;`: the second value (`b`) wins.
- - `&quot;append&quot;`: arrays are concatenated; other conflicting values are collected into `[a, b]`.
- - `&quot;error&quot;`: raises an error describing the conflict.</td>
-                  <td><code>a</code>, <code>b</code>, <code>policy</code></td>
-                  <td><code>merge_with(a, b, policy)</code></td>
                 </tr>
                 <tr>
                   <td><code>min</code></td>
@@ -3017,7 +2997,7 @@
     <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     <input type="text" class="search-input" placeholder="Filter functions..." />
   </div>
-  <p class="count"><span class="count-num">331</span> functions</p>
+  <p class="count"><span class="count-num">329</span> functions</p>
   <table>
     <thead><tr><th>Function</th><th>Description</th><th>Parameters</th><th>Example</th></tr></thead>
     <tbody>
@@ -4089,26 +4069,6 @@
                   <td> Returns the average (mean) of an array of numbers, or None if the array is empty.</td>
                   <td><code>arr</code></td>
                   <td><code>mean(arr)</code></td>
-                </tr>
-                <tr>
-                  <td><code>merge_defaults</code></td>
-                  <td> Deep merges `d` over `defaults`, similar to Jsonnet's object inheritance: values present
- in `d` win (recursively for nested dicts), while keys missing from `d` fall back to the
- corresponding value in `defaults`. Arrays and scalar conflicts are resolved by letting
- `d` replace `defaults`. Neither input is mutated.</td>
-                  <td><code>d</code>, <code>defaults</code></td>
-                  <td><code>merge_defaults(d, defaults)</code></td>
-                </tr>
-                <tr>
-                  <td><code>merge_with</code></td>
-                  <td> Deep merges two values, recursing into dicts key by key. Neither input is mutated.
- When both sides provide a leaf/array value for the same key, the conflict is resolved
- according to `policy`, one of:
- - `&quot;replace&quot;`: the second value (`b`) wins.
- - `&quot;append&quot;`: arrays are concatenated; other conflicting values are collected into `[a, b]`.
- - `&quot;error&quot;`: raises an error describing the conflict.</td>
-                  <td><code>a</code>, <code>b</code>, <code>policy</code></td>
-                  <td><code>merge_with(a, b, policy)</code></td>
                 </tr>
                 <tr>
                   <td><code>min</code></td>


### PR DESCRIPTION
## Summary

Adds Jsonnet-style object-inheritance merging: merge_with(a, b, policy) deep-merges dicts recursively and resolves array/null/type conflicts via an explicit "replace"/"append"/"error" policy, without mutating either input. merge_defaults(d, defaults) layers d's explicit values over defaults, falling back to defaults for missing keys.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
