### PR TITLE
✨ feat(mq-lang): add http_all builtin for batched concurrent requests

### DIFF
--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -20,6 +20,8 @@ use crate::error::runtime::RuntimeError;
 use crate::eval::builtin::convert::Convert;
 use crate::eval::env::{self, Env};
 use crate::ident::all_symbols;
+#[cfg(feature = "http")]
+use crate::io::HttpRequestSpec;
 #[cfg(feature = "file-io")]
 use crate::io::Io;
 use crate::number::{self};
@@ -4448,6 +4450,89 @@ fn http_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
     }
 }
 
+#[cfg(feature = "http")]
+#[mq_macros::mq_fn(name = "http_all", params = Fixed(1))]
+fn http_all_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Array(requests)] => {
+            let specs = requests.iter().map(parse_http_request).collect::<Result<Vec<_>, _>>()?;
+            let io = io_context::current();
+            let bodies = io
+                .http_request_all(&specs)
+                .map_err(|e| Error::Runtime(format!("http_all: {e}")))?;
+            Ok(RuntimeValue::Array(Shared::new(
+                bodies.into_iter().map(RuntimeValue::String).collect(),
+            )))
+        }
+        args => Err(Error::InvalidTypes(
+            ident.to_string(),
+            args.iter_mut().map(std::mem::take).collect(),
+        )),
+    }
+}
+
+#[cfg(feature = "http")]
+fn parse_http_request(value: &RuntimeValue) -> Result<HttpRequestSpec, Error> {
+    let RuntimeValue::Dict(fields) = value else {
+        return Err(Error::Runtime(
+            "http_all: each request must be a dict with `url` (and optional `method`, `body`, `headers`)".to_string(),
+        ));
+    };
+    let url = fields
+        .get(&Ident::from("url"))
+        .ok_or_else(|| Error::Runtime("http_all: each request dict needs a `url` string".to_string()))
+        .and_then(|value| match value {
+            RuntimeValue::String(url) => Ok(url.clone()),
+            other => Err(Error::Runtime(format!("http_all: `url` must be a string, got {other}"))),
+        })?;
+    let method = match fields.get(&Ident::from("method")) {
+        Some(RuntimeValue::Symbol(method)) => method.as_str().to_string(),
+        Some(RuntimeValue::String(method)) => method.clone(),
+        Some(other) => {
+            return Err(Error::Runtime(format!(
+                "http_all: `method` must be a string or symbol, got {other}"
+            )));
+        }
+        None => "GET".to_string(),
+    };
+    let method = method
+        .parse::<ureq::http::Method>()
+        .map_err(|_| Error::Runtime(format!("http_all: invalid HTTP method {method:?}")))?
+        .to_string();
+    let body = match fields.get(&Ident::from("body")) {
+        Some(RuntimeValue::String(body)) => Some(body.clone()),
+        Some(other) => {
+            return Err(Error::Runtime(format!(
+                "http_all: `body` must be a string, got {other}"
+            )));
+        }
+        None => None,
+    };
+    let headers = match fields.get(&Ident::from("headers")) {
+        Some(RuntimeValue::Dict(headers)) => headers
+            .iter()
+            .map(|(name, value)| match value {
+                RuntimeValue::String(value) => Ok((name.as_str().to_string(), value.clone())),
+                other => Err(Error::Runtime(format!(
+                    "http_all: header {name:?} must be a string, got {other}"
+                ))),
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(other) => {
+            return Err(Error::Runtime(format!(
+                "http_all: `headers` must be a dict, got {other}"
+            )));
+        }
+        None => Vec::new(),
+    };
+    Ok(HttpRequestSpec {
+        method,
+        url,
+        body,
+        headers,
+    })
+}
+
 #[cfg(all(feature = "http", feature = "mock-io"))]
 #[mq_macros::mq_fn(name = "mock_fetch", params = Fixed(2))]
 fn mock_fetch_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
@@ -4899,6 +4984,8 @@ mq_macros::builtin_dispatch! {
     EXTRACT_IMAGES,
     #[cfg(feature = "http")]
     HTTP,
+    #[cfg(feature = "http")]
+    HTTP_ALL,
     #[cfg(all(feature = "http", feature = "mock-io"))]
     MOCK_FETCH,
     #[cfg(feature = "process-io")]
@@ -12994,6 +13081,75 @@ mod tests {
             ),
             Ok(RuntimeValue::String("body".into()))
         );
+    }
+
+    #[cfg(all(feature = "http", feature = "mock-io"))]
+    #[test]
+    fn test_http_all_fetches_each_request_in_batch_order() {
+        let _guard = io_context::scoped(Shared::new(SandboxedIo::new(MemIo::default()).allow_net(true)));
+        for (url, body) in [
+            ("https://example.invalid/a", "body-a"),
+            ("https://example.invalid/b", "body-b"),
+            ("https://example.invalid/c", "body-c"),
+        ] {
+            call(
+                "mock_fetch",
+                vec![RuntimeValue::String(url.into()), RuntimeValue::String(body.into())],
+            )
+            .unwrap();
+        }
+
+        let requests = RuntimeValue::Array(Shared::new(vec![
+            RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::from([(
+                Ident::new("url"),
+                RuntimeValue::String("https://example.invalid/a".into()),
+            )]))),
+            RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::from([(
+                Ident::new("url"),
+                RuntimeValue::String("https://example.invalid/b".into()),
+            )]))),
+            RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::from([
+                (Ident::new("method"), RuntimeValue::Symbol(Ident::new("post"))),
+                (
+                    Ident::new("url"),
+                    RuntimeValue::String("https://example.invalid/c".into()),
+                ),
+                (Ident::new("body"), RuntimeValue::String("payload".into())),
+            ]))),
+        ]));
+
+        assert_eq!(
+            call("http_all", vec![requests]),
+            Ok(RuntimeValue::Array(Shared::new(vec![
+                RuntimeValue::String("body-a".into()),
+                RuntimeValue::String("body-b".into()),
+                RuntimeValue::String("body-c".into()),
+            ])))
+        );
+    }
+
+    #[cfg(all(feature = "http", feature = "mock-io"))]
+    #[test]
+    fn test_http_all_rejects_non_dict_request() {
+        let _guard = io_context::scoped(Shared::new(SandboxedIo::new(MemIo::default()).allow_net(true)));
+
+        let requests = RuntimeValue::Array(Shared::new(vec![RuntimeValue::String(
+            "https://example.invalid".into(),
+        )]));
+
+        assert!(call("http_all", vec![requests]).is_err());
+    }
+
+    #[cfg(all(feature = "http", feature = "mock-io"))]
+    #[test]
+    fn test_http_all_rejects_request_without_url() {
+        let _guard = io_context::scoped(Shared::new(SandboxedIo::new(MemIo::default()).allow_net(true)));
+
+        let requests = RuntimeValue::Array(Shared::new(vec![RuntimeValue::Dict(Shared::new(
+            std::collections::BTreeMap::from([(Ident::new("method"), RuntimeValue::Symbol(Ident::new("get")))]),
+        ))]));
+
+        assert!(call("http_all", vec![requests]).is_err());
     }
 
     #[cfg(all(feature = "http", feature = "mock-io"))]

--- a/crates/mq-lang/src/io.rs
+++ b/crates/mq-lang/src/io.rs
@@ -52,6 +52,15 @@ pub trait IoSyncBound {}
 #[cfg(not(feature = "sync"))]
 impl<T> IoSyncBound for T {}
 
+/// One batched HTTP request specification for [`Io::http_request_all`].
+#[derive(Debug, Clone)]
+pub struct HttpRequestSpec {
+    pub method: String,
+    pub url: String,
+    pub body: Option<String>,
+    pub headers: Vec<(String, String)>,
+}
+
 /// Abstracts file, environment-variable, and network access for the mq
 /// engine. All methods are synchronous, matching the existing sync contract
 /// of [`ModuleResolver::resolve`](crate::module::resolver::ModuleResolver::resolve)
@@ -94,6 +103,18 @@ pub trait Io: std::fmt::Debug + IoSyncBound + 'static {
         body: Option<&str>,
         headers: &[(String, String)],
     ) -> Result<String, IoError>;
+
+    /// Batched HTTP requests, backing the `http_all()` builtin. The default
+    /// implementation issues each request sequentially through
+    /// [`Io::http_request`]; implementations that can safely fan out (e.g.
+    /// `NativeIo`) override this with concurrent execution. Callers are
+    /// responsible for the same URL/domain policy as `http_request`.
+    fn http_request_all(&self, requests: &[HttpRequestSpec]) -> Result<Vec<String>, IoError> {
+        requests
+            .iter()
+            .map(|spec| self.http_request(&spec.method, &spec.url, spec.body.as_deref(), &spec.headers))
+            .collect()
+    }
 
     fn home_dir(&self) -> Option<PathBuf>;
     fn current_dir(&self) -> Option<PathBuf>;

--- a/crates/mq-lang/src/io/native.rs
+++ b/crates/mq-lang/src/io/native.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "http")]
+use super::HttpRequestSpec;
 use super::{Io, IoError};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
@@ -195,6 +197,33 @@ impl Io for NativeIo {
         Err(IoError::Other(Cow::Borrowed(
             "network access is not compiled into this build",
         )))
+    }
+
+    #[cfg(feature = "http")]
+    fn http_request_all(&self, requests: &[HttpRequestSpec]) -> Result<Vec<String>, IoError> {
+        // Each request runs on its own thread; NativeIo is a thin handle
+        // (a timeout Duration) around the shared SSRF-hardened agent, so
+        // concurrent fan-out is safe and bounded by the caller's batch size.
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = requests
+                .iter()
+                .map(|spec| {
+                    let method = spec.method.clone();
+                    let url = spec.url.clone();
+                    let body = spec.body.clone();
+                    let headers = spec.headers.clone();
+                    scope.spawn(move || self.http_request(&method, &url, body.as_deref(), &headers))
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .unwrap_or(Err(IoError::Other(Cow::Borrowed("http_all worker thread panicked"))))
+                })
+                .collect()
+        })
     }
 
     #[cfg(feature = "process-io")]

--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -1,4 +1,4 @@
-use super::{Io, IoError, NativeIo};
+use super::{HttpRequestSpec, Io, IoError, NativeIo};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
@@ -264,6 +264,18 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
             return Err(denied_domain(url));
         }
         self.inner.http_request(method, url, body, headers)
+    }
+
+    fn http_request_all(&self, requests: &[HttpRequestSpec]) -> Result<Vec<String>, IoError> {
+        if self.allow_net.is_denied() {
+            return Err(denied("network access is disabled"));
+        }
+        for spec in requests {
+            if !self.allow_net.permits(&spec.url) {
+                return Err(denied_domain(&spec.url));
+            }
+        }
+        self.inner.http_request_all(requests)
     }
 
     // Not gated by the domain allowlist: this seeds mock data for the `mock_fetch` builtin

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -304,6 +304,19 @@ body regardless of method. The optional `headers` argument is a dict of string t
 around `http(:get, url, headers)`, `http(:post, url, body, headers)`, and so on, for the most
 common cases — `headers` defaults to `{}` and can be omitted.
 
+`http_all([...requests])` issues a batch of HTTP requests and returns an array of response
+bodies in the same order. Each request is a dict with a required `url` and optional `method`
+(defaults to `get`), `body`, and `headers` keys, e.g.:
+
+```sh
+mq --allow-net 'http_all([{"url": "https://example.com/a"}, {"url": "https://example.com/b", "method": "post", "body": "{}", "headers": {"Content-Type": "application/json"}}])'
+```
+
+Requests in the batch run concurrently when the runtime supports it, so fanning out to
+multiple endpoints is faster than calling `http()` in a loop. The same URL/domain policy
+applies as for `http()`: HTTPS only, and `--allow-net` (with or without a domain allowlist)
+is required.
+
 > **Security note:** `http` only accepts `https://` URLs and is routed through the same
 > SSRF-hardened client used for HTTP imports — no automatic redirects, and DNS results are
 > filtered to publicly routable addresses, so a loopback/private/link-local address can't be


### PR DESCRIPTION
Adds `http_all([...requests])` which issues a batch of HTTP requests and returns the response bodies in order. Each request is a dict with a required `url` and optional `method` (defaults to `get`), `body`, and `headers` keys.

The `Io` trait gains `http_request_all` with a sequential default implementation; `NativeIo` overrides it with a thread-scoped concurrent fan-out, and `SandboxedIo` gates the batch with the same net permission checks as `http()`.

Closes #1998.