### PR TITLE
♻️ refactor(scripts): auto-detect current version in bump_version.sh

### DIFF
--- a/justfile
+++ b/justfile
@@ -112,9 +112,9 @@ deps:
 docs:
   ./scripts/update_doc.sh
 
-# Bump version for all crates
-bump-version:
-    cd scripts && ./bump_version.sh
+# Bump version for all crates (bump: major|minor|patch|X.Y.Z, default: patch)
+bump-version bump="patch":
+    cd scripts && ./bump_version.sh {{bump}}
 
 # Publish crates
 publish:

--- a/scripts/bump_version.mq
+++ b/scripts/bump_version.mq
@@ -23,18 +23,9 @@ ${line}"
 end
 
 def crates_version(line):
-  line
-  | replace(s"path = \"crates/mq-lang\", version = \"${prev_version}\"", s"path = \"crates/mq-lang\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-hir\", version = \"${prev_version}\"", s"path = \"crates/mq-hir\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-formatter\", version = \"${prev_version}\"", s"path = \"crates/mq-formatter\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-markdown\", version = \"${prev_version}\"", s"path = \"crates/mq-markdown\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-lsp\", version = \"${prev_version}\"", s"path = \"crates/mq-lsp\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-repl\", version = \"${prev_version}\"", s"path = \"crates/mq-repl\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-dap\", version = \"${prev_version}\"", s"path = \"crates/mq-dap\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-check\", version = \"${prev_version}\"", s"path = \"crates/mq-check\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-test\", version = \"${prev_version}\"", s"path = \"crates/mq-test\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-macros\", version = \"${prev_version}\"", s"path = \"crates/mq-macros\", version = \"${version}\"")
-  | replace(s"path = \"crates/mq-lint\", version = \"${prev_version}\"", s"path = \"crates/mq-lint\", version = \"${version}\"")
+  if (contains(line, "path = \"crates/")):
+    gsub(line, "version = \"[0-9]+.[0-9]+.[0-9]+\"", s"version = \"${version}\"")
+  else: line
 end
 
 def code_block_version(line, version):

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,18 +1,53 @@
 #!/bin/bash
+set -euo pipefail
 
-export MQ_PREV_VERSION="0.6.5"
-export MQ_VERSION="0.7.0"
+cd "$(dirname "$0")"
+
 export README="../README.md"
 export INSTALL_DOC="../docs/books/src/start/install.md"
 
+BUMP="${1:-patch}"
+
+CURRENT_VERSION=$(grep -m1 '^mq-lang = ' ../Cargo.toml | sed -E 's/.*version = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "Could not determine the current version from ../Cargo.toml" >&2
+    exit 1
+fi
+
+if [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    NEW_VERSION="$BUMP"
+else
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+    case "$BUMP" in
+        major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+        minor) NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+        patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+        *)
+            echo "Usage: $0 [major|minor|patch|X.Y.Z]" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+export MQ_VERSION="$NEW_VERSION"
+
+echo "Bumping version: ${CURRENT_VERSION} -> ${MQ_VERSION}"
+
 tmpfile=$(mktemp)
-mq -I text --args version $MQ_VERSION --args prev_version $MQ_PREV_VERSION 'import "bump_version" | bump_version::crates_version()' ../Cargo.toml > "$tmpfile" && mv "$tmpfile" ../Cargo.toml
+mq -I text --args version $MQ_VERSION 'import "bump_version" | bump_version::crates_version()' ../Cargo.toml > "$tmpfile"
+tmpfile2=$(mktemp)
+awk -v transformed="$tmpfile" '
+    BEGIN { while ((getline line < transformed) > 0) t[++n] = line }
+    { if ($0 == "") print ""; else print t[++i] }
+' ../Cargo.toml > "$tmpfile2" && mv "$tmpfile2" ../Cargo.toml
+rm -f "$tmpfile"
 
 # Update Cargo.toml files
 for crate in ../crates/*; do
     if [ -f "$crate/Cargo.toml" ]; then
         tmpfile=$(mktemp)
-        mq -I text --args version $MQ_VERSION --args prev_version $MQ_PREV_VERSION 'import "bump_version" | bump_version::crate_version()' "$crate/Cargo.toml" > "$tmpfile" && mv "$tmpfile" "$crate/Cargo.toml"
+        mq -I text --args version $MQ_VERSION 'import "bump_version" | bump_version::crate_version()' "$crate/Cargo.toml" > "$tmpfile" && mv "$tmpfile" "$crate/Cargo.toml"
     fi
 done
 
@@ -21,7 +56,7 @@ for dir in ../packages ../editors; do
     for package in "$dir"/*; do
         if [ -f "$package/package.json" ]; then
             tmpfile=$(mktemp)
-            mq -I text --args version $MQ_VERSION --args prev_version $MQ_PREV_VERSION 'import "bump_version" | bump_version::npm_version()' "$package/package.json" > "$tmpfile" && mv "$tmpfile" "$package/package.json"
+            mq -I text --args version $MQ_VERSION 'import "bump_version" | bump_version::npm_version()' "$package/package.json" > "$tmpfile" && mv "$tmpfile" "$package/package.json"
         fi
     done
 done
@@ -33,3 +68,7 @@ mq -U --args VERSION $MQ_VERSION 'import "bump_version" | bump_version::code_blo
 # Update INSTALL_DOC.md with the new version
 mq -U --args VERSION $MQ_VERSION 'import "bump_version" | bump_version::code_block_version(VERSION)' $INSTALL_DOC > INSTALL_DOC.md.tmp \
   && mv INSTALL_DOC.md.tmp $INSTALL_DOC
+
+echo "Done. Review with 'git diff', then:"
+echo "  git add -A && git commit -m \"chore: bump version to ${MQ_VERSION}\""
+echo "  git tag v${MQ_VERSION}"


### PR DESCRIPTION
## Summary

Reads the current version from Cargo.toml instead of hardcoding MQ_PREV_VERSION/MQ_VERSION, and accepts a bump argument (major|minor|patch|X.Y.Z, default patch) to compute the new version. Updates crates_version() in bump_version.mq to match any crate path version via regex instead of listing each crate individually, and exposes the bump argument through the justfile bump-version recipe.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
