### PR TITLE
🐛 fix: resolve CodeFactor warnings across scripts, playground CSS, and complexity

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -406,6 +406,72 @@ function updateCodeLensProvider(context: vscode.ExtensionContext) {
   }
 }
 
+async function promptUpdateAndStartFromStorage(
+  context: vscode.ExtensionContext,
+  storageLspPath: string,
+) {
+  const prevVersion = context.globalState.get<string>(MQ_VERSION_KEY);
+  const currentVersion = context.extension.packageJSON.version;
+
+  if (!prevVersion || currentVersion === prevVersion) {
+    await startLspServer(storageLspPath);
+    return;
+  }
+
+  const selected = await vscode.window.showInformationMessage(
+    "mq has been updated. Would you like to download the latest version?",
+    "Yes",
+    "No",
+  );
+
+  if (selected === "Yes") {
+    const newPath = await downloadFromRelease(context, true);
+    await startLspServer(newPath ?? storageLspPath);
+  } else {
+    await context.globalState.update(MQ_VERSION_KEY, currentVersion);
+    await startLspServer(storageLspPath);
+  }
+}
+
+async function promptUpdateAndStartFromPath(context: vscode.ExtensionContext) {
+  const prevVersion = context.globalState.get<string>(MQ_VERSION_KEY);
+  const currentVersion = context.extension.packageJSON.version;
+
+  if (prevVersion && currentVersion === prevVersion) {
+    await startLspServer();
+    return;
+  }
+
+  const selected = await vscode.window.showInformationMessage(
+    "mq has been updated. Would you like to install the latest version?",
+    "Yes",
+    "No",
+  );
+
+  if (selected === "Yes") {
+    await installServers(context, false);
+  } else {
+    await context.globalState.update(MQ_VERSION_KEY, currentVersion);
+  }
+
+  await startLspServer();
+}
+
+async function promptInstallAndStart(context: vscode.ExtensionContext) {
+  const selected = await vscode.window.showInformationMessage(
+    "Install mq?",
+    "Yes",
+    "No",
+  );
+
+  if (selected === "Yes") {
+    const installedPath = await installServers(context, false);
+    await startLspServer(installedPath ?? undefined);
+  } else {
+    vscode.window.showErrorMessage("mq not found in PATH");
+  }
+}
+
 async function initializeLspServer(context: vscode.ExtensionContext) {
   if (process.env._MQ_DEBUG_BIN) {
     await startLspServer();
@@ -428,65 +494,18 @@ async function initializeLspServer(context: vscode.ExtensionContext) {
   );
 
   if (fs.existsSync(storageLspPath)) {
-    const prevVersion = context.globalState.get<string>(MQ_VERSION_KEY);
-    const currentVersion = context.extension.packageJSON.version;
-
-    if (prevVersion && currentVersion !== prevVersion) {
-      const selected = await vscode.window.showInformationMessage(
-        "mq has been updated. Would you like to download the latest version?",
-        "Yes",
-        "No",
-      );
-
-      if (selected === "Yes") {
-        const newPath = await downloadFromRelease(context, true);
-        await startLspServer(newPath ?? storageLspPath);
-      } else {
-        await context.globalState.update(MQ_VERSION_KEY, currentVersion);
-        await startLspServer(storageLspPath);
-      }
-    } else {
-      await startLspServer(storageLspPath);
-    }
+    await promptUpdateAndStartFromStorage(context, storageLspPath);
     return;
   }
 
   const lspInPath = await which("mq-lsp", { nothrow: true });
 
   if (lspInPath !== null) {
-    const prevVersion = context.globalState.get<string>(MQ_VERSION_KEY);
-    const currentVersion = context.extension.packageJSON.version;
-
-    if (!prevVersion || currentVersion !== prevVersion) {
-      const selected = await vscode.window.showInformationMessage(
-        "mq has been updated. Would you like to install the latest version?",
-        "Yes",
-        "No",
-      );
-
-      if (selected === "Yes") {
-        await installServers(context, false);
-      } else {
-        await context.globalState.update(MQ_VERSION_KEY, currentVersion);
-      }
-    }
-
-    await startLspServer();
+    await promptUpdateAndStartFromPath(context);
     return;
   }
 
-  const selected = await vscode.window.showInformationMessage(
-    "Install mq?",
-    "Yes",
-    "No",
-  );
-
-  if (selected === "Yes") {
-    const installedPath = await installServers(context, false);
-    await startLspServer(installedPath ?? undefined);
-  } else {
-    vscode.window.showErrorMessage("mq not found in PATH");
-  }
+  await promptInstallAndStart(context);
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -589,47 +608,38 @@ const executeCommand = async (
   }
 };
 
-const startLspServer = async (providedLspPath?: string) => {
-  if (client !== null) {
-    if (client.state === lc.State.Running || client.state === lc.State.Starting) {
-      return;
-    }
-    // client exists but in a non-running state (e.g. startFailed), reset it
-    client = null;
-  }
-
-  let lspPath: string | null;
-  const config = vscode.workspace.getConfiguration("mq");
-
+async function resolveLspPath(
+  providedLspPath: string | undefined,
+  config: vscode.WorkspaceConfiguration,
+): Promise<string | null> {
   if (process.env._MQ_DEBUG_BIN) {
-    lspPath = process.env._MQ_DEBUG_BIN;
-  } else if (providedLspPath) {
-    lspPath = providedLspPath;
-  } else {
-    const configLspPath = config.get<string>("lspPath");
-
-    if (configLspPath) {
-      lspPath = configLspPath;
-    } else {
-      const ext = process.platform === "win32" ? ".exe" : "";
-      const storageLspPath = globalStorageBinPath
-        ? path.join(globalStorageBinPath, `mq-lsp${ext}`)
-        : null;
-
-      if (storageLspPath && fs.existsSync(storageLspPath)) {
-        lspPath = storageLspPath;
-      } else {
-        lspPath = await which("mq-lsp", { nothrow: true });
-      }
-    }
-
-    if (lspPath === null) {
-      vscode.window.showErrorMessage("mq not found in PATH");
-      statusBarManager?.updateStatusBar(lc.State.Stopped);
-      return;
-    }
+    return process.env._MQ_DEBUG_BIN;
+  }
+  if (providedLspPath) {
+    return providedLspPath;
   }
 
+  const configLspPath = config.get<string>("lspPath");
+  if (configLspPath) {
+    return configLspPath;
+  }
+
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const storageLspPath = globalStorageBinPath
+    ? path.join(globalStorageBinPath, `mq-lsp${ext}`)
+    : null;
+
+  if (storageLspPath && fs.existsSync(storageLspPath)) {
+    return storageLspPath;
+  }
+
+  return await which("mq-lsp", { nothrow: true });
+}
+
+function buildLspExecutable(
+  lspPath: string,
+  config: vscode.WorkspaceConfiguration,
+): lc.Executable {
   const enableTypeCheck = config.get<boolean>("typeCheck.enableTypeCheck");
   const strictArray = config.get<boolean>("typeCheck.strictArray");
   const enableLint = config.get<boolean>("lint.enableLint");
@@ -648,7 +658,7 @@ const startLspServer = async (providedLspPath?: string) => {
       ]
     : [];
 
-  const run: lc.Executable = {
+  return {
     command: lspPath,
     args: [
       ...multiWorkspaceArgs,
@@ -660,6 +670,27 @@ const startLspServer = async (providedLspPath?: string) => {
     ],
     options: {},
   };
+}
+
+const startLspServer = async (providedLspPath?: string) => {
+  if (client !== null) {
+    if (client.state === lc.State.Running || client.state === lc.State.Starting) {
+      return;
+    }
+    // client exists but in a non-running state (e.g. startFailed), reset it
+    client = null;
+  }
+
+  const config = vscode.workspace.getConfiguration("mq");
+  const lspPath = await resolveLspPath(providedLspPath, config);
+
+  if (lspPath === null) {
+    vscode.window.showErrorMessage("mq not found in PATH");
+    statusBarManager?.updateStatusBar(lc.State.Stopped);
+    return;
+  }
+
+  const run = buildLspExecutable(lspPath, config);
 
   const serverOptions: lc.ServerOptions = {
     run,

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -346,8 +346,102 @@ export const Playground = () => {
     }
     hasInitialized.current = true;
 
+    // Returns true if an all-files share was found and restored.
+    const restoreAllFilesShare = async (): Promise<boolean> => {
+      if (!window.location.hash) {
+        return false;
+      }
+
+      try {
+        const compressed = window.location.hash.substring(1);
+        const decompressed =
+          LZString.decompressFromEncodedURIComponent(compressed);
+        if (!decompressed) {
+          return false;
+        }
+
+        const parsedData = JSON.parse(decompressed);
+        if (
+          parsedData.type !== "all-files" ||
+          !Array.isArray(parsedData.files)
+        ) {
+          return false;
+        }
+
+        for (const file of parsedData.files as {
+          path: string;
+          content: string;
+        }[]) {
+          await fileSystem.writeFile(file.path, file.content);
+        }
+        await loadFiles();
+        const options = parsedData.options || {};
+        setIsUpdate(!!options.isUpdate);
+        setInputFormat(options.inputFormat || null);
+        setListStyle(options.listStyle || null);
+        setLinkUrlStyle(options.linkUrlStyle || null);
+        setLinkTitleStyle(options.linkTitleStyle || null);
+        const activeFilePath =
+          parsedData.activeFile || parsedData.files[0]?.path;
+        if (activeFilePath) {
+          const content = await fileSystem.readFile(activeFilePath);
+          openOrSwitchToTab(activeFilePath, content);
+          setSelectedFile(activeFilePath);
+        }
+        return true;
+      } catch (e) {
+        console.error("Failed to restore all-files share:", e);
+        return false;
+      }
+    };
+
+    const restoreTabsFromStorage = async () => {
+      const savedTabs = localStorage.getItem(TABS_KEY);
+      const initialTabs = savedTabs ? JSON.parse(savedTabs) : [];
+      const savedActiveTabId = localStorage.getItem(ACTIVE_TAB_ID_KEY);
+
+      if (savedActiveTabId && initialTabs.length > 0) {
+        const activeTab = initialTabs.find(
+          (tab: Tab) => tab.id === savedActiveTabId,
+        );
+        if (!activeTab) {
+          return;
+        }
+        try {
+          // Verify the file still exists and load its current content
+          const content = await fileSystem.readFile(activeTab.filePath);
+          setEditorContent(activeTab.filePath, content);
+          setSelectedFile(activeTab.filePath);
+        } catch (error) {
+          console.error("Failed to restore active tab:", error);
+          // If active tab file doesn't exist, clear it
+          setTabs((prev) => prev.filter((tab) => tab.id !== savedActiveTabId));
+          setActiveTabId(null);
+        }
+        return;
+      }
+
+      if (initialTabs.length > 0) {
+        return;
+      }
+
+      // Only open a new tab if no tabs were restored
+      const savedFilePath = localStorage.getItem(CURRENT_FILE_PATH_KEY);
+      if (!savedFilePath) {
+        return;
+      }
+      try {
+        const content = await fileSystem.readFile(savedFilePath);
+        openOrSwitchToTab(savedFilePath, content);
+        setSelectedFile(savedFilePath);
+      } catch (error) {
+        console.error("Failed to restore last file:", error);
+        localStorage.removeItem(CURRENT_FILE_PATH_KEY);
+        localStorage.removeItem(SELECTED_FILE_KEY);
+      }
+    };
+
     const initFileSystem = async () => {
-      // Check if OPFS is supported
       const supported = OPFSFileSystem.isSupported();
       setIsOPFSSupported(supported);
 
@@ -362,89 +456,14 @@ export const Playground = () => {
         await fileSystem.initialize();
         await loadFiles();
 
-        // Handle all-files share restoration from URL hash
-        if (window.location.hash) {
-          try {
-            const compressed = window.location.hash.substring(1);
-            const decompressed =
-              LZString.decompressFromEncodedURIComponent(compressed);
-            if (decompressed) {
-              const parsedData = JSON.parse(decompressed);
-              if (
-                parsedData.type === "all-files" &&
-                Array.isArray(parsedData.files)
-              ) {
-                for (const file of parsedData.files as {
-                  path: string;
-                  content: string;
-                }[]) {
-                  await fileSystem.writeFile(file.path, file.content);
-                }
-                await loadFiles();
-                const options = parsedData.options || {};
-                setIsUpdate(!!options.isUpdate);
-                setInputFormat(options.inputFormat || null);
-                setListStyle(options.listStyle || null);
-                setLinkUrlStyle(options.linkUrlStyle || null);
-                setLinkTitleStyle(options.linkTitleStyle || null);
-                const activeFilePath =
-                  parsedData.activeFile || parsedData.files[0]?.path;
-                if (activeFilePath) {
-                  const content = await fileSystem.readFile(activeFilePath);
-                  openOrSwitchToTab(activeFilePath, content);
-                  setSelectedFile(activeFilePath);
-                }
-                return;
-              }
-            }
-          } catch (e) {
-            console.error("Failed to restore all-files share:", e);
-          }
+        const restoredAllFiles = await restoreAllFilesShare();
+        if (restoredAllFiles) {
+          return;
         }
 
-        // Get initial tabs and activeTabId from localStorage
-        const savedTabs = localStorage.getItem(TABS_KEY);
-        const initialTabs = savedTabs ? JSON.parse(savedTabs) : [];
-        const savedActiveTabId = localStorage.getItem(ACTIVE_TAB_ID_KEY);
-
-        // Restore active tab content if tabs were restored from localStorage
-        if (
-          !window.location.hash &&
-          savedActiveTabId &&
-          initialTabs.length > 0
-        ) {
-          const activeTab = initialTabs.find(
-            (tab: Tab) => tab.id === savedActiveTabId,
-          );
-          if (activeTab) {
-            try {
-              // Verify the file still exists and load its current content
-              const content = await fileSystem.readFile(activeTab.filePath);
-              setEditorContent(activeTab.filePath, content);
-              setSelectedFile(activeTab.filePath);
-            } catch (error) {
-              console.error("Failed to restore active tab:", error);
-              // If active tab file doesn't exist, clear it
-              setTabs((prev) =>
-                prev.filter((tab) => tab.id !== savedActiveTabId),
-              );
-              setActiveTabId(null);
-            }
-          }
-        } else if (!window.location.hash && initialTabs.length === 0) {
-          // Only open a new tab if no tabs were restored
-          const savedFilePath = localStorage.getItem(CURRENT_FILE_PATH_KEY);
-          if (savedFilePath) {
-            try {
-              const content = await fileSystem.readFile(savedFilePath);
-              openOrSwitchToTab(savedFilePath, content);
-              setSelectedFile(savedFilePath);
-            } catch (error) {
-              console.error("Failed to restore last file:", error);
-              localStorage.removeItem(CURRENT_FILE_PATH_KEY);
-              localStorage.removeItem(SELECTED_FILE_KEY);
-            }
-          }
+        // Tab/file restoration below is only relevant when there's no share hash
+        if (!window.location.hash) {
+          await restoreTabsFromStorage();
         }
       } catch (error) {
         console.error("Failed to initialize file system:", error);
@@ -452,75 +471,85 @@ export const Playground = () => {
       }
     };
 
-    initFileSystem();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-
-    if (window.location.hash) {
+    // all-files shares are restored inside initFileSystem after OPFS init.
+    const restoreSingleShareFromHash = () => {
+      if (!window.location.hash) {
+        return;
+      }
       try {
         const compressed = window.location.hash.substring(1);
         const decompressed =
           LZString.decompressFromEncodedURIComponent(compressed);
-        if (decompressed) {
-          const parsedData = JSON.parse(decompressed);
-          // all-files shares are restored inside initFileSystem after OPFS init
-          if (parsedData.type !== "all-files") {
-            const options = parsedData.options || {};
-            const data: SharedData = {
-              code: typeof parsedData.code === "string" ? parsedData.code : "",
-              markdown:
-                typeof parsedData.markdown === "string"
-                  ? parsedData.markdown
-                  : "",
-              options: {
-                isUpdate: !!options.isUpdate,
-                inputFormat: options.inputFormat || null,
-                listStyle: options.listStyle,
-                linkUrlStyle: options.linkUrlStyle || null,
-                linkTitleStyle: options.linkTitleStyle || null,
-              },
-            };
-            setCode(data.code);
-            setMarkdown(data.markdown);
-            setIsUpdate(data.options.isUpdate === true);
-            setInputFormat(data.options.inputFormat);
-            setListStyle(data.options.listStyle);
-            setLinkUrlStyle(data.options.linkUrlStyle);
-            setLinkTitleStyle(data.options.linkTitleStyle);
-          }
+        if (!decompressed) {
+          return;
         }
+        const parsedData = JSON.parse(decompressed);
+        if (parsedData.type === "all-files") {
+          return;
+        }
+        const options = parsedData.options || {};
+        const data: SharedData = {
+          code: typeof parsedData.code === "string" ? parsedData.code : "",
+          markdown:
+            typeof parsedData.markdown === "string"
+              ? parsedData.markdown
+              : "",
+          options: {
+            isUpdate: !!options.isUpdate,
+            inputFormat: options.inputFormat || null,
+            listStyle: options.listStyle,
+            linkUrlStyle: options.linkUrlStyle || null,
+            linkTitleStyle: options.linkTitleStyle || null,
+          },
+        };
+        setCode(data.code);
+        setMarkdown(data.markdown);
+        setIsUpdate(data.options.isUpdate === true);
+        setInputFormat(data.options.inputFormat);
+        setListStyle(data.options.listStyle);
+        setLinkUrlStyle(data.options.linkUrlStyle);
+        setLinkTitleStyle(data.options.linkTitleStyle);
       } catch {
         showToast("Failed to load shared playground", "error");
       }
-    }
+    };
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const embedParam = urlParams.get("embed");
-    setIsEmbed(embedParam === "true");
+    const applyUrlParams = () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const embedParam = urlParams.get("embed");
+      setIsEmbed(embedParam === "true");
 
-    const themeParam = urlParams.get("theme");
-    if (themeParam) {
-      const isDark = themeParam === "dark" || themeParam === "mq";
-      document.documentElement.style.colorScheme = isDark ? "dark" : "light";
-      if (themeParam === "mq") {
-        document.documentElement.setAttribute("data-theme", "mq");
-      } else {
-        document.documentElement.removeAttribute("data-theme");
+      const themeParam = urlParams.get("theme");
+      if (themeParam) {
+        const isDark = themeParam === "dark" || themeParam === "mq";
+        document.documentElement.style.colorScheme = isDark
+          ? "dark"
+          : "light";
+        if (themeParam === "mq") {
+          document.documentElement.setAttribute("data-theme", "mq");
+        } else {
+          document.documentElement.removeAttribute("data-theme");
+        }
+        document.documentElement.style.setProperty(
+          "--lightningcss-light",
+          isDark ? " " : "initial",
+        );
+        document.documentElement.style.setProperty(
+          "--lightningcss-dark",
+          isDark ? "initial" : " ",
+        );
       }
-      document.documentElement.style.setProperty(
-        "--lightningcss-light",
-        isDark ? " " : "initial",
-      );
-      document.documentElement.style.setProperty(
-        "--lightningcss-dark",
-        isDark ? "initial" : " ",
-      );
-    }
 
-    // Update sidebar visibility from URL parameter if present
-    const sidebarParam = urlParams.get("sidebar");
-    if (sidebarParam !== null) {
-      setIsSidebarVisible(sidebarParam === "true");
-    }
+      const sidebarParam = urlParams.get("sidebar");
+      if (sidebarParam !== null) {
+        setIsSidebarVisible(sidebarParam === "true");
+      }
+    };
+
+    initFileSystem();
+    restoreSingleShareFromHash();
+    applyUrlParams();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadFiles]);
 
   const [isFirstRun, setIsFirstRun] = useState(true);

--- a/packages/mq-playground/src/components/SettingsDialog.css
+++ b/packages/mq-playground/src/components/SettingsDialog.css
@@ -61,7 +61,7 @@
 }
 
 .settings-section h4 {
-    margin: 0 0 12px 0;
+    margin: 0 0 12px;
     font-size: 0.9rem;
     color: var(--accent-blue);
     text-transform: uppercase;

--- a/packages/mq-playground/src/index.css
+++ b/packages/mq-playground/src/index.css
@@ -15,12 +15,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: var(--secondary-color);
+  background-color: light-dark(var(--dark-color), var(--secondary-color));
   color: white;
   padding: 2px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  display: flex;
-  align-items: center;
 }
 
 .playground-header h1 {
@@ -218,8 +216,11 @@ body {
 }
 
 .right-panel {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   min-width: 0;
+  height: 100%;
 }
 
 .editor-container {
@@ -256,19 +257,13 @@ body {
   height: 100%;
 }
 
-.right-panel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
 .editor-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 32px;
-  background-color: var(--secondary-color);
-  color: var(--light-color);
+  background-color: light-dark(#edf2f7, var(--secondary-color));
+  color: light-dark(var(--text-color), var(--light-color));
   padding: 4px;
   gap: 8px;
 }
@@ -355,7 +350,8 @@ body {
 .loading-message,
 .empty-message {
   padding: 16px;
-  background-color: var(--secondary-color);
+  background-color: light-dark(#f7fafc, var(--secondary-color));
+  color: light-dark(#718096, #a0aec0);
   height: 100%;
 }
 
@@ -404,22 +400,6 @@ body {
   /* Context menu colors */
   --context-menu-bg: light-dark(#ffffff, #2d2d30);
   --context-menu-item-hover-bg: light-dark(#edf2f7, #37373d);
-}
-
-.playground-header {
-  background-color: light-dark(var(--dark-color), var(--secondary-color));
-  color: white;
-}
-
-.editor-header {
-  background-color: light-dark(#edf2f7, var(--secondary-color));
-  color: light-dark(var(--text-color), var(--light-color));
-}
-
-.loading-message,
-.empty-message {
-  color: light-dark(#718096, #a0aec0);
-  background-color: light-dark(#f7fafc, var(--secondary-color));
 }
 
 .logo-icon {

--- a/packages/mq-playground/src/index.css
+++ b/packages/mq-playground/src/index.css
@@ -262,7 +262,7 @@ body {
   justify-content: space-between;
   align-items: center;
   height: 32px;
-  background-color: light-dark(#edf2f7, var(--secondary-color));
+  background-color: var(--surface-color);
   color: light-dark(var(--text-color), var(--light-color));
   padding: 4px;
   gap: 8px;
@@ -350,8 +350,8 @@ body {
 .loading-message,
 .empty-message {
   padding: 16px;
-  background-color: light-dark(#f7fafc, var(--secondary-color));
-  color: light-dark(#718096, #a0aec0);
+  background-color: var(--secondary-color);
+  color: var(--muted-text-color);
   height: 100%;
 }
 
@@ -360,6 +360,8 @@ body {
 
   /* Common values that don't change between modes */
   --accent-blue: light-dark(#4299e1, #5dade2);
+  --surface-color: light-dark(#edf2f7, var(--secondary-color));
+  --muted-text-color: light-dark(#718096, #a0aec0);
 
   /* Light/dark mode values */
   --primary-color: light-dark(#3182ce, #3a8ec5);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -372,7 +372,7 @@ verify_installation() {
         fi
     fi
 
-    if [[ "$mq_installed" == "true" ]] && ([[ "$INSTALL_DEBUG" != "true" ]] || [[ "$mq_dbg_installed" == "true" ]]); then
+    if [[ "$mq_installed" == "true" ]] && { [[ "$INSTALL_DEBUG" != "true" ]] || [[ "$mq_dbg_installed" == "true" ]]; }; then
         log "Installation verification successful!"
         return 0
     else

--- a/scripts/update_doc.sh
+++ b/scripts/update_doc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CLI_HELP=`mq -h | tail -n +3`
+CLI_HELP=$(mq -h | tail -n +3)
 # Update the documentation with the latest CLI help and builtin functions
 mq -U -o docs/books/src/reference/cli.md --args mq_run_help "$CLI_HELP" 'select(.code.lang == "sh") | update(mq_run_help)' docs/books/src/reference/cli.md
 mq -U -o README.md --args mq_run_help "$CLI_HELP" 'select(.code.lang == "sh") | select(contains("Usage: mq")) | update(mq_run_help)' README.md


### PR DESCRIPTION
## Summary

- scripts/update_doc.sh: replace legacy backtick command substitution with $(...)
- scripts/install.sh: replace subshell (( )) with brace grouping { ; } to avoid a subshell fork
- mq-playground CSS: drop a duplicate display/align-items declaration and merge selector blocks that were split into a base rule plus a shadowed duplicate (.playground-header, .editor-header, .loading-message/.empty-message, .right-panel); normalize a non-canonical margin shorthand in SettingsDialog.css
- mq-playground Playground.tsx: split the init useEffect and its nested initFileSystem into five focused functions to bring cyclomatic complexity down from 19/24 to well under threshold
- vscode extension.ts: split initializeLspServer and startLspServer into smaller helpers (resolveLspPath, buildLspExecutable, and three update-prompt helpers), reducing complexity from 18/23

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
