### PR TITLE
✨ feat(mq-lang): add variance, stddev, mode, and describe builtins

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1803,7 +1803,7 @@ end
 # Example:
 # ```
 # describe([1, 2, 3, 4, 5])
-# #=> {"min": 1, "max": 5, "mean": 3, "median": 3, "stddev": 1.4142135623730951, "variance": 2, "count": 5}
+# #=> {"count": 5, "min": 1, "max": 5, "mean": 3, "variance": 2, "stddev": 1.414214, "median": 3}
 # ```
 #
 # Returns: dict

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1715,7 +1715,7 @@ def mean(arr):
     sum(arr) / len(arr)
 end
 
-# Returns the median of an array of numbers, or None if the array is empty.
+# Returns the geometric mean of an array of numbers, or None if the array is empty.
 #
 # Example:
 # ```
@@ -1731,6 +1731,99 @@ def geomean(arr):
     do
       let product = fold(arr, 1, ->(acc, x): acc * x;)
       | pow(product, 1 / len(arr))
+    end
+end
+
+# Returns the population variance of an array of numbers, or None if the array is empty.
+#
+# Example:
+# ```
+# variance([2, 4, 4, 4, 5, 5, 7, 9])
+# #=> 4
+# ```
+#
+# Returns: number
+def variance(arr):
+  if (not(is_array(arr))):
+    error("first argument must be an array")
+  elif (is_empty(arr)):
+    None
+  else:
+    do
+      let m = mean(arr)
+      | mean(map(arr, fn(x): pow(x - m, 2);))
+    end
+end
+
+# Returns the population standard deviation of an array of numbers, or None if the array is empty.
+#
+# Example:
+# ```
+# stddev([2, 4, 4, 4, 5, 5, 7, 9])
+# #=> 2
+# ```
+#
+# Returns: number
+def stddev(arr):
+  if (not(is_array(arr))):
+    error("first argument must be an array")
+  elif (is_empty(arr)):
+    None
+  else:
+    sqrt(variance(arr))
+end
+
+# Returns the mode(s) of an array, i.e. the most frequently occurring value(s).
+# Multiple values are returned if there is a tie for the highest frequency.
+# Returns None if the array is empty.
+#
+# Example:
+# ```
+# mode([1, 2, 2, 3])
+# #=> [2]
+# ```
+#
+# Returns: array
+def mode(arr):
+  if (not(is_array(arr))):
+    error("first argument must be an array")
+  elif (is_empty(arr)):
+    None
+  else:
+    do
+      let groups = chunk_by(sort(arr), identity)
+      | let max_count = fold(groups, 0, fn(acc, g): if (len(g) > acc): len(g) else: acc;)
+      | map(filter(groups, fn(g): len(g) == max_count;), first)
+    end
+end
+
+# Returns a dict of summary statistics for an array of numbers:
+# `{min, max, mean, median, stddev, variance, count}`. Returns None if the array is empty.
+#
+# Example:
+# ```
+# describe([1, 2, 3, 4, 5])
+# #=> {"min": 1, "max": 5, "mean": 3, "median": 3, "stddev": 1.4142135623730951, "variance": 2, "count": 5}
+# ```
+#
+# Returns: dict
+def describe(arr):
+  if (not(is_array(arr))):
+    error("first argument must be an array")
+  elif (is_empty(arr)):
+    None
+  else:
+    do
+      let sorted = sort(arr)
+      | {
+        min: first(sorted),
+        max: last(sorted),
+        mean: mean(arr),
+        median: percentile(arr, 0.5),
+        stddev: stddev(arr),
+        variance: variance(arr),
+        count: len(arr),
+      }
     end
 end
 

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -940,6 +940,55 @@ def test_geomean():
   | assert_eq(result3, 4)
 end
 
+def test_variance():
+  let result1 = variance([2, 4, 4, 4, 5, 5, 7, 9])
+  | assert_eq(result1, 4)
+
+  | let result2 = variance([])
+  | assert_eq(result2, None)
+
+  | let result3 = variance([5])
+  | assert_eq(result3, 0)
+end
+
+def test_stddev():
+  let result1 = stddev([2, 4, 4, 4, 5, 5, 7, 9])
+  | assert_eq(result1, 2)
+
+  | let result2 = stddev([])
+  | assert_eq(result2, None)
+
+  | let result3 = stddev([5])
+  | assert_eq(result3, 0)
+end
+
+def test_mode():
+  let result1 = mode([1, 2, 2, 3])
+  | assert_eq(result1, [2])
+
+  | let result2 = mode([1, 1, 2, 2, 3])
+  | assert_eq(result2, [1, 2])
+
+  | let result3 = mode([])
+  | assert_eq(result3, None)
+
+  | let result4 = mode([1, 2, 3])
+  | assert_eq(result4, [1, 2, 3])
+end
+
+def test_describe():
+  let result1 = describe([1, 2, 3, 4, 5])
+  | assert_eq(get(result1, "min"), 1)
+  | assert_eq(get(result1, "max"), 5)
+  | assert_eq(get(result1, "mean"), 3)
+  | assert_eq(get(result1, "median"), 3)
+  | assert_eq(get(result1, "variance"), 2)
+  | assert_eq(get(result1, "count"), 5)
+
+  | let result2 = describe([])
+  | assert_eq(result2, None)
+end
+
 def test_ngram():
   let result1 = ngram("hello", 2)
   | assert_eq(result1, ["he", "el", "ll", "lo"])


### PR DESCRIPTION
## Summary

Add stddev/variance/mode as individual statistical functions and describe(arr) to summarize an array as {min, max, mean, median, stddev, variance, count}, reusing existing mean/percentile helpers. Also fixes a stale doc comment on geomean that incorrectly described it as returning the median.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x]  I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
