### PR TITLE
🐛 fix(mq-markdown): fix html-to-markdown correctness and completeness bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,6 +2728,7 @@ dependencies = [
  "serde_yaml",
  "smol_str",
  "unicode-width 0.2.2",
+ "url",
 ]
 
 [[package]]

--- a/crates/mq-crawler/src/crawler.rs
+++ b/crates/mq-crawler/src/crawler.rs
@@ -549,7 +549,10 @@ impl Crawler {
 
                 let query = self.mq_query.clone();
                 let html_content_clone = html_content.clone();
-                let conversion_options = self.conversion_options;
+                // Resolve relative links/images against the URL actually being crawled,
+                // rather than a single static base for the whole crawl.
+                let mut conversion_options = self.conversion_options.clone();
+                conversion_options.base_url = Some(current_url.to_string());
                 let current_url_clone = current_url.clone();
                 let self_clone = self.clone();
                 let new_links = tokio::task::spawn_blocking(move || {

--- a/crates/mq-crawler/src/crawler.rs
+++ b/crates/mq-crawler/src/crawler.rs
@@ -549,8 +549,7 @@ impl Crawler {
 
                 let query = self.mq_query.clone();
                 let html_content_clone = html_content.clone();
-                // Resolve relative links/images against the URL actually being crawled,
-                // rather than a single static base for the whole crawl.
+                // Resolve relative links against the page actually being crawled, not one static base.
                 let mut conversion_options = self.conversion_options.clone();
                 conversion_options.base_url = Some(current_url.to_string());
                 let current_url_clone = current_url.clone();

--- a/crates/mq-crawler/src/main.rs
+++ b/crates/mq-crawler/src/main.rs
@@ -385,6 +385,7 @@ async fn main() {
             extract_scripts_as_code_blocks: args.conversion.extract_scripts_as_code_blocks,
             generate_front_matter: args.conversion.generate_front_matter,
             use_title_as_h1: args.conversion.use_title_as_h1,
+            base_url: None,
         },
         args.depth,
         effective_allowed,

--- a/crates/mq-ffi/mq.h
+++ b/crates/mq-ffi/mq.h
@@ -40,9 +40,7 @@ typedef struct MqConversionOptions {
    */
   bool use_title_as_h1;
   /**
-   * Base URL used to resolve relative `href`/`src` values into absolute URLs.
-   * A null pointer means no explicit base URL (falls back to a `<base href>`
-   * found in the document, if any).
+   * Base URL for resolving relative `href`/`src` values; null falls back to `<base href>`.
    */
   const char *base_url;
 } MqConversionOptions;

--- a/crates/mq-ffi/mq.h
+++ b/crates/mq-ffi/mq.h
@@ -39,6 +39,12 @@ typedef struct MqConversionOptions {
    * Use HTML title tag as H1 heading
    */
   bool use_title_as_h1;
+  /**
+   * Base URL used to resolve relative `href`/`src` values into absolute URLs.
+   * A null pointer means no explicit base URL (falls back to a `<base href>`
+   * found in the document, if any).
+   */
+  const char *base_url;
 } MqConversionOptions;
 
 /**

--- a/crates/mq-ffi/src/lib.rs
+++ b/crates/mq-ffi/src/lib.rs
@@ -95,9 +95,7 @@ pub struct MqConversionOptions {
     pub generate_front_matter: bool,
     /// Use HTML title tag as H1 heading
     pub use_title_as_h1: bool,
-    /// Base URL used to resolve relative `href`/`src` values into absolute URLs.
-    /// A null pointer means no explicit base URL (falls back to a `<base href>`
-    /// found in the document, if any).
+    /// Base URL for resolving relative `href`/`src` values; null falls back to `<base href>`.
     pub base_url: *const c_char,
 }
 

--- a/crates/mq-ffi/src/lib.rs
+++ b/crates/mq-ffi/src/lib.rs
@@ -95,14 +95,27 @@ pub struct MqConversionOptions {
     pub generate_front_matter: bool,
     /// Use HTML title tag as H1 heading
     pub use_title_as_h1: bool,
+    /// Base URL used to resolve relative `href`/`src` values into absolute URLs.
+    /// A null pointer means no explicit base URL (falls back to a `<base href>`
+    /// found in the document, if any).
+    pub base_url: *const c_char,
 }
 
 impl From<MqConversionOptions> for ConversionOptions {
     fn from(options: MqConversionOptions) -> Self {
+        let base_url = if options.base_url.is_null() {
+            None
+        } else {
+            unsafe { c_str_to_rust_str_slice(options.base_url) }
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        };
         ConversionOptions {
             extract_scripts_as_code_blocks: options.extract_scripts_as_code_blocks,
             generate_front_matter: options.generate_front_matter,
             use_title_as_h1: options.use_title_as_h1,
+            base_url,
         }
     }
 }
@@ -1138,6 +1151,7 @@ mod tests {
             extract_scripts_as_code_blocks: false,
             generate_front_matter: true,
             use_title_as_h1: true,
+            base_url: ptr::null(),
         };
         let mut error_msg: *mut c_char = ptr::null_mut();
 
@@ -1242,6 +1256,7 @@ mod tests {
             extract_scripts_as_code_blocks: true,
             generate_front_matter: true,
             use_title_as_h1: true,
+            base_url: ptr::null(),
         };
 
         let rust_options: ConversionOptions = mq_options.into();

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -400,6 +400,7 @@ mod tests {
                 extract_scripts_as_code_blocks: true,
                 generate_front_matter: true,
                 use_title_as_h1: true,
+                base_url: None,
             },
         );
         assert!(result.is_ok());

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = {workspace = true, optional = true}
 serde_yaml = {workspace = true, optional = true}
 smol_str = {workspace = true}
 unicode-width = {workspace = true}
+url = {workspace = true, optional = true}
 
 [dev-dependencies]
 divan = {workspace = true}
@@ -38,7 +39,7 @@ callout = []
 color = []
 default = ["std"]
 embed = []
-html-to-markdown = ["dep:scraper", "dep:ego-tree", "dep:serde_yaml"]
+html-to-markdown = ["dep:scraper", "dep:ego-tree", "dep:serde_yaml", "dep:url"]
 json = ["dep:serde", "dep:serde_json", "smol_str/serde"]
 obsidian = ["wikilink", "callout", "embed"]
 std = []

--- a/crates/mq-markdown/examples/html_convert.rs
+++ b/crates/mq-markdown/examples/html_convert.rs
@@ -19,6 +19,7 @@ fn main() {
         extract_scripts_as_code_blocks: false,
         generate_front_matter: false,
         use_title_as_h1: false,
+        base_url: None,
     };
 
     match convert_html_to_markdown(&html, options) {

--- a/crates/mq-markdown/src/html_to_markdown.rs
+++ b/crates/mq-markdown/src/html_to_markdown.rs
@@ -17,8 +17,7 @@ fn find_element<'a>(html: &'a Html, selector_str: &str) -> Option<scraper::Eleme
         .and_then(|sel| html.select(&sel).next())
 }
 
-/// Resolves the document's effective base URL: the explicit `options.base_url` takes
-/// priority, falling back to a `<base href>` element in `<head>` if present.
+/// Resolves the base URL: `options.base_url` takes priority over a `<base href>` in `<head>`.
 fn resolve_base_url(html: &Html, options_base: Option<&str>) -> Option<url::Url> {
     if let Some(explicit) = options_base {
         return url::Url::parse(explicit).ok();
@@ -27,9 +26,7 @@ fn resolve_base_url(html: &Html, options_base: Option<&str>) -> Option<url::Url>
     url::Url::parse(base_href).ok()
 }
 
-/// Rewrites `href`/`src` attributes on link-, image-, and embed-bearing elements into
-/// absolute URLs, resolved against `base`. Leaves already-absolute URLs and empty
-/// values untouched.
+/// Rewrites relative `href`/`src` on link/image/embed elements into absolute URLs against `base`.
 fn resolve_relative_urls(nodes: &mut [node::HtmlNode], base: &url::Url) {
     for n in nodes.iter_mut() {
         if let node::HtmlNode::Element(el) = n {

--- a/crates/mq-markdown/src/html_to_markdown.rs
+++ b/crates/mq-markdown/src/html_to_markdown.rs
@@ -17,6 +17,39 @@ fn find_element<'a>(html: &'a Html, selector_str: &str) -> Option<scraper::Eleme
         .and_then(|sel| html.select(&sel).next())
 }
 
+/// Resolves the document's effective base URL: the explicit `options.base_url` takes
+/// priority, falling back to a `<base href>` element in `<head>` if present.
+fn resolve_base_url(html: &Html, options_base: Option<&str>) -> Option<url::Url> {
+    if let Some(explicit) = options_base {
+        return url::Url::parse(explicit).ok();
+    }
+    let base_href = find_element(html, "base").and_then(|el| el.value().attr("href"))?;
+    url::Url::parse(base_href).ok()
+}
+
+/// Rewrites `href`/`src` attributes on link-, image-, and embed-bearing elements into
+/// absolute URLs, resolved against `base`. Leaves already-absolute URLs and empty
+/// values untouched.
+fn resolve_relative_urls(nodes: &mut [node::HtmlNode], base: &url::Url) {
+    for n in nodes.iter_mut() {
+        if let node::HtmlNode::Element(el) = n {
+            let attr_name = match el.tag_name.as_str() {
+                "a" => Some("href"),
+                "img" | "source" | "iframe" | "embed" | "video" | "audio" | "object" => Some("src"),
+                _ => None,
+            };
+            if let Some(attr_name) = attr_name
+                && let Some(Some(value)) = el.attributes.get(attr_name)
+                && !value.is_empty()
+                && let Ok(resolved) = base.join(value)
+            {
+                el.attributes.insert(attr_name.to_string(), Some(resolved.to_string()));
+            }
+            resolve_relative_urls(&mut el.children, base);
+        }
+    }
+}
+
 fn extract_title_text(html: &Html) -> Option<String> {
     let head = find_element(html, "head")?;
     let title_sel = Selector::parse("title").ok()?;
@@ -125,8 +158,11 @@ pub fn convert_html_to_markdown(html_input: &str, options: ConversionOptions) ->
         .find_map(|sel| find_element(&html, sel).map(|el| el.children().collect::<Vec<_>>()))
         .unwrap_or_else(|| html.root_element().children().collect());
 
-    let nodes_for_markdown_conversion = parser::map_nodes_to_html_nodes(doc_children)?;
-    let body_markdown = converter::convert_nodes_to_markdown(&nodes_for_markdown_conversion, options)?;
+    let mut nodes_for_markdown_conversion = parser::map_nodes_to_html_nodes(doc_children)?;
+    if let Some(base) = resolve_base_url(&html, options.base_url.as_deref()) {
+        resolve_relative_urls(&mut nodes_for_markdown_conversion, &base);
+    }
+    let body_markdown = converter::convert_nodes_to_markdown(&nodes_for_markdown_conversion, &options)?;
 
     // Extract <title> from <head> separately so it is available even when smart extraction
     // selected only the children of <main>/<article> (which do not include <head>).

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -74,12 +74,7 @@ fn get_cell_alignment(element: &HtmlElement) -> Alignment {
     Alignment::Default
 }
 
-/// Escapes/sanitizes cell content for use inside a markdown table row.
-///
-/// Table rows are single lines, so a raw newline (from a `<br>`, which renders as
-/// a "  \n" hard break in inline markdown) would otherwise split the row into
-/// extra, malformed table rows. It's converted to a literal `<br>` tag instead,
-/// which GFM table renderers support directly.
+/// Converts newlines to a literal `<br>` since a raw newline would split the table row.
 fn escape_table_cell_content(content: &str) -> String {
     content
         .replace("  \n", "<br>")
@@ -87,9 +82,7 @@ fn escape_table_cell_content(content: &str) -> String {
         .replace("|", "\\|")
 }
 
-/// Wraps raw text in a CommonMark code span, choosing a backtick fence longer than
-/// any backtick run inside the content, and padding with a space when the content
-/// starts or ends with a backtick, so the content survives verbatim.
+/// Wraps `raw` in a code span, choosing a backtick fence longer than any backtick run inside it.
 fn wrap_code_span(raw: &str) -> String {
     if raw.is_empty() {
         return "``".to_string();
@@ -103,12 +96,8 @@ fn wrap_code_span(raw: &str) -> String {
     }
 }
 
-/// Wraps `content` in a markdown delimiter (e.g. `**`, `*`, `~~`), moving any
-/// leading/trailing whitespace outside the delimiters. CommonMark emphasis
-/// requires the delimiter run to be immediately adjacent to non-whitespace
-/// content, so `**  padded  **` is not valid emphasis and would round-trip as
-/// literal asterisks; `  **padded**  ` is. Returns an empty string if `content`
-/// is empty or entirely whitespace, so callers can skip pushing an empty wrap.
+/// Wraps `content` in `delimiter`, moving leading/trailing whitespace outside it since
+/// CommonMark emphasis can't be adjacent to whitespace.
 fn wrap_with_delimiter(content: &str, delimiter: &str) -> String {
     let trimmed = content.trim();
     if trimmed.is_empty() {
@@ -119,10 +108,8 @@ fn wrap_with_delimiter(content: &str, delimiter: &str) -> String {
     format!("{leading_ws}{delimiter}{trimmed}{delimiter}{trailing_ws}")
 }
 
-/// Escapes markdown inline-syntax characters found in literal HTML text so they
-/// survive as literal text instead of being reinterpreted as markdown syntax
-/// (emphasis, code spans, links, raw HTML) when the generated markdown string is
-/// re-parsed by a CommonMark parser.
+/// Backslash-escapes markdown inline-syntax characters so literal HTML text isn't
+/// reinterpreted as markdown when re-parsed.
 fn escape_markdown_inline(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     for c in text.chars() {
@@ -134,10 +121,8 @@ fn escape_markdown_inline(text: &str) -> String {
     result
 }
 
-/// Escapes markdown block-marker characters (`#`, `-`/`*`/`+`, ordered-list
-/// numbers, `>`, thematic breaks) when they appear at the start of a line, so
-/// literal text like "1. Not a list" or "# Not a heading" isn't reinterpreted
-/// as block structure when the generated markdown is re-parsed.
+/// Escapes leading block markers (`#`, list markers, `>`, thematic breaks) so literal
+/// text like "1. Not a list" isn't reinterpreted as block structure when re-parsed.
 fn escape_leading_block_markers(text: &str) -> String {
     text.lines()
         .map(escape_line_leading_marker)
@@ -149,12 +134,10 @@ fn escape_line_leading_marker(line: &str) -> String {
     let trimmed_start = line.trim_start_matches(' ');
     let indent_len = line.len() - trimmed_start.len();
     if indent_len > 3 || trimmed_start.is_empty() {
-        // 4+ leading spaces would already form an indented code block; leave as-is.
         return line.to_string();
     }
     let indent = &line[..indent_len];
 
-    // ATX heading: 1-6 '#' followed by a space or end of line.
     let hashes = trimmed_start.chars().take_while(|&c| c == '#').count();
     if (1..=6).contains(&hashes) {
         let rest = &trimmed_start[hashes..];
@@ -163,7 +146,6 @@ fn escape_line_leading_marker(line: &str) -> String {
         }
     }
 
-    // Bullet list marker: -, *, + followed by a space.
     let mut chars = trimmed_start.chars();
     if let Some(first) = chars.next()
         && matches!(first, '-' | '*' | '+')
@@ -172,7 +154,6 @@ fn escape_line_leading_marker(line: &str) -> String {
         return format!("{}\\{}", indent, trimmed_start);
     }
 
-    // Ordered list marker: digits followed by '.' or ')' then a space or end of line.
     let digit_count = trimmed_start.chars().take_while(|c| c.is_ascii_digit()).count();
     if digit_count > 0 {
         let after_digits = &trimmed_start[digit_count..];
@@ -191,12 +172,10 @@ fn escape_line_leading_marker(line: &str) -> String {
         }
     }
 
-    // Blockquote marker.
     if trimmed_start.starts_with('>') {
         return format!("{}\\{}", indent, trimmed_start);
     }
 
-    // Thematic break: a line made up solely of 3+ of the same character among -, _, *.
     for marker in ['-', '_', '*'] {
         let stripped: String = trimmed_start.chars().filter(|&c| c != ' ').collect();
         if stripped.len() >= 3 && stripped.chars().all(|c| c == marker) {
@@ -207,9 +186,7 @@ fn escape_line_leading_marker(line: &str) -> String {
     line.to_string()
 }
 
-/// Parses a `colspan`/`rowspan` attribute, defaulting to 1 for missing/invalid/zero
-/// values and clamping to a sane maximum so a pathological value (e.g. `colspan="99999999"`)
-/// can't blow up table generation.
+/// Parses `colspan`/`rowspan`, defaulting to 1 and clamping to 64 to guard against pathological values.
 fn get_span_attr(element: &HtmlElement, attr: &str) -> usize {
     element
         .attributes
@@ -221,10 +198,8 @@ fn get_span_attr(element: &HtmlElement, attr: &str) -> usize {
         .min(64)
 }
 
-/// Extracts a header row's cells, honoring `colspan` by repeating the cell's content
-/// (and alignment) across each spanned column. Without this, a `colspan` header
-/// collapses to a single column while data rows below keep their real column count,
-/// producing a table whose header and body widths don't match.
+/// Extracts a header row's cells, repeating content/alignment across `colspan` so header
+/// and body column counts match.
 fn expand_header_row_cells(tr_element: &HtmlElement) -> miette::Result<(Vec<String>, Vec<Alignment>)> {
     let mut cells = Vec::new();
     let mut alignments = Vec::new();
@@ -245,9 +220,8 @@ fn expand_header_row_cells(tr_element: &HtmlElement) -> miette::Result<(Vec<Stri
     Ok((cells, alignments))
 }
 
-/// Extracts one `<tr>`'s cells, honoring `colspan` (repeating content across spanned
-/// columns) and `rowspan` (recording carry-over into `rowspan_carry`, keyed by column
-/// index, so subsequent rows can pull in the repeated content at the right position).
+/// Extracts one `<tr>`'s cells, repeating content across `colspan` and carrying `rowspan`
+/// content into `rowspan_carry` for subsequent rows.
 fn expand_data_row_cells(
     tr_element: &HtmlElement,
     rowspan_carry: &mut FxHashMap<usize, (String, usize)>,
@@ -370,8 +344,7 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
         }
     }
 
-    // `tfoot` rows have no separate representation in a markdown table; append them
-    // as trailing body rows rather than dropping them.
+    // tfoot rows aren't representable separately in markdown tables; append as trailing body rows.
     for node in &table_element.children {
         if let HtmlNode::Element(tfoot_element) = node
             && tfoot_element.tag_name == "tfoot"
@@ -534,10 +507,7 @@ fn handle_pre_element(element: &HtmlElement, _options: &ConversionOptions) -> mi
     Ok(format!("```{}\n{}\n```", lang_specifier, text_content))
 }
 
-/// GFM/CommonMark tables can't nest (a markdown table can't contain another table),
-/// so a `<table>` with a `<table>` among its descendants can't be represented as a
-/// markdown table without losing the inner table's structure entirely. Returns true
-/// if `element` has a nested `<table>` anywhere below it.
+/// Returns true if `element` contains a nested `<table>`, which GFM tables can't represent.
 fn contains_nested_table(element: &HtmlElement) -> bool {
     element.children.iter().any(|child| match child {
         HtmlNode::Element(el) => el.tag_name == "table" || contains_nested_table(el),
@@ -557,9 +527,7 @@ fn escape_html_attr_value(s: &str) -> String {
     escape_html_text(s).replace('"', "&quot;")
 }
 
-/// Serializes an [`HtmlElement`] tree back into an HTML string. Used as a fallback
-/// for constructs markdown can't represent (e.g. nested tables), since CommonMark
-/// passes raw HTML blocks through untouched.
+/// Serializes back to HTML; used as a fallback for constructs markdown can't represent (e.g. nested tables).
 fn html_element_to_html(element: &HtmlElement) -> String {
     let mut attr_keys: Vec<&String> = element.attributes.keys().collect();
     attr_keys.sort();
@@ -814,13 +782,8 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
     convert_children_to_string_impl(nodes, true)
 }
 
-/// Converts inline HTML nodes to a markdown string.
-///
-/// `escape_text` controls whether literal markdown-syntax characters in text nodes
-/// are backslash-escaped. It is turned off while rendering the content of a `<code>`
-/// element, since code span content is already verbatim and must not gain escape
-/// backslashes (the code span fence itself protects the content from being
-/// reinterpreted as markdown).
+/// Converts inline HTML nodes to markdown; `escape_text` is off inside `<code>`, whose
+/// content is already verbatim.
 fn convert_children_to_string_impl(nodes: &[HtmlNode], escape_text: bool) -> miette::Result<String> {
     let mut parts = Vec::new();
     for node in nodes {
@@ -1047,12 +1010,8 @@ fn convert_children_to_string_impl(nodes: &[HtmlNode], escape_text: bool) -> mie
     Ok(collapse_redundant_spaces(&parts.join("")))
 }
 
-/// Collapses runs of 2+ plain spaces into one, matching HTML's whitespace-collapse
-/// rendering rules. This mainly cleans up doubled-up spaces that appear when an
-/// inline element (e.g. `<strong> padded </strong>`) contributes its own boundary
-/// space right next to a sibling text node that already ends/starts with one.
-/// Runs immediately followed by a newline are left untouched since two trailing
-/// spaces before `\n` are a meaningful CommonMark hard line break.
+/// Collapses runs of 2+ spaces to one (HTML whitespace collapsing), except before a
+/// newline where they form a meaningful CommonMark hard line break.
 fn collapse_redundant_spaces(text: &str) -> String {
     let chars: Vec<char> = text.chars().collect();
     let mut result = String::with_capacity(text.len());

--- a/crates/mq-markdown/src/html_to_markdown/converter.rs
+++ b/crates/mq-markdown/src/html_to_markdown/converter.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use miette::miette;
+use rustc_hash::FxHashMap;
 
 use super::iframe::detect_embed;
 use super::node::HtmlElement;
@@ -73,8 +74,216 @@ fn get_cell_alignment(element: &HtmlElement) -> Alignment {
     Alignment::Default
 }
 
+/// Escapes/sanitizes cell content for use inside a markdown table row.
+///
+/// Table rows are single lines, so a raw newline (from a `<br>`, which renders as
+/// a "  \n" hard break in inline markdown) would otherwise split the row into
+/// extra, malformed table rows. It's converted to a literal `<br>` tag instead,
+/// which GFM table renderers support directly.
 fn escape_table_cell_content(content: &str) -> String {
-    content.replace("|", "\\|")
+    content
+        .replace("  \n", "<br>")
+        .replace('\n', "<br>")
+        .replace("|", "\\|")
+}
+
+/// Wraps raw text in a CommonMark code span, choosing a backtick fence longer than
+/// any backtick run inside the content, and padding with a space when the content
+/// starts or ends with a backtick, so the content survives verbatim.
+fn wrap_code_span(raw: &str) -> String {
+    if raw.is_empty() {
+        return "``".to_string();
+    }
+    let max_backtick_run = raw.split(|c: char| c != '`').map(str::len).max().unwrap_or(0);
+    let fence = "`".repeat(max_backtick_run + 1);
+    if raw.starts_with('`') || raw.ends_with('`') {
+        format!("{fence} {raw} {fence}")
+    } else {
+        format!("{fence}{raw}{fence}")
+    }
+}
+
+/// Wraps `content` in a markdown delimiter (e.g. `**`, `*`, `~~`), moving any
+/// leading/trailing whitespace outside the delimiters. CommonMark emphasis
+/// requires the delimiter run to be immediately adjacent to non-whitespace
+/// content, so `**  padded  **` is not valid emphasis and would round-trip as
+/// literal asterisks; `  **padded**  ` is. Returns an empty string if `content`
+/// is empty or entirely whitespace, so callers can skip pushing an empty wrap.
+fn wrap_with_delimiter(content: &str, delimiter: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let leading_ws = &content[..content.len() - content.trim_start().len()];
+    let trailing_ws = &content[content.trim_end().len()..];
+    format!("{leading_ws}{delimiter}{trimmed}{delimiter}{trailing_ws}")
+}
+
+/// Escapes markdown inline-syntax characters found in literal HTML text so they
+/// survive as literal text instead of being reinterpreted as markdown syntax
+/// (emphasis, code spans, links, raw HTML) when the generated markdown string is
+/// re-parsed by a CommonMark parser.
+fn escape_markdown_inline(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    for c in text.chars() {
+        if matches!(c, '\\' | '`' | '*' | '_' | '[' | ']' | '<' | '~') {
+            result.push('\\');
+        }
+        result.push(c);
+    }
+    result
+}
+
+/// Escapes markdown block-marker characters (`#`, `-`/`*`/`+`, ordered-list
+/// numbers, `>`, thematic breaks) when they appear at the start of a line, so
+/// literal text like "1. Not a list" or "# Not a heading" isn't reinterpreted
+/// as block structure when the generated markdown is re-parsed.
+fn escape_leading_block_markers(text: &str) -> String {
+    text.lines()
+        .map(escape_line_leading_marker)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn escape_line_leading_marker(line: &str) -> String {
+    let trimmed_start = line.trim_start_matches(' ');
+    let indent_len = line.len() - trimmed_start.len();
+    if indent_len > 3 || trimmed_start.is_empty() {
+        // 4+ leading spaces would already form an indented code block; leave as-is.
+        return line.to_string();
+    }
+    let indent = &line[..indent_len];
+
+    // ATX heading: 1-6 '#' followed by a space or end of line.
+    let hashes = trimmed_start.chars().take_while(|&c| c == '#').count();
+    if (1..=6).contains(&hashes) {
+        let rest = &trimmed_start[hashes..];
+        if rest.is_empty() || rest.starts_with(' ') {
+            return format!("{}\\{}", indent, trimmed_start);
+        }
+    }
+
+    // Bullet list marker: -, *, + followed by a space.
+    let mut chars = trimmed_start.chars();
+    if let Some(first) = chars.next()
+        && matches!(first, '-' | '*' | '+')
+        && chars.next() == Some(' ')
+    {
+        return format!("{}\\{}", indent, trimmed_start);
+    }
+
+    // Ordered list marker: digits followed by '.' or ')' then a space or end of line.
+    let digit_count = trimmed_start.chars().take_while(|c| c.is_ascii_digit()).count();
+    if digit_count > 0 {
+        let after_digits = &trimmed_start[digit_count..];
+        let mut rest_chars = after_digits.chars();
+        if let Some(marker_char) = rest_chars.next()
+            && matches!(marker_char, '.' | ')')
+            && rest_chars.next().is_none_or(|c| c == ' ')
+        {
+            return format!(
+                "{}{}\\{}{}",
+                indent,
+                &trimmed_start[..digit_count],
+                marker_char,
+                &after_digits[1..]
+            );
+        }
+    }
+
+    // Blockquote marker.
+    if trimmed_start.starts_with('>') {
+        return format!("{}\\{}", indent, trimmed_start);
+    }
+
+    // Thematic break: a line made up solely of 3+ of the same character among -, _, *.
+    for marker in ['-', '_', '*'] {
+        let stripped: String = trimmed_start.chars().filter(|&c| c != ' ').collect();
+        if stripped.len() >= 3 && stripped.chars().all(|c| c == marker) {
+            return format!("{}\\{}", indent, trimmed_start);
+        }
+    }
+
+    line.to_string()
+}
+
+/// Parses a `colspan`/`rowspan` attribute, defaulting to 1 for missing/invalid/zero
+/// values and clamping to a sane maximum so a pathological value (e.g. `colspan="99999999"`)
+/// can't blow up table generation.
+fn get_span_attr(element: &HtmlElement, attr: &str) -> usize {
+    element
+        .attributes
+        .get(attr)
+        .and_then(|opt| opt.as_ref())
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(1)
+        .min(64)
+}
+
+/// Extracts a header row's cells, honoring `colspan` by repeating the cell's content
+/// (and alignment) across each spanned column. Without this, a `colspan` header
+/// collapses to a single column while data rows below keep their real column count,
+/// producing a table whose header and body widths don't match.
+fn expand_header_row_cells(tr_element: &HtmlElement) -> miette::Result<(Vec<String>, Vec<Alignment>)> {
+    let mut cells = Vec::new();
+    let mut alignments = Vec::new();
+    for cell_node in &tr_element.children {
+        if let HtmlNode::Element(cell_element) = cell_node
+            && (cell_element.tag_name == "th" || cell_element.tag_name == "td")
+        {
+            let cell_content = convert_children_to_string(&cell_element.children)?;
+            let content = escape_table_cell_content(cell_content.trim());
+            let alignment = get_cell_alignment(cell_element);
+            let colspan = get_span_attr(cell_element, "colspan");
+            for _ in 0..colspan {
+                cells.push(content.clone());
+                alignments.push(alignment);
+            }
+        }
+    }
+    Ok((cells, alignments))
+}
+
+/// Extracts one `<tr>`'s cells, honoring `colspan` (repeating content across spanned
+/// columns) and `rowspan` (recording carry-over into `rowspan_carry`, keyed by column
+/// index, so subsequent rows can pull in the repeated content at the right position).
+fn expand_data_row_cells(
+    tr_element: &HtmlElement,
+    rowspan_carry: &mut FxHashMap<usize, (String, usize)>,
+) -> miette::Result<Vec<String>> {
+    let mut current_row_cells: Vec<String> = Vec::new();
+    let mut real_cells = tr_element.children.iter().filter_map(|n| match n {
+        HtmlNode::Element(el) if el.tag_name == "td" || el.tag_name == "th" => Some(el),
+        _ => None,
+    });
+    let mut col = 0usize;
+    loop {
+        if let Some((content, rows_left)) = rowspan_carry.get_mut(&col) {
+            current_row_cells.push(content.clone());
+            *rows_left -= 1;
+            if *rows_left == 0 {
+                rowspan_carry.remove(&col);
+            }
+            col += 1;
+            continue;
+        }
+        let Some(cell_element) = real_cells.next() else {
+            break;
+        };
+        let cell_content = convert_children_to_string(&cell_element.children)?;
+        let content = escape_table_cell_content(cell_content.trim());
+        let colspan = get_span_attr(cell_element, "colspan");
+        let rowspan = get_span_attr(cell_element, "rowspan");
+        for i in 0..colspan {
+            current_row_cells.push(content.clone());
+            if rowspan > 1 {
+                rowspan_carry.insert(col + i, (content.clone(), rowspan - 1));
+            }
+        }
+        col += colspan;
+    }
+    Ok(current_row_cells)
 }
 
 fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result<String> {
@@ -105,15 +314,9 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
                 .iter()
                 .find(|n| matches!(n, HtmlNode::Element(el) if el.tag_name == "tr"))
         {
-            for cell_node in &tr_element.children {
-                if let HtmlNode::Element(cell_element) = cell_node
-                    && (cell_element.tag_name == "th" || cell_element.tag_name == "td")
-                {
-                    let cell_content = convert_children_to_string(&cell_element.children)?;
-                    header_cells.push(escape_table_cell_content(cell_content.trim()));
-                    header_alignments.push(get_cell_alignment(cell_element));
-                }
-            }
+            let (cells, alignments) = expand_header_row_cells(tr_element)?;
+            header_cells = cells;
+            header_alignments = alignments;
 
             break;
         }
@@ -128,15 +331,9 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
                         .iter()
                         .find(|n| matches!(n, HtmlNode::Element(el) if el.tag_name == "tr"))
                 {
-                    for cell_node in &tr_element.children {
-                        if let HtmlNode::Element(cell_element) = cell_node
-                            && (cell_element.tag_name == "td" || cell_element.tag_name == "th")
-                        {
-                            let cell_content = convert_children_to_string(&cell_element.children)?;
-                            header_cells.push(escape_table_cell_content(cell_content.trim()));
-                            header_alignments.push(get_cell_alignment(cell_element));
-                        }
-                    }
+                    let (cells, alignments) = expand_header_row_cells(tr_element)?;
+                    header_cells = cells;
+                    header_alignments = alignments;
                     if !header_cells.is_empty() {
                         first_tbody_first_row_used_as_header = true;
                     }
@@ -151,6 +348,8 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
     }
     let column_count = header_cells.len();
 
+    // Cells carried down from a `rowspan` in an earlier row: column index -> (content, rows left).
+    let mut rowspan_carry: FxHashMap<usize, (String, usize)> = FxHashMap::default();
     let mut first_tbody_processed_for_data = false;
     for node in &table_element.children {
         if let HtmlNode::Element(tbody_element) = node
@@ -165,16 +364,23 @@ fn convert_html_table_to_markdown(table_element: &HtmlElement) -> miette::Result
                 if let HtmlNode::Element(tr_element) = tr_node
                     && tr_element.tag_name == "tr"
                 {
-                    let mut current_row_cells: Vec<String> = Vec::new();
-                    for td_node in &tr_element.children {
-                        if let HtmlNode::Element(td_element) = td_node
-                            && (td_element.tag_name == "td" || td_element.tag_name == "th")
-                        {
-                            let cell_content = convert_children_to_string(&td_element.children)?;
-                            current_row_cells.push(escape_table_cell_content(cell_content.trim()));
-                        }
-                    }
-                    body_rows.push(current_row_cells);
+                    body_rows.push(expand_data_row_cells(tr_element, &mut rowspan_carry)?);
+                }
+            }
+        }
+    }
+
+    // `tfoot` rows have no separate representation in a markdown table; append them
+    // as trailing body rows rather than dropping them.
+    for node in &table_element.children {
+        if let HtmlNode::Element(tfoot_element) = node
+            && tfoot_element.tag_name == "tfoot"
+        {
+            for tr_node in &tfoot_element.children {
+                if let HtmlNode::Element(tr_element) = tr_node
+                    && tr_element.tag_name == "tr"
+                {
+                    body_rows.push(expand_data_row_cells(tr_element, &mut rowspan_carry)?);
                 }
             }
         }
@@ -238,18 +444,19 @@ fn handle_heading_element(element: &HtmlElement) -> miette::Result<String> {
 }
 
 fn handle_paragraph_element(element: &HtmlElement) -> miette::Result<String> {
-    convert_children_to_string(&element.children)
+    let content = convert_children_to_string(&element.children)?;
+    Ok(escape_leading_block_markers(&content))
 }
 
 fn handle_hr_element() -> miette::Result<String> {
     Ok("---".to_string())
 }
 
-fn handle_list_element(element: &HtmlElement, options: ConversionOptions) -> miette::Result<String> {
+fn handle_list_element(element: &HtmlElement, options: &ConversionOptions) -> miette::Result<String> {
     convert_html_list_to_markdown(element, 0, options)
 }
 
-fn handle_blockquote_element(element: &HtmlElement, options: ConversionOptions) -> miette::Result<String> {
+fn handle_blockquote_element(element: &HtmlElement, options: &ConversionOptions) -> miette::Result<String> {
     let inner_markdown = convert_nodes_to_markdown(&element.children, options)?;
     if !inner_markdown.is_empty() {
         let quoted_lines: Vec<String> = inner_markdown.lines().map(|line| format!("> {}", line)).collect();
@@ -283,7 +490,7 @@ fn dedent(text: &str) -> String {
         .join("\n")
 }
 
-fn handle_pre_element(element: &HtmlElement, _options: ConversionOptions) -> miette::Result<String> {
+fn handle_pre_element(element: &HtmlElement, _options: &ConversionOptions) -> miette::Result<String> {
     let mut lang_specifier = String::new();
     // Find <code> among children, skipping leading whitespace-only text nodes.
     let code_child = element.children.iter().find_map(|n| {
@@ -327,11 +534,70 @@ fn handle_pre_element(element: &HtmlElement, _options: ConversionOptions) -> mie
     Ok(format!("```{}\n{}\n```", lang_specifier, text_content))
 }
 
-fn handle_table_element(element: &HtmlElement, _options: ConversionOptions) -> miette::Result<String> {
+/// GFM/CommonMark tables can't nest (a markdown table can't contain another table),
+/// so a `<table>` with a `<table>` among its descendants can't be represented as a
+/// markdown table without losing the inner table's structure entirely. Returns true
+/// if `element` has a nested `<table>` anywhere below it.
+fn contains_nested_table(element: &HtmlElement) -> bool {
+    element.children.iter().any(|child| match child {
+        HtmlNode::Element(el) => el.tag_name == "table" || contains_nested_table(el),
+        _ => false,
+    })
+}
+
+const VOID_HTML_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr",
+];
+
+fn escape_html_text(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
+fn escape_html_attr_value(s: &str) -> String {
+    escape_html_text(s).replace('"', "&quot;")
+}
+
+/// Serializes an [`HtmlElement`] tree back into an HTML string. Used as a fallback
+/// for constructs markdown can't represent (e.g. nested tables), since CommonMark
+/// passes raw HTML blocks through untouched.
+fn html_element_to_html(element: &HtmlElement) -> String {
+    let mut attr_keys: Vec<&String> = element.attributes.keys().collect();
+    attr_keys.sort();
+    let attrs_str = attr_keys
+        .into_iter()
+        .map(|key| match &element.attributes[key] {
+            Some(value) => format!(" {}=\"{}\"", key, escape_html_attr_value(value)),
+            None => format!(" {}", key),
+        })
+        .collect::<String>();
+
+    if VOID_HTML_ELEMENTS.contains(&element.tag_name.as_str()) {
+        return format!("<{}{}>", element.tag_name, attrs_str);
+    }
+
+    let inner = html_nodes_to_html(&element.children);
+    format!("<{}{}>{}</{}>", element.tag_name, attrs_str, inner, element.tag_name)
+}
+
+fn html_nodes_to_html(nodes: &[HtmlNode]) -> String {
+    nodes
+        .iter()
+        .map(|node| match node {
+            HtmlNode::Text(text) => escape_html_text(text),
+            HtmlNode::Element(el) => html_element_to_html(el),
+            HtmlNode::Comment(text) => format!("<!--{}-->", text),
+        })
+        .collect::<String>()
+}
+
+fn handle_table_element(element: &HtmlElement, _options: &ConversionOptions) -> miette::Result<String> {
+    if contains_nested_table(element) {
+        return Ok(html_element_to_html(element));
+    }
     convert_html_table_to_markdown(element)
 }
 
-fn handle_dl_element(element: &HtmlElement, options: ConversionOptions) -> miette::Result<String> {
+fn handle_dl_element(element: &HtmlElement, options: &ConversionOptions) -> miette::Result<String> {
     let mut dl_content_parts = Vec::new();
     for child_node in &element.children {
         match child_node {
@@ -371,7 +637,7 @@ fn handle_dl_element(element: &HtmlElement, options: ConversionOptions) -> miett
     }
 }
 
-fn handle_script_element(element: &HtmlElement, options: ConversionOptions) -> miette::Result<Option<String>> {
+fn handle_script_element(element: &HtmlElement, options: &ConversionOptions) -> miette::Result<Option<String>> {
     if options.extract_scripts_as_code_blocks {
         if element.attributes.get("src").and_then(|opt| opt.as_ref()).is_none() {
             let type_attr = element
@@ -491,7 +757,7 @@ fn handle_svg_element(element: &HtmlElement) -> miette::Result<String> {
 fn convert_html_list_to_markdown(
     list_element: &HtmlElement,
     indent_level: usize,
-    options: ConversionOptions,
+    options: &ConversionOptions,
 ) -> miette::Result<String> {
     let mut markdown_items = Vec::new();
     let base_indent = "    ".repeat(indent_level);
@@ -545,10 +811,28 @@ fn convert_html_list_to_markdown(
 }
 
 pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> {
+    convert_children_to_string_impl(nodes, true)
+}
+
+/// Converts inline HTML nodes to a markdown string.
+///
+/// `escape_text` controls whether literal markdown-syntax characters in text nodes
+/// are backslash-escaped. It is turned off while rendering the content of a `<code>`
+/// element, since code span content is already verbatim and must not gain escape
+/// backslashes (the code span fence itself protects the content from being
+/// reinterpreted as markdown).
+fn convert_children_to_string_impl(nodes: &[HtmlNode], escape_text: bool) -> miette::Result<String> {
     let mut parts = Vec::new();
     for node in nodes {
         match node {
             HtmlNode::Text(text) => {
+                let escaped_owned;
+                let text: &str = if escape_text {
+                    escaped_owned = escape_markdown_inline(text);
+                    &escaped_owned
+                } else {
+                    text
+                };
                 let normalized = normalize_unicode_whitespace(text);
                 let trimmed = normalized.trim_start_matches('\n').trim_end_matches('\n');
                 // Collapse internal newline+whitespace sequences (HTML whitespace collapsing).
@@ -582,16 +866,18 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                 parts.push(collapsed);
             }
             HtmlNode::Element(element) => {
-                let link_text = convert_children_to_string(&element.children)?;
+                let link_text = convert_children_to_string_impl(&element.children, escape_text)?;
                 match element.tag_name.as_str() {
                     "strong" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("**{}**", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "**");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "em" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("*{}*", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "*");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "a" => {
@@ -615,11 +901,8 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         }
                     }
                     "code" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("`{}`", link_text));
-                        } else {
-                            parts.push("``".to_string());
-                        }
+                        let raw_text = convert_children_to_string_impl(&element.children, false)?;
+                        parts.push(wrap_code_span(&raw_text));
                     }
                     "br" => parts.push("  \n".to_string()),
                     "img" => {
@@ -630,8 +913,8 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                                 .attributes
                                 .get("alt")
                                 .and_then(|opt_alt| opt_alt.as_ref())
-                                .map(|s| s.as_str())
-                                .unwrap_or("");
+                                .map(|s| escape_markdown_inline(s))
+                                .unwrap_or_default();
                             let title_part = element
                                 .attributes
                                 .get("title")
@@ -668,8 +951,9 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         }
                     }
                     "s" | "strike" | "del" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("~~{}~~", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "~~");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "kbd" => parts.push(format!("<kbd>{}</kbd>", link_text)),
@@ -684,8 +968,9 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         }
                     }
                     "cite" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("*{}*", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "*");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "ins" => {
@@ -695,8 +980,9 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                     }
                     "mark" => parts.push(format!("<mark>{}</mark>", link_text)),
                     "summary" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("**{}**", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "**");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "abbr" => {
@@ -716,13 +1002,17 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         let mut annotation = String::new();
                         for child in &element.children {
                             match child {
-                                HtmlNode::Text(t) => base.push_str(t),
+                                HtmlNode::Text(t) => base.push_str(&if escape_text {
+                                    escape_markdown_inline(t)
+                                } else {
+                                    t.clone()
+                                }),
                                 HtmlNode::Element(el) if el.tag_name == "rt" => {
-                                    annotation.push_str(&convert_children_to_string(&el.children)?);
+                                    annotation.push_str(&convert_children_to_string_impl(&el.children, escape_text)?);
                                 }
                                 HtmlNode::Element(el) if el.tag_name == "rp" => {}
                                 HtmlNode::Element(el) => {
-                                    base.push_str(&convert_children_to_string(&el.children)?);
+                                    base.push_str(&convert_children_to_string_impl(&el.children, escape_text)?);
                                 }
                                 HtmlNode::Comment(_) => {}
                             }
@@ -736,8 +1026,9 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
                         }
                     }
                     "dfn" => {
-                        if !link_text.is_empty() {
-                            parts.push(format!("*{}*", link_text));
+                        let wrapped = wrap_with_delimiter(&link_text, "*");
+                        if !wrapped.is_empty() {
+                            parts.push(wrapped);
                         }
                     }
                     "time" | "small" | "bdi" => {
@@ -753,7 +1044,38 @@ pub fn convert_children_to_string(nodes: &[HtmlNode]) -> miette::Result<String> 
             HtmlNode::Comment(_) => {}
         }
     }
-    Ok(parts.join("").to_string())
+    Ok(collapse_redundant_spaces(&parts.join("")))
+}
+
+/// Collapses runs of 2+ plain spaces into one, matching HTML's whitespace-collapse
+/// rendering rules. This mainly cleans up doubled-up spaces that appear when an
+/// inline element (e.g. `<strong> padded </strong>`) contributes its own boundary
+/// space right next to a sibling text node that already ends/starts with one.
+/// Runs immediately followed by a newline are left untouched since two trailing
+/// spaces before `\n` are a meaningful CommonMark hard line break.
+fn collapse_redundant_spaces(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == ' ' {
+            let mut j = i;
+            while j < chars.len() && chars[j] == ' ' {
+                j += 1;
+            }
+            let run_len = j - i;
+            if run_len >= 2 && chars.get(j) == Some(&'\n') {
+                result.extend(std::iter::repeat_n(' ', run_len));
+            } else {
+                result.push(' ');
+            }
+            i = j;
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+    result
 }
 
 /// Returns true if the element is a CSS-only UI widget (dropdown or tab switcher).
@@ -817,13 +1139,14 @@ fn is_heading_with_aux_siblings(element: &HtmlElement) -> bool {
     })
 }
 
-pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: ConversionOptions) -> miette::Result<String> {
+pub fn convert_nodes_to_markdown(nodes: &[HtmlNode], options: &ConversionOptions) -> miette::Result<String> {
     let mut markdown_blocks: Vec<MarkdownBlock> = Vec::new();
     for node in nodes {
         match node {
             HtmlNode::Text(text) => {
                 if !text.trim().is_empty() {
-                    markdown_blocks.push((text.to_string(), true));
+                    let escaped = escape_leading_block_markers(&escape_markdown_inline(text));
+                    markdown_blocks.push((escaped, true));
                 }
             }
             HtmlNode::Element(element) => {
@@ -1083,7 +1406,7 @@ mod tests {
         "![alt text](img.png)"
     )]
     fn test_convert_nodes_to_markdown_param(#[case] nodes: Vec<HtmlNode>, #[case] expected: &str) {
-        let md = convert_nodes_to_markdown(&nodes, ConversionOptions::default()).unwrap();
+        let md = convert_nodes_to_markdown(&nodes, &ConversionOptions::default()).unwrap();
         let md_trimmed = md.trim();
         assert_eq!(md_trimmed, expected);
     }
@@ -1102,7 +1425,7 @@ mod tests {
         ""
     )]
     fn test_noisy_elements_are_skipped(#[case] nodes: Vec<HtmlNode>, #[case] expected: &str) {
-        let md = convert_nodes_to_markdown(&nodes, ConversionOptions::default()).unwrap();
+        let md = convert_nodes_to_markdown(&nodes, &ConversionOptions::default()).unwrap();
         assert_eq!(md.trim(), expected);
     }
 }

--- a/crates/mq-markdown/src/html_to_markdown/options.rs
+++ b/crates/mq-markdown/src/html_to_markdown/options.rs
@@ -1,6 +1,10 @@
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ConversionOptions {
     pub extract_scripts_as_code_blocks: bool,
     pub generate_front_matter: bool,
     pub use_title_as_h1: bool,
+    /// Base URL used to resolve relative `href`/`src` values (e.g. `/path`, `../img.png`)
+    /// into absolute URLs. Falls back to a `<base href>` found in the document's `<head>`
+    /// when unset. Relative URLs are left unresolved if neither is available.
+    pub base_url: Option<String>,
 }

--- a/crates/mq-markdown/src/html_to_markdown/options.rs
+++ b/crates/mq-markdown/src/html_to_markdown/options.rs
@@ -3,8 +3,6 @@ pub struct ConversionOptions {
     pub extract_scripts_as_code_blocks: bool,
     pub generate_front_matter: bool,
     pub use_title_as_h1: bool,
-    /// Base URL used to resolve relative `href`/`src` values (e.g. `/path`, `../img.png`)
-    /// into absolute URLs. Falls back to a `<base href>` found in the document's `<head>`
-    /// when unset. Relative URLs are left unresolved if neither is available.
+    /// Base URL for resolving relative `href`/`src` values; falls back to `<base href>`.
     pub base_url: Option<String>,
 }

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -1555,6 +1555,31 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "| H |\n|---|\n| 1 |"
 )]
+#[case::multibyte_text_with_strong_and_link(
+    "<p>これは<strong>太字</strong>と<a href=\"/パス\">リンク</a>です。</p>",
+    ConversionOptions::default(),
+    "これは**太字**と[リンク](/パス)です。"
+)]
+#[case::ascii_hash_marker_followed_by_multibyte_text_is_escaped(
+    "<p># 日本語のあとに全角文字：漢字とひらがなを含む</p>",
+    ConversionOptions::default(),
+    "\\# 日本語のあとに全角文字：漢字とひらがなを含む"
+)]
+#[case::fullwidth_hash_lookalike_is_not_escaped(
+    "<p>＃これは見出しではない日本語です</p>",
+    ConversionOptions::default(),
+    "＃これは見出しではない日本語です"
+)]
+#[case::code_span_with_multibyte_content(
+    "<p>変数<code>日本語変数名</code>です</p>",
+    ConversionOptions::default(),
+    "変数`日本語変数名`です"
+)]
+#[case::emoji_padded_strong_does_not_panic(
+    "<p>絵文字テスト🎉です<strong> 太字😀 </strong>終わり</p>",
+    ConversionOptions::default(),
+    "絵文字テスト🎉です **太字😀** 終わり"
+)]
 fn test_html_to_markdown(#[case] html: &str, #[case] options: ConversionOptions, #[case] expected: &str) {
     assert_conversion_with_options(html, expected, options);
 }

--- a/crates/mq-markdown/tests/html_to_markdown_tests.rs
+++ b/crates/mq-markdown/tests/html_to_markdown_tests.rs
@@ -360,7 +360,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     concat!(
         "| Header |\n",
         "|---|\n",
-        "| Cell with **bold**, *italic*,  \nand a [link](#). |\n",
+        "| Cell with **bold**, *italic*,<br>and a [link](#). |\n",
         "| Cell with list:L1L2 (list becomes inline) |\n",
         "| Cell with image: ![alt](img.png) |"
     )
@@ -741,15 +741,15 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "| H1 | H2 |\n|---|---|\n| C1 | C2 |"
 )]
-#[case::table_with_colspan_ignored(
+#[case::table_with_colspan_repeated_across_columns(
     "<table><thead><tr><th colspan=\"2\">H</th></tr></thead><tbody><tr><td>A</td><td>B</td></tr></tbody></table>",
     ConversionOptions::default(),
-    "| H |\n|---|\n| A |"
+    "| H | H |\n|---|---|\n| A | B |"
 )]
-#[case::table_with_rowspan_ignored(
+#[case::table_with_rowspan_carried_into_next_row(
     "<table><thead><tr><th>H1</th><th>H2</th></tr></thead><tbody><tr><td rowspan=\"2\">R1C1</td><td>R1C2</td></tr><tr><td>R2C2</td></tr></tbody></table>",
     ConversionOptions::default(),
-    "| H1 | H2 |\n|---|---|\n| R1C1 | R1C2 |\n| R2C2 |  |"
+    "| H1 | H2 |\n|---|---|\n| R1C1 | R1C2 |\n| R1C1 | R2C2 |"
 )]
 #[case::table_thead_with_td_cells(
     "<table><thead><tr><td>H1</td><td>H2</td></tr></thead><tbody><tr><td>C1</td><td>C2</td></tr></tbody></table>",
@@ -761,10 +761,10 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "| H1 |\n|---|\n| R1C1 |"
 )]
-#[case::table_with_tfoot_ignored(
+#[case::table_with_tfoot_appended_as_trailing_row(
     "<table><thead><tr><th>H1</th></tr></thead><tbody><tr><td>C1</td></tr></tbody><tfoot><tr><td>F1</td></tr></tfoot></table>",
     ConversionOptions::default(),
-    "| H1 |\n|---|\n| C1 |"
+    "| H1 |\n|---|\n| C1 |\n| F1 |"
 )]
 #[case::s_tag("<s>strike</s>", ConversionOptions::default(), "~~strike~~")]
 #[case::strike_tag("<strike>strike</strike>", ConversionOptions::default(), "~~strike~~")]
@@ -985,7 +985,7 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "### Part1 **bold** and *italic* Part2"
 )]
-#[case::strong_with_internal_whitespace("<strong>  spaced  </strong>", ConversionOptions::default(), "** spaced **")]
+#[case::strong_with_internal_whitespace("<strong>  spaced  </strong>", ConversionOptions::default(), "**spaced**")]
 #[case::em_around_strong(
     "<em>Emphasis around <strong>bold</strong> text.</em>",
     ConversionOptions::default(),
@@ -1476,6 +1476,85 @@ fn assert_conversion_with_options(html: &str, expected_markdown: &str, options: 
     ConversionOptions::default(),
     "Just a caption"
 )]
+#[case::literal_asterisks_and_underscores_escaped(
+    "<p>Use *bold* and _italic_ literally.</p>",
+    ConversionOptions::default(),
+    "Use \\*bold\\* and \\_italic\\_ literally."
+)]
+#[case::literal_brackets_and_backticks_escaped(
+    "<p>See [brackets] and `backticks`.</p>",
+    ConversionOptions::default(),
+    "See \\[brackets\\] and \\`backticks\\`."
+)]
+#[case::literal_leading_hash_escaped("<p># Not a heading</p>", ConversionOptions::default(), "\\# Not a heading")]
+#[case::literal_leading_dash_escaped("<p>- Not a list item</p>", ConversionOptions::default(), "\\- Not a list item")]
+#[case::literal_leading_ordered_marker_escaped(
+    "<p>1. Not a list item</p>",
+    ConversionOptions::default(),
+    "1\\. Not a list item"
+)]
+#[case::mid_sentence_hash_not_escaped(
+    "<p>Written in C# today.</p>",
+    ConversionOptions::default(),
+    "Written in C# today."
+)]
+#[case::code_with_backtick_uses_longer_fence("<p><code>`x`</code></p>", ConversionOptions::default(), "`` `x` ``")]
+#[case::code_content_not_escaped("<p><code>a*b_c</code></p>", ConversionOptions::default(), "`a*b_c`")]
+#[case::img_alt_with_brackets_escaped(
+    "<img src=\"a.png\" alt=\"a [b] c\">",
+    ConversionOptions::default(),
+    "![a \\[b\\] c](a.png)"
+)]
+#[case::strong_padded_in_paragraph_no_double_space(
+    "<p>Some <strong> padded </strong> text and <em> also padded </em> here.</p>",
+    ConversionOptions::default(),
+    "Some **padded** text and *also padded* here."
+)]
+#[case::strong_padded_touching_words_gets_single_space(
+    "<p>Word<strong> bold </strong>Word2</p>",
+    ConversionOptions::default(),
+    "Word **bold** Word2"
+)]
+#[case::strikethrough_padded_in_paragraph(
+    "<p>Was <del> removed </del> now.</p>",
+    ConversionOptions::default(),
+    "Was ~~removed~~ now."
+)]
+#[case::strong_whitespace_only_content_dropped(
+    "<p>Before<strong>   </strong>After</p>",
+    ConversionOptions::default(),
+    "BeforeAfter"
+)]
+#[case::table_cell_br_does_not_split_row(
+    "<table><tr><th>H</th></tr><tr><td>line1<br>line2</td></tr></table>",
+    ConversionOptions::default(),
+    "| H |\n|---|\n| line1<br>line2 |"
+)]
+#[case::table_cell_multiple_br_does_not_split_row(
+    "<table><tr><th>H</th></tr><tr><td>a<br><br>b</td></tr></table>",
+    ConversionOptions::default(),
+    "| H |\n|---|\n| a<br><br>b |"
+)]
+#[case::table_with_colspan_and_rowspan_mixed(
+    concat!(
+        "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead><tbody>",
+        "<tr><td rowspan=\"2\">R1</td><td colspan=\"2\">wide</td></tr>",
+        "<tr><td>x</td><td>y</td></tr>",
+        "</tbody></table>"
+    ),
+    ConversionOptions::default(),
+    "| A | B | C |\n|---|---|---|\n| R1 | wide | wide |\n| R1 | x | y |"
+)]
+#[case::nested_table_falls_back_to_raw_html(
+    "<table><tr><td>outer<table><tr><td>inner</td></tr></table></td></tr></table>",
+    ConversionOptions::default(),
+    "<table><tbody><tr><td>outer<table><tbody><tr><td>inner</td></tr></tbody></table></td></tr></tbody></table>"
+)]
+#[case::table_without_nesting_still_renders_as_markdown(
+    "<table><tr><th>H</th></tr><tr><td>1</td></tr></table>",
+    ConversionOptions::default(),
+    "| H |\n|---|\n| 1 |"
+)]
 fn test_html_to_markdown(#[case] html: &str, #[case] options: ConversionOptions, #[case] expected: &str) {
     assert_conversion_with_options(html, expected, options);
 }
@@ -1545,6 +1624,48 @@ fn test_html_comment_stripped() {
     assert!(md.contains("Text"));
     assert!(!md.contains("<!--"));
     assert!(md.contains("More"));
+}
+
+#[test]
+fn test_base_url_resolves_relative_links_and_images() {
+    let html = r#"<p><a href="/absolute-path">a</a> and <a href="../sibling">b</a> and
+        <img src="pic.png" alt="x"> and <a href="https://other.com/x">already-absolute</a></p>"#;
+    let options = ConversionOptions {
+        base_url: Some("https://example.com/blog/post/".to_string()),
+        ..Default::default()
+    };
+    let md = convert_html_to_markdown(html, options).unwrap();
+    assert!(md.contains("[a](https://example.com/absolute-path)"));
+    assert!(md.contains("[b](https://example.com/blog/sibling)"));
+    assert!(md.contains("![x](https://example.com/blog/post/pic.png)"));
+    assert!(md.contains("[already-absolute](https://other.com/x)"));
+}
+
+#[test]
+fn test_base_href_tag_resolves_relative_links_when_no_explicit_base_url() {
+    let html = r#"<html><head><base href="https://example.com/docs/"></head>
+        <body><p><a href="../other">link</a></p></body></html>"#;
+    let md = convert_html_to_markdown(html, ConversionOptions::default()).unwrap();
+    assert!(md.contains("[link](https://example.com/other)"));
+}
+
+#[test]
+fn test_explicit_base_url_takes_priority_over_base_href_tag() {
+    let html = r#"<html><head><base href="https://ignored.example.com/"></head>
+        <body><p><a href="rel">link</a></p></body></html>"#;
+    let options = ConversionOptions {
+        base_url: Some("https://example.com/blog/".to_string()),
+        ..Default::default()
+    };
+    let md = convert_html_to_markdown(html, options).unwrap();
+    assert!(md.contains("[link](https://example.com/blog/rel)"));
+}
+
+#[test]
+fn test_no_base_url_leaves_relative_links_unresolved() {
+    let html = r#"<p><a href="/relative/path">link</a></p>"#;
+    let md = convert_html_to_markdown(html, ConversionOptions::default()).unwrap();
+    assert!(md.contains("[link](/relative/path)"));
 }
 
 // TODO: Add tests for headings with links, images etc. once those elements are supported.

--- a/crates/mq-wasm/src/script.rs
+++ b/crates/mq-wasm/src/script.rs
@@ -218,8 +218,7 @@ pub struct ConversionOptions {
     pub extract_scripts_as_code_blocks: bool,
     pub generate_front_matter: bool,
     pub use_title_as_h1: bool,
-    /// Base URL used to resolve relative `href`/`src` values into absolute URLs.
-    /// Empty means no explicit base URL (falls back to a `<base href>` in the document, if any).
+    /// Base URL for resolving relative `href`/`src` values; empty falls back to `<base href>`.
     #[wasm_bindgen(getter_with_clone)]
     pub base_url: String,
 }

--- a/crates/mq-wasm/src/script.rs
+++ b/crates/mq-wasm/src/script.rs
@@ -218,6 +218,10 @@ pub struct ConversionOptions {
     pub extract_scripts_as_code_blocks: bool,
     pub generate_front_matter: bool,
     pub use_title_as_h1: bool,
+    /// Base URL used to resolve relative `href`/`src` values into absolute URLs.
+    /// Empty means no explicit base URL (falls back to a `<base href>` in the document, if any).
+    #[wasm_bindgen(getter_with_clone)]
+    pub base_url: String,
 }
 
 impl From<ConversionOptions> for mq_markdown::ConversionOptions {
@@ -226,6 +230,7 @@ impl From<ConversionOptions> for mq_markdown::ConversionOptions {
             extract_scripts_as_code_blocks: options.extract_scripts_as_code_blocks,
             generate_front_matter: options.generate_front_matter,
             use_title_as_h1: options.use_title_as_h1,
+            base_url: Some(options.base_url).filter(|s| !s.is_empty()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix several structural-corruption bugs in HTML-to-Markdown conversion.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
