### PR TITLE
✨ feat(mq-lint, mq-check): add json/markdown output formats and richer default report

### DIFF
--- a/crates/mq-check/README.md
+++ b/crates/mq-check/README.md
@@ -110,7 +110,7 @@ When used as a command-line tool (`mq-typecheck`), the following options are ava
 | `--show-types`   | Display inferred types for all user-defined symbols                |
 | `--no-builtins`  | Disable automatic builtin preloading                               |
 | `--strict-array` | Reject heterogeneous arrays (e.g., `[1, "hello"]` is a type error) |
-| `--format`       | Diagnostic output format: `text` (default), `json`, or `sarif`      |
+| `--format`       | Diagnostic output format: `text` (default), `json`, `markdown`, or `sarif` |
 
 ### `--strict-array`
 
@@ -129,12 +129,14 @@ echo '[1, "hello"]' | mq-check --strict-array
 - `json` — a single JSON array of diagnostics (syntax errors/warnings and type errors) across every
   checked file, each with `file`, `severity` (`error`/`warning`), `code`, `message`, and an optional
   `range`.
+- `markdown` — a Markdown table of diagnostics, suitable for pasting into a PR description or comment.
 - `sarif` — a single SARIF 2.1.0 log covering every checked file, suitable for
   [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif) or any
   other SARIF-consuming tool.
 
 ```bash
 mq-check --format json script.mq
+mq-check --format markdown script.mq
 mq-check --format sarif $(git ls-files '*.mq') > mq-check.sarif
 ```
 

--- a/crates/mq-check/src/format.rs
+++ b/crates/mq-check/src/format.rs
@@ -1,6 +1,7 @@
 //! Machine-readable diagnostic output formats for the `mq-check` CLI.
 
 mod json;
+mod markdown;
 mod sarif;
 
 use std::io::{self, Write};
@@ -42,6 +43,8 @@ pub(crate) enum OutputFormat {
     Text,
     /// A single JSON array of diagnostics across every checked file
     Json,
+    /// GitHub-flavored Markdown table, suitable for a PR description or comment
+    Markdown,
     /// SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF consumers
     Sarif,
 }
@@ -139,6 +142,7 @@ pub(crate) fn write_report(
     match format {
         OutputFormat::Text => unreachable!("text output is handled separately"),
         OutputFormat::Json => json::write_json_report(w, results),
+        OutputFormat::Markdown => markdown::write_markdown_report(w, results),
         OutputFormat::Sarif => sarif::write_sarif_report(w, results),
     }
 }

--- a/crates/mq-check/src/format/markdown.rs
+++ b/crates/mq-check/src/format/markdown.rs
@@ -1,0 +1,93 @@
+use std::io::{self, Write};
+
+use super::CheckDiagnostic;
+
+/// Writes a GitHub-flavored Markdown table of diagnostics across every checked file.
+pub(super) fn write_markdown_report(w: &mut impl Write, results: &[(String, Vec<CheckDiagnostic>)]) -> io::Result<()> {
+    let issue_count: usize = results.iter().map(|(_, diagnostics)| diagnostics.len()).sum();
+
+    writeln!(w, "# mq-check Report")?;
+    writeln!(w)?;
+
+    if issue_count == 0 {
+        writeln!(w, "No type errors found.")?;
+        return Ok(());
+    }
+
+    writeln!(w, "| File | Severity | Code | Location | Message |")?;
+    writeln!(w, "| --- | --- | --- | --- | --- |")?;
+
+    for (file_label, diagnostics) in results {
+        for diagnostic in diagnostics {
+            let loc = match &diagnostic.range {
+                Some(range) => format!("{}:{}", range.start.line, range.start.column),
+                None => String::new(),
+            };
+
+            writeln!(
+                w,
+                "| {} | {} | `{}` | {} | {} |",
+                escape_cell(file_label),
+                diagnostic.severity.as_str(),
+                diagnostic.code,
+                loc,
+                escape_cell(&diagnostic.message),
+            )?;
+        }
+    }
+
+    writeln!(w)?;
+    writeln!(
+        w,
+        "**Found {issue_count} issue{}.**",
+        if issue_count == 1 { "" } else { "s" }
+    )
+}
+
+/// Escapes pipes and newlines, which would otherwise break a Markdown table cell.
+fn escape_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::Severity;
+
+    #[test]
+    fn test_write_markdown_report_produces_table() {
+        let diagnostics = vec![CheckDiagnostic {
+            severity: Severity::Error,
+            code: "typechecker::undefined_symbol",
+            message: "Undefined symbol: foo".to_string(),
+            range: Some(mq_lang::Range::default()),
+        }];
+        let results = vec![("test.mq".to_string(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_markdown_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("# mq-check Report"));
+        assert!(output.contains("| File | Severity | Code | Location | Message |"));
+        assert!(output.contains("`typechecker::undefined_symbol`"));
+        assert!(output.contains("Undefined symbol: foo"));
+        assert!(output.contains("**Found 1 issue.**"));
+    }
+
+    #[test]
+    fn test_write_markdown_report_no_issues() {
+        let results = vec![("test.mq".to_string(), Vec::new())];
+        let mut buf = Vec::new();
+        write_markdown_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("No type errors found."));
+        assert!(!output.contains('|'));
+    }
+
+    #[test]
+    fn test_escape_cell() {
+        assert_eq!(escape_cell("a | b"), "a \\| b");
+        assert_eq!(escape_cell("line1\nline2"), "line1 line2");
+    }
+}

--- a/crates/mq-check/src/main.rs
+++ b/crates/mq-check/src/main.rs
@@ -35,8 +35,8 @@ struct Cli {
     no_exhaustive_patterns: bool,
 
     /// Diagnostic output format: `text` (human-readable), `json` (a single JSON array of
-    /// diagnostics), or `sarif` (SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF
-    /// consumers)
+    /// diagnostics), `markdown` (a Markdown table, for PR descriptions or comments), or
+    /// `sarif` (SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF consumers)
     #[arg(long, value_enum, default_value_t)]
     format: OutputFormat,
 }
@@ -538,6 +538,7 @@ mod tests {
     #[case(vec!["mq-check"], OutputFormat::Text)]
     #[case(vec!["mq-check", "--format", "text"], OutputFormat::Text)]
     #[case(vec!["mq-check", "--format", "json"], OutputFormat::Json)]
+    #[case(vec!["mq-check", "--format", "markdown"], OutputFormat::Markdown)]
     #[case(vec!["mq-check", "--format", "sarif"], OutputFormat::Sarif)]
     fn test_cli_format(#[case] args: Vec<&str>, #[case] expected: OutputFormat) {
         let cli = Cli::try_parse_from(args).unwrap();

--- a/crates/mq-lint/README.md
+++ b/crates/mq-lint/README.md
@@ -64,6 +64,8 @@ mq-lint --min-severity warn script.mq # only show warn/error diagnostics
 mq-lint --list-rules                  # print all rule IDs and their severity
 mq-lint --fix script.mq               # rewrite the file, applying every fixable diagnostic
 echo "let x = .h1" | mq-lint --fix     # write the fixed code to stdout
+mq-lint --format json script.mq       # a single JSON array of diagnostics
+mq-lint --format markdown script.mq   # a Markdown table, for PR descriptions or comments
 mq-lint --format sarif script.mq      # SARIF 2.1.0 JSON, e.g. for github/codeql-action/upload-sarif
 mq-lint --format github script.mq     # GitHub Actions ::error/::warning/::notice annotations
 ```
@@ -77,6 +79,9 @@ reports any remaining diagnostics as usual.
 `--format` controls how diagnostics are rendered, independent of the rules and severities selected above:
 
 - `text` (default) — human-readable Credo-style report.
+- `json` — a single JSON array of diagnostics across every linted file, each with `file`, `severity`, `rule`,
+  `message`, `help`, and an optional `range`.
+- `markdown` — a Markdown table of diagnostics, suitable for pasting into a PR description or comment.
 - `sarif` — a single SARIF 2.1.0 log covering every linted file, suitable for
   [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif) or any other
   SARIF-consuming tool.

--- a/crates/mq-lint/src/format.rs
+++ b/crates/mq-lint/src/format.rs
@@ -1,6 +1,8 @@
 //! Diagnostic output formats for the `mq-lint` CLI.
 
 mod github;
+mod json;
+mod markdown;
 mod sarif;
 mod text;
 
@@ -14,6 +16,10 @@ pub(crate) enum OutputFormat {
     /// Credo-style human-readable report (default)
     #[default]
     Text,
+    /// A single JSON array of diagnostics across every linted file
+    Json,
+    /// GitHub-flavored Markdown table, suitable for a PR description or comment
+    Markdown,
     /// SARIF 2.1.0 JSON
     Sarif,
     /// GitHub Actions workflow-command annotations
@@ -21,18 +27,23 @@ pub(crate) enum OutputFormat {
 }
 
 /// Dispatches to the writer for the requested output format.
+///
+/// Each entry is `(file_label, source_code, diagnostics)`; the source is only used by the
+/// `Text` report, to render a snippet with a caret under each diagnostic's range.
 pub(crate) fn write_report(
     w: &mut impl Write,
     format: OutputFormat,
-    results: &[(String, Vec<Diagnostic>)],
+    results: &[(String, String, Vec<Diagnostic>)],
 ) -> io::Result<()> {
     match format {
         OutputFormat::Text => {
-            for (file_label, diagnostics) in results {
-                text::write_text_report(w, file_label, diagnostics)?;
+            for (file_label, code, diagnostics) in results {
+                text::write_text_report(w, file_label, code, diagnostics)?;
             }
             Ok(())
         }
+        OutputFormat::Json => json::write_json_report(w, results),
+        OutputFormat::Markdown => markdown::write_markdown_report(w, results),
         OutputFormat::Sarif => sarif::write_sarif_report(w, results),
         OutputFormat::Github => github::write_github_report(w, results),
     }

--- a/crates/mq-lint/src/format/github.rs
+++ b/crates/mq-lint/src/format/github.rs
@@ -6,8 +6,8 @@ use mq_lint::{Diagnostic, Severity};
 /// (`::error`/`::warning`/`::notice`) per diagnostic.
 ///
 /// See <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>.
-pub(super) fn write_github_report(w: &mut impl Write, results: &[(String, Vec<Diagnostic>)]) -> io::Result<()> {
-    for (file_label, diagnostics) in results {
+pub(super) fn write_github_report(w: &mut impl Write, results: &[(String, String, Vec<Diagnostic>)]) -> io::Result<()> {
+    for (file_label, _code, diagnostics) in results {
         for diagnostic in diagnostics {
             let level = match diagnostic.severity {
                 Severity::Error => "error",
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn test_write_github_report_emits_workflow_command_annotations() {
         let diagnostics = sample_diagnostics();
-        let results = vec![("test.mq".to_string(), diagnostics)];
+        let results = vec![("test.mq".to_string(), String::new(), diagnostics)];
 
         let mut buf = Vec::new();
         write_github_report(&mut buf, &results).unwrap();
@@ -75,7 +75,7 @@ mod tests {
             bool_val: "true".to_string(),
         };
         let diagnostic = Diagnostic::new(kind, severity);
-        let results = vec![("test.mq".to_string(), vec![diagnostic])];
+        let results = vec![("test.mq".to_string(), String::new(), vec![diagnostic])];
 
         let mut buf = Vec::new();
         write_github_report(&mut buf, &results).unwrap();

--- a/crates/mq-lint/src/format/json.rs
+++ b/crates/mq-lint/src/format/json.rs
@@ -1,0 +1,69 @@
+use std::io::{self, Write};
+
+use mq_lint::Diagnostic;
+
+/// Writes a single JSON array of diagnostics across every linted file.
+pub(super) fn write_json_report(w: &mut impl Write, results: &[(String, String, Vec<Diagnostic>)]) -> io::Result<()> {
+    let entries: Vec<serde_json::Value> = results
+        .iter()
+        .flat_map(|(file_label, _code, diagnostics)| {
+            diagnostics.iter().map(move |diagnostic| {
+                serde_json::json!({
+                    "file": file_label,
+                    "severity": diagnostic.severity.to_string(),
+                    "rule": diagnostic.rule_id().as_str(),
+                    "message": diagnostic.message(),
+                    "help": diagnostic.help(),
+                    "range": diagnostic.range.map(|range| serde_json::json!({
+                        "startLine": range.start.line,
+                        "startColumn": range.start.column,
+                        "endLine": range.end.line,
+                        "endColumn": range.end.column,
+                    })),
+                })
+            })
+        })
+        .collect();
+
+    writeln!(
+        w,
+        "{}",
+        serde_json::to_string_pretty(&entries).map_err(io::Error::other)?
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lint::{LintConfig, Linter};
+
+    fn sample_diagnostics() -> Vec<Diagnostic> {
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        crate::collect_diagnostics(r#".checked == true"#, &linter, &config, mq_lint::Severity::Style)
+    }
+
+    #[test]
+    fn test_write_json_report_produces_expected_shape() {
+        let diagnostics = sample_diagnostics();
+        let results = vec![("test.mq".to_string(), String::new(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_json_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+
+        assert_eq!(json[0]["file"], "test.mq");
+        assert_eq!(json[0]["rule"], "boolean_comparison");
+        assert!(json[0]["message"].is_string());
+        assert!(json[0]["range"].is_object());
+    }
+
+    #[test]
+    fn test_write_json_report_empty_diagnostics() {
+        let results = vec![("test.mq".to_string(), String::new(), Vec::new())];
+        let mut buf = Vec::new();
+        write_json_report(&mut buf, &results).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/mq-lint/src/format/markdown.rs
+++ b/crates/mq-lint/src/format/markdown.rs
@@ -1,0 +1,102 @@
+use std::io::{self, Write};
+
+use mq_lint::Diagnostic;
+
+/// Writes a GitHub-flavored Markdown table of diagnostics across every linted file.
+pub(super) fn write_markdown_report(
+    w: &mut impl Write,
+    results: &[(String, String, Vec<Diagnostic>)],
+) -> io::Result<()> {
+    let issue_count: usize = results.iter().map(|(_, _code, diagnostics)| diagnostics.len()).sum();
+
+    writeln!(w, "# mq-lint Report")?;
+    writeln!(w)?;
+
+    if issue_count == 0 {
+        writeln!(w, "No lint issues found.")?;
+        return Ok(());
+    }
+
+    writeln!(w, "| File | Severity | Rule | Location | Message |")?;
+    writeln!(w, "| --- | --- | --- | --- | --- |")?;
+
+    for (file_label, _code, diagnostics) in results {
+        for diagnostic in diagnostics {
+            let loc = match &diagnostic.range {
+                Some(range) => format!("{}:{}", range.start.line, range.start.column),
+                None => String::new(),
+            };
+            let mut message = escape_cell(&diagnostic.message());
+            if let Some(help) = diagnostic.help() {
+                message.push_str(" — help: ");
+                message.push_str(&escape_cell(&help));
+            }
+
+            writeln!(
+                w,
+                "| {} | {} | `{}` | {} | {} |",
+                escape_cell(file_label),
+                diagnostic.severity,
+                diagnostic.rule_id().as_str(),
+                loc,
+                message,
+            )?;
+        }
+    }
+
+    writeln!(w)?;
+    writeln!(
+        w,
+        "**Found {issue_count} issue{}.**",
+        if issue_count == 1 { "" } else { "s" }
+    )
+}
+
+/// Escapes pipes and newlines, which would otherwise break a Markdown table cell.
+fn escape_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mq_lint::{LintConfig, Linter};
+
+    fn sample_diagnostics() -> Vec<Diagnostic> {
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        crate::collect_diagnostics(r#".checked == true"#, &linter, &config, mq_lint::Severity::Style)
+    }
+
+    #[test]
+    fn test_write_markdown_report_produces_table() {
+        let diagnostics = sample_diagnostics();
+        let results = vec![("test.mq".to_string(), String::new(), diagnostics)];
+
+        let mut buf = Vec::new();
+        write_markdown_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("# mq-lint Report"));
+        assert!(output.contains("| File | Severity | Rule | Location | Message |"));
+        assert!(output.contains("test.mq"));
+        assert!(output.contains("`boolean_comparison`"));
+        assert!(output.contains("**Found 1 issue.**"));
+    }
+
+    #[test]
+    fn test_write_markdown_report_no_issues() {
+        let results = vec![("test.mq".to_string(), String::new(), Vec::new())];
+        let mut buf = Vec::new();
+        write_markdown_report(&mut buf, &results).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("No lint issues found."));
+        assert!(!output.contains('|'));
+    }
+
+    #[test]
+    fn test_escape_cell() {
+        assert_eq!(escape_cell("a | b"), "a \\| b");
+        assert_eq!(escape_cell("line1\nline2"), "line1 line2");
+    }
+}

--- a/crates/mq-lint/src/format/sarif.rs
+++ b/crates/mq-lint/src/format/sarif.rs
@@ -5,10 +5,10 @@ use mq_lint::{Diagnostic, Severity};
 /// Writes a single SARIF 2.1.0 log document covering every linted file.
 ///
 /// See <https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html>.
-pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, Vec<Diagnostic>)]) -> io::Result<()> {
+pub(super) fn write_sarif_report(w: &mut impl Write, results: &[(String, String, Vec<Diagnostic>)]) -> io::Result<()> {
     let sarif_results: Vec<serde_json::Value> = results
         .iter()
-        .flat_map(|(file_label, diagnostics)| {
+        .flat_map(|(file_label, _code, diagnostics)| {
             diagnostics.iter().map(move |diagnostic| {
                 let mut physical_location = serde_json::json!({
                     "artifactLocation": {"uri": file_label},
@@ -74,7 +74,7 @@ mod tests {
     fn test_write_sarif_report_produces_valid_sarif_shape() {
         let diagnostics = sample_diagnostics();
         assert!(!diagnostics.is_empty());
-        let results = vec![("test.mq".to_string(), diagnostics)];
+        let results = vec![("test.mq".to_string(), String::new(), diagnostics)];
 
         let mut buf = Vec::new();
         write_sarif_report(&mut buf, &results).unwrap();
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_write_sarif_report_empty_diagnostics() {
-        let results = vec![("test.mq".to_string(), Vec::new())];
+        let results = vec![("test.mq".to_string(), String::new(), Vec::new())];
         let mut buf = Vec::new();
         write_sarif_report(&mut buf, &results).unwrap();
         let json: serde_json::Value = serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();

--- a/crates/mq-lint/src/format/text.rs
+++ b/crates/mq-lint/src/format/text.rs
@@ -8,7 +8,12 @@ const SEVERITY_ORDER: [Severity; 4] = [Severity::Error, Severity::Warn, Severity
 
 /// Writes `diagnostics` grouped by severity in a Credo-style report and returns `true` if any
 /// were reported.
-pub(super) fn write_text_report(w: &mut impl Write, file_label: &str, diagnostics: &[Diagnostic]) -> io::Result<bool> {
+pub(super) fn write_text_report(
+    w: &mut impl Write,
+    file_label: &str,
+    code: &str,
+    diagnostics: &[Diagnostic],
+) -> io::Result<bool> {
     let mut printed_category = false;
     for severity in SEVERITY_ORDER {
         let group: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.severity == severity).collect();
@@ -19,7 +24,7 @@ pub(super) fn write_text_report(w: &mut impl Write, file_label: &str, diagnostic
             writeln!(w)?;
         }
         printed_category = true;
-        write_category(w, severity, &group, file_label)?;
+        write_category(w, severity, &group, file_label, code)?;
     }
 
     if diagnostics.is_empty() {
@@ -37,46 +42,55 @@ pub(super) fn write_text_report(w: &mut impl Write, file_label: &str, diagnostic
     Ok(!diagnostics.is_empty())
 }
 
-/// Maps a severity to its Credo-style category title and one-letter marker.
+/// Maps a severity to its category title and one-letter marker.
 fn severity_category(severity: Severity) -> (colored::ColoredString, colored::ColoredString) {
     match severity {
-        Severity::Error => ("## Errors".bright_red().bold(), "[E]".bright_red().bold()),
-        Severity::Warn => ("## Warnings".bright_yellow().bold(), "[W]".bright_yellow().bold()),
-        Severity::Perf => ("## Performance".blue().bold(), "[P]".blue().bold()),
-        Severity::Style => ("## Style".cyan().bold(), "[S]".cyan().bold()),
+        Severity::Error => ("Errors".bright_red().bold(), "[E]".bright_red().bold()),
+        Severity::Warn => ("Warnings".bright_yellow().bold(), "[W]".bright_yellow().bold()),
+        Severity::Perf => ("Performance".blue().bold(), "[P]".blue().bold()),
+        Severity::Style => ("Style".cyan().bold(), "[S]".cyan().bold()),
     }
 }
 
-/// Uses mq's own pipe operator `|` as the gutter bar.
-fn severity_bar(severity: Severity) -> colored::ColoredString {
+/// Colors `s` to match `severity`, shared by the box frame, gutter bar, message text, and the
+/// snippet's caret.
+fn severity_color(severity: Severity, s: &str) -> colored::ColoredString {
     match severity {
-        Severity::Error => "|".bright_red(),
-        Severity::Warn => "|".bright_yellow(),
-        Severity::Perf => "|".blue(),
-        Severity::Style => "|".cyan(),
+        Severity::Error => s.bright_red(),
+        Severity::Warn => s.bright_yellow(),
+        Severity::Perf => s.blue(),
+        Severity::Style => s.cyan(),
     }
 }
 
-/// Writes one severity category: a heading followed by its diagnostics, each as a
-/// `[X] message` line with the `file:line:col .rule_id` location on the line below
-/// (the rule id rendered as an mq selector, e.g. `.unused_variable`).
+/// Writes one severity category as a box-drawn frame (`┌─ Title` … `└─`) around its
+/// diagnostics, each as a `[X] message` line, a source snippet with a caret underline (when a
+/// range is known), then the `file:line:col .rule_id` location (the rule id rendered as an mq
+/// selector, e.g. `.unused_variable`).
 fn write_category(
     w: &mut impl Write,
     severity: Severity,
     diagnostics: &[&Diagnostic],
     file_label: &str,
+    code: &str,
 ) -> io::Result<()> {
     let (title, letter) = severity_category(severity);
-    let bar = severity_bar(severity);
+    let bar = severity_color(severity, "│");
 
-    writeln!(w, "{}\n", title)?;
+    writeln!(w, "{} {title}", severity_color(severity, "┌─").bold())?;
+    writeln!(w, "{bar}")?;
 
     for (i, diagnostic) in diagnostics.iter().enumerate() {
-        match diagnostic.severity {
-            Severity::Error => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_red().bold())?,
-            Severity::Warn => writeln!(w, "{bar} {} {}", letter, diagnostic.message().bright_yellow().bold())?,
-            Severity::Perf => writeln!(w, "{bar} {} {}", letter, diagnostic.message().blue().bold())?,
-            Severity::Style => writeln!(w, "{bar} {} {}", letter, diagnostic.message().cyan().bold())?,
+        writeln!(
+            w,
+            "{bar} {} {}",
+            letter,
+            severity_color(diagnostic.severity, &diagnostic.message()).bold()
+        )?;
+
+        if let Some(range) = &diagnostic.range {
+            writeln!(w, "{bar}")?;
+            write_snippet(w, code, range, diagnostic.severity, &bar)?;
         }
 
         let loc = match &diagnostic.range {
@@ -99,7 +113,45 @@ fn write_category(
         }
     }
 
+    writeln!(w, "{}", severity_color(severity, "└─"))?;
+
     Ok(())
+}
+
+/// Writes the offending source line with a caret underline beneath it, colored to match
+/// `severity` and indented under the category's gutter `bar`.
+fn write_snippet(
+    w: &mut impl Write,
+    code: &str,
+    range: &mq_lang::Range,
+    severity: Severity,
+    bar: &colored::ColoredString,
+) -> io::Result<()> {
+    let lines: Vec<&str> = code.lines().collect();
+    let line_idx = range.start.line.saturating_sub(1) as usize;
+    let Some(source_line) = lines.get(line_idx) else {
+        return Ok(());
+    };
+
+    let col_start = range.start.column.saturating_sub(1);
+    let col_end = if range.end.line == range.start.line {
+        range.end.column.saturating_sub(1)
+    } else {
+        source_line.len()
+    };
+    let underline_len = col_end.saturating_sub(col_start).max(1);
+    let line_num = range.start.line.to_string();
+
+    writeln!(w, "{bar}    {} {} {}", line_num.dimmed(), "│".dimmed(), source_line)?;
+    writeln!(
+        w,
+        "{bar}    {} {} {}{}",
+        " ".repeat(line_num.len()),
+        "│".dimmed(),
+        " ".repeat(col_start),
+        severity_color(severity, &"^".repeat(underline_len)).bold(),
+    )?;
+    writeln!(w, "{bar}")
 }
 
 /// Writes the trailing summary line, e.g. `found 3 issues (2 warnings, 1 style).`
@@ -139,24 +191,41 @@ mod tests {
     #[test]
     fn test_write_text_report_no_issues() {
         let mut buf = Vec::new();
-        let had_diagnostics = write_text_report(&mut buf, "test.mq", &[]).unwrap();
+        let had_diagnostics = write_text_report(&mut buf, "test.mq", "", &[]).unwrap();
         assert!(!had_diagnostics);
         assert!(String::from_utf8(buf).unwrap().contains("No lint issues found."));
     }
 
     #[test]
     fn test_write_text_report_with_diagnostics() {
+        let code = r#".checked == true"#;
         let config = LintConfig::default();
         let linter = Linter::with_default_rules();
-        let diagnostics = crate::collect_diagnostics(r#".checked == true"#, &linter, &config, Severity::Style);
+        let diagnostics = crate::collect_diagnostics(code, &linter, &config, Severity::Style);
 
         let mut buf = Vec::new();
-        let had_diagnostics = write_text_report(&mut buf, "test.mq", &diagnostics).unwrap();
+        let had_diagnostics = write_text_report(&mut buf, "test.mq", code, &diagnostics).unwrap();
         assert!(had_diagnostics);
 
         let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("## Style"));
+        assert!(output.contains("┌─ Style"));
+        assert!(output.contains("└─"));
         assert!(output.contains("test.mq:1:1"));
         assert!(output.contains("found 1 issue (1 style)."));
+    }
+
+    #[test]
+    fn test_write_text_report_shows_snippet_with_caret() {
+        let code = ".checked == true";
+        let config = LintConfig::default();
+        let linter = Linter::with_default_rules();
+        let diagnostics = crate::collect_diagnostics(code, &linter, &config, Severity::Style);
+
+        let mut buf = Vec::new();
+        write_text_report(&mut buf, "test.mq", code, &diagnostics).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains(".checked == true"));
+        assert!(output.contains('^'));
     }
 }

--- a/crates/mq-lint/src/main.rs
+++ b/crates/mq-lint/src/main.rs
@@ -35,9 +35,10 @@ struct Cli {
     #[arg(long)]
     fix: bool,
 
-    /// Diagnostic output format: `text` (human-readable), `sarif` (SARIF 2.1.0 JSON, for
-    /// GitHub code scanning and other SARIF consumers), or `github` (GitHub Actions
-    /// `::error`/`::warning`/`::notice` workflow-command annotations)
+    /// Diagnostic output format: `text` (human-readable), `json` (a single JSON array of
+    /// diagnostics), `markdown` (a Markdown table, for PR descriptions or comments), `sarif`
+    /// (SARIF 2.1.0 JSON, for GitHub code scanning and other SARIF consumers), or `github`
+    /// (GitHub Actions `::error`/`::warning`/`::notice` workflow-command annotations)
     #[arg(long, value_enum, default_value_t)]
     format: OutputFormat,
 }
@@ -105,11 +106,11 @@ fn run() -> io::Result<bool> {
 
         let diagnostics = collect_diagnostics(&code, &linter, &config, min_severity);
         let had_diagnostics = !diagnostics.is_empty();
-        format::write_report(&mut w, cli.format, &[("<stdin>".to_string(), diagnostics)])?;
+        format::write_report(&mut w, cli.format, &[("<stdin>".to_string(), code, diagnostics)])?;
         return Ok(had_diagnostics);
     }
 
-    let mut results: Vec<(String, Vec<Diagnostic>)> = Vec::with_capacity(cli.files.len());
+    let mut results: Vec<(String, String, Vec<Diagnostic>)> = Vec::with_capacity(cli.files.len());
 
     for path in &cli.files {
         let code = std::fs::read_to_string(path)
@@ -137,10 +138,11 @@ fn run() -> io::Result<bool> {
             code
         };
 
-        results.push((label, collect_diagnostics(&code, &linter, &config, min_severity)));
+        let diagnostics = collect_diagnostics(&code, &linter, &config, min_severity);
+        results.push((label, code, diagnostics));
     }
 
-    let had_diagnostics = results.iter().any(|(_, diagnostics)| !diagnostics.is_empty());
+    let had_diagnostics = results.iter().any(|(_, _code, diagnostics)| !diagnostics.is_empty());
     format::write_report(&mut w, cli.format, &results)?;
 
     Ok(had_diagnostics)
@@ -247,6 +249,8 @@ mod tests {
     #[rstest]
     #[case(vec!["mq-lint"], OutputFormat::Text)]
     #[case(vec!["mq-lint", "--format", "text"], OutputFormat::Text)]
+    #[case(vec!["mq-lint", "--format", "json"], OutputFormat::Json)]
+    #[case(vec!["mq-lint", "--format", "markdown"], OutputFormat::Markdown)]
     #[case(vec!["mq-lint", "--format", "sarif"], OutputFormat::Sarif)]
     #[case(vec!["mq-lint", "--format", "github"], OutputFormat::Github)]
     fn test_cli_format(#[case] args: Vec<&str>, #[case] expected: OutputFormat) {


### PR DESCRIPTION
## Summary

mq-lint gains --format json and --format markdown (mq-check already had json, now also gains markdown). The default text report replaces the "## Errors" Markdown-style headings with a box-drawn frame (┌─/└─) and a continuous │ gutter, and now renders a source snippet with a severity-colored caret under each diagnostic's range.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
