### PR TITLE
✨ feat(mq-chrome-extension): persist query across side panel sessions

### DIFF
--- a/packages/mq-chrome-extension/entrypoints/sidepanel/App.tsx
+++ b/packages/mq-chrome-extension/entrypoints/sidepanel/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { htmlToMarkdown, run, toHtml } from "./lib/mq";
 import { extractActivePageHtml, toggleActivePagePreview } from "./lib/activeTab";
 import { buildSrcDoc } from "./lib/buildSrcDoc";
+import { queryStorage } from "./lib/queryStorage";
 import { SourcePane, type SourceMode } from "./components/SourcePane";
 import { QueryEditor } from "./components/QueryEditor";
 import { ResultPane } from "./components/ResultPane";
@@ -26,41 +27,44 @@ export function App() {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryLoadedRef = useRef(false);
 
   const source = sourceMode === "html" ? html : markdown;
 
-  const handleExtract = async () => {
+  const handleExtract = async (): Promise<string | undefined> => {
     setError(null);
     setIsExtracting(true);
     try {
       const extracted = await extractActivePageHtml();
       if (!extracted.ok) {
         setError(extracted.message);
-        return;
+        return undefined;
       }
       setHtml(extracted.value);
       const md = await htmlToMarkdown(extracted.value);
       setMarkdown(md);
       setResult("");
+      return md;
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      return undefined;
     } finally {
       setIsExtracting(false);
     }
   };
 
-  useEffect(() => {
-    handleExtract();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleRun = async () => {
+  const runQuery = async (
+    q: string,
+    src: string,
+    mode: SourceMode,
+    opts: RunOptions,
+  ) => {
     setError(null);
     setIsRunning(true);
     try {
-      const filtered = await run(query, source, {
-        ...options,
-        inputFormat: sourceMode === "html" ? "html" : "markdown",
+      const filtered = await run(q, src, {
+        ...opts,
+        inputFormat: mode === "html" ? "html" : "markdown",
       });
       setResult(filtered);
     } catch (err) {
@@ -69,6 +73,33 @@ export function App() {
       setIsRunning(false);
     }
   };
+
+  const handleRun = () => runQuery(query, source, sourceMode, options);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [extractedMarkdown, storedQuery] = await Promise.all([
+        handleExtract(),
+        queryStorage.getValue(),
+      ]);
+      if (cancelled) return;
+      setQuery(storedQuery);
+      queryLoadedRef.current = true;
+      if (storedQuery.trim() && extractedMarkdown) {
+        await runQuery(storedQuery, extractedMarkdown, "markdown", options);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!queryLoadedRef.current) return;
+    queryStorage.setValue(query);
+  }, [query]);
 
   const handleCopy = () => {
     navigator.clipboard

--- a/packages/mq-chrome-extension/entrypoints/sidepanel/lib/queryStorage.ts
+++ b/packages/mq-chrome-extension/entrypoints/sidepanel/lib/queryStorage.ts
@@ -1,0 +1,9 @@
+import { storage } from "wxt/utils/storage";
+
+/**
+ * Persists the last entered query so it survives the side panel being
+ * closed and reopened (the panel's React tree is torn down on close).
+ */
+export const queryStorage = storage.defineItem<string>("local:query", {
+  fallback: "",
+});

--- a/packages/mq-chrome-extension/wxt.config.ts
+++ b/packages/mq-chrome-extension/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     description:
       "Convert the current page to Markdown, filter it with mq queries, and preview the result on the page.",
     minimum_chrome_version: "116",
-    permissions: ["activeTab", "scripting", "sidePanel"],
+    permissions: ["activeTab", "scripting", "sidePanel", "storage"],
     action: {},
     content_security_policy: {
       extension_pages:


### PR DESCRIPTION
## Summary

Save the query to chrome.storage.local so it survives closing and reopening the side panel, and auto-run it against the freshly extracted markdown when a saved query exists on open.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
