### PR TITLE
✨ feat(mq-lang): decompress deflate/zstd http() responses, bound decompressed size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,6 +2623,7 @@ dependencies = [
  "codspeed-divan-compat",
  "csv",
  "dirs 6.0.0",
+ "flate2",
  "getrandom 0.4.3",
  "glob",
  "html-escape",
@@ -2642,6 +2643,7 @@ dependencies = [
  "ropey",
  "rstest",
  "rustc-hash",
+ "ruzstd",
  "scopeguard",
  "scraper",
  "serde",
@@ -3999,6 +4001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,6 +5161,12 @@ dependencies = [
  "thiserror 2.0.19",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ dirs = "6.0.0"
 divan = {version = "4.7.0", package = "codspeed-divan-compat"}
 ego-tree = "0.11.0"
 fantoccini = {version = "0.22.1", default-features = false, features = ["rustls-tls"]}
+flate2 = "1"
 futures = "0.3"
 glob = "0.3.3"
 httpmock = "0.8.2"
@@ -89,6 +90,7 @@ ropey = "1.6"
 rstest = "0.26.1"
 rustc-hash = "2.1.2"
 rustyline = {version = "18.0.0", default-features = false}
+ruzstd = "0.9"
 scopeguard = "1.2.0"
 scraper = "0.27.0"
 serde = "1.0"

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -49,6 +49,8 @@ quick-xml = {workspace = true}
 unicode-width = {workspace = true}
 similar = {workspace = true}
 tiktoken-rs = { version = "0.12", optional = true }
+flate2 = { workspace = true, optional = true }
+ruzstd = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
 uuid = {workspace = true, features = ["v4", "v7"]}
 ammonia = {workspace = true}
@@ -70,7 +72,7 @@ process-io = []
 std = []
 sync = []
 http-import = []
-http = ["dep:ureq"]
+http = ["dep:ureq", "dep:flate2", "dep:ruzstd"]
 http-import-ureq = ["http-import", "http"]
 mock-io = []
 tiktoken = ["dep:tiktoken-rs"]

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -8108,7 +8108,7 @@ x
     map.insert(
         SmolStr::new("http"),
         BuiltinFunctionDoc {
-            description: "Performs an HTTPS request with the given method (a string or symbol, e.g. \"post\" or :post — get, post, put, delete, patch, head, ... are all supported) and returns the response body as a string. An optional body argument (string) sends a request body regardless of method, and an optional headers argument (a dict of string to string, e.g. {\"Content-Type\": \"application/json\"}) is applied to the request. Requires the --allow-net CLI flag; otherwise returns a runtime error. Only https:// URLs are allowed.",
+            description: "Performs an HTTPS request with the given method (a string or symbol, e.g. \"post\" or :post — get, post, put, delete, patch, head, ... are all supported) and returns the response body as a string. An optional body argument (string) sends a request body regardless of method, and an optional headers argument (a dict of string to string, e.g. {\"Content-Type\": \"application/json\"}) is applied to the request. gzip, deflate, and zstd compressed responses are decompressed transparently (a response over 10MB decompressed is a runtime error, guarding against decompression bombs); pass your own \"Accept-Encoding\" header to opt out. Requires the --allow-net CLI flag; otherwise returns a runtime error. Only https:// URLs are allowed.",
             params: &["method", "url", "body", "headers"],
             param_types: &["string", "string", "string", "dict"],
             returns: "string",
@@ -9081,7 +9081,11 @@ mod tests {
 
     #[cfg(all(feature = "http", feature = "mock-io"))]
     use crate::io::MemIo;
-    #[cfg(any(feature = "file-io", feature = "http", feature = "process-io"))]
+    #[cfg(any(
+        feature = "file-io",
+        feature = "process-io",
+        all(feature = "http", feature = "mock-io")
+    ))]
     use crate::io::{NativeIo, SandboxedIo};
 
     use super::*;

--- a/crates/mq-lang/src/io/native.rs
+++ b/crates/mq-lang/src/io/native.rs
@@ -40,6 +40,42 @@ fn io_err(err: std::io::Error, path: &Path) -> IoError {
     }
 }
 
+/// Reads `reader` into a `Vec`, erroring once more than `limit` bytes have
+/// been produced instead of buffering an unbounded amount (protects against
+/// decompression bombs when `reader` is a decoder).
+#[cfg(feature = "http")]
+fn read_bounded_to_vec(mut reader: impl std::io::Read, limit: u64) -> std::io::Result<Vec<u8>> {
+    let limit = limit as usize;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+
+    loop {
+        let n = reader.read(&mut chunk)?;
+        if n == 0 {
+            return Ok(buf);
+        }
+        if buf.len() + n > limit {
+            return Err(std::io::Error::other(format!(
+                "response body exceeds the {limit}-byte limit"
+            )));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+}
+
+/// Some servers send raw deflate instead of the zlib wrapper `Content-Encoding: deflate` implies.
+#[cfg(feature = "http")]
+fn decode_deflate(compressed: &[u8], limit: u64) -> std::io::Result<Vec<u8>> {
+    read_bounded_to_vec(flate2::read::ZlibDecoder::new(compressed), limit)
+        .or_else(|_| read_bounded_to_vec(flate2::read::DeflateDecoder::new(compressed), limit))
+}
+
+#[cfg(feature = "http")]
+fn decode_zstd(reader: impl std::io::Read, limit: u64) -> std::io::Result<Vec<u8>> {
+    let decoder = ruzstd::decoding::StreamingDecoder::new(reader).map_err(std::io::Error::other)?;
+    read_bounded_to_vec(decoder, limit)
+}
+
 impl Io for NativeIo {
     fn read_to_string(&self, path: &Path) -> Result<String, IoError> {
         std::fs::read_to_string(path).map_err(|e| io_err(e, path))
@@ -134,7 +170,7 @@ impl Io for NativeIo {
         body: Option<&str>,
         headers: &[(String, String)],
     ) -> Result<String, IoError> {
-        /// Matches the `http()` builtin's existing limits.
+        /// Applied to the decompressed body, to guard against decompression bombs.
         const MAX_RESPONSE_SIZE: u64 = 10 * 1024 * 1024;
         const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
         static AGENT: std::sync::LazyLock<ureq::Agent> =
@@ -150,7 +186,14 @@ impl Io for NativeIo {
             .parse()
             .map_err(|_| IoError::Other(Cow::Owned(format!("invalid HTTP method {method:?}"))))?;
 
+        let has_accept_encoding = headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("accept-encoding"));
         let mut builder = ureq::http::Request::builder().method(method).uri(url);
+        if !has_accept_encoding {
+            // ureq only advertises encodings it decodes itself (gzip); deflate/zstd are ours below.
+            builder = builder.header("accept-encoding", "gzip, deflate, zstd");
+        }
         for (name, value) in headers {
             builder = builder.header(name, value);
         }
@@ -178,12 +221,33 @@ impl Io for NativeIo {
             ))));
         }
 
-        response
-            .body_mut()
-            .with_config()
-            .limit(MAX_RESPONSE_SIZE)
-            .read_to_string()
-            .map_err(|e| IoError::Other(Cow::Owned(format!("failed to read response body: {e}"))))
+        // ureq decodes `gzip` itself; `deflate`/`zstd` are ours to handle.
+        let content_encoding = response
+            .headers()
+            .get("content-encoding")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.trim().to_ascii_lowercase());
+
+        let bytes = match content_encoding.as_deref() {
+            Some("deflate") => {
+                let compressed = read_bounded_to_vec(response.body_mut().as_reader(), MAX_RESPONSE_SIZE)
+                    .map_err(|e| IoError::Other(Cow::Owned(format!("failed to read response body: {e}"))))?;
+                decode_deflate(&compressed, MAX_RESPONSE_SIZE).map_err(|e| {
+                    IoError::Other(Cow::Owned(format!(
+                        "failed to inflate deflate-encoded response body: {e}"
+                    )))
+                })?
+            }
+            Some("zstd") => decode_zstd(response.body_mut().as_reader(), MAX_RESPONSE_SIZE).map_err(|e| {
+                IoError::Other(Cow::Owned(format!(
+                    "failed to decompress zstd-encoded response body: {e}"
+                )))
+            })?,
+            _ => read_bounded_to_vec(response.body_mut().as_reader(), MAX_RESPONSE_SIZE)
+                .map_err(|e| IoError::Other(Cow::Owned(format!("failed to read response body: {e}"))))?,
+        };
+
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     #[cfg(not(feature = "http"))]
@@ -255,6 +319,8 @@ impl Io for NativeIo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "http")]
+    use rstest::rstest;
 
     #[test]
     fn test_read_write_round_trip() {
@@ -321,7 +387,7 @@ mod tests {
     #[test]
     fn test_fetch_rejects_non_https() {
         let io = NativeIo::default();
-        assert!(matches!(io.fetch("http://example.com"), Err(IoError::Other(_))));
+        assert!(matches!(io.fetch("http://example.invalid"), Err(IoError::Other(_))));
     }
 
     #[cfg(all(feature = "process-io", not(windows)))]
@@ -370,5 +436,96 @@ mod tests {
             io.execute("mq-this-command-should-not-exist", &[]),
             Err(IoError::Other(_))
         ));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_http_request_rejects_non_https() {
+        let io = NativeIo::default();
+        assert!(matches!(
+            io.http_request("GET", "http://example.invalid", None, &[]),
+            Err(IoError::Other(_))
+        ));
+    }
+
+    #[cfg(feature = "http")]
+    #[rstest]
+    #[case(b"hello world".as_slice(), 11)]
+    #[case(b"".as_slice(), 0)]
+    fn test_read_bounded_to_vec_within_limit(#[case] data: &[u8], #[case] limit: u64) {
+        assert_eq!(read_bounded_to_vec(data, limit).unwrap(), data);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_read_bounded_to_vec_rejects_oversized_input() {
+        assert!(read_bounded_to_vec(vec![0u8; 100].as_slice(), 50).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_deflate_zlib_wrapped() {
+        let original = b"deflate payload";
+        let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, original).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        assert_eq!(decode_deflate(&compressed, 1024).unwrap(), original);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_deflate_raw_fallback() {
+        // Some servers send raw deflate under `Content-Encoding: deflate`, without the zlib wrapper.
+        let original = b"deflate payload";
+        let mut encoder = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, original).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        assert_eq!(decode_deflate(&compressed, 1024).unwrap(), original);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_deflate_rejects_garbage() {
+        assert!(decode_deflate(b"not compressed data at all", 1024).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_deflate_enforces_decompressed_limit() {
+        // Highly compressible: well under the limit compressed, far past it decompressed.
+        let original = vec![0u8; 1024 * 1024];
+        let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::best());
+        std::io::Write::write_all(&mut encoder, &original).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(compressed.len() < original.len() / 100);
+
+        assert!(decode_deflate(&compressed, 1024).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_zstd_round_trip() {
+        let original = b"zstd payload";
+        let compressed = ruzstd::encoding::compress_to_vec(&original[..], ruzstd::encoding::CompressionLevel::Fastest);
+
+        assert_eq!(decode_zstd(compressed.as_slice(), 1024).unwrap(), original);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_zstd_rejects_garbage() {
+        assert!(decode_zstd(&b"not zstd data"[..], 1024).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_zstd_enforces_decompressed_limit() {
+        let original = vec![0u8; 1024 * 1024];
+        let compressed = ruzstd::encoding::compress_to_vec(&original[..], ruzstd::encoding::CompressionLevel::Fastest);
+        assert!(compressed.len() < 1024);
+
+        assert!(decode_zstd(compressed.as_slice(), 1024).is_err());
     }
 }


### PR DESCRIPTION
## Summary

gzip was already decoded transparently via ureq's built-in decoder, but the response size limit only bounded the on-wire (compressed) bytes, not the decompressed output, so a small compressed body could exhaust memory. deflate/zstd Content-Encoding wasn't recognized at all: ureq passed the raw compressed bytes through and read_to_string() silently reinterpreted them as garbled text instead of erroring.

Close #1997

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
