### PR TITLE
✨ feat(mq-lang): add del_path/del_paths builtins

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -2094,6 +2094,46 @@ def set_path(value, path, new_value):
     end
 end
 
+# Deletes the value at a nested path, following an array of keys/indices, e.g. `del_path(d, ["a", "b", 0])`.
+# An empty path deletes the whole value, mirroring jq's `delpaths([[]])`. A path through a missing
+# intermediate container, or ending in a missing key/out-of-range index, leaves `value` unchanged.
+#
+# Example:
+# ```
+# del_path({"a": {"b": 1, "c": 2}}, ["a", "b"])
+# #=> {"a": {"c": 2}}
+# ```
+#
+# Returns: dynamic
+def del_path(value, path):
+  if (is_empty(path)):
+    None
+  else:
+    do
+      let init = take(path, len(path) - 1)
+      | let key = last(path)
+      | let container = get_path(value, init)
+      | if (has(container, key)):
+          set_path(value, init, del(container, key))
+        else:
+          value
+    end
+end
+
+# Deletes the values at multiple nested paths, e.g. `del_paths(d, [["a"], ["b", 0]])`.
+# Paths are applied deepest-first (via `sort`/`reverse`) so that deleting one array element
+# doesn't shift the indices used by the remaining paths, mirroring jq's `delpaths`.
+#
+# Example:
+# ```
+# del_paths({"a": 1, "b": 2, "c": 3}, [["a"], ["c"]])
+# #=> {"b": 2}
+# ```
+#
+# Returns: dynamic
+def del_paths(value, paths):
+  fold(reverse(sort(paths)), value, fn(acc, p): del_path(acc, p););
+
 # Returns an array of leaf-path arrays for a value, e.g. `paths({"a": {"b": 1}})` returns `[["a", "b"]]`.
 # Each returned path can be passed to `get_path`/`set_path`. Containers with no leaves (e.g. `{}`, `[]`)
 # contribute no paths.

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -1141,6 +1141,42 @@ def test_set_path():
   | assert_eq(result4, {"a": {"b": 10, "c": 20}, "d": [30, 40]})
 end
 
+def test_del_path():
+  let result1 = del_path({"a": {"b": 1, "c": 2}}, ["a", "b"])
+  | assert_eq(result1, {"a": {"c": 2}})
+
+  | let result2 = del_path([1, 2, 3, 4], [1])
+  | assert_eq(result2, [1, 3, 4])
+
+  # A missing intermediate container leaves the value unchanged
+  | let result3 = del_path({"a": 1}, ["x", "y"])
+  | assert_eq(result3, {"a": 1})
+
+  # A missing key leaves the value unchanged
+  | let result4 = del_path({"a": 1}, ["b"])
+  | assert_eq(result4, {"a": 1})
+
+  # An out-of-range array index leaves the value unchanged
+  | let result5 = del_path([1, 2, 3], [10])
+  | assert_eq(result5, [1, 2, 3])
+
+  # An empty path deletes the whole value
+  | let result6 = del_path({"a": 1}, [])
+  | assert_eq(result6, None)
+end
+
+def test_del_paths():
+  let result1 = del_paths({"a": 1, "b": 2, "c": 3}, [["a"], ["c"]])
+  | assert_eq(result1, {"b": 2})
+
+  # Paths are applied deepest-first so index shifts don't affect other deletions
+  | let result2 = del_paths([1, 2, 3, 4], [[0], [2]])
+  | assert_eq(result2, [2, 4])
+
+  | let result3 = del_paths({"a": {"b": 1, "c": 2}}, [["a", "b"], ["a", "c"]])
+  | assert_eq(result3, {"a": {}})
+end
+
 def test_paths():
   let result1 = paths({"a": {"b": 1, "c": 2}, "d": [3, 4]})
   | assert_eq(result1, [["a", "b"], ["a", "c"], ["d", 0], ["d", 1]])


### PR DESCRIPTION
## Summary

Add jq's delpaths equivalent, implemented in pure mq alongside the existing get_path/set_path/paths helpers. del_paths applies deletions deepest-first so array index shifts don't affect other paths.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
