### PR TITLE
✨ feat(mq-run): add --watch flag to re-run queries on file change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1192,7 +1192,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1416,6 +1416,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -2131,6 +2140,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2270,26 @@ dependencies = [
  "futures-core",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -2489,6 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2767,10 +2817,12 @@ dependencies = [
  "mq-lang",
  "mq-markdown",
  "mq-repl",
+ "notify",
  "quick-xml",
  "rayon",
  "regex",
  "rstest",
+ "rustc-hash",
  "rustyline",
  "scopeguard",
  "serde_json",
@@ -2910,12 +2962,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3499,7 +3578,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3880,7 +3959,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3939,7 +4018,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4345,7 +4424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4567,7 +4646,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4586,7 +4665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5633,7 +5712,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ miette = "7.6.0"
 mimalloc = "0.1.48"
 nom = "8.0.0"
 nom_locate = "5.0.0"
+notify = "8.2.0"
 opentelemetry = "0.32"
 opentelemetry-otlp = {version = "0.32", features = ["grpc-tonic"]}
 opentelemetry_sdk = {version = "0.32", features = ["rt-tokio"]}

--- a/crates/mq-run/Cargo.toml
+++ b/crates/mq-run/Cargo.toml
@@ -15,11 +15,12 @@ default-run = "mq"
 [features]
 css-selector = ["mq-lang/css-selector"]
 debugger = ["mq-lang/debugger", "dep:rustyline", "dep:strum", "dep:regex", "mq-dap"]
-default = ["std", "use_mimalloc", "http-import", "css-selector"]
+default = ["std", "use_mimalloc", "http-import", "css-selector", "watch"]
 http-import = ["mq-lang/http-import-ureq"]
 std = []
 tiktoken = ["mq-lang/tiktoken"]
 use_mimalloc = ["mimalloc"]
+watch = ["dep:notify"]
 
 [dependencies]
 clap = {workspace = true, features = ["derive"]}
@@ -35,8 +36,10 @@ mq-help = {workspace = true}
 mq-lang = {workspace = true, features = ["file-io", "process-io"]}
 mq-markdown = {workspace = true, features = ["json", "html-to-markdown", "color"]}
 mq-repl = {workspace = true}
+notify = {workspace = true, optional = true}
 quick-xml = {workspace = true}
 rayon = {workspace = true}
+rustc-hash = {workspace = true}
 serde_json = {workspace = true}
 similar = {workspace = true}
 serde_yaml = {workspace = true}

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -5,7 +5,8 @@ use miette::miette;
 use mq_lang::DefaultEngine;
 use mq_lang::Shared;
 use rayon::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::io::BufRead;
 use std::io::IsTerminal;
@@ -14,6 +15,8 @@ use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
 use std::{fs, path::PathBuf};
 use which::which;
 
@@ -312,6 +315,14 @@ struct InputArgs {
     /// Enable streaming mode for processing large files line by line
     #[arg(long, default_value_t = false)]
     stream: bool,
+
+    /// Watch the input file(s) for changes and automatically re-run the query whenever
+    /// they change. Requires at least one input file (stdin cannot be watched). With
+    /// --from-file, the query file is watched too. Runs until interrupted (Ctrl-C); a
+    /// query error is printed to stderr and watching continues rather than exiting.
+    #[cfg(feature = "watch")]
+    #[arg(long, default_value_t = false)]
+    watch: bool,
 
     /// Evaluate the query once against all input files combined (like yq's `eval-all`),
     /// instead of once per file. Enables cross-file aggregation in a single query.
@@ -1241,12 +1252,10 @@ impl Cli {
             Some(Commands::Dap) => mq_dap::start().map_err(|e| miette!(e.to_string())),
             Some(Commands::Completion { shell }) => Self::generate_completion(shell),
             Some(Commands::Help { name, json, markdown }) => Self::run_help(name.as_deref(), *json, *markdown),
+            #[cfg(feature = "watch")]
+            None if self.input.watch => self.run_watch(),
             None => {
-                let result = if self.input.stream {
-                    self.process_streaming()
-                } else {
-                    self.process_batch()
-                };
+                let result = self.execute_once();
 
                 // --exit-status / -e: exit with code 1 if no truthy value was
                 // produced. Mirrors jq's behaviour: false and null are falsy;
@@ -1630,6 +1639,115 @@ impl Cli {
         }
         let first = self.auto_query_prefix(&files[0].0);
         files[1..].iter().all(|(f, _)| self.auto_query_prefix(f) == first)
+    }
+
+    fn execute_once(&self) -> miette::Result<()> {
+        if self.input.stream {
+            self.process_streaming()
+        } else {
+            self.process_batch()
+        }
+    }
+
+    #[cfg(feature = "watch")]
+    fn watch_targets(&self) -> miette::Result<Vec<PathBuf>> {
+        let mut targets = self.files.clone().unwrap_or_default();
+
+        if targets.is_empty() {
+            return Err(miette!(
+                "--watch requires at least one input file; stdin cannot be watched"
+            ));
+        }
+
+        if self.input.from_file
+            && let Some(query_path) = &self.query
+        {
+            targets.push(PathBuf::from(query_path));
+        }
+
+        Ok(targets)
+    }
+
+    #[cfg(feature = "watch")]
+    fn canonical_parent_dir(path: &Path) -> PathBuf {
+        let dir = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf())
+    }
+
+    /// Errors go to stderr instead of ending the loop, so one bad query doesn't stop watching.
+    #[cfg(feature = "watch")]
+    fn run_once_watch(&self) {
+        if let Err(err) = self.execute_once() {
+            eprintln!("{:?}", err);
+        }
+    }
+
+    /// Watches each target's parent dir (not the file itself) and filters by filename,
+    /// since editors that save via delete-and-rename would break a watch on the file's inode.
+    #[cfg(feature = "watch")]
+    fn run_watch(&self) -> miette::Result<()> {
+        use notify::Watcher as _;
+
+        let watch_paths = self.watch_targets()?;
+        let targets: rustc_hash::FxHashSet<(PathBuf, OsString)> = watch_paths
+            .iter()
+            .filter_map(|p| {
+                p.file_name()
+                    .map(|name| (Self::canonical_parent_dir(p), name.to_os_string()))
+            })
+            .collect();
+
+        eprintln!(
+            "Watching {} file(s) for changes. Press Ctrl-C to stop.",
+            watch_paths.len()
+        );
+        self.run_once_watch();
+
+        let (tx, rx) = mpsc::channel::<PathBuf>();
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            if let Ok(event) = res {
+                for path in event.paths {
+                    let _ = tx.send(path);
+                }
+            }
+        })
+        .map_err(|e| miette!("Failed to start file watcher: {e}"))?;
+
+        let mut watched_dirs = BTreeSet::new();
+        for path in &watch_paths {
+            let dir = Self::canonical_parent_dir(path);
+            if watched_dirs.insert(dir.clone()) {
+                watcher
+                    .watch(&dir, notify::RecursiveMode::NonRecursive)
+                    .map_err(|e| miette!("Failed to watch {}: {e}", dir.display()))?;
+            }
+        }
+
+        loop {
+            let Ok(first) = rx.recv() else {
+                return Ok(());
+            };
+
+            // Debounce: a single save often fires several fs events in quick
+            // succession (write + rename, etc.); coalesce them into one re-run.
+            let mut changed = vec![first];
+            while let Ok(path) = rx.recv_timeout(Duration::from_millis(150)) {
+                changed.push(path);
+            }
+
+            let relevant = changed.iter().any(|p| {
+                p.file_name()
+                    .is_some_and(|name| targets.contains(&(Self::canonical_parent_dir(p), name.to_os_string())))
+            });
+
+            if relevant {
+                eprintln!("\nChange detected, re-running...");
+                self.run_once_watch();
+            }
+        }
     }
 
     fn process_batch(&self) -> Result<(), miette::Error> {
@@ -5125,5 +5243,51 @@ mod tests {
             ..Cli::default()
         };
         assert!(cli.run().is_ok(), "--args with a valid NAME VALUE pair should succeed");
+    }
+
+    #[cfg(feature = "watch")]
+    #[test]
+    fn test_watch_targets_requires_a_file() {
+        let cli = Cli {
+            files: None,
+            query: Some("self".to_string()),
+            ..Cli::default()
+        };
+        assert!(
+            cli.watch_targets().is_err(),
+            "--watch on stdin (no files) should be rejected"
+        );
+    }
+
+    #[cfg(feature = "watch")]
+    #[test]
+    fn test_watch_targets_includes_input_files() {
+        let file = PathBuf::from("input.md");
+        let cli = Cli {
+            files: Some(vec![file.clone()]),
+            query: Some("self".to_string()),
+            ..Cli::default()
+        };
+        assert_eq!(cli.watch_targets().unwrap(), vec![file]);
+    }
+
+    #[cfg(feature = "watch")]
+    #[test]
+    fn test_watch_targets_includes_query_file_when_from_file() {
+        let input_file = PathBuf::from("input.md");
+        let query_file = "query.mq";
+        let cli = Cli {
+            input: InputArgs {
+                from_file: true,
+                ..Default::default()
+            },
+            files: Some(vec![input_file.clone()]),
+            query: Some(query_file.to_string()),
+            ..Cli::default()
+        };
+        assert_eq!(
+            cli.watch_targets().unwrap(),
+            vec![input_file, PathBuf::from(query_file)]
+        );
     }
 }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1685,6 +1685,41 @@ impl Cli {
         }
     }
 
+    /// A `[filename]` tag for status lines, so they're never mistaken for query output
+    /// interleaved on the same terminal. Colorized when possible, plain text otherwise.
+    #[cfg(feature = "watch")]
+    fn watch_badge(watch_paths: &[PathBuf]) -> String {
+        let names: Vec<String> = watch_paths
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .map_or_else(|| p.display().to_string(), |n| n.to_string_lossy().to_string())
+            })
+            .collect();
+        let label = if names.len() <= 3 {
+            names.join(",")
+        } else {
+            format!("{} files", names.len())
+        };
+        let tag = format!("[{label}]");
+
+        if io::stderr().is_terminal() && !Self::is_no_color() {
+            tag.cyan().bold().to_string()
+        } else {
+            tag
+        }
+    }
+
+    #[cfg(feature = "watch")]
+    fn watch_divider() -> String {
+        let line = "─".repeat(40);
+        if io::stderr().is_terminal() && !Self::is_no_color() {
+            line.dimmed().to_string()
+        } else {
+            line
+        }
+    }
+
     /// Watches each target's parent dir (not the file itself) and filters by filename,
     /// since editors that save via delete-and-rename would break a watch on the file's inode.
     #[cfg(feature = "watch")]
@@ -1701,8 +1736,8 @@ impl Cli {
             .collect();
 
         eprintln!(
-            "Watching {} file(s) for changes. Press Ctrl-C to stop.",
-            watch_paths.len()
+            "{} Watching for changes. Press Ctrl-C to stop.",
+            Self::watch_badge(&watch_paths)
         );
         self.run_once_watch();
 
@@ -1744,7 +1779,11 @@ impl Cli {
             });
 
             if relevant {
-                eprintln!("\nChange detected, re-running...");
+                eprintln!(
+                    "\n{}\n{} Changed, re-running...",
+                    Self::watch_divider(),
+                    Self::watch_badge(&watch_paths)
+                );
                 self.run_once_watch();
             }
         }

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -1501,3 +1501,76 @@ fn test_completion(#[case] shell: &str, #[case] expected_substring: &str) -> Res
 
     Ok(())
 }
+
+#[test]
+fn test_watch_requires_input_file() {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+
+    cmd.arg("--watch").arg(".h").write_stdin("# hello").assert().failure();
+}
+
+#[test]
+fn test_watch_reruns_on_file_change() -> Result<(), Box<dyn std::error::Error>> {
+    use assert_cmd::prelude::*;
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    let (_, file_path) = create_file("test_watch_reruns_on_file_change.md", "# hello\n");
+    let file_path_clone = file_path.clone();
+    defer! {
+        std::fs::remove_file(&file_path_clone).ok();
+    }
+
+    let mut child = Command::cargo_bin("mq")?
+        .arg("--watch")
+        .arg(".h")
+        .arg(&file_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let stdout = child.stdout.take().expect("child stdout was piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Bounded polling rather than a fixed sleep: passes as soon as the line shows up,
+    // only takes the full timeout if the watcher is actually broken.
+    let wait_for = |expected: &str, timeout: Duration| -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+                Ok(line) if line == expected => return true,
+                Ok(_) => {}
+                Err(_) => return false,
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+        }
+    };
+
+    assert!(
+        wait_for("# hello", Duration::from_secs(10)),
+        "expected the initial run to print the file's current heading"
+    );
+
+    std::fs::write(&file_path, "# updated\n")?;
+
+    assert!(
+        wait_for("# updated", Duration::from_secs(10)),
+        "expected a re-run to print the heading after the file changed"
+    );
+
+    child.kill()?;
+    child.wait()?;
+
+    Ok(())
+}

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow = [
   "Apache-2.0",
   "BSD-3-Clause",
   "BSL-1.0",
+  "CC0-1.0",
   "CDLA-Permissive-2.0",
   "ISC",
   "MIT",


### PR DESCRIPTION
## Summary

Watches each input file's (and, with --from-file, the query file's) parent directory via notify and re-runs the query on change, filtering events by filename since editors that save via delete-and-rename break a watch placed directly on the file's inode. Gated behind a new default-enabled `watch` Cargo feature.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
