### PR TITLE
✅ test(mq-markdown): check -U round-trip fidelity against the GFM spec suite

### DIFF
--- a/.github/workflows/gfm-spec.yml
+++ b/.github/workflows/gfm-spec.yml
@@ -1,0 +1,23 @@
+name: GFM spec round-trip fidelity
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gfm_roundtrip:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Run GFM spec round-trip check
+        run: just test-gfm-spec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,7 @@ dependencies = [
  "serde_yaml",
  "smol_str",
  "unicode-width 0.2.2",
+ "ureq",
  "url",
 ]
 

--- a/crates/mq-markdown/Cargo.toml
+++ b/crates/mq-markdown/Cargo.toml
@@ -29,6 +29,7 @@ url = {workspace = true, optional = true}
 divan = {workspace = true}
 proptest = {workspace = true}
 rstest = {workspace = true}
+ureq = {workspace = true}
 
 [[bench]]
 harness = false

--- a/crates/mq-markdown/tests/gfm_roundtrip_fidelity.rs
+++ b/crates/mq-markdown/tests/gfm_roundtrip_fidelity.rs
@@ -1,0 +1,143 @@
+//! Checks that the parse+render round trip used by `-U` preserves rendered
+//! meaning across the GFM spec's example corpus, the same methodology used
+//! to find https://github.com/harehare/mq/issues/2148.
+//!
+//! Not run by `just test-all` because it fetches `spec.txt` over the network
+//! on every run; run it explicitly via `just test-gfm-spec`.
+//!
+//! The spec text itself (CC-BY-SA 4.0, distinct from mq's own MIT license)
+//! is intentionally not vendored into this repository. It's fetched fresh
+//! from a pinned commit of `github/cmark-gfm` so nothing under that license
+//! is stored in or distributed with mq, and so the example numbering behind
+//! `KNOWN_FAILURES` below stays stable.
+
+use mq_markdown::{Markdown, to_html};
+
+const SPEC_URL: &str =
+    "https://raw.githubusercontent.com/github/cmark-gfm/828322d1ee4facdab56f0d3edccb13e9af90dcd2/test/spec.txt";
+
+struct SpecExample {
+    number: usize,
+    section: String,
+    markdown: String,
+}
+
+/// Parses the CommonMark/GFM `spec.txt` example format: sections are `#`
+/// headings, and each example is a fence of 32 backticks followed by
+/// `example`, the markdown source, a lone `.` line, the expected HTML, then
+/// a closing fence matching the opening one. The expected HTML is skipped;
+/// this only needs the markdown source to run its own before/after check.
+fn parse_spec_examples(text: &str) -> Vec<SpecExample> {
+    let fence = "`".repeat(32);
+    let open = format!("{fence} example");
+
+    let mut examples = Vec::new();
+    let mut section = String::new();
+    let mut number = 0usize;
+    let mut lines = text.lines();
+
+    while let Some(line) = lines.next() {
+        if let Some(rest) = line.strip_prefix('#') {
+            section = rest.trim_start_matches('#').trim().to_string();
+            continue;
+        }
+        if line == open {
+            let mut markdown_lines: Vec<&str> = Vec::new();
+            for l in lines.by_ref() {
+                if l == "." {
+                    break;
+                }
+                markdown_lines.push(l);
+            }
+            for l in lines.by_ref() {
+                if l == fence {
+                    break;
+                }
+            }
+            number += 1;
+            examples.push(SpecExample {
+                number,
+                section: section.clone(),
+                // `→` is spec.txt's only escape, standing in for a literal tab.
+                markdown: markdown_lines.join("\n").replace('\u{2192}', "\t") + "\n",
+            });
+        }
+    }
+    examples
+}
+
+/// Examples where the round trip currently changes rendered meaning, by
+/// number in the spec revision pinned above. Remove an entry once it's
+/// fixed; add one (with its section) if a new gap turns up.
+const KNOWN_FAILURES: &[usize] = &[
+    5, 6, 7,   // Tabs
+    116, // Fenced code blocks
+    219, // Block quotes
+    227, 229, 248, 262, 263, 269, // List items
+    271, 272, 283, 295, // Lists
+    300, 306, // Backslash escapes
+    325, 326, // Entity and numeric character references
+    346, // Code spans
+    479, 480, // Emphasis and strong emphasis
+    490, 522, 534, // Links
+    569, 570, 572, 581, 585, 589, // Images
+    599, 602, // Autolinks
+];
+
+#[test]
+#[ignore = "fetches spec.txt over the network; run via `just test-gfm-spec`"]
+fn gfm_round_trip_fidelity() {
+    let body = ureq::get(SPEC_URL)
+        .call()
+        .expect("failed to fetch the GFM spec")
+        .body_mut()
+        .read_to_string()
+        .expect("failed to read the GFM spec response body");
+
+    let examples = parse_spec_examples(&body);
+    assert!(
+        examples.len() > 600,
+        "parsed only {} examples from spec.txt, the parser is likely out of sync with its format",
+        examples.len()
+    );
+
+    let mut new_failures = Vec::new();
+    let mut newly_fixed = Vec::new();
+
+    for example in &examples {
+        let before = to_html(&example.markdown);
+        let round_tripped = example
+            .markdown
+            .parse::<Markdown>()
+            .unwrap_or_else(|e| panic!("example #{} [{}] failed to parse: {e}", example.number, example.section))
+            .to_string();
+        let after = to_html(&round_tripped);
+
+        let changed = before != after;
+        let known = KNOWN_FAILURES.contains(&example.number);
+
+        if changed && !known {
+            new_failures.push(format!("#{} [{}]", example.number, example.section));
+        } else if !changed && known {
+            newly_fixed.push(example.number);
+        }
+    }
+
+    assert!(
+        new_failures.is_empty(),
+        "new round-trip fidelity regressions not in KNOWN_FAILURES: {new_failures:#?}"
+    );
+    assert!(
+        newly_fixed.is_empty(),
+        "these examples round-trip correctly now, remove them from KNOWN_FAILURES: {newly_fixed:?}"
+    );
+
+    // Passing only means no *new* regressions were found, not that
+    // round-trip fidelity is complete: this many examples are still known
+    // to be broken and tracked in KNOWN_FAILURES above.
+    println!(
+        "{} known round-trip fidelity gaps still open, out of {} examples checked",
+        KNOWN_FAILURES.len(),
+        examples.len()
+    );
+}

--- a/justfile
+++ b/justfile
@@ -85,6 +85,10 @@ fmt:
 test-mq:
     cargo run -p mq-test -- crates/mq-lang/builtin_tests.mq crates/mq-lang/modules/*_test.mq
 
+# Check -U round-trip fidelity against the GFM spec examples (fetches spec.txt over the network)
+test-gfm-spec:
+    cargo test -p mq-markdown --test gfm_roundtrip_fidelity -- --ignored --nocapture
+
 test-doc:
     cargo test --doc --workspace
 


### PR DESCRIPTION
## Summary

Adds an integration test that parses the GFM spec's example corpus directly from spec.txt and compares rendered HTML before/after the same parse+render round trip -U performs, the same methodology used to find #2148. spec.txt is fetched from a pinned cmark-gfm commit rather than vendored, since it's CC-BY-SA 4.0 and mq is MIT.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [x] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
