### PR TITLE
✅ test(mq-lang): convert repeated test cases to @parametrize 

### DIFF
--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -1,71 +1,39 @@
-include "test"
+include "test" |
 
-|
-
-def test_is_array():
-  let result1 = is_array([1, 2, 3])
-  | assert_eq(result1, true)
-
-  | let result2 = is_array("string")
-  | assert_eq(result2, false)
-
-  | let result3 = is_array(42)
-  | assert_eq(result3, false)
+# @parametrize([[[1, 2, 3], true], ["string", false], [42, false], [None, false], [dict(), false]])
+def test_is_array(arr, expected):
+  let result1 = is_array(arr)
+  | assert_eq(result1, expected)
 end
 
-def test_is_bool():
-  let result1 = is_bool(true)
-  | assert_eq(result1, true)
-
-  | let result2 = is_bool(false)
-  | assert_eq(result2, true)
-
-  | let result3 = is_bool(1)
-  | assert_eq(result3, false)
+# @parametrize([[true, true], [false, true], [1, false]])
+def test_is_bool(value, expected):
+  let result = is_bool(value)
+  | assert_eq(result, expected)
 end
 
-def test_is_number():
-  let result1 = is_number(42)
-  | assert_eq(result1, true)
-
-  | let result2 = is_number(3.14)
-  | assert_eq(result2, true)
-
-  | let result3 = is_number("42")
-  | assert_eq(result3, false)
+# @parametrize([[42, true], [3.14, true], ["42", false]])
+def test_is_number(value, expected):
+  let result = is_number(value)
+  | assert_eq(result, expected)
 end
 
-def test_is_string():
-  let result1 = is_string("hello")
-  | assert_eq(result1, true)
-
-  | let result2 = is_string(42)
-  | assert_eq(result2, false)
-
-  | let result3 = is_string([])
-  | assert_eq(result3, false)
+# @parametrize([["hello", true], [42, false], [[], false]])
+def test_is_string(value, expected):
+  let result = is_string(value)
+  | assert_eq(result, expected)
 end
 
-def test_is_none():
-  let result1 = is_none(None)
-  | assert_eq(result1, true)
-
-  | let result2 = is_none(0)
-  | assert_eq(result2, false)
-
-  | let result3 = is_none("")
-  | assert_eq(result3, false)
+# @parametrize([[None, true], [0, false], ["", false]])
+def test_is_none(value, expected):
+  let result = is_none(value)
+  | assert_eq(result, expected)
 end
 
-def test_is_dict():
-  let result1 = is_dict(dict())
-  | assert_eq(result1, true)
-
-  | let result2 = is_dict({"key": "value"})
-  | assert_eq(result2, true)
-
-  | let result3 = is_dict([])
-  | assert_eq(result3, false)
+# @parametrize([[dict(), true], [{"key": "value"}, true], [[], false]])
+def test_is_dict(value, expected):
+  let result = is_dict(value)
+  | assert_eq(result, expected)
 end
 
 def test_is_mdx():
@@ -79,449 +47,260 @@ def test_is_mdx():
   | assert_eq(result3, false)
 end
 
-def test_is_callout():
-  let result1 = do "> [!NOTE]\n> This is a note." | to_markdown() | first() | is_callout();
-  | assert_eq(result1, true)
+# @parametrize([["> [!NOTE]\n> This is a note.", true], ["> [!WARNING]\n> Watch out!", true], ["> [!WARNING] Watch out!", true], ["> Just a plain blockquote.", false]])
+def test_is_callout(markdown, expected):
+  let node = do markdown | to_markdown() | first();
+  | let result = is_callout(node)
+  | assert_eq(result, expected)
+end
 
-  | let result2 = do "> [!WARNING]\n> Watch out!" | to_markdown() | first() | is_callout();
-  | assert_eq(result2, true)
-
-  | let result3 = do "> [!WARNING] Watch out!" | to_markdown() | first() | is_callout();
-  | assert_eq(result3, true)
-
-  | let result4 = do "> Just a plain blockquote." | to_markdown() | first() | is_callout();
-  | assert_eq(result4, false)
-
-  | let result5 = is_callout("not a blockquote")
-  | assert_eq(result5, false)
+def test_is_callout_non_node():
+  let result = is_callout("not a blockquote")
+  | assert_eq(result, false)
 end
 
 # String manipulation tests
-def test_contains():
-  let result1 = contains("hello world", "world")
-  | assert_eq(result1, true)
-
-  | let result2 = contains("hello world", "foo")
-  | assert_eq(result2, false)
-
-  | let result3 = contains({"a": 1, "b": 2}, "a")
-  | assert_eq(result3, true)
-
-  | let result4 = contains({"a": 1, "b": 2}, "c")
-  | assert_eq(result4, false)
+# @parametrize([["hello world", "world", true], ["hello world", "foo", false], [{"a": 1, "b": 2}, "a", true], [{"a": 1, "b": 2}, "c", false]])
+def test_contains(value, needle, expected):
+  let result = contains(value, needle)
+  | assert_eq(result, expected)
 end
 
-def test_ltrimstr():
-  let result1 = ltrimstr("hello world", "hello ")
-  | assert_eq(result1, "world")
-
-  | let result2 = ltrimstr("hello world", "foo")
-  | assert_eq(result2, "hello world")
-
-  | let result3 = ltrimstr("test", "test")
-  | assert_eq(result3, "")
+# @parametrize([["hello world", "hello ", "world"], ["hello world", "foo", "hello world"], ["test", "test", ""]])
+def test_ltrimstr(value, prefix, expected):
+  let result = ltrimstr(value, prefix)
+  | assert_eq(result, expected)
 end
 
-def test_rtrimstr():
-  let result1 = rtrimstr("hello world", " world")
-  | assert_eq(result1, "hello")
-
-  | let result2 = rtrimstr("hello world", "foo")
-  | assert_eq(result2, "hello world")
-
-  | let result3 = rtrimstr("test", "test")
-  | assert_eq(result3, "")
+# @parametrize([["hello world", " world", "hello"], ["hello world", "foo", "hello world"], ["test", "test", ""]])
+def test_rtrimstr(value, suffix, expected):
+  let result = rtrimstr(value, suffix)
+  | assert_eq(result, expected)
 end
 
 # Collection tests
-def test_is_empty():
-  let result1 = is_empty([])
-  | assert_eq(result1, true)
-
-  | let result2 = is_empty("")
-  | assert_eq(result2, true)
-
-  | let result3 = is_empty(dict())
-  | assert_eq(result3, true)
-
-  | let result4 = is_empty([1, 2, 3])
-  | assert_eq(result4, false)
-
-  | let result5 = is_empty("hello")
-  | assert_eq(result5, false)
-
-  | let result6 = is_empty(None)
-  | assert_eq(result6, true)
-
-  | let result7 = is_empty(b"binary\x20data")
-  | assert_eq(result7, false)
-
-  | let result8 = is_empty(b"")
-  | assert_eq(result8, true)
-
+# @parametrize([[[], true], ["", true], [dict(), true], [[1, 2, 3], false], ["hello", false], [None, true], [b"binary\x20data", false], [b"", true]])
+def test_is_empty(value, expected):
+  let result = is_empty(value)
+  | assert_eq(result, expected)
 end
 
 # Selector tests
-def test_select():
-  let result1 = select(42, true)
-  | assert_eq(result1, 42)
-
-  | let result2 = select(42, false)
-  | assert_eq(result2, None)
+# @parametrize([[42, true, 42], [42, false, None]])
+def test_select(value, cond, expected):
+  let result = select(value, cond)
+  | assert_eq(result, expected)
 end
 
-def test_arrays():
-  let result1 = arrays([1, 2, 3])
-  | assert_eq(result1, [1, 2, 3])
-
-  | let result2 = arrays("not an array")
-  | assert_eq(result2, None)
+# @parametrize([[[1, 2, 3], [1, 2, 3]], ["not an array", None]])
+def test_arrays(value, expected):
+  let result = arrays(value)
+  | assert_eq(result, expected)
 end
 
-def test_booleans():
-  let result1 = booleans(true)
-  | assert_eq(result1, true)
-
-  | let result2 = booleans(42)
-  | assert_eq(result2, None)
+# @parametrize([[true, true], [42, None]])
+def test_booleans(value, expected):
+  let result = booleans(value)
+  | assert_eq(result, expected)
 end
 
-def test_numbers():
-  let result1 = numbers(42)
-  | assert_eq(result1, 42)
-
-  | let result2 = numbers("42")
-  | assert_eq(result2, None)
+# @parametrize([[42, 42], ["42", None]])
+def test_numbers(value, expected):
+  let result = numbers(value)
+  | assert_eq(result, expected)
 end
 
-def test_strings():
-  let result1 = strings("hello")
-  | assert_eq(result1, "hello")
-
-  | let result2 = strings(42)
-  | assert_eq(result2, None)
+# @parametrize([["hello", "hello"], [42, None]])
+def test_strings(value, expected):
+  let result = strings(value)
+  | assert_eq(result, expected)
 end
 
-def test_dicts():
-  let result1 = dicts({"a": 1})
-  | assert_eq(result1, {"a": 1})
-
-  | let result2 = dicts([1, 2])
-  | assert_eq(result2, None)
+# @parametrize([[{"a": 1}, {"a": 1}], [[1, 2], None]])
+def test_dicts(value, expected):
+  let result = dicts(value)
+  | assert_eq(result, expected)
 end
 
-def test_nones():
-  let result1 = nones(None)
-  | assert_eq(result1, None)
-
-  | let result2 = nones(42)
-  | assert_eq(result2, None)
+# @parametrize([[None, None], [42, None]])
+def test_nones(value, expected):
+  let result = nones(value)
+  | assert_eq(result, expected)
 end
 
-def test_bytes():
-  let result1 = bytes(b"data")
-  | assert_eq(result1, b"data")
-
-  | let result2 = bytes("not bytes")
-  | assert_eq(result2, None)
+# @parametrize([[b"data", b"data"], ["not bytes", None]])
+def test_bytes(value, expected):
+  let result = bytes(value)
+  | assert_eq(result, expected)
 end
 
-def test_iterables():
-  let result1 = iterables([1, 2, 3])
-  | assert_eq(result1, [1, 2, 3])
-
-  | let result2 = iterables({"a": 1})
-  | assert_eq(result2, {"a": 1})
-
-  | let result3 = iterables(42)
-  | assert_eq(result3, None)
+# @parametrize([[[1, 2, 3], [1, 2, 3]], [{"a": 1}, {"a": 1}], [42, None]])
+def test_iterables(value, expected):
+  let result = iterables(value)
+  | assert_eq(result, expected)
 end
 
-def test_scalars():
-  let result1 = scalars(42)
-  | assert_eq(result1, 42)
-
-  | let result2 = scalars("hello")
-  | assert_eq(result2, "hello")
-
-  | let result3 = scalars([1, 2, 3])
-  | assert_eq(result3, None)
-
-  | let result4 = scalars({"a": 1})
-  | assert_eq(result4, None)
+# @parametrize([[42, 42], ["hello", "hello"], [[1, 2, 3], None], [{"a": 1}, None]])
+def test_scalars(value, expected):
+  let result = scalars(value)
+  | assert_eq(result, expected)
 end
 
 # Array manipulation tests
-def test_map():
-  let result1 = map([1, 2, 3], fn(x): x * 2;)
-  | assert_eq(result1, [2, 4, 6])
-
-  | let result2 = map({"a": 1, "b": 2}, fn(x): [x[0], x[1] * 2];)
-  | assert_eq(result2, {"a": 2, "b": 4})
-
-  | let result3 = map(None, fn(x): [x[0], x[1] * 2];)
-  | assert_eq(result3, None)
+# @parametrize([[[1, 2, 3], fn(x): x * 2;, [2, 4, 6]], [{"a": 1, "b": 2}, fn(x): [x[0], x[1] * 2];, {"a": 2, "b": 4}], [None, fn(x): [x[0], x[1] * 2];, None]])
+def test_map(value, f, expected):
+  let result = map(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_flat_map():
-  let result1 = flat_map([1, 2, 3], fn(x): [x, x * 2];)
-  | assert_eq(result1, [1, 2, 2, 4, 3, 6])
-
-  | let result2 = flat_map([[1, 2], [3, 4]], fn(x): x;)
-  | assert_eq(result2, [1, 2, 3, 4])
-
-  | let result3 = flat_map(None, fn(x): [x[0], x[1] * 2];)
-  | assert_eq(result3, None)
+# @parametrize([[[1, 2, 3], fn(x): [x, x * 2];, [1, 2, 2, 4, 3, 6]], [[[1, 2], [3, 4]], fn(x): x;, [1, 2, 3, 4]], [None, fn(x): [x[0], x[1] * 2];, None]])
+def test_flat_map(value, f, expected):
+  let result = flat_map(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_filter():
-  let result1 = filter([1, 2, 3, 4, 5], fn(x): x > 2;)
-  | assert_eq(result1, [3, 4, 5])
-
-  | let result2 = filter({"a": 1, "b": 2, "c": 3}, fn(x): x[1] > 1;)
-  | assert_eq(result2, {"b": 2, "c": 3})
-
-  | let result3 = filter(None, fn(x): [x[0], x[1] * 2];)
-  | assert_eq(result3, None)
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 2;, [3, 4, 5]], [{"a": 1, "b": 2, "c": 3}, fn(x): x[1] > 1;, {"b": 2, "c": 3}], [None, fn(x): [x[0], x[1] * 2];, None]])
+def test_filter(value, f, expected):
+  let result = filter(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_first():
-  let result1 = first([1, 2, 3])
-  | assert_eq(result1, 1)
-
-  | let result2 = first([])
-  | assert_eq(result2, None)
+# @parametrize([[[1, 2, 3], 1], [[], None]])
+def test_first(value, expected):
+  let result = first(value)
+  | assert_eq(result, expected)
 end
 
-def test_last():
-  let result1 = last([1, 2, 3])
-  | assert_eq(result1, 3)
-
-  | let result2 = last([42])
-  | assert_eq(result2, 42)
+# @parametrize([[[1, 2, 3], 3], [[42], 42]])
+def test_last(value, expected):
+  let result = last(value)
+  | assert_eq(result, expected)
 end
 
-def test_second():
-  let result1 = second([1, 2, 3])
-  | assert_eq(result1, 2)
-
-  | let result2 = second([42])
-  | assert_eq(result2, None)
+# @parametrize([[[1, 2, 3], 2], [[42], None]])
+def test_second(value, expected):
+  let result = second(value)
+  | assert_eq(result, expected)
 end
 
-def test_fill():
-  let result1 = fill("x", 3)
-  | assert_eq(result1, ["x", "x", "x"])
-
-  | let result2 = fill(0, 0)
-  | assert_eq(result2, [])
-
-  | let result3 = fill(42, 2)
-  | assert_eq(result3, [42, 42])
+# @parametrize([["x", 3, ["x", "x", "x"]], [0, 0, []], [42, 2, [42, 42]]])
+def test_fill(value, n, expected):
+  let result = fill(value, n)
+  | assert_eq(result, expected)
 end
 
-def test_sort_natural():
-  let result1 = sort_natural(["file10", "file2", "file1"])
-  | assert_eq(result1, ["file1", "file2", "file10"])
-
-  | let result2 = sort_natural(["chapter-2.md", "chapter-10.md", "chapter-1.md"])
-  | assert_eq(result2, ["chapter-1.md", "chapter-2.md", "chapter-10.md"])
-
-  | let result3 = sort_natural([])
-  | assert_eq(result3, [])
+# @parametrize([[["file10", "file2", "file1"], ["file1", "file2", "file10"]], [["chapter-2.md", "chapter-10.md", "chapter-1.md"], ["chapter-1.md", "chapter-2.md", "chapter-10.md"]], [[], []]])
+def test_sort_natural(value, expected):
+  let result = sort_natural(value)
+  | assert_eq(result, expected)
 end
 
-def test_skip():
-  let result1 = skip([1, 2, 3, 4, 5], 2)
-  | assert_eq(result1, [3, 4, 5])
-
-  | let result2 = skip([1, 2, 3], 0)
-  | assert_eq(result2, [1, 2, 3])
-
-  | let result3 = skip([1, 2, 3], 5)
-  | assert_eq(result3, [])
+# @parametrize([[[1, 2, 3, 4, 5], 2, [3, 4, 5]], [[1, 2, 3], 0, [1, 2, 3]], [[1, 2, 3], 5, []]])
+def test_skip(value, n, expected):
+  let result = skip(value, n)
+  | assert_eq(result, expected)
 end
 
-def test_take():
-  let result1 = take([1, 2, 3, 4, 5], 3)
-  | assert_eq(result1, [1, 2, 3])
-
-  | let result2 = take([1, 2, 3], 0)
-  | assert_eq(result2, [])
-
-  | let result3 = take([1, 2, 3], 5)
-  | assert_eq(result3, [1, 2, 3])
+# @parametrize([[[1, 2, 3, 4, 5], 3, [1, 2, 3]], [[1, 2, 3], 0, []], [[1, 2, 3], 5, [1, 2, 3]]])
+def test_take(value, n, expected):
+  let result = take(value, n)
+  | assert_eq(result, expected)
 end
 
-def test_find_index():
-  let result1 = find_index([1, 2, 3, 4, 5], fn(x): x == 3;)
-  | assert_eq(result1, 2)
-
-  | let result2 = find_index([1, 2, 3, 4, 5], fn(x): x > 10;)
-  | assert_eq(result2, -1)
-
-  | let result3 = find_index([10, 20, 30], fn(x): x == 10;)
-  | assert_eq(result3, 0)
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x == 3;, 2], [[1, 2, 3, 4, 5], fn(x): x > 10;, -1], [[10, 20, 30], fn(x): x == 10;, 0]])
+def test_find_index(value, f, expected):
+  let result = find_index(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_skip_while():
-  let result1 = skip_while([1, 2, 3, 4, 5], fn(x): x < 3;)
-  | assert_eq(result1, [3, 4, 5])
-
-  | let result2 = skip_while([1, 2, 3], fn(x): x > 10;)
-  | assert_eq(result2, [1, 2, 3])
-
-  | let result3 = skip_while([], fn(x): x < 5;)
-  | assert_eq(result3, [])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x < 3;, [3, 4, 5]], [[1, 2, 3], fn(x): x > 10;, [1, 2, 3]], [[], fn(x): x < 5;, []]])
+def test_skip_while(value, f, expected):
+  let result = skip_while(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_take_while():
-  let result1 = take_while([1, 2, 3, 4, 5], fn(x): x < 4;)
-  | assert_eq(result1, [1, 2, 3])
-
-  | let result2 = take_while([1, 2, 3], fn(x): x > 10;)
-  | assert_eq(result2, [])
-
-  | let result3 = take_while([], fn(x): x < 5;)
-  | assert_eq(result3, [])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x < 4;, [1, 2, 3]], [[1, 2, 3], fn(x): x > 10;, []], [[], fn(x): x < 5;, []]])
+def test_take_while(value, f, expected):
+  let result = take_while(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_group_by():
-  let result1 = group_by([1, 2, 3, 4, 5, 6], fn(x): x % 2;)
-  | assert_eq(result1["0"], [2, 4, 6])
-  | assert_eq(result1["1"], [1, 3, 5])
-
-  | let result2 = group_by([], fn(x): x;)
-  | assert_eq(result2, dict())
+# @parametrize([[[1, 2, 3, 4, 5, 6], fn(x): x % 2;, {"0": [2, 4, 6], "1": [1, 3, 5]}], [[], fn(x): x;, dict()]])
+def test_group_by(value, f, expected):
+  let result = group_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_frequencies_by():
-  let result1 = frequencies_by([1, 2, 3, 4, 5, 6], fn(x): x % 2;)
-  | assert_eq(result1["0"], 3)
-  | assert_eq(result1["1"], 3)
-
-  | let result2 = frequencies_by([], fn(x): x;)
-  | assert_eq(result2, dict())
+# @parametrize([[[1, 2, 3, 4, 5, 6], fn(x): x % 2;, {"0": 3, "1": 3}], [[], fn(x): x;, dict()]])
+def test_frequencies_by(value, f, expected):
+  let result = frequencies_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_tally():
-  let result1 = tally(["a", "b", "a", "c", "b", "a"])
-  | assert_eq(result1["a"], 3)
-  | assert_eq(result1["b"], 2)
-  | assert_eq(result1["c"], 1)
-
-  | let result2 = tally([])
-  | assert_eq(result2, dict())
+# @parametrize([[["a", "b", "a", "c", "b", "a"], {"a": 3, "b": 2, "c": 1}], [[], dict()]])
+def test_tally(value, expected):
+  let result = tally(value)
+  | assert_eq(result, expected)
 end
 
-def test_count_by():
-  let result1 = count_by([1, 2, 3, 4, 5], fn(x): x > 2;)
-  | assert_eq(result1, 3)
-
-  | let result2 = count_by([1, 2, 3, 4, 5], fn(x): x > 10;)
-  | assert_eq(result2, 0)
-
-  | let result3 = count_by([], fn(x): x > 0;)
-  | assert_eq(result3, 0)
-
-  | let result4 = count_by([2, 4, 6, 8], fn(x): x % 2 == 0;)
-  | assert_eq(result4, 4)
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 2;, 3], [[1, 2, 3, 4, 5], fn(x): x > 10;, 0], [[], fn(x): x > 0;, 0], [[2, 4, 6, 8], fn(x): x % 2 == 0;, 4]])
+def test_count_by(value, f, expected):
+  let result = count_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_any():
-  let result1 = any([1, 2, 3, 4, 5], fn(x): x > 3;)
-  | assert_eq(result1, true)
-
-  | let result2 = any([1, 2, 3], fn(x): x > 10;)
-  | assert_eq(result2, false)
-
-  | let result3 = any([], fn(x): x > 0;)
-  | assert_eq(result3, false)
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 3;, true], [[1, 2, 3], fn(x): x > 10;, false], [[], fn(x): x > 0;, false]])
+def test_any(value, f, expected):
+  let result = any(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_all():
-  let result1 = all([1, 2, 3, 4, 5], fn(x): x > 0;)
-  | assert_eq(result1, true)
-
-  | let result2 = all([1, 2, 3, 4, 5], fn(x): x > 3;)
-  | assert_eq(result2, false)
-
-  | let result3 = all([], fn(x): x > 0;)
-  | assert_eq(result3, true)
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 0;, true], [[1, 2, 3, 4, 5], fn(x): x > 3;, false], [[], fn(x): x > 0;, true]])
+def test_all(value, f, expected):
+  let result = all(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_in():
-  let result1 = in([1, 2, 3, 4, 5], 3)
-  | assert_eq(result1, true)
-
-  | let result2 = in([1, 2, 3], 10)
-  | assert_eq(result2, false)
-
-  | let result3 = in([1, 2, 3, 4, 5], [2, 3])
-  | assert_eq(result3, true)
-
-  | let result4 = in("hello world", "world")
-  | assert_eq(result4, true)
+# @parametrize([[[1, 2, 3, 4, 5], 3, true], [[1, 2, 3], 10, false], [[1, 2, 3, 4, 5], [2, 3], true], ["hello world", "world", true]])
+def test_in(value, needle, expected):
+  let result = in(value, needle)
+  | assert_eq(result, expected)
 end
 
-def test_fold():
-  let result1 = fold([1, 2, 3, 4, 5], 0, fn(acc, x): acc + x;)
-  | assert_eq(result1, 15)
-
-  | let result2 = fold([1, 2, 3], 1, fn(acc, x): acc * x;)
-  | assert_eq(result2, 6)
-
-  | let result3 = fold([], 10, fn(acc, x): acc + x;)
-  | assert_eq(result3, 10)
+# @parametrize([[[1, 2, 3, 4, 5], 0, fn(acc, x): acc + x;, 15], [[1, 2, 3], 1, fn(acc, x): acc * x;, 6], [[], 10, fn(acc, x): acc + x;, 10]])
+def test_fold(value, init, f, expected):
+  let result = fold(value, init, f)
+  | assert_eq(result, expected)
 end
 
-def test_unique_by():
-  let result1 = unique_by([1, 2, 3, 2, 1, 4], fn(x): x;)
-  | assert_eq(result1, [1, 2, 3, 4])
-
-  | let result2 = unique_by([{"id": 1}, {"id": 2}, {"id": 1}], fn(x): x["id"];)
-  | assert_eq(len(result2), 2)
-
-  | let result3 = unique_by([], fn(x): x;)
-  | assert_eq(result3, [])
+# @parametrize([[[1, 2, 3, 2, 1, 4], fn(x): x;, [1, 2, 3, 4]], [[{"id": 1}, {"id": 2}, {"id": 1}], fn(x): x["id"];, [{"id": 1}, {"id": 2}]], [[], fn(x): x;, []]])
+def test_unique_by(value, f, expected):
+  let result = unique_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_identity():
-  let result1 = identity(42)
-  | assert_eq(result1, 42)
-
-  | let result2 = identity("test")
-  | assert_eq(result2, "test")
-
-  | let result3 = identity([1, 2, 3])
-  | assert_eq(result3, [1, 2, 3])
+# @parametrize([[42, 42], ["test", "test"], [[1, 2, 3], [1, 2, 3]]])
+def test_identity(value, expected):
+  let result = identity(value)
+  | assert_eq(result, expected)
 end
 
-def test_transpose():
-  let result1 = transpose([[1, 2, 3], [4, 5, 6]])
-  | assert_eq(result1, [[1, 4], [2, 5], [3, 6]])
-
-  | let result2 = transpose([])
-  | assert_eq(result2, [])
-
-  | let result3 = transpose([[1, 2], [3, 4], [5, 6]])
-  | assert_eq(result3, [[1, 3, 5], [2, 4, 6]])
+# @parametrize([[[[1, 2, 3], [4, 5, 6]], [[1, 4], [2, 5], [3, 6]]], [[], []], [[[1, 2], [3, 4], [5, 6]], [[1, 3, 5], [2, 4, 6]]]])
+def test_transpose(value, expected):
+  let result = transpose(value)
+  | assert_eq(result, expected)
 end
 
-def test_regex_test():
-  let result1 = test("aaa", "[a-z]+")
-  | assert_eq(result1, true)
-
-  | let result2 = test("aaa", "[0-9]+")
-  | assert_eq(result2, false)
+# @parametrize([["aaa", "[a-z]+", true], ["aaa", "[0-9]+", false]])
+def test_regex_test(value, pattern, expected):
+  let result = test(value, pattern)
+  | assert_eq(result, expected)
 end
 
-def test_regex_match():
-  let result1 = regex_match("aaa", "[a-z]+")
-  | assert_eq(result1, ["aaa"])
-
-  | let result2 = regex_match("aaa", "[0-9]+")
-  | assert_eq(result2, [])
+# @parametrize([["aaa", "[a-z]+", ["aaa"]], ["aaa", "[0-9]+", []]])
+def test_regex_match(value, pattern, expected):
+  let result = regex_match(value, pattern)
+  | assert_eq(result, expected)
 end
 
 def test_tap():
@@ -553,113 +332,52 @@ def test_until():
   | assert_eq(result1, 6)
 end
 
-def test_compact_map():
-  let result1 = compact_map([1, 2, 3, 4, 5], fn(x): if (x > 2): x;)
-  | assert_eq(result1, [3, 4, 5])
-
-  | let result2 = compact_map([1, 2, 3], fn(x): if (x % 2 == 0): x * 2;)
-  | assert_eq(result2, [4])
-
-  | let result3 = compact_map([], fn(x): x;)
-  | assert_eq(result3, [])
-
-  | let result4 = compact_map([1, 2, 3], fn(x): None;)
-  | assert_eq(result4, [])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): if (x > 2): x;, [3, 4, 5]], [[1, 2, 3], fn(x): if (x % 2 == 0): x * 2;, [4]], [[], fn(x): x;, []], [[1, 2, 3], fn(x): None;, []]])
+def test_compact_map(value, f, expected):
+  let result = compact_map(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_reject():
-  let result1 = reject([1, 2, 3, 4, 5], fn(x): x > 3;)
-  | assert_eq(result1, [1, 2, 3])
-
-  | let result2 = reject([1, 2, 3, 4], fn(x): x % 2 == 0;)
-  | assert_eq(result2, [1, 3])
-
-  | let result3 = reject([], fn(x): x > 0;)
-  | assert_eq(result3, [])
-
-  | let result4 = reject([1, 2, 3], fn(x): false;)
-  | assert_eq(result4, [1, 2, 3])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 3;, [1, 2, 3]], [[1, 2, 3, 4], fn(x): x % 2 == 0;, [1, 3]], [[], fn(x): x > 0;, []], [[1, 2, 3], fn(x): false;, [1, 2, 3]]])
+def test_reject(value, f, expected):
+  let result = reject(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_partition():
-  let result1 = partition([1, 2, 3, 4, 5], fn(x): x > 3;)
-  | assert_eq(result1, [[4, 5], [1, 2, 3]])
-
-  | let result2 = partition([1, 2, 3, 4], fn(x): x % 2 == 0;)
-  | assert_eq(result2, [[2, 4], [1, 3]])
-
-  | let result3 = partition([], fn(x): x > 0;)
-  | assert_eq(result3, [[], []])
-
-  | let result4 = partition([1, 2, 3], fn(x): true;)
-  | assert_eq(result4, [[1, 2, 3], []])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x > 3;, [[4, 5], [1, 2, 3]]], [[1, 2, 3, 4], fn(x): x % 2 == 0;, [[2, 4], [1, 3]]], [[], fn(x): x > 0;, [[], []]], [[1, 2, 3], fn(x): true;, [[1, 2, 3], []]]])
+def test_partition(value, f, expected):
+  let result = partition(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_get_or():
-  let d = dict([["a", 1], ["b", 2]])
-  | let result1 = get_or(d, "a", 0)
-  | assert_eq(result1, 1)
-
-  | let result2 = get_or(d, "c", 0)
-  | assert_eq(result2, 0)
-
-  | let result3 = get_or(d, "b", 999)
-  | assert_eq(result3, 2)
-
-  | let result4 = get_or(dict(), "key", "default")
-  | assert_eq(result4, "default")
+# @parametrize([[dict([["a", 1], ["b", 2]]), "a", 0, 1], [dict([["a", 1], ["b", 2]]), "c", 0, 0], [dict([["a", 1], ["b", 2]]), "b", 999, 2], [dict(), "key", "default", "default"]])
+def test_get_or(d, key, default, expected):
+  let result = get_or(d, key, default)
+  | assert_eq(result, expected)
 end
 
-def test_times():
-  let result1 = times(3, 5)
-  | assert_eq(result1, [5, 5, 5])
-
-  | let result2 = times(0, "hello")
-  | assert_eq(result2, [])
-
-  | let result3 = times(4, 1)
-  | assert_eq(result3, [1, 1, 1, 1])
+# @parametrize([[3, 5, [5, 5, 5]], [0, "hello", []], [4, 1, [1, 1, 1, 1]]])
+def test_times(n, value, expected):
+  let result = times(n, value)
+  | assert_eq(result, expected)
 end
 
-def test_between():
-  let result1 = between(5, 1, 10)
-  | assert_eq(result1, true)
-
-  | let result2 = between(0, 1, 10)
-  | assert_eq(result2, false)
-
-  | let result3 = between(10, 1, 10)
-  | assert_eq(result3, true)
-
-  | let result4 = between(1, 1, 10)
-  | assert_eq(result4, true)
-
-  | let result5 = between(15, 1, 10)
-  | assert_eq(result5, false)
+# @parametrize([[5, 1, 10, true], [0, 1, 10, false], [10, 1, 10, true], [1, 1, 10, true], [15, 1, 10, false]])
+def test_between(value, lo, hi, expected):
+  let result = between(value, lo, hi)
+  | assert_eq(result, expected)
 end
 
-def test_sum_by():
-  let result1 = sum_by([1, 2, 3, 4], fn(x): x;)
-  | assert_eq(result1, 10)
-
-  | let result2 = sum_by([1, 2, 3], fn(x): x * 2;)
-  | assert_eq(result2, 12)
-
-  | let result3 = sum_by([], fn(x): x;)
-  | assert_eq(result3, 0)
-
-  | let result4 = sum_by([5, 10, 15], fn(x): x / 5;)
-  | assert_eq(result4, 6)
+# @parametrize([[[1, 2, 3, 4], fn(x): x;, 10], [[1, 2, 3], fn(x): x * 2;, 12], [[], fn(x): x;, 0], [[5, 10, 15], fn(x): x / 5;, 6]])
+def test_sum_by(value, f, expected):
+  let result = sum_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_index_by():
-  let arr = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-  | let result1 = index_by(arr, fn(item): item["id"];)
-  | assert_eq(get(result1, "1")["name"], "Alice")
-  | assert_eq(get(result1, "2")["name"], "Bob")
-
-  | let result2 = index_by([], fn(item): item["id"];)
-  | assert_eq(result2, dict())
+# @parametrize([[[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}], fn(item): item["id"];, {"1": {"id": 1, "name": "Alice"}, "2": {"id": 2, "name": "Bob"}}], [[], fn(item): item["id"];, dict()]])
+def test_index_by(value, f, expected):
+  let result = index_by(value, f)
+  | assert_eq(result, expected)
 end
 
 def test_join_by_inner():
@@ -741,42 +459,10 @@ def test_join_by_non_array_left_errors():
   | assert(contains(result, "left must be an array"))
 end
 
-def test_percentile():
-  # median of odd-length array
-  let result1 = percentile([1, 2, 3, 4, 5], 0.5)
-  | assert_eq(result1, 3)
-
-  # median of even-length array (linear interpolation)
-  | let result2 = percentile([1, 2, 3, 4], 0.5)
-  | assert_eq(result2, 2.5)
-
-  # 0th percentile = min
-  | let result3 = percentile([3, 1, 4, 1, 5], 0)
-  | assert_eq(result3, 1)
-
-  # 100th percentile = max
-  | let result4 = percentile([3, 1, 4, 1, 5], 1)
-  | assert_eq(result4, 5)
-
-  # 25th percentile
-  | let result5 = percentile([1, 2, 3, 4], 0.25)
-  | assert_eq(result5, 1.75)
-
-  # 75th percentile
-  | let result6 = percentile([1, 2, 3, 4], 0.75)
-  | assert_eq(result6, 3.25)
-
-  # single element array
-  | let result7 = percentile([42], 0.5)
-  | assert_eq(result7, 42)
-
-  # unsorted input is handled correctly
-  | let result8 = percentile([5, 1, 3], 0.5)
-  | assert_eq(result8, 3)
-
-  # empty array returns None
-  | let result9 = percentile([], 0.5)
-  | assert_eq(result9, None)
+# @parametrize([[[1, 2, 3, 4, 5], 0.5, 3], [[1, 2, 3, 4], 0.5, 2.5], [[3, 1, 4, 1, 5], 0, 1], [[3, 1, 4, 1, 5], 1, 5], [[1, 2, 3, 4], 0.25, 1.75], [[1, 2, 3, 4], 0.75, 3.25], [[42], 0.5, 42], [[5, 1, 3], 0.5, 3], [[], 0.5, None]])
+def test_percentile(value, p, expected):
+  let result = percentile(value, p)
+  | assert_eq(result, expected)
 end
 
 def test_inspect():
@@ -791,89 +477,46 @@ def test_each():
   | assert_eq(i, 6)
 end
 
-def test_lpad():
-  let result1 = lpad("test", 6, "0")
-  | assert_eq(result1, "00test")
-
-  | let result2 = lpad("hello", 3, "x")
-  | assert_eq(result2, "hello")
-
-  | let result3 = lpad("abc", 5)
-  | assert_eq(result3, "  abc")
+# @parametrize([["test", 6, "0", "00test"], ["hello", 3, "x", "hello"], ["abc", 5, " ", "  abc"]])
+def test_lpad(value, n, pad, expected):
+  let result = lpad(value, n, pad)
+  | assert_eq(result, expected)
 end
 
-def test_rpad():
-  let result1 = rpad("test", 6, "0")
-  | assert_eq(result1, "test00")
-
-  | let result2 = rpad("hello", 3, "x")
-  | assert_eq(result2, "hello")
-
-  | let result3 = rpad("abc", 5)
-  | assert_eq(result3, "abc  ")
+# @parametrize([["test", 6, "0", "test00"], ["hello", 3, "x", "hello"], ["abc", 5, " ", "abc  "]])
+def test_rpad(value, n, pad, expected):
+  let result = rpad(value, n, pad)
+  | assert_eq(result, expected)
 end
 
-def test_bsearch():
-  let result1 = bsearch([1, 2, 3, 4, 5], 3)
-  | assert_eq(result1, 2)
-
-  | let result2 = bsearch([1, 2, 3, 4, 5], 6)
-  | assert_eq(result2, -1)
-
-  | let result3 = bsearch([10, 20, 30], 10)
-  | assert_eq(result3, 0)
-
-  | let result4 = bsearch(["a", "b", "c"], "b")
-  | assert_eq(result4, 1)
+# @parametrize([[[1, 2, 3, 4, 5], 3, 2], [[1, 2, 3, 4, 5], 6, -1], [[10, 20, 30], 10, 0], [["a", "b", "c"], "b", 1]])
+def test_bsearch(value, target, expected):
+  let result = bsearch(value, target)
+  | assert_eq(result, expected)
 end
 
-def test_slugify():
-  let result1 = slugify("Hello World!")
-  | assert_eq(result1, "hello-world")
-
-  | let result2 = slugify("This is a test.")
-  | assert_eq(result2, "this-is-a-test")
-
-  | let result3 = slugify("Special characters: @#$%^&*()")
-  | assert_eq(result3, "special-characters")
+# @parametrize([["Hello World!", "hello-world"], ["This is a test.", "this-is-a-test"], ["Special characters: @#$%^&*()", "special-characters"]])
+def test_slugify(value, expected):
+  let result = slugify(value)
+  | assert_eq(result, expected)
 end
 
-def test_chunks():
-  let result1 = chunks([1, 2, 3, 4, 5], 2)
-  | assert_eq(result1, [[1, 2], [3, 4], [5]])
-
-  | let result2 = chunks([1, 2, 3, 4], 3)
-  | assert_eq(result2, [[1, 2, 3], [4]])
-
-  | let result3 = chunks([], 2)
-  | assert_eq(result3, [])
-
-  | let result4 = chunks("123456", 2)
-  | assert_eq(result4, ["12", "34", "56"])
+# @parametrize([[[1, 2, 3, 4, 5], 2, [[1, 2], [3, 4], [5]]], [[1, 2, 3, 4], 3, [[1, 2, 3], [4]]], [[], 2, []], ["123456", 2, ["12", "34", "56"]]])
+def test_chunks(value, n, expected):
+  let result = chunks(value, n)
+  | assert_eq(result, expected)
 end
 
-def test_chunk_by():
-  let result1 = chunk_by([1, 2, 3, 4, 5], fn(x): x % 2;)
-  | assert_eq(result1, [[1], [2], [3], [4], [5]])
-
-  | let result2 = chunk_by([1, 2, 3, 4], fn(x): x > 2;)
-  | assert_eq(result2, [[1, 2], [3, 4]])
-
-  | let result3 = chunk_by([], fn(x): x;)
-  | assert_eq(result3, [])
-
-  | let result4 = chunk_by("123456", fn(x): x == "1";)
-  | assert_eq(result4, ["1", "23456"])
+# @parametrize([[[1, 2, 3, 4, 5], fn(x): x % 2;, [[1], [2], [3], [4], [5]]], [[1, 2, 3, 4], fn(x): x > 2;, [[1, 2], [3, 4]]], [[], fn(x): x;, []], ["123456", fn(x): x == "1";, ["1", "23456"]]])
+def test_chunk_by(value, f, expected):
+  let result = chunk_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_flip():
-  let a = fn(a, b): a + b;
-  | let result1 = do a | flip(2, 3);
-  | assert_eq(result1, 5)
-
-  | let b = fn(a, b): a - b;
-  | let result2 = do b | flip(5, 2);
-  | assert_eq(result2, -3)
+# @parametrize([[fn(a, b): a + b;, 2, 3, 5], [fn(a, b): a - b;, 5, 2, -3]])
+def test_flip(f, x, y, expected):
+  let result = do f | flip(x, y);
+  | assert_eq(result, expected)
 end
 
 def test_complement():
@@ -907,26 +550,16 @@ def test_juxt():
   | assert_eq(g(5), [])
 end
 
-def test_sum():
-  let result1 = sum([1, 2, 3, 4, 5])
-  | assert_eq(result1, 15)
-
-  | let result2 = sum([])
-  | assert_eq(result2, 0)
-
-  | let result3 = sum([42])
-  | assert_eq(result3, 42)
+# @parametrize([[[1, 2, 3, 4, 5], 15], [[], 0], [[42], 42]])
+def test_sum(value, expected):
+  let result = sum(value)
+  | assert_eq(result, expected)
 end
 
-def test_mean():
-  let result1 = mean([1, 2, 3, 4, 5])
-  | assert_eq(result1, 3)
-
-  | let result2 = mean([])
-  | assert_eq(result2, None)
-
-  | let result3 = mean([10, 20])
-  | assert_eq(result3, 15)
+# @parametrize([[[1, 2, 3, 4, 5], 3], [[], None], [[10, 20], 15]])
+def test_mean(value, expected):
+  let result = mean(value)
+  | assert_eq(result, expected)
 end
 
 def test_geomean():
@@ -940,40 +573,22 @@ def test_geomean():
   | assert_eq(result3, 4)
 end
 
-def test_variance():
-  let result1 = variance([2, 4, 4, 4, 5, 5, 7, 9])
-  | assert_eq(result1, 4)
-
-  | let result2 = variance([])
-  | assert_eq(result2, None)
-
-  | let result3 = variance([5])
-  | assert_eq(result3, 0)
+# @parametrize([[[2, 4, 4, 4, 5, 5, 7, 9], 4], [[], None], [[5], 0]])
+def test_variance(value, expected):
+  let result = variance(value)
+  | assert_eq(result, expected)
 end
 
-def test_stddev():
-  let result1 = stddev([2, 4, 4, 4, 5, 5, 7, 9])
-  | assert_eq(result1, 2)
-
-  | let result2 = stddev([])
-  | assert_eq(result2, None)
-
-  | let result3 = stddev([5])
-  | assert_eq(result3, 0)
+# @parametrize([[[2, 4, 4, 4, 5, 5, 7, 9], 2], [[], None], [[5], 0]])
+def test_stddev(value, expected):
+  let result = stddev(value)
+  | assert_eq(result, expected)
 end
 
-def test_mode():
-  let result1 = mode([1, 2, 2, 3])
-  | assert_eq(result1, [2])
-
-  | let result2 = mode([1, 1, 2, 2, 3])
-  | assert_eq(result2, [1, 2])
-
-  | let result3 = mode([])
-  | assert_eq(result3, None)
-
-  | let result4 = mode([1, 2, 3])
-  | assert_eq(result4, [1, 2, 3])
+# @parametrize([[[1, 2, 2, 3], [2]], [[1, 1, 2, 2, 3], [1, 2]], [[], None], [[1, 2, 3], [1, 2, 3]]])
+def test_mode(value, expected):
+  let result = mode(value)
+  | assert_eq(result, expected)
 end
 
 def test_describe():
@@ -989,432 +604,169 @@ def test_describe():
   | assert_eq(result2, None)
 end
 
-def test_ngram():
-  let result1 = ngram("hello", 2)
-  | assert_eq(result1, ["he", "el", "ll", "lo"])
-
-  | let result2 = ngram("test", 3)
-  | assert_eq(result2, ["tes", "est"])
-
-  | let result3 = ngram("abc", 4)
-  | assert_eq(result3, [])
-
-  | let result4 = ngram([1, 2, 3, 4], 2)
-  | assert_eq(result4, [[1, 2], [2, 3], [3, 4]])
-
-  | let result5 = ngram([1, 2, 3], 1)
-  | assert_eq(result5, [[1], [2], [3]])
-
-  | let result6 = ngram([1, 2], 4)
-  | assert_eq(result6, [])
+# @parametrize([["hello", 2, ["he", "el", "ll", "lo"]], ["test", 3, ["tes", "est"]], ["abc", 4, []], [[1, 2, 3, 4], 2, [[1, 2], [2, 3], [3, 4]]], [[1, 2, 3], 1, [[1], [2], [3]]], [[1, 2], 4, []]])
+def test_ngram(value, n, expected):
+  let result = ngram(value, n)
+  | assert_eq(result, expected)
 end
 
-def test_zip():
-  let result1 = zip([1, 2, 3], ["a", "b", "c"])
-  | assert_eq(result1, [[1, "a"], [2, "b"], [3, "c"]])
-
-  | let result2 = zip([1, 2], ["x", "y", "z"])
-  | assert_eq(result2, [[1, "x"], [2, "y"]])
-
-  | let result3 = zip([], ["a", "b"])
-  | assert_eq(result3, [])
+# @parametrize([[[1, 2, 3], ["a", "b", "c"], [[1, "a"], [2, "b"], [3, "c"]]], [[1, 2], ["x", "y", "z"], [[1, "x"], [2, "y"]]], [[], ["a", "b"], []]])
+def test_zip(value1, value2, expected):
+  let result = zip(value1, value2)
+  | assert_eq(result, expected)
 end
 
-def test_min_by():
-  let result1 = min_by([{"value": 3}, {"value": 1}, {"value": 2}], fn(x): x["value"];)
-  | assert_eq(result1["value"], 1)
-
-  | let result2 = min_by([], fn(x): x;)
-  | assert_eq(result2, None)
-
-  | let result3 = min_by([{"score": 10}, {"score": 5}], fn(x): x["score"];)
-  | assert_eq(result3["score"], 5)
+# @parametrize([[[{"value": 3}, {"value": 1}, {"value": 2}], fn(x): x["value"];, {"value": 1}], [[], fn(x): x;, None], [[{"score": 10}, {"score": 5}], fn(x): x["score"];, {"score": 5}]])
+def test_min_by(value, f, expected):
+  let result = min_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_max_by():
-  let result1 = max_by([{"value": 3}, {"value": 1}, {"value": 2}], fn(x): x["value"];)
-  | assert_eq(result1["value"], 3)
-
-  | let result2 = max_by([], fn(x): x;)
-  | assert_eq(result2, None)
-
-  | let result3 = max_by([{"score": 10}, {"score": 5}], fn(x): x["score"];)
-  | assert_eq(result3["score"], 10)
+# @parametrize([[[{"value": 3}, {"value": 1}, {"value": 2}], fn(x): x["value"];, {"value": 3}], [[], fn(x): x;, None], [[{"score": 10}, {"score": 5}], fn(x): x["score"];, {"score": 10}]])
+def test_max_by(value, f, expected):
+  let result = max_by(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_lines():
-  let result1 = lines("line1\nline2\nline3")
-  | assert_eq(result1, ["line1", "line2", "line3"])
-
-  | let result2 = lines("single line")
-  | assert_eq(result2, ["single line"])
-
-  | let result3 = lines("")
-  | assert_eq(result3, [""])
+# @parametrize([["line1\nline2\nline3", ["line1", "line2", "line3"]], ["single line", ["single line"]], ["", [""]]])
+def test_lines(value, expected):
+  let result = lines(value)
+  | assert_eq(result, expected)
 end
 
-def test_unlines():
-  let result1 = unlines(["line1", "line2", "line3"])
-  | assert_eq(result1, "line1\nline2\nline3")
-
-  | let result2 = unlines(["single line"])
-  | assert_eq(result2, "single line")
-
-  | let result3 = unlines([])
-  | assert_eq(result3, "")
+# @parametrize([[["line1", "line2", "line3"], "line1\nline2\nline3"], [["single line"], "single line"], [[], ""]])
+def test_unlines(value, expected):
+  let result = unlines(value)
+  | assert_eq(result, expected)
 end
 
-def test_pick():
-  let result1 = pick({"a": 1, "b": 2, "c": 3}, ["a", "c"])
-  | assert_eq(result1, {"a": 1, "c": 3})
-
-  | let result2 = pick({"x": 10, "y": 20}, ["y"])
-  | assert_eq(result2, {"y": 20})
-
-  | let result3 = pick({"key": "value"}, ["nonexistent"])
-  | assert_eq(result3, dict())
+# @parametrize([[{"a": 1, "b": 2, "c": 3}, ["a", "c"], {"a": 1, "c": 3}], [{"x": 10, "y": 20}, ["y"], {"y": 20}], [{"key": "value"}, ["nonexistent"], dict()]])
+def test_pick(value, keys, expected):
+  let result = pick(value, keys)
+  | assert_eq(result, expected)
 end
 
-def test_omit():
-  let result1 = omit({"a": 1, "b": 2, "c": 3}, ["b"])
-  | assert_eq(result1, {"a": 1, "c": 3})
-
-  | let result2 = omit({"x": 10, "y": 20}, ["x", "y"])
-  | assert_eq(result2, {})
-
-  | let result3 = omit({"key": "value"}, ["nonexistent"])
-  | assert_eq(result3, {"key": "value"})
+# @parametrize([[{"a": 1, "b": 2, "c": 3}, ["b"], {"a": 1, "c": 3}], [{"x": 10, "y": 20}, ["x", "y"], {}], [{"key": "value"}, ["nonexistent"], {"key": "value"}]])
+def test_omit(value, keys, expected):
+  let result = omit(value, keys)
+  | assert_eq(result, expected)
 end
 
-def test_has():
-  let result1 = has({"a": 1, "b": 2}, "a")
-  | assert_eq(result1, true)
-
-  | let result2 = has({"a": 1, "b": 2}, "c")
-  | assert_eq(result2, false)
-
-  | let result3 = has([1, 2, 3], 1)
-  | assert_eq(result3, true)
-
-  | let result4 = has([1, 2, 3], 5)
-  | assert_eq(result4, false)
-
-  | let result5 = has([1, 2, 3], -1)
-  | assert_eq(result5, false)
-
-  | let result6 = has("not a container", "key")
-  | assert_eq(result6, false)
+# @parametrize([[{"a": 1, "b": 2}, "a", true], [{"a": 1, "b": 2}, "c", false], [[1, 2, 3], 1, true], [[1, 2, 3], 5, false], [[1, 2, 3], -1, false], ["not a container", "key", false]])
+def test_has(value, key, expected):
+  let result = has(value, key)
+  | assert_eq(result, expected)
 end
 
-def test_get_path():
-  let result1 = get_path({"a": {"b": [1, 2, 3]}}, ["a", "b", 1])
-  | assert_eq(result1, 2)
-
-  # Missing intermediate key short-circuits to None
-  | let result2 = get_path({"a": {"b": 1}}, ["a", "x", "y"])
-  | assert_eq(result2, None)
-
-  # Empty path returns the value itself
-  | let result3 = get_path({"a": 1}, [])
-  | assert_eq(result3, {"a": 1})
-
-  # Out-of-bounds array index yields None
-  | let result4 = get_path([1, 2, 3], [10])
-  | assert_eq(result4, None)
+# @parametrize([[{"a": {"b": [1, 2, 3]}}, ["a", "b", 1], 2], [{"a": {"b": 1}}, ["a", "x", "y"], None], [{"a": 1}, [], {"a": 1}], [[1, 2, 3], [10], None]])
+def test_get_path(value, path, expected):
+  let result = get_path(value, path)
+  | assert_eq(result, expected)
 end
 
-def test_set_path():
-  let result1 = set_path({"a": {"b": [1, 2, 3]}}, ["a", "b", 1], 99)
-  | assert_eq(result1, {"a": {"b": [1, 99, 3]}})
+# @parametrize([[{"a": {"b": [1, 2, 3]}}, ["a", "b", 1], 99, {"a": {"b": [1, 99, 3]}}], [{}, ["a", "b", 0], 42, {"a": {"b": [42]}}], [{"a": 1}, [], 99, 99]])
+def test_set_path(value, path, new_value, expected):
+  let result = set_path(value, path, new_value)
+  | assert_eq(result, expected)
+end
 
-  # Missing intermediate containers are created automatically
-  | let result2 = set_path({}, ["a", "b", 0], 42)
-  | assert_eq(result2, {"a": {"b": [42]}})
-
-  # Empty path replaces the whole value
-  | let result3 = set_path({"a": 1}, [], 99)
-  | assert_eq(result3, 99)
-
+def test_set_path_round_trip():
   # A round-trip through paths()/get_path() reconstructs every leaf via set_path()
-  | let v = {"a": {"b": 1, "c": 2}, "d": [3, 4]}
-  | let result4 = fold(paths(v), v, fn(acc, p): set_path(acc, p, get_path(v, p) * 10);)
-  | assert_eq(result4, {"a": {"b": 10, "c": 20}, "d": [30, 40]})
+  let v = {"a": {"b": 1, "c": 2}, "d": [3, 4]}
+  | let result = fold(paths(v), v, fn(acc, p): set_path(acc, p, get_path(v, p) * 10);)
+  | assert_eq(result, {"a": {"b": 10, "c": 20}, "d": [30, 40]})
 end
 
-def test_del_path():
-  let result1 = del_path({"a": {"b": 1, "c": 2}}, ["a", "b"])
-  | assert_eq(result1, {"a": {"c": 2}})
-
-  | let result2 = del_path([1, 2, 3, 4], [1])
-  | assert_eq(result2, [1, 3, 4])
-
-  # A missing intermediate container leaves the value unchanged
-  | let result3 = del_path({"a": 1}, ["x", "y"])
-  | assert_eq(result3, {"a": 1})
-
-  # A missing key leaves the value unchanged
-  | let result4 = del_path({"a": 1}, ["b"])
-  | assert_eq(result4, {"a": 1})
-
-  # An out-of-range array index leaves the value unchanged
-  | let result5 = del_path([1, 2, 3], [10])
-  | assert_eq(result5, [1, 2, 3])
-
-  # An empty path deletes the whole value
-  | let result6 = del_path({"a": 1}, [])
-  | assert_eq(result6, None)
+# @parametrize([[{"a": {"b": 1, "c": 2}}, ["a", "b"], {"a": {"c": 2}}], [[1, 2, 3, 4], [1], [1, 3, 4]], [{"a": 1}, ["x", "y"], {"a": 1}], [{"a": 1}, ["b"], {"a": 1}], [[1, 2, 3], [10], [1, 2, 3]], [{"a": 1}, [], None]])
+def test_del_path(value, path, expected):
+  let result = del_path(value, path)
+  | assert_eq(result, expected)
 end
 
-def test_del_paths():
-  let result1 = del_paths({"a": 1, "b": 2, "c": 3}, [["a"], ["c"]])
-  | assert_eq(result1, {"b": 2})
-
-  # Paths are applied deepest-first so index shifts don't affect other deletions
-  | let result2 = del_paths([1, 2, 3, 4], [[0], [2]])
-  | assert_eq(result2, [2, 4])
-
-  | let result3 = del_paths({"a": {"b": 1, "c": 2}}, [["a", "b"], ["a", "c"]])
-  | assert_eq(result3, {"a": {}})
+# @parametrize([[{"a": 1, "b": 2, "c": 3}, [["a"], ["c"]], {"b": 2}], [[1, 2, 3, 4], [[0], [2]], [2, 4]], [{"a": {"b": 1, "c": 2}}, [["a", "b"], ["a", "c"]], {"a": {}}]])
+def test_del_paths(value, paths_list, expected):
+  let result = del_paths(value, paths_list)
+  | assert_eq(result, expected)
 end
 
-def test_paths():
-  let result1 = paths({"a": {"b": 1, "c": 2}, "d": [3, 4]})
-  | assert_eq(result1, [["a", "b"], ["a", "c"], ["d", 0], ["d", 1]])
-
-  # Containers with no leaves contribute no paths
-  | let result2 = paths({})
-  | assert_eq(result2, [])
-
-  | let result3 = paths([])
-  | assert_eq(result3, [])
-
-  # A bare scalar has a single, empty leaf path
-  | let result4 = paths(42)
-  | assert_eq(result4, [[]])
+# @parametrize([[{"a": {"b": 1, "c": 2}, "d": [3, 4]}, [["a", "b"], ["a", "c"], ["d", 0], ["d", 1]]], [{}, []], [[], []], [42, [[]]]])
+def test_paths(value, expected):
+  let result = paths(value)
+  | assert_eq(result, expected)
 end
 
-def test_from_entries():
-  let result1 = from_entries([["a", 1], ["b", 2]])
-  | assert_eq(result1, {"a": 1, "b": 2})
-
-  | let result2 = from_entries([])
-  | assert_eq(result2, dict())
-
-  # Later occurrences of the same key overwrite earlier ones
-  | let result3 = from_entries([["a", 1], ["a", 2]])
-  | assert_eq(result3, {"a": 2})
+# @parametrize([[[["a", 1], ["b", 2]], {"a": 1, "b": 2}], [[], dict()], [[["a", 1], ["a", 2]], {"a": 2}]])
+def test_from_entries(value, expected):
+  let result = from_entries(value)
+  | assert_eq(result, expected)
 end
 
-def test_with_entries():
-  let result1 = with_entries({"a": 1, "b": 2}, fn(pair): [pair[0], pair[1] * 10];)
-  | assert_eq(result1, {"a": 10, "b": 20})
-
-  | let result2 = with_entries({}, fn(pair): pair;)
-  | assert_eq(result2, dict())
+# @parametrize([[{"a": 1, "b": 2}, fn(pair): [pair[0], pair[1] * 10];, {"a": 10, "b": 20}], [{}, fn(pair): pair;, dict()]])
+def test_with_entries(value, f, expected):
+  let result = with_entries(value, f)
+  | assert_eq(result, expected)
 end
 
-def test_merge_with():
-  # Nested dicts are merged recursively; non-overlapping keys are kept from both sides
-  let result1 = merge_with({"a": 1, "b": {"x": 1}}, {"b": {"y": 2}, "c": 3}, "replace")
-  | assert_eq(result1, {"a": 1, "b": {"x": 1, "y": 2}, "c": 3})
-
-  # "replace" policy: the second value wins on leaf/array conflicts
-  | let result2 = merge_with({"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "replace")
-  | assert_eq(result2, {"a": [3], "b": 2})
-
-  # "append" policy: arrays are concatenated, scalar conflicts become [a, b]
-  | let result3 = merge_with({"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "append")
-  | assert_eq(result3, {"a": [1, 2, 3], "b": [1, 2]})
-
-  # "error" policy: raises on conflicting leaf values
-  | let result4 = try: merge_with({"a": 1}, {"a": 2}, "error") catch: "error"
-  | assert_eq(result4, "error")
-
-  # Null on either side is not an error; "replace" lets the null win, "append" keeps the non-null value
-  | let result5 = merge_with({"a": 1}, {"a": None}, "replace")
-  | assert_eq(result5, {"a": None})
-
-  | let result6 = merge_with({"a": 1}, {"a": None}, "append")
-  | assert_eq(result6, {"a": 1})
-
-  # An invalid policy is rejected
-  | let result7 = try: merge_with({}, {}, "invalid") catch: "error"
-  | assert_eq(result7, "error")
+# @parametrize([[{"a": 1, "b": {"x": 1}}, {"b": {"y": 2}, "c": 3}, "replace", {"a": 1, "b": {"x": 1, "y": 2}, "c": 3}], [{"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "replace", {"a": [3], "b": 2}], [{"a": [1, 2], "b": 1}, {"a": [3], "b": 2}, "append", {"a": [1, 2, 3], "b": [1, 2]}], [{"a": 1}, {"a": 2}, "error", "error"], [{"a": 1}, {"a": None}, "replace", {"a": None}], [{"a": 1}, {"a": None}, "append", {"a": 1}], [{}, {}, "invalid", "error"]])
+def test_merge_with(a, b, policy, expected):
+  let result = try: merge_with(a, b, policy) catch: "error"
+  | assert_eq(result, expected)
 end
 
-def test_merge_defaults():
-  # Values from `d` win, missing keys fall back to `defaults`, recursively
-  let result1 = merge_defaults({"a": {"x": 1}}, {"a": {"x": 0, "y": 2}, "b": 3})
-  | assert_eq(result1, {"a": {"x": 1, "y": 2}, "b": 3})
-
-  # `d`'s arrays replace `defaults`'s arrays entirely
-  | let result2 = merge_defaults({"a": [1]}, {"a": [2, 3]})
-  | assert_eq(result2, {"a": [1]})
-
-  # An empty override falls back entirely to defaults
-  | let result3 = merge_defaults({}, {"a": 1, "b": 2})
-  | assert_eq(result3, {"a": 1, "b": 2})
+# @parametrize([[{"a": {"x": 1}}, {"a": {"x": 0, "y": 2}, "b": 3}, {"a": {"x": 1, "y": 2}, "b": 3}], [{"a": [1]}, {"a": [2, 3]}, {"a": [1]}], [{}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]])
+def test_merge_defaults(d, defaults, expected):
+  let result = merge_defaults(d, defaults)
+  | assert_eq(result, expected)
 end
 
-def test_frontmatter():
-  # YAML frontmatter is parsed into a dict
-  let result1 = do "---\ntitle: Hello\nauthor: World\n---\n\n# Heading" | to_markdown() | first() | frontmatter();
-  | assert_eq(result1["title"], "Hello")
-  | assert_eq(result1["author"], "World")
-
-  # TOML frontmatter is parsed into a dict
-  | let result2 = do "+++\ntitle = \"Hello\"\nauthor = \"World\"\n+++\n\n# Heading" | to_markdown() | first() | frontmatter();
-  | assert_eq(result2["title"], "Hello")
-  | assert_eq(result2["author"], "World")
-
-  # Non-frontmatter node returns None
-  | let result3 = do "# Heading" | to_markdown() | first() | frontmatter();
-  | assert_eq(result3, None)
-
-  # YAML frontmatter with nested values
-  | let result4 = do "---\ntitle: My Post\ntags:\n  - rust\n  - markdown\n---\n" | to_markdown() | first() | frontmatter();
-  | assert_eq(result4["title"], "My Post")
-  | assert_eq(result4["tags"], ["rust", "markdown"])
+# @parametrize([["---\ntitle: Hello\nauthor: World\n---\n\n# Heading", {"title": "Hello", "author": "World"}], ["+++\ntitle = \"Hello\"\nauthor = \"World\"\n+++\n\n# Heading", {"title": "Hello", "author": "World"}], ["# Heading", None], ["---\ntitle: My Post\ntags:\n  - rust\n  - markdown\n---\n", {"title": "My Post", "tags": ["rust", "markdown"]}]])
+def test_frontmatter(markdown, expected):
+  let result = do markdown | to_markdown() | first() | frontmatter();
+  | assert_eq(result, expected)
 end
 
-def test_walk():
-  # scalar: number — f applied directly
-  let result1 = walk(42, fn(x): x * 2;)
-  | assert_eq(result1, 84)
+# @parametrize([[42, fn(x): x * 2;, 84], ["hello", fn(x): if (is_string(x)): upcase(x) else: x;, "HELLO"], [None, identity, None], [true, fn(x): if (is_bool(x)): !x else: x;, false], [[], identity, []], [[1, 2, 3], identity, [1, 2, 3]], [[1, 2, 3], fn(x): if (is_number(x)): x * 2 else: x;, [2, 4, 6]], [[[1, 2], [3, 4]], fn(x): if (is_number(x)): x + 10 else: x;, [[11, 12], [13, 14]]], [[[[1]]], fn(x): if (is_number(x)): x + 100 else: x;, [[[101]]]], [[1, "hello", None], identity, [1, "hello", None]], [[2, 4, 6], fn(x): if (is_number(x)): x * -1 else: x;, [-2, -4, -6]], [["a", "b"], fn(x): if (is_string(x)): upcase(x) else: x;, ["A", "B"]], [[true, false], fn(x): if (is_bool(x)): !x else: x;, [false, true]], [[1, 2, 3], fn(x): if (is_number(x)): x * 2 else: x;, [2, 4, 6]], [{}, identity, dict()], [{"a": 1, "b": 2}, fn(x): if (is_number(x)): x * 10 else: x;, {"a": 10, "b": 20}], [{"x": "hello"}, fn(x): if (is_string(x)): upcase(x) else: x;, {"x": "HELLO"}], [{"a": 1, "b": 2}, identity, {"a": 1, "b": 2}]])
+def test_walk(value, f, expected):
+  let result = walk(value, f)
+  | assert_eq(result, expected)
+end
 
-  # scalar: string — f applied directly
-  | let result2 = walk("hello", fn(x): if (is_string(x)): upcase(x) else: x;)
-  | assert_eq(result2, "HELLO")
-
-  # scalar: None — f applied directly
-  | let result3 = walk(None, identity)
-  | assert_eq(result3, None)
-
-  # scalar: bool — f applied directly
-  | let result4 = walk(true, fn(x): if (is_bool(x)): !x else: x;)
-  | assert_eq(result4, false)
-
-  # array: empty array returns []
-  | let result5 = walk([], identity)
-  | assert_eq(result5, [])
-
-  # array: identity preserves all elements
-  | let result6 = walk([1, 2, 3], identity)
-  | assert_eq(result6, [1, 2, 3])
-
-  # array: transform each number
-  | let result7 = walk([1, 2, 3], fn(x): if (is_number(x)): x * 2 else: x;)
-  | assert_eq(result7, [2, 4, 6])
-
-  # array: recurses into nested subarrays
-  | let result8 = walk([[1, 2], [3, 4]], fn(x): if (is_number(x)): x + 10 else: x;)
-  | assert_eq(result8, [[11, 12], [13, 14]])
-
-  # array: 3 levels of nesting
-  | let result9 = walk([[[1]]], fn(x): if (is_number(x)): x + 100 else: x;)
-  | assert_eq(result9, [[[101]]])
-
-  # array: identity preserves mixed types including None
-  | let result10 = walk([1, "hello", None], identity)
-  | assert_eq(result10, [1, "hello", None])
-
-  # array: negate each number
-  | let result11 = walk([2, 4, 6], fn(x): if (is_number(x)): x * -1 else: x;)
-  | assert_eq(result11, [-2, -4, -6])
-
-  # array: upcase each string
-  | let result12 = walk(["a", "b"], fn(x): if (is_string(x)): upcase(x) else: x;)
-  | assert_eq(result12, ["A", "B"])
-
-  # array: flip each boolean
-  | let result13 = walk([true, false], fn(x): if (is_bool(x)): !x else: x;)
-  | assert_eq(result13, [false, true])
-
-  # array: named def as function argument
-  | def double(x): if (is_number(x)): x * 2 else: x;
-  | let result14 = walk([1, 2, 3], double)
-  | assert_eq(result14, [2, 4, 6])
-
-  # dict: empty dict returns {}
-  | let result15 = walk({}, identity)
-  | assert_eq(result15, dict())
-
-  # dict: only values are transformed, keys unchanged
-  | let result16 = walk({"a": 1, "b": 2}, fn(x): if (is_number(x)): x * 10 else: x;)
-  | assert_eq(result16["a"], 10)
-  | assert_eq(result16["b"], 20)
-
-  # dict: string values uppercased
-  | let result17 = walk({"x": "hello"}, fn(x): if (is_string(x)): upcase(x) else: x;)
-  | assert_eq(result17["x"], "HELLO")
-
-  # dict: identity preserves full structure
-  | let result18 = walk({"a": 1, "b": 2}, identity)
-  | assert_eq(result18, {"a": 1, "b": 2})
-
+def test_walk_markdown():
   # markdown: text leaf — identity preserves text content
-  | let result19 = do "plain text" | to_markdown() | first() | walk(fn(n): n;) | to_text();
-  | assert_eq(result19, "plain text")
+  let result1 = do "plain text" | to_markdown() | first() | walk(fn(n): n;) | to_text();
+  | assert_eq(result1, "plain text")
 
   # markdown: heading — identity preserves HTML output
-  | let result20 = do "# heading" | to_markdown() | first() | walk(fn(n): n;) | to_html();
-  | assert_eq(result20, "<h1>heading</h1>")
+  | let result2 = do "# heading" | to_markdown() | first() | walk(fn(n): n;) | to_html();
+  | assert_eq(result2, "<h1>heading</h1>")
 
   # markdown: h2 — identity preserves depth
-  | let result21 = do "## section" | to_markdown() | first() | walk(fn(n): n;) | to_html();
-  | assert_eq(result21, "<h2>section</h2>")
+  | let result3 = do "## section" | to_markdown() | first() | walk(fn(n): n;) | to_html();
+  | assert_eq(result3, "<h2>section</h2>")
 
   # markdown: demote h1 → h2
-  | let result22 = do "# Title" | to_markdown() | first() | walk(fn(n): if (is_h(n)): demote_heading(n) else: n;) | to_html();
-  | assert_eq(result22, "<h2>Title</h2>")
+  | let result4 = do "# Title" | to_markdown() | first() | walk(fn(n): if (is_h(n)): demote_heading(n) else: n;) | to_html();
+  | assert_eq(result4, "<h2>Title</h2>")
 
   # markdown: promote h2 → h1
-  | let result23 = do "## Title" | to_markdown() | first() | walk(fn(n): if (is_h(n)): promote_heading(n) else: n;) | to_html();
-  | assert_eq(result23, "<h1>Title</h1>")
+  | let result5 = do "## Title" | to_markdown() | first() | walk(fn(n): if (is_h(n)): promote_heading(n) else: n;) | to_html();
+  | assert_eq(result5, "<h1>Title</h1>")
 
   # markdown: node name reflects transformation
-  | let result24 = do "# hi" | to_markdown() | first() | walk(fn(n): if (is_h(n)): demote_heading(n) else: n;) | to_md_name();
-  | assert_eq(result24, "h2")
+  | let result6 = do "# hi" | to_markdown() | first() | walk(fn(n): if (is_h(n)): demote_heading(n) else: n;) | to_md_name();
+  | assert_eq(result6, "h2")
 end
 
-def test_human_bytes():
-  let result1 = human_bytes(0)
-  | assert_eq(result1, "0B")
-
-  | let result2 = human_bytes(500)
-  | assert_eq(result2, "500B")
-
-  | let result3 = human_bytes(1500)
-  | assert_eq(result3, "1.5KB")
-
-  | let result4 = human_bytes(1000000)
-  | assert_eq(result4, "1MB")
-
-  | let result5 = human_bytes(1500000000)
-  | assert_eq(result5, "1.5GB")
-
-  | let result6 = human_bytes(-1500)
-  | assert_eq(result6, "-1.5KB")
+# @parametrize([[0, "0B"], [500, "500B"], [1500, "1.5KB"], [1000000, "1MB"], [1500000000, "1.5GB"], [-1500, "-1.5KB"]])
+def test_human_bytes(value, expected):
+  let result = human_bytes(value)
+  | assert_eq(result, expected)
 end
 
-def test_human_size():
-  let result1 = human_size(0)
-  | assert_eq(result1, "0B")
-
-  | let result2 = human_size(500)
-  | assert_eq(result2, "500B")
-
-  | let result3 = human_size(1536)
-  | assert_eq(result3, "1.5K")
-
-  | let result4 = human_size(1048576)
-  | assert_eq(result4, "1M")
-
-  | let result5 = human_size(1610612736)
-  | assert_eq(result5, "1.5G")
-
-  | let result6 = human_size(-1536)
-  | assert_eq(result6, "-1.5K")
+# @parametrize([[0, "0B"], [500, "500B"], [1536, "1.5K"], [1048576, "1M"], [1610612736, "1.5G"], [-1536, "-1.5K"]])
+def test_human_size(value, expected):
+  let result = human_size(value)
+  | assert_eq(result, expected)
 end
 
 def test_assert_type():
@@ -1464,4 +816,3 @@ def test_assert_matches():
   | let result4 = assert_matches("hello world", "^bye")
   | assert_eq(result4["error"], true)
 end
-

--- a/crates/mq-lang/modules/csv_test.mq
+++ b/crates/mq-lang/modules/csv_test.mq
@@ -5,59 +5,22 @@ import "csv"
 
 | let csv_input = "a,b,c\n\"1,2\",\"2,3\",\"3,4\"\n4,5,6\n\"multi\nline\",7,8\n9,10,\"quoted,comma\"\n\"\",11,12\n13,14,15\n" |
 
-def test_csv_parse_for_dict():
-  let result = csv::csv_parse(csv_input, true)
-  | assert_eq(len(result), 6)
+# @parametrize([[true, 6], [false, 7]])
+def test_csv_parse(as_dict, expected_len):
+  let result = csv::csv_parse(csv_input, as_dict)
+  | assert_eq(len(result), expected_len)
 end
 
-def test_csv_to_json_for_dict():
-  let result = csv::csv_to_json(csv::csv_parse(csv_input, true))
-  | assert_eq(result, "[{\"a\":\"1,2\",\"b\":\"2,3\",\"c\":\"3,4\"},{\"a\":\"4\",\"b\":\"5\",\"c\":\"6\"},{\"a\":\"multi\\nline\",\"b\":\"7\",\"c\":\"8\"},{\"a\":\"9\",\"b\":\"10\",\"c\":\"quoted,comma\"},{\"a\":\"\",\"b\":\"11\",\"c\":\"12\"},{\"a\":\"13\",\"b\":\"14\",\"c\":\"15\"}]")
+# @parametrize([[true, "[{\"a\":\"1,2\",\"b\":\"2,3\",\"c\":\"3,4\"},{\"a\":\"4\",\"b\":\"5\",\"c\":\"6\"},{\"a\":\"multi\\nline\",\"b\":\"7\",\"c\":\"8\"},{\"a\":\"9\",\"b\":\"10\",\"c\":\"quoted,comma\"},{\"a\":\"\",\"b\":\"11\",\"c\":\"12\"},{\"a\":\"13\",\"b\":\"14\",\"c\":\"15\"}]"], [false, "[[\"a\",\"b\",\"c\"],[\"1,2\",\"2,3\",\"3,4\"],[\"4\",\"5\",\"6\"],[\"multi\\nline\",\"7\",\"8\"],[\"9\",\"10\",\"quoted,comma\"],[\"\",\"11\",\"12\"],[\"13\",\"14\",\"15\"]]"]])
+def test_csv_to_json(as_dict, expected):
+  let result = csv::csv_to_json(csv::csv_parse(csv_input, as_dict))
+  | assert_eq(result, expected)
 end
 
-def test_csv_parse_for_array():
-  let result = csv::csv_parse(csv_input, false)
-  | assert_eq(len(result), 7)
-end
-
-def test_csv_to_json_for_array():
-  let result = csv::csv_to_json(csv::csv_parse(csv_input, false))
-  | assert_eq(result, "[[\"a\",\"b\",\"c\"],[\"1,2\",\"2,3\",\"3,4\"],[\"4\",\"5\",\"6\"],[\"multi\\nline\",\"7\",\"8\"],[\"9\",\"10\",\"quoted,comma\"],[\"\",\"11\",\"12\"],[\"13\",\"14\",\"15\"]]")
-end
-
-def test_csv_stringify_plain_for_array():
-  let result = csv::csv_stringify([["a", "b"], ["1", "2"], ["3", "4"]], ",")
-  | assert_eq(result, "a,b\n1,2\n3,4")
-end
-
-def test_csv_stringify_plain_for_dict():
-  let result = csv::csv_stringify([{"a": "1", "b": "2"}, {"a": "3", "b": "4"}], ",")
-  | assert_eq(result, "a,b\n1,2\n3,4")
-end
-
-def test_csv_stringify_escapes_quotes_for_array():
-  let result = csv::csv_stringify([["a", "b"], ["he said \"hi\"", "plain"]], ",")
-  | assert_eq(result, "a,b\n\"he said \"\"hi\"\"\",plain")
-end
-
-def test_csv_stringify_escapes_quotes_for_dict():
-  let result = csv::csv_stringify([{"a": "he said \"hi\"", "b": "plain"}], ",")
-  | assert_eq(result, "a,b\n\"he said \"\"hi\"\"\",plain")
-end
-
-def test_csv_stringify_escapes_multiple_quotes():
-  let result = csv::csv_stringify([["a"], ["\"\"\""]], ",")
-  | assert_eq(result, "a\n\"\"\"\"\"\"\"\"")
-end
-
-def test_csv_stringify_escapes_quote_and_delimiter_together():
-  let result = csv::csv_stringify([["a", "b"], ["x\",y", "plain"]], ",")
-  | assert_eq(result, "a,b\n\"x\"\",y\",plain")
-end
-
-def test_csv_stringify_escapes_quotes_in_header():
-  let result = csv::csv_stringify([["he said \"hi\""], ["v"]], ",")
-  | assert_eq(result, "\"he said \"\"hi\"\"\"\nv")
+# @parametrize([[[["a", "b"], ["1", "2"], ["3", "4"]], "a,b\n1,2\n3,4"], [[{"a": "1", "b": "2"}, {"a": "3", "b": "4"}], "a,b\n1,2\n3,4"], [[["a", "b"], ["he said \"hi\"", "plain"]], "a,b\n\"he said \"\"hi\"\"\",plain"], [[{"a": "he said \"hi\"", "b": "plain"}], "a,b\n\"he said \"\"hi\"\"\",plain"], [[["a"], ["\"\"\""]], "a\n\"\"\"\"\"\"\"\""], [[["a", "b"], ["x\",y", "plain"]], "a,b\n\"x\"\",y\",plain"], [[["he said \"hi\""], ["v"]], "\"he said \"\"hi\"\"\"\nv"]])
+def test_csv_stringify(rows, expected):
+  let result = csv::csv_stringify(rows, ",")
+  | assert_eq(result, expected)
 end
 
 def test_csv_stringify_roundtrip_with_quotes():
@@ -68,22 +31,14 @@ end
 
 | let psv_input = "a|b|c\n\"1,2\"|\"2,3\"|\"3,4\"\n4|5|6\n\"multi\nline\"|7|8\n9|10|\"quoted,comma\"\n\"\"|11|12\n13|14|15\n" |
 
-def test_psv_parse_for_dict():
-  let result = csv::psv_parse(psv_input, true)
-  | assert_eq(len(result), 6)
+# @parametrize([[true, 6], [false, 7]])
+def test_psv_parse(as_dict, expected_len):
+  let result = csv::psv_parse(psv_input, as_dict)
+  | assert_eq(len(result), expected_len)
 end
 
-def test_psv_to_json_for_dict():
-  let result = csv::csv_to_json(csv::psv_parse(psv_input, true))
-  | assert_eq(result, "[{\"a\":\"1,2\",\"b\":\"2,3\",\"c\":\"3,4\"},{\"a\":\"4\",\"b\":\"5\",\"c\":\"6\"},{\"a\":\"multi\\nline\",\"b\":\"7\",\"c\":\"8\"},{\"a\":\"9\",\"b\":\"10\",\"c\":\"quoted,comma\"},{\"a\":\"\",\"b\":\"11\",\"c\":\"12\"},{\"a\":\"13\",\"b\":\"14\",\"c\":\"15\"}]")
-end
-
-def test_psv_parse_for_array():
-  let result = csv::psv_parse(psv_input, false)
-  | assert_eq(len(result), 7)
-end
-
-def test_psv_to_json_for_array():
-  let result = csv::csv_to_json(csv::psv_parse(psv_input, false))
-  | assert_eq(result, "[[\"a\",\"b\",\"c\"],[\"1,2\",\"2,3\",\"3,4\"],[\"4\",\"5\",\"6\"],[\"multi\\nline\",\"7\",\"8\"],[\"9\",\"10\",\"quoted,comma\"],[\"\",\"11\",\"12\"],[\"13\",\"14\",\"15\"]]")
+# @parametrize([[true, "[{\"a\":\"1,2\",\"b\":\"2,3\",\"c\":\"3,4\"},{\"a\":\"4\",\"b\":\"5\",\"c\":\"6\"},{\"a\":\"multi\\nline\",\"b\":\"7\",\"c\":\"8\"},{\"a\":\"9\",\"b\":\"10\",\"c\":\"quoted,comma\"},{\"a\":\"\",\"b\":\"11\",\"c\":\"12\"},{\"a\":\"13\",\"b\":\"14\",\"c\":\"15\"}]"], [false, "[[\"a\",\"b\",\"c\"],[\"1,2\",\"2,3\",\"3,4\"],[\"4\",\"5\",\"6\"],[\"multi\\nline\",\"7\",\"8\"],[\"9\",\"10\",\"quoted,comma\"],[\"\",\"11\",\"12\"],[\"13\",\"14\",\"15\"]]"]])
+def test_psv_to_json(as_dict, expected):
+  let result = csv::csv_to_json(csv::psv_parse(psv_input, as_dict))
+  | assert_eq(result, expected)
 end

--- a/crates/mq-lang/modules/fuzzy_test.mq
+++ b/crates/mq-lang/modules/fuzzy_test.mq
@@ -1,75 +1,42 @@
 import "fuzzy"
 | include "test"
 
-def test_levenshtein():
-  let result1 = fuzzy::levenshtein("flaw", "lawn")
-  | assert_eq(result1, 2)
-
-  | let result2 = fuzzy::levenshtein("", "")
-  | assert_eq(result2, 0)
-
-  | let result3 = fuzzy::levenshtein("a", "")
-  | assert_eq(result3, 1)
-
-  | let result4 = fuzzy::levenshtein("", "a")
-  | assert_eq(result4, 1)
-
-  | let result5 = fuzzy::levenshtein("abc", "abc")
-  | assert_eq(result5, 0)
+# @parametrize([["flaw", "lawn", 2], ["", "", 0], ["a", "", 1], ["", "a", 1], ["abc", "abc", 0]])
+def test_levenshtein(a, b, expected):
+  let result = fuzzy::levenshtein(a, b)
+  | assert_eq(result, expected)
 end
 
-def test_jaro_winkler():
-  let result1 = fuzzy::jaro_winkler("flaw", "lawn")
-  | assert(result1 > 0 && result1 < 1)
-
-  | let result2 = fuzzy::jaro_winkler("", "")
-  | assert_eq(result2, 1)
-
-  | let result3 = fuzzy::jaro_winkler("a", "")
-  | assert_eq(result3, 0)
-
-  | let result4 = fuzzy::jaro_winkler("", "a")
-  | assert_eq(result4, 0)
-
-  | let result5 = fuzzy::jaro_winkler("abc", "abc")
-  | assert_eq(result5, 1)
+def test_jaro_winkler_partial_match():
+  let result = fuzzy::jaro_winkler("flaw", "lawn")
+  | assert(result > 0 && result < 1)
 end
 
-def test_fuzzy_best_match():
-  let result1 = fuzzy::fuzzy_best_match("lawn", "lawn")
-  | assert_eq(result1, {"score": 1, "text": "lawn"})
-
-  | let result2 = fuzzy::fuzzy_best_match(["flaw", "lawn", "pawn"], "lawn")
-  | assert_eq(result2, {"score": 1, "text": "lawn"})
-
-  | let result3 = fuzzy::fuzzy_best_match(["lawn", "flaw", "claw"], "flaw")
-  | assert_eq(result3, {"score": 1, "text": "flaw"})
-
-  | let result4 = fuzzy::fuzzy_best_match(["lawn", "claw"], "flaw")
-  | assert(result4["score"] < 1 && (result4["text"] == "lawn" || result4["text"] == "claw"))
-
-  | let result5 = fuzzy::fuzzy_best_match([], "flaw")
-  | assert_eq(result5, None)
+# @parametrize([["", "", 1], ["a", "", 0], ["", "a", 0], ["abc", "abc", 1]])
+def test_jaro_winkler(a, b, expected):
+  let result = fuzzy::jaro_winkler(a, b)
+  | assert_eq(result, expected)
 end
 
-def test_fuzzy_match_levenshtein():
-  let result1 = fuzzy::fuzzy_match_levenshtein("lawn", "lawn")
-  | assert_eq(result1, [{"score": 0, "text": "lawn"}])
-
-  | let result2 = fuzzy::fuzzy_match_levenshtein("back", "book")
-  | assert_eq(result2, [{"score": 2, "text": "back"}])
+def test_fuzzy_best_match_partial():
+  let result = fuzzy::fuzzy_best_match(["lawn", "claw"], "flaw")
+  | assert(result["score"] < 1 && (result["text"] == "lawn" || result["text"] == "claw"))
 end
 
-def test_fuzzy_filter():
-  let result1 = fuzzy::fuzzy_filter(["flaw", "lawn", "pawn"], "lawn", 0.9)
-  | assert_eq(len(result1), 1)
+# @parametrize([["lawn", "lawn", {"score": 1, "text": "lawn"}], [["flaw", "lawn", "pawn"], "lawn", {"score": 1, "text": "lawn"}], [["lawn", "flaw", "claw"], "flaw", {"score": 1, "text": "flaw"}], [[], "flaw", None]])
+def test_fuzzy_best_match(candidates, target, expected):
+  let result = fuzzy::fuzzy_best_match(candidates, target)
+  | assert_eq(result, expected)
+end
 
-  | let result2 = fuzzy::fuzzy_filter(["lawn", "claw"], "lawn", 0.7)
-  | assert_eq(len(result2), 2)
+# @parametrize([["lawn", "lawn", [{"score": 0, "text": "lawn"}]], ["back", "book", [{"score": 2, "text": "back"}]]])
+def test_fuzzy_match_levenshtein(a, b, expected):
+  let result = fuzzy::fuzzy_match_levenshtein(a, b)
+  | assert_eq(result, expected)
+end
 
-  | let result3 = fuzzy::fuzzy_filter(["lawn", "claw"], "flaw", 0.6)
-  | assert_eq(len(result3), 2)
-
-  | let result4 = fuzzy::fuzzy_filter([], "flaw", 0.8)
-  | assert_eq(len(result4), 0)
+# @parametrize([[["flaw", "lawn", "pawn"], "lawn", 0.9, 1], [["lawn", "claw"], "lawn", 0.7, 2], [["lawn", "claw"], "flaw", 0.6, 2], [[], "flaw", 0.8, 0]])
+def test_fuzzy_filter(candidates, target, threshold, expected_len):
+  let result = fuzzy::fuzzy_filter(candidates, target, threshold)
+  | assert_eq(len(result), expected_len)
 end

--- a/crates/mq-lang/modules/gron_test.mq
+++ b/crates/mq-lang/modules/gron_test.mq
@@ -8,17 +8,13 @@ def test_gron_parse_scalar():
   | assert_eq(result, "hello")
 end
 
-def test_gron_parse_nested():
-  let result = gron::gron_parse("json = {};\njson.a = {};\njson.a.b = \"deep\";")
-  | assert_eq(result["a"]["b"], "deep")
+# @parametrize([["json = {};\njson.a = {};\njson.a.b = \"deep\";", "deep"], ["json.a.b = \"deep\";", "deep"]])
+def test_gron_parse_nested(input, expected):
+  let result = gron::gron_parse(input)
+  | assert_eq(result["a"]["b"], expected)
 end
 
 def test_gron_parse_array():
   let result = gron::gron_parse("json = [];\njson[0] = \"x\";\njson[1] = \"y\";")
   | assert_eq(result, ["x", "y"])
-end
-
-def test_gron_parse_ignores_redundant_container_decls():
-  let result = gron::gron_parse("json.a.b = \"deep\";")
-  | assert_eq(result["a"]["b"], "deep")
 end

--- a/crates/mq-lang/modules/md_test.mq
+++ b/crates/mq-lang/modules/md_test.mq
@@ -43,14 +43,10 @@ def test_md_blockquote():
   | assert_eq(result, "> quote")
 end
 
-def test_md_callout():
-  let result = to_string(md::callout("note body", "note"))
-  | assert_eq(result, "> [!NOTE]\n> note body")
-end
-
-def test_md_callout_with_title():
-  let result = to_string(md::callout("warn body", "warning", "Careful"))
-  | assert_eq(result, "> [!WARNING] Careful\n> warn body")
+# @parametrize([["note body", "note", "", "> [!NOTE]\n> note body"], ["warn body", "warning", "Careful", "> [!WARNING] Careful\n> warn body"]])
+def test_md_callout(value, kind, title, expected):
+  let result = to_string(md::callout(value, kind, title))
+  | assert_eq(result, expected)
 end
 
 def test_md_hr():
@@ -78,24 +74,10 @@ def test_md_image():
   | assert_eq(result, "![Alt](https://example.com/a.png \"\")")
 end
 
-def test_md_list():
-  let result = to_string(md::list("Item"))
-  | assert_eq(result, "- Item")
-end
-
-def test_md_list_nested():
-  let result = to_string(md::list("Nested", 1))
-  | assert_eq(result, "  - Nested")
-end
-
-def test_md_list_ordered():
-  let result = to_string(md::list("Ordered", 0, true))
-  | assert_eq(result, "1. Ordered")
-end
-
-def test_md_list_checked():
-  let result = to_string(md::list("Checked", 0, false, true))
-  | assert_eq(result, "- [x] Checked")
+# @parametrize([["Item", 0, false, None, "- Item"], ["Nested", 1, false, None, "  - Nested"], ["Ordered", 0, true, None, "1. Ordered"], ["Checked", 0, false, true, "- [x] Checked"]])
+def test_md_list(value, level, ordered, checked, expected):
+  let result = to_string(md::list(value, level, ordered, checked))
+  | assert_eq(result, expected)
 end
 
 def test_md_table_row():

--- a/crates/mq-lang/modules/section_test.mq
+++ b/crates/mq-lang/modules/section_test.mq
@@ -4,12 +4,10 @@ import "section"
 | let section_md = "# Introduction\nThis is the introduction section.\n\n## Advanced Topics\nThis section covers advanced topics.\n\n# Conclusion\nThis is the conclusion section.\n"
 | let test_sections = to_markdown(section_md) |
 
-def test_section_sections():
-  let sections = do test_sections | section::sections();
-  | assert_eq(len(sections), 3)
-
-  | let sections = do "# test" | to_markdown() | section::sections();
-  | assert_eq(len(sections), 1)
+# @parametrize([[section_md, 3], ["# test", 1]])
+def test_section_sections(markdown, expected_len):
+  let sections = do markdown | to_markdown() | section::sections();
+  | assert_eq(len(sections), expected_len)
 end
 
 def test_section_filter_sections():
@@ -27,16 +25,11 @@ def test_section_split():
   | assert_eq(len(sections), 2)
 end
 
-def test_section_title_contains():
+# @parametrize([[section::title_contains, "Introduction", 1], [section::title_match, "^I.*", 1]])
+def test_section_title_filter(f, pattern, expected_len):
   let sections = do test_sections | section::split(1);
-  | let filtered = section::title_contains(sections, "Introduction")
-  | assert_eq(len(filtered), 1)
-end
-
-def test_section_title_match():
-  let sections = do test_sections | section::split(1);
-  | let filtered = section::title_match(sections, "^I.*")
-  | assert_eq(len(filtered), 1)
+  | let filtered = f(sections, pattern)
+  | assert_eq(len(filtered), expected_len)
 end
 
 def test_section_title():
@@ -116,21 +109,11 @@ def test_section_bodies_pipe():
   | assert(is_array(first(body_list)))
 end
 
-def test_section_by_level_scalar():
-  let secs = do test_sections | section::sections() | section::by_level(1);
-  | assert_eq(len(secs), 2)
-  | assert_eq(section::level(first(secs)), 1)
-end
-
-def test_section_by_level_h2():
-  let secs = do test_sections | section::sections() | section::by_level(2);
-  | assert_eq(len(secs), 1)
-  | assert_eq(section::level(first(secs)), 2)
-end
-
-def test_section_by_level_range():
-  let secs = do test_sections | section::sections() | section::by_level(1..2);
-  | assert_eq(len(secs), 3)
+# @parametrize([[1, 2, 1], [2, 1, 2], [1..2, 3, 1]])
+def test_section_by_level(level_arg, expected_len, expected_first_level):
+  let secs = do test_sections | section::sections() | section::by_level(level_arg);
+  | assert_eq(len(secs), expected_len)
+  | assert_eq(section::level(first(secs)), expected_first_level)
 end
 
 def test_section_by_level_empty():

--- a/crates/mq-lang/modules/semver_test.mq
+++ b/crates/mq-lang/modules/semver_test.mq
@@ -3,134 +3,42 @@ import "semver"
 
 # -- SemVer Tests --
 
-def test_semver_parse_basic():
-  let v = semver::semver_parse("1.2.3")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["minor"], 2)
-  | assert_eq(v["patch"], 3)
-  | assert_eq(v["pre"], "")
-  | assert_eq(v["build"], "")
+# @parametrize([["1.2.3", 1, 2, 3, "", ""], ["1.0.0-alpha.1", 1, 0, 0, "alpha.1", ""], ["1.0.0+build.123", 1, 0, 0, "", "build.123"], ["1.0.0-beta.2+exp.sha.5114f85", 1, 0, 0, "beta.2", "exp.sha.5114f85"], ["v1.2.3", 1, 2, 3, "", ""], ["V1.2.3", 1, 2, 3, "", ""], ["v1.0.0-alpha.1+build.5", 1, 0, 0, "alpha.1", "build.5"]])
+def test_semver_parse(version, major, minor, patch, pre, build):
+  let v = semver::semver_parse(version)
+  | assert_eq(v["major"], major)
+  | assert_eq(v["minor"], minor)
+  | assert_eq(v["patch"], patch)
+  | assert_eq(v["pre"], pre)
+  | assert_eq(v["build"], build)
 end
 
-def test_semver_parse_with_prerelease():
-  let v = semver::semver_parse("1.0.0-alpha.1")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["minor"], 0)
-  | assert_eq(v["patch"], 0)
-  | assert_eq(v["pre"], "alpha.1")
-  | assert_eq(v["build"], "")
+# @parametrize([["1.2.3"], ["2.0.0-rc.1"], ["1.0.0+sha.abc123"]])
+def test_semver_to_string(version):
+  let v = semver::semver_parse(version)
+  | assert_eq(semver::semver_to_string(v), version)
 end
 
-def test_semver_parse_with_build():
-  let v = semver::semver_parse("1.0.0+build.123")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["pre"], "")
-  | assert_eq(v["build"], "build.123")
+# @parametrize([["1.2.3", "1.2.3", 0], ["2.0.0", "1.9.9", 1], ["1.9.9", "2.0.0", -1], ["1.3.0", "1.2.9", 1], ["1.2.4", "1.2.3", 1], ["1.0.0+build.1", "1.0.0+build.2", 0]])
+def test_semver_compare(a_str, b_str, expected):
+  let a = semver::semver_parse(a_str)
+  | let b = semver::semver_parse(b_str)
+  | assert_eq(semver::semver_compare(a, b), expected)
 end
 
-def test_semver_parse_with_pre_and_build():
-  let v = semver::semver_parse("1.0.0-beta.2+exp.sha.5114f85")
-  | assert_eq(v["pre"], "beta.2")
-  | assert_eq(v["build"], "exp.sha.5114f85")
-end
-
-def test_semver_parse_with_lowercase_v_prefix():
-  let v = semver::semver_parse("v1.2.3")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["minor"], 2)
-  | assert_eq(v["patch"], 3)
-end
-
-def test_semver_parse_with_uppercase_v_prefix():
-  let v = semver::semver_parse("V1.2.3")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["minor"], 2)
-  | assert_eq(v["patch"], 3)
-end
-
-def test_semver_parse_with_v_prefix_and_prerelease():
-  let v = semver::semver_parse("v1.0.0-alpha.1+build.5")
-  | assert_eq(v["major"], 1)
-  | assert_eq(v["pre"], "alpha.1")
-  | assert_eq(v["build"], "build.5")
-end
-
-def test_semver_to_string_basic():
-  let v = semver::semver_parse("1.2.3")
-  | assert_eq(semver::semver_to_string(v), "1.2.3")
-end
-
-def test_semver_to_string_with_pre():
-  let v = semver::semver_parse("2.0.0-rc.1")
-  | assert_eq(semver::semver_to_string(v), "2.0.0-rc.1")
-end
-
-def test_semver_to_string_with_build():
-  let v = semver::semver_parse("1.0.0+sha.abc123")
-  | assert_eq(semver::semver_to_string(v), "1.0.0+sha.abc123")
-end
-
-def test_semver_compare_equal():
-  let a = semver::semver_parse("1.2.3")
-  | let b = semver::semver_parse("1.2.3")
-  | assert_eq(semver::semver_compare(a, b), 0)
-end
-
-def test_semver_compare_major():
-  let a = semver::semver_parse("2.0.0")
-  | let b = semver::semver_parse("1.9.9")
-  | assert_eq(semver::semver_compare(a, b), 1)
-  | assert_eq(semver::semver_compare(b, a), -1)
-end
-
-def test_semver_compare_minor():
-  let a = semver::semver_parse("1.3.0")
-  | let b = semver::semver_parse("1.2.9")
-  | assert_eq(semver::semver_compare(a, b), 1)
-end
-
-def test_semver_compare_patch():
-  let a = semver::semver_parse("1.2.4")
-  | let b = semver::semver_parse("1.2.3")
-  | assert_eq(semver::semver_compare(a, b), 1)
-end
-
-def test_semver_compare_pre_vs_release():
-  let release = semver::semver_parse("1.0.0")
-  | let pre = semver::semver_parse("1.0.0-alpha")
-  | assert_true(semver::semver_gt(release, pre))
-end
-
-def test_semver_compare_pre_numeric():
-  let a = semver::semver_parse("1.0.0-alpha.2")
-  | let b = semver::semver_parse("1.0.0-alpha.1")
+# @parametrize([["1.0.0", "1.0.0-alpha"], ["1.0.0-alpha.2", "1.0.0-alpha.1"], ["1.0.0-beta", "1.0.0-alpha"]])
+def test_semver_gt_prerelease(a_str, b_str):
+  let a = semver::semver_parse(a_str)
+  | let b = semver::semver_parse(b_str)
   | assert_true(semver::semver_gt(a, b))
 end
 
-def test_semver_compare_pre_string():
-  let a = semver::semver_parse("1.0.0-beta")
-  | let b = semver::semver_parse("1.0.0-alpha")
-  | assert_true(semver::semver_gt(a, b))
-end
-
-def test_semver_compare_build_ignored():
-  let a = semver::semver_parse("1.0.0+build.1")
-  | let b = semver::semver_parse("1.0.0+build.2")
-  | assert_eq(semver::semver_compare(a, b), 0)
-end
-
-def test_semver_gt():
-  let a = semver::semver_parse("2.0.0")
-  | let b = semver::semver_parse("1.0.0")
-  | assert_true(semver::semver_gt(a, b))
-  | assert_false(semver::semver_gt(b, a))
-end
-
-def test_semver_lt():
-  let a = semver::semver_parse("1.0.0")
-  | let b = semver::semver_parse("2.0.0")
-  | assert_true(semver::semver_lt(a, b))
-  | assert_false(semver::semver_lt(b, a))
+# @parametrize([[semver::semver_gt, "2.0.0", "1.0.0"], [semver::semver_lt, "1.0.0", "2.0.0"]])
+def test_semver_gt_lt(f, x_str, y_str):
+  let x = semver::semver_parse(x_str)
+  | let y = semver::semver_parse(y_str)
+  | assert_true(f(x, y))
+  | assert_false(f(y, x))
 end
 
 def test_semver_eq():
@@ -139,46 +47,20 @@ def test_semver_eq():
   | assert_true(semver::semver_eq(a, b))
 end
 
-def test_semver_gte():
-  let a = semver::semver_parse("1.2.3")
-  | let b = semver::semver_parse("1.2.3")
-  | assert_true(semver::semver_gte(a, b))
-  | let c = semver::semver_parse("1.2.4")
-  | assert_true(semver::semver_gte(c, a))
+# @parametrize([[semver::semver_gte, "1.2.3", "1.2.3"], [semver::semver_gte, "1.2.4", "1.2.3"], [semver::semver_lte, "1.2.3", "1.2.3"], [semver::semver_lte, "1.2.2", "1.2.3"]])
+def test_semver_gte_lte(f, x_str, y_str):
+  let x = semver::semver_parse(x_str)
+  | let y = semver::semver_parse(y_str)
+  | assert_true(f(x, y))
 end
 
-def test_semver_lte():
-  let a = semver::semver_parse("1.2.3")
-  | let b = semver::semver_parse("1.2.3")
-  | assert_true(semver::semver_lte(a, b))
-  | let c = semver::semver_parse("1.2.2")
-  | assert_true(semver::semver_lte(c, a))
-end
-
-def test_semver_bump_major():
+# @parametrize([[semver::semver_bump_major, 2, 0, 0], [semver::semver_bump_minor, 1, 3, 0], [semver::semver_bump_patch, 1, 2, 4]])
+def test_semver_bump(f, expected_major, expected_minor, expected_patch):
   let v = semver::semver_parse("1.2.3")
-  | let bumped = semver::semver_bump_major(v)
-  | assert_eq(bumped["major"], 2)
-  | assert_eq(bumped["minor"], 0)
-  | assert_eq(bumped["patch"], 0)
-  | assert_eq(bumped["pre"], "")
-end
-
-def test_semver_bump_minor():
-  let v = semver::semver_parse("1.2.3")
-  | let bumped = semver::semver_bump_minor(v)
-  | assert_eq(bumped["major"], 1)
-  | assert_eq(bumped["minor"], 3)
-  | assert_eq(bumped["patch"], 0)
-  | assert_eq(bumped["pre"], "")
-end
-
-def test_semver_bump_patch():
-  let v = semver::semver_parse("1.2.3")
-  | let bumped = semver::semver_bump_patch(v)
-  | assert_eq(bumped["major"], 1)
-  | assert_eq(bumped["minor"], 2)
-  | assert_eq(bumped["patch"], 4)
+  | let bumped = f(v)
+  | assert_eq(bumped["major"], expected_major)
+  | assert_eq(bumped["minor"], expected_minor)
+  | assert_eq(bumped["patch"], expected_patch)
   | assert_eq(bumped["pre"], "")
 end
 
@@ -209,44 +91,8 @@ def test_semver_min():
   | assert_eq(semver::semver_to_string(min), "1.0.0")
 end
 
-def test_semver_satisfies_range_true():
-  assert_true(semver::semver_satisfies("1.5.0", ">=1.0.0,<2.0.0"))
-end
-
-def test_semver_satisfies_range_false():
-  assert_false(semver::semver_satisfies("2.0.0", ">=1.0.0,<2.0.0"))
-end
-
-def test_semver_satisfies_range_lower_bound_inclusive():
-  assert_true(semver::semver_satisfies("1.0.0", ">=1.0.0,<2.0.0"))
-end
-
-def test_semver_satisfies_exact_match():
-  assert_true(semver::semver_satisfies("1.2.3", "1.2.3"))
-  | assert_false(semver::semver_satisfies("1.2.4", "1.2.3"))
-end
-
-def test_semver_satisfies_eq_operator():
-  assert_true(semver::semver_satisfies("1.2.3", "=1.2.3"))
-  | assert_true(semver::semver_satisfies("1.2.3", "==1.2.3"))
-end
-
-def test_semver_satisfies_not_equal():
-  assert_true(semver::semver_satisfies("1.2.4", "!=1.2.3"))
-  | assert_false(semver::semver_satisfies("1.2.3", "!=1.2.3"))
-end
-
-def test_semver_satisfies_gt_lt():
-  assert_true(semver::semver_satisfies("1.5.0", ">1.0.0"))
-  | assert_false(semver::semver_satisfies("1.0.0", ">1.0.0"))
-  | assert_true(semver::semver_satisfies("1.0.0", "<2.0.0"))
-  | assert_false(semver::semver_satisfies("2.0.0", "<2.0.0"))
-end
-
-def test_semver_satisfies_ignores_whitespace():
-  assert_true(semver::semver_satisfies("1.5.0", " >= 1.0.0 , < 2.0.0 "))
-end
-
-def test_semver_satisfies_with_prerelease():
-  assert_true(semver::semver_satisfies("1.0.0-alpha", "<1.0.0"))
+# @parametrize([["1.5.0", ">=1.0.0,<2.0.0", true], ["2.0.0", ">=1.0.0,<2.0.0", false], ["1.0.0", ">=1.0.0,<2.0.0", true], ["1.2.3", "1.2.3", true], ["1.2.4", "1.2.3", false], ["1.2.3", "=1.2.3", true], ["1.2.3", "==1.2.3", true], ["1.2.4", "!=1.2.3", true], ["1.2.3", "!=1.2.3", false], ["1.5.0", ">1.0.0", true], ["1.0.0", ">1.0.0", false], ["1.0.0", "<2.0.0", true], ["2.0.0", "<2.0.0", false], ["1.5.0", " >= 1.0.0 , < 2.0.0 ", true], ["1.0.0-alpha", "<1.0.0", true]])
+def test_semver_satisfies(version, range_expr, expected):
+  let result = semver::semver_satisfies(version, range_expr)
+  | assert_eq(result, expected)
 end

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -21,24 +21,9 @@ def test_table_tables_empty():
   | assert_eq(result, [])
 end
 
-def test_table_tables_followed_by_paragraph():
-  let md_nodes = to_markdown(table_md_followed_by_paragraph)
-  | let result = table::tables(md_nodes)
-  | assert_eq(len(result), 1)
-  | let t = result[0]
-  | assert_eq(len(t[:rows]), 2)
-end
-
-def test_table_tables_followed_by_heading():
-  let md_nodes = to_markdown(table_md_followed_by_heading)
-  | let result = table::tables(md_nodes)
-  | assert_eq(len(result), 1)
-  | let t = result[0]
-  | assert_eq(len(t[:rows]), 2)
-end
-
-def test_table_tables_followed_by_break():
-  let md_nodes = to_markdown(table_md_followed_by_break)
+# @parametrize([[table_md_followed_by_paragraph], [table_md_followed_by_heading], [table_md_followed_by_break]])
+def test_table_tables_followed_by(markdown):
+  let md_nodes = to_markdown(markdown)
   | let result = table::tables(md_nodes)
   | assert_eq(len(result), 1)
   | let t = result[0]

--- a/crates/mq-test/src/runner.rs
+++ b/crates/mq-test/src/runner.rs
@@ -1,5 +1,5 @@
 use glob::glob;
-use miette::IntoDiagnostic;
+use miette::{IntoDiagnostic, NamedSource};
 use mq_lang::{CstNodeKind, CstTrivia, RuntimeValue};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -128,7 +128,10 @@ impl TestRunner {
 
     /// Discovers and executes all test functions.
     ///
-    /// Returns `Ok(true)` if every executed test passed.
+    /// A file that fails to read, parse, or evaluate is reported in place but does not
+    /// stop the remaining files from running.
+    ///
+    /// Returns `Ok(true)` if every executed test passed and every file ran.
     pub fn run(self) -> miette::Result<bool> {
         let test_files: Vec<PathBuf> = if self.files.is_empty() {
             glob("./**/*.mq")
@@ -144,15 +147,25 @@ impl TestRunner {
         // Behind a `Mutex` so files can be run in parallel.
         let module_paths: Mutex<FxHashMap<String, PathBuf>> = Mutex::new(FxHashMap::default());
         let any_failed = AtomicBool::new(false);
+        // Files that failed to read/parse/evaluate, reported as a rollup at the end.
+        let file_errors: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
-        let run_file = |file: &PathBuf| -> miette::Result<()> {
-            let content = fs::read_to_string(file).into_diagnostic()?;
+        let run_file = |file: &PathBuf| {
+            let content = match fs::read_to_string(file) {
+                Ok(content) => content,
+                Err(e) => {
+                    any_failed.store(true, Ordering::Relaxed);
+                    file_errors.lock().unwrap().push(file.clone());
+                    eprintln!("# {}\n\n❌ Failed to read file: {e}\n\n---\n", file.display());
+                    return;
+                }
+            };
             let tests: Vec<DiscoveredTest> = Self::discover_tests(&content)
                 .into_iter()
                 .filter(|test| self.matches(test))
                 .collect();
             if tests.is_empty() {
-                return Ok(());
+                return;
             }
 
             let query = Self::build_test_query(&content, &tests);
@@ -189,34 +202,40 @@ impl TestRunner {
             };
 
             let input = mq_lang::null_input();
-            let result = engine.eval(&query, input.into_iter()).map_err(|e| *e)?;
-            let passed = matches!(result.values().first(), Some(RuntimeValue::Boolean(true)));
-            if !passed {
-                any_failed.store(true, Ordering::Relaxed);
-            }
-
-            if self.coverage {
-                let mut module_paths = module_paths.lock().unwrap();
-                for module_name in coverage_data.snapshot().keys() {
-                    if before_modules.contains(module_name) {
-                        continue;
+            match engine.eval(&query, input.into_iter()) {
+                Ok(result) => {
+                    let passed = matches!(result.values().first(), Some(RuntimeValue::Boolean(true)));
+                    if !passed {
+                        any_failed.store(true, Ordering::Relaxed);
                     }
-                    module_paths.entry(module_name.clone()).or_insert_with(|| {
-                        engine
-                            .get_module_path(module_name)
-                            .map(PathBuf::from)
-                            .unwrap_or_else(|_| PathBuf::from(module_name))
-                    });
+
+                    if self.coverage {
+                        let mut module_paths = module_paths.lock().unwrap();
+                        for module_name in coverage_data.snapshot().keys() {
+                            if before_modules.contains(module_name) {
+                                continue;
+                            }
+                            module_paths.entry(module_name.clone()).or_insert_with(|| {
+                                engine
+                                    .get_module_path(module_name)
+                                    .map(PathBuf::from)
+                                    .unwrap_or_else(|_| PathBuf::from(module_name))
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    any_failed.store(true, Ordering::Relaxed);
+                    file_errors.lock().unwrap().push(file.clone());
+                    eprintln!("{}", Self::render_file_error(file, *e));
                 }
             }
-
-            Ok(())
         };
 
         if test_files.len() > self.parallel_threshold {
-            test_files.par_iter().try_for_each(run_file)?;
+            test_files.par_iter().for_each(run_file);
         } else {
-            test_files.iter().try_for_each(run_file)?;
+            test_files.iter().for_each(run_file);
         }
 
         if self.coverage {
@@ -255,7 +274,35 @@ impl TestRunner {
             }
         }
 
+        let file_errors = file_errors.into_inner().unwrap();
+        if !file_errors.is_empty() {
+            let list = file_errors
+                .iter()
+                .map(|f| format!("  - {}", f.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            eprintln!(
+                "⚠ {} of {} file(s) failed to run and were skipped:\n{list}",
+                file_errors.len(),
+                test_files.len()
+            );
+        }
+
         Ok(!any_failed.load(Ordering::Relaxed))
+    }
+
+    /// Renders a file-level failure (parse/eval error, not a failing test) with a
+    /// per-file header. mq-lang's top-level query has no file name of its own, so this
+    /// re-attaches `file` when the diagnostic's source name is blank.
+    fn render_file_error(file: &Path, mut error: mq_lang::Error) -> String {
+        if error.source_code.name().is_empty() {
+            error.source_code = NamedSource::new(file.display().to_string(), error.source_code.inner().clone());
+        }
+        format!(
+            "# {}\n\n❌ Failed to run tests\n\n{:?}\n---\n",
+            file.display(),
+            miette::Report::new(error)
+        )
     }
 
     /// Returns `true` if `test` should run given `self.filter`/`self.tags`.
@@ -978,6 +1025,79 @@ mod tests {
 
         let passed = TestRunner::new(vec![failing, passing]).run().unwrap();
         assert!(!passed, "run() must report failure when any test fails");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_run_continues_after_a_file_with_a_syntax_error() {
+        let dir = temp_project_dir("continues_after_syntax_error");
+        fs::write(dir.join("lib.mq"), "def add(a, b):\n  a + b\nend\n").unwrap();
+
+        let broken = dir.join("a_broken.mq");
+        fs::write(
+            &broken,
+            "include \"test\"\n|\ndef test_broken():\n  assert_eq(1, 1)\nend\nend\n",
+        )
+        .unwrap();
+
+        let ok = dir.join("b_ok.mq");
+        fs::write(
+            &ok,
+            "include \"test\" | include \"lib\"\n|\n\ndef test_ok():\n  assert_eq(add(1, 2), 3)\nend\n",
+        )
+        .unwrap();
+        let output = dir.join("coverage.json");
+
+        let passed = TestRunner::new(vec![broken, ok])
+            .with_coverage(true)
+            .with_coverage_format(CoverageFormat::Json)
+            .with_coverage_output(Some(output.clone()))
+            .run()
+            .unwrap();
+        assert!(!passed, "a broken file must fail the overall run");
+
+        // Proves b_ok.mq still ran despite a_broken.mq's syntax error.
+        let report = fs::read_to_string(&output).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let files = parsed["files"].as_array().unwrap();
+        assert_eq!(
+            files.len(),
+            1,
+            "b_ok.mq must still have run and exercised lib.mq: {files:?}"
+        );
+        assert!(files[0]["file"].as_str().unwrap().ends_with("lib.mq"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_render_file_error_attaches_the_file_name_when_mq_lang_left_it_blank() {
+        let dir = temp_project_dir("render_file_error");
+        let broken = dir.join("broken.mq");
+        let content = "include \"test\"\n|\ndef test_x():\n  1\nend\nend\n";
+        fs::write(&broken, content).unwrap();
+
+        let tests = TestRunner::discover_tests(content);
+        let query = TestRunner::build_test_query(content, &tests);
+
+        let mut engine = mq_lang::Engine::with_io(
+            mq_lang::DefaultModuleResolver::default(),
+            mq_lang::Shared::new(mq_lang::MemIo::default()),
+        );
+        engine.load_builtin_module();
+        let err = *engine.eval(&query, mq_lang::null_input().into_iter()).unwrap_err();
+        assert_eq!(
+            err.source_code.name(),
+            "",
+            "sanity check: mq-lang itself doesn't know the file name"
+        );
+
+        let rendered = TestRunner::render_file_error(&broken, err);
+        assert!(
+            rendered.contains(&broken.display().to_string()),
+            "rendered error must name the failing file:\n{rendered}"
+        );
 
         fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
## Summary

Collapse test functions that repeat the same call shape with different inputs into @parametrize tables (builtin_tests.mq and the module test files), matching the existing test_is_array style. Cases with differing assertion shapes or pipelines are left as-is. 

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
