### PR TITLE
🔒 feat(mq-lang,mq-run): make HTTP module imports opt-in via --allow-http-import

### DIFF
--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -466,6 +466,14 @@ impl Engine<DefaultModuleResolver> {
         self.evaluator.module_loader.set_http_allowed_domains(domains);
     }
 
+    /// Enables or disables HTTP module imports outright, independent of the domain allowlist.
+    ///
+    /// The `mq` CLI calls this with `false` unless `--allow-http-import` is passed, so
+    /// imports are opt-in there; disabled regardless of `--allowed-domain`.
+    pub fn set_http_import_enabled(&mut self, enabled: bool) {
+        self.evaluator.module_loader.set_http_import_enabled(enabled);
+    }
+
     /// Clears all locally-cached HTTP module files.
     ///
     /// Call this once before processing to force a re-fetch of all cached modules

--- a/crates/mq-lang/src/engine.rs
+++ b/crates/mq-lang/src/engine.rs
@@ -494,6 +494,14 @@ impl Engine<DefaultModuleResolver> {
         self.evaluator.module_loader.set_lockfile_enabled(enabled);
     }
 
+    /// When `true`, a URL with no existing `mq.lock` entry is a hard error instead of being
+    /// recorded as a new entry (off by default). Mirrors `npm ci` / `cargo build --locked`:
+    /// pass `--frozen` on the CLI so trusting a module's content for the first time
+    /// only ever happens in a reviewable local run, not silently in CI.
+    pub fn set_lockfile_frozen(&mut self, frozen: bool) {
+        self.evaluator.module_loader.set_lockfile_frozen(frozen);
+    }
+
     /// Sets the path used for `mq.lock`.
     pub fn set_lockfile_path(&mut self, path: std::path::PathBuf) {
         self.evaluator.module_loader.set_lockfile_path(path);

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -391,6 +391,11 @@ impl ModuleLoader<DefaultModuleResolver> {
         self.resolver.set_allowed_domains(domains);
     }
 
+    /// Enables or disables HTTP module imports outright, independent of the domain allowlist.
+    pub fn set_http_import_enabled(&mut self, enabled: bool) {
+        self.resolver.set_http_import_enabled(enabled);
+    }
+
     /// Clears all locally-cached HTTP module files.
     ///
     /// Call this once before processing to force a re-fetch of all cached modules.

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -413,6 +413,12 @@ impl ModuleLoader<DefaultModuleResolver> {
         self.resolver.set_lockfile_enabled(enabled);
     }
 
+    /// When `true`, a URL with no existing `mq.lock` entry is a hard error instead of being
+    /// recorded as a new entry.
+    pub fn set_lockfile_frozen(&mut self, frozen: bool) {
+        self.resolver.set_lockfile_frozen(frozen);
+    }
+
     /// Sets the path used for `mq.lock`.
     pub fn set_lockfile_path(&mut self, path: std::path::PathBuf) {
         self.resolver.set_lockfile_path(path);

--- a/crates/mq-lang/src/module/resolver.rs
+++ b/crates/mq-lang/src/module/resolver.rs
@@ -175,6 +175,12 @@ impl DefaultModuleResolver {
         self.http_resolver.set_allowed_domains(domains);
     }
 
+    /// Enables or disables HTTP module imports outright, independent of the domain allowlist.
+    #[cfg(feature = "http-import-ureq")]
+    pub fn set_http_import_enabled(&mut self, enabled: bool) {
+        self.http_resolver.set_enabled(enabled);
+    }
+
     /// Clears all locally-cached HTTP module files (mutable/HEAD only).
     #[cfg(feature = "http-import-ureq")]
     pub fn clear_http_cache(&self) -> Result<(), crate::module::error::ModuleError> {
@@ -285,6 +291,16 @@ mod tests {
     fn test_http_url_not_in_local(#[case] url: &str) {
         let resolver = DefaultModuleResolver::new(vec![]);
         assert!(resolver.resolve(url).is_err());
+    }
+
+    #[cfg(feature = "http-import-ureq")]
+    #[test]
+    fn test_set_http_import_enabled_blocks_resolution() {
+        let mut resolver = DefaultModuleResolver::new(vec![]);
+        resolver.set_http_import_enabled(false);
+
+        let err = resolver.resolve("github.com/harehare/lisp").unwrap_err();
+        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
     }
 
     #[cfg(feature = "http-import-ureq")]

--- a/crates/mq-lang/src/module/resolver.rs
+++ b/crates/mq-lang/src/module/resolver.rs
@@ -156,12 +156,14 @@ impl DefaultModuleResolver {
     pub fn with_http(mut self, allowed_domains: Vec<String>, timeout: Option<std::time::Duration>) -> Self {
         let lockfile_path = self.http_resolver.lockfile_path();
         let lockfile_enabled = self.http_resolver.lockfile_enabled();
+        let lockfile_frozen = self.http_resolver.lockfile_frozen();
         let mut http_resolver = http_resolver::HttpModuleResolver::new(
             allowed_domains,
             http_resolver::UreqFetcher::new(timeout.unwrap_or(std::time::Duration::from_secs(10))),
         );
         http_resolver.set_lockfile_path(lockfile_path);
         http_resolver.set_lockfile_enabled(lockfile_enabled);
+        http_resolver.set_lockfile_frozen(lockfile_frozen);
         self.http_resolver = http_resolver;
         self
     }
@@ -197,6 +199,13 @@ impl DefaultModuleResolver {
     #[cfg(feature = "http-import-ureq")]
     pub fn set_lockfile_enabled(&mut self, enabled: bool) {
         self.http_resolver.set_lockfile_enabled(enabled);
+    }
+
+    /// When `true`, a URL with no existing `mq.lock` entry is a hard error instead of being
+    /// recorded as a new entry. See [`http_resolver::UreqFetcher::set_lockfile_frozen`].
+    #[cfg(feature = "http-import-ureq")]
+    pub fn set_lockfile_frozen(&mut self, frozen: bool) {
+        self.http_resolver.set_lockfile_frozen(frozen);
     }
 
     /// Sets the path used for `mq.lock`.
@@ -300,7 +309,10 @@ mod tests {
         resolver.set_http_import_enabled(false);
 
         let err = resolver.resolve("github.com/harehare/lisp").unwrap_err();
-        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
+        assert!(
+            err.to_string().contains("HTTP module imports are disabled"),
+            "error was: {err}"
+        );
     }
 
     #[cfg(feature = "http-import-ureq")]

--- a/crates/mq-lang/src/module/resolver/http_resolver.rs
+++ b/crates/mq-lang/src/module/resolver/http_resolver.rs
@@ -117,9 +117,7 @@ impl<F: HttpFetcher> HttpModuleResolver<F> {
     fn to_fetch_url(&self, module_name: &str) -> Result<String, ModuleError> {
         let is_import_attempt = is_github_url(module_name) || is_remote_url(module_name);
         if is_import_attempt && !self.enabled {
-            return Err(ModuleError::IOError(
-                "HTTP module imports are disabled; pass --allow-http-import to enable them".into(),
-            ));
+            return Err(ModuleError::IOError("HTTP module imports are disabled".into()));
         }
 
         if is_github_url(module_name) {
@@ -168,6 +166,7 @@ pub struct UreqFetcher {
     cache_dir: std::path::PathBuf,
     lockfile_path: std::path::PathBuf,
     lockfile_enabled: bool,
+    lockfile_frozen: bool,
     lockfile_cache: std::sync::Arc<std::sync::Mutex<Option<super::lockfile::ModuleLock>>>,
 }
 
@@ -179,6 +178,7 @@ impl Default for UreqFetcher {
             cache_dir: dirs::cache_dir().unwrap_or_default().join("mq"),
             lockfile_path: std::path::PathBuf::from(lockfile::LOCKFILE_NAME),
             lockfile_enabled: true,
+            lockfile_frozen: false,
             lockfile_cache: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
@@ -199,6 +199,14 @@ impl UreqFetcher {
         self.lockfile_enabled = enabled;
     }
 
+    /// When `true`, a URL with no existing `mq.lock` entry is a hard error instead of being
+    /// recorded as a new entry. Has no effect if the lockfile check itself is disabled.
+    /// Mirrors `npm ci` / `cargo build --locked`: use for CI/reproducible runs so trusting a
+    /// new module's content only ever happens in a reviewable local run, not silently in CI.
+    pub fn set_lockfile_frozen(&mut self, frozen: bool) {
+        self.lockfile_frozen = frozen;
+    }
+
     /// Sets the path used for `mq.lock`. Clears any in-memory cache of the previous path.
     pub fn set_lockfile_path(&mut self, path: std::path::PathBuf) {
         self.lockfile_path = path;
@@ -211,6 +219,10 @@ impl UreqFetcher {
 
     pub(crate) fn lockfile_enabled(&self) -> bool {
         self.lockfile_enabled
+    }
+
+    pub(crate) fn lockfile_frozen(&self) -> bool {
+        self.lockfile_frozen
     }
 
     /// Removes mutable-ref cached modules and their `mq.lock` entries, regardless of
@@ -290,7 +302,7 @@ impl UreqFetcher {
         super::lockfile::ModuleLock::parse(&content).map_err(|e| {
             ModuleError::IOError(
                 format!(
-                    "failed to parse {}: {e}. Delete the file to reset it, or pass --no-lockfile to skip the check.",
+                    "failed to parse {}: {e}. Delete the file to reset it, or disable the lock file check.",
                     path.display()
                 )
                 .into(),
@@ -357,19 +369,27 @@ impl UreqFetcher {
             let lock = cache.as_mut().unwrap();
             match lock.check(url, hash) {
                 lockfile::LockCheck::Match => Ok(()),
+                lockfile::LockCheck::NewEntry if self.lockfile_frozen => Err(ModuleError::IOError(
+                    format!(
+                        "{url} has no entry in {} and the lock file is frozen. \
+                         Run once without freezing it to record the entry, then commit the updated lock file.",
+                        super::lockfile::LOCKFILE_NAME
+                    )
+                    .into(),
+                )),
                 lockfile::LockCheck::NewEntry => {
                     lock.insert(url, hash);
                     Self::save_lock(&self.lockfile_path, lock)?;
                     Ok(())
                 }
                 lockfile::LockCheck::Mismatch { locked } => {
-                    // --refresh-modules only clears mutable-ref cache and lock entries, so
-                    // a drifted versioned (tagged) module needs the full reset instead.
+                    // A mutable-ref refresh only clears mutable-ref cache and lock entries, so
+                    // a drifted versioned (tagged) module needs a full cache reset instead.
 
                     let hint = if http_import::is_versioned_url(url) {
-                        "re-run with --clear-cache to reset the module cache and the lock file"
+                        "reset the module cache and the lock file to accept it"
                     } else {
-                        "re-run with --refresh-modules to update the lock file"
+                        "re-fetch the module to accept the new content and update the lock file"
                     };
                     Err(ModuleError::IOError(
                         format!(
@@ -490,6 +510,12 @@ impl HttpModuleResolver<UreqFetcher> {
         self.fetcher.set_lockfile_enabled(enabled);
     }
 
+    /// When `true`, a URL with no existing `mq.lock` entry is a hard error instead of being
+    /// recorded as a new entry. See [`UreqFetcher::set_lockfile_frozen`].
+    pub fn set_lockfile_frozen(&mut self, frozen: bool) {
+        self.fetcher.set_lockfile_frozen(frozen);
+    }
+
     /// Sets the path used for `mq.lock`.
     pub fn set_lockfile_path(&mut self, path: std::path::PathBuf) {
         self.fetcher.set_lockfile_path(path);
@@ -501,6 +527,10 @@ impl HttpModuleResolver<UreqFetcher> {
 
     pub(crate) fn lockfile_enabled(&self) -> bool {
         self.fetcher.lockfile_enabled()
+    }
+
+    pub(crate) fn lockfile_frozen(&self) -> bool {
+        self.fetcher.lockfile_frozen()
     }
 }
 
@@ -762,12 +792,12 @@ mod tests {
         let resolver = HttpModuleResolver::new(vec![], fetcher);
 
         let err = resolver.resolve(url).unwrap_err();
-        assert!(err.to_string().contains("--refresh-modules"), "message was: {err}");
+        assert!(err.to_string().contains("re-fetch the module"), "message was: {err}");
     }
 
     #[test]
     #[cfg(feature = "http-import-ureq")]
-    fn test_resolve_cache_hit_versioned_lock_mismatch_mentions_clear_cache() {
+    fn test_resolve_cache_hit_versioned_lock_mismatch_mentions_cache_reset() {
         let dir = TempDir::new().unwrap();
         let url = "https://raw.githubusercontent.com/harehare/mymod/v0.1.0/mymod.mq";
         seed_cache(dir.path(), "versioned", url, "def pinned(): 1;");
@@ -785,7 +815,7 @@ mod tests {
         let resolver = HttpModuleResolver::new(vec![], fetcher);
 
         let err = resolver.resolve(url).unwrap_err();
-        assert!(err.to_string().contains("--clear-cache"), "message was: {err}");
+        assert!(err.to_string().contains("reset the module cache"), "message was: {err}");
     }
 
     #[test]
@@ -812,6 +842,53 @@ mod tests {
             lock.check(url, &lockfile::compute_hash(content)),
             lockfile::LockCheck::Match
         );
+    }
+
+    #[test]
+    #[cfg(feature = "http-import-ureq")]
+    fn test_resolve_cache_hit_frozen_lockfile_blocks_new_entry() {
+        let dir = TempDir::new().unwrap();
+        let url = "https://raw.githubusercontent.com/harehare/mymod/HEAD/mymod.mq";
+        let content = "def cached(): 42;";
+        seed_cache(dir.path(), "mutable", url, content);
+
+        let lock_path = dir.path().join("mq.lock");
+        let mut fetcher = UreqFetcher {
+            cache_dir: dir.path().to_path_buf(),
+            lockfile_path: lock_path.clone(),
+            ..UreqFetcher::default()
+        };
+        fetcher.set_lockfile_frozen(true);
+        let resolver = HttpModuleResolver::new(vec![], fetcher);
+
+        let err = resolver.resolve(url).unwrap_err();
+        assert!(err.to_string().contains("lock file is frozen"), "error was: {err}");
+        // No entry should have been recorded, and no lock file created at all.
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    #[cfg(feature = "http-import-ureq")]
+    fn test_resolve_cache_hit_frozen_lockfile_allows_matching_entry() {
+        let dir = TempDir::new().unwrap();
+        let url = "https://raw.githubusercontent.com/harehare/mymod/HEAD/mymod.mq";
+        let content = "def cached(): 42;";
+        seed_cache(dir.path(), "mutable", url, content);
+
+        let lock_path = dir.path().join("mq.lock");
+        let mut lock = lockfile::ModuleLock::default();
+        lock.insert(url, lockfile::compute_hash(content));
+        std::fs::write(&lock_path, lock.to_json()).unwrap();
+
+        let mut fetcher = UreqFetcher {
+            cache_dir: dir.path().to_path_buf(),
+            lockfile_path: lock_path,
+            ..UreqFetcher::default()
+        };
+        fetcher.set_lockfile_frozen(true);
+        let resolver = HttpModuleResolver::new(vec![], fetcher);
+
+        assert_eq!(resolver.resolve(url).unwrap(), content);
     }
 
     #[test]
@@ -857,7 +934,7 @@ mod tests {
 
         let err = resolver.resolve("github.com/harehare/lisp").unwrap_err();
         assert!(
-            matches!(err, ModuleError::IOError(_)) && err.to_string().contains("--allow-http-import"),
+            matches!(err, ModuleError::IOError(_)) && err.to_string().contains("HTTP module imports are disabled"),
             "error was: {err}"
         );
     }
@@ -1198,7 +1275,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "http-import-ureq")]
-    fn test_load_lock_parse_error_mentions_no_lockfile_recovery() {
+    fn test_load_lock_parse_error_mentions_recovery_options() {
         let dir = TempDir::new().unwrap();
         let lock_path = dir.path().join("mq.lock");
         std::fs::write(&lock_path, "not json").unwrap();
@@ -1213,7 +1290,10 @@ mod tests {
             .check_lock("https://example.invalid/a.mq", "hash-a")
             .unwrap_err();
         let message = err.to_string();
-        assert!(message.contains("--no-lockfile"), "message was: {message}");
+        assert!(
+            message.contains("disable the lock file check"),
+            "message was: {message}"
+        );
     }
 
     #[test]

--- a/crates/mq-lang/src/module/resolver/http_resolver.rs
+++ b/crates/mq-lang/src/module/resolver/http_resolver.rs
@@ -40,6 +40,7 @@ pub trait HttpFetcher: Clone + Default {
 pub struct HttpModuleResolver<F: HttpFetcher> {
     pub(crate) allowed_remote_domains: Vec<String>,
     fetcher: F,
+    enabled: bool,
 }
 
 impl<F: HttpFetcher> Default for HttpModuleResolver<F> {
@@ -47,6 +48,7 @@ impl<F: HttpFetcher> Default for HttpModuleResolver<F> {
         Self {
             allowed_remote_domains: Vec::new(),
             fetcher: F::default(),
+            enabled: true,
         }
     }
 }
@@ -88,6 +90,7 @@ impl<F: HttpFetcher> HttpModuleResolver<F> {
                 .map(|d| normalize_allowed_domain(&d))
                 .collect(),
             fetcher,
+            enabled: true,
         }
     }
 
@@ -103,7 +106,22 @@ impl<F: HttpFetcher> HttpModuleResolver<F> {
         self.allowed_remote_domains = domains.into_iter().map(|d| normalize_allowed_domain(&d)).collect();
     }
 
+    /// Enables or disables HTTP module imports outright, independent of the domain allowlist.
+    ///
+    /// On by default for direct library use; the `mq` CLI turns this off unless
+    /// `--allow-http-import` is passed, so imports are opt-in there.
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
     fn to_fetch_url(&self, module_name: &str) -> Result<String, ModuleError> {
+        let is_import_attempt = is_github_url(module_name) || is_remote_url(module_name);
+        if is_import_attempt && !self.enabled {
+            return Err(ModuleError::IOError(
+                "HTTP module imports are disabled; pass --allow-http-import to enable them".into(),
+            ));
+        }
+
         if is_github_url(module_name) {
             let url = github_to_raw_url(module_name)
                 .ok_or_else(|| ModuleError::IOError(format!("Invalid GitHub URL: {}", module_name).into()))?;
@@ -829,6 +847,36 @@ mod tests {
     fn test_resolve_non_url_returns_not_found(#[case] module_name: &str) {
         let resolver = HttpModuleResolver::<UreqFetcher>::default();
         assert!(matches!(resolver.resolve(module_name), Err(ModuleError::NotFound(_))));
+    }
+
+    #[test]
+    #[cfg(feature = "http-import-ureq")]
+    fn test_resolve_blocked_when_disabled() {
+        let mut resolver = resolver_with_domains(vec![]);
+        resolver.set_enabled(false);
+
+        let err = resolver.resolve("github.com/harehare/lisp").unwrap_err();
+        assert!(
+            matches!(err, ModuleError::IOError(_)) && err.to_string().contains("--allow-http-import"),
+            "error was: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "http-import-ureq")]
+    fn test_resolve_non_url_ignores_disabled_flag() {
+        // Disabling HTTP import must not break resolution of non-URL module names, which
+        // should keep falling through to NotFound so other resolver stages get a turn.
+        let mut resolver = HttpModuleResolver::<UreqFetcher>::default();
+        resolver.set_enabled(false);
+        assert!(matches!(resolver.resolve("csv"), Err(ModuleError::NotFound(_))));
+    }
+
+    #[test]
+    #[cfg(feature = "http-import-ureq")]
+    fn test_enabled_by_default() {
+        let resolver = HttpModuleResolver::<UreqFetcher>::default();
+        assert!(resolver.enabled);
     }
 
     #[rstest]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -364,8 +364,14 @@ struct InputArgs {
     /// By default a fetched URL's content is checked against mq.lock, and a mismatch is
     /// rejected unless --refresh-modules is also passed.
     #[cfg(feature = "http-import")]
-    #[arg(long = "no-lockfile", default_value_t = false, conflicts_with = "lockfile_path")]
+    #[arg(long = "no-lockfile", default_value_t = false, conflicts_with_all = ["lockfile_path", "frozen"])]
     no_lockfile: bool,
+
+    /// Fail instead of recording a new mq.lock entry.
+    /// `--frozen`; use in CI so a new module's content is only ever trusted during a reviewable local run whose mq.lock diff gets committed, not silently during CI.
+    #[cfg(feature = "http-import")]
+    #[arg(long = "frozen", default_value_t = false)]
+    frozen: bool,
 
     /// Path to the mq.lock file used for HTTP import integrity checks.
     /// Defaults to ./mq.lock (relative to the current directory).
@@ -1313,12 +1319,6 @@ impl Cli {
     }
 
     fn create_engine(&self) -> miette::Result<DefaultEngine> {
-        // --module-directories/--module-names/include/import resolve local modules from
-        // directories the invoker explicitly configured, so local module resolution keeps
-        // full native access (unchanged from before this Io existed). --allow-read/write/
-        // net/run instead gate what a running query's read_file/write_file/http/system
-        // builtins can do at runtime, via the ambient Io set below. HTTP module imports are
-        // gated separately, by --allow-http-import below, not by this Io.
         let sandboxed_io = mq_lang::SandboxedIo::new(mq_lang::NativeIo::default());
         let sandboxed_io = if self.input.allow_all {
             sandboxed_io.allow_all()
@@ -1441,6 +1441,9 @@ impl Cli {
             }
             if self.input.no_lockfile {
                 engine.set_lockfile_enabled(false);
+            }
+            if self.input.frozen {
+                engine.set_lockfile_frozen(true);
             }
             if let Some(path) = &self.input.lockfile_path {
                 engine.set_lockfile_path(path.clone());
@@ -2690,7 +2693,10 @@ mod tests {
         };
 
         let err = cli.run().unwrap_err();
-        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
+        assert!(
+            err.to_string().contains("HTTP module imports are disabled"),
+            "error was: {err}"
+        );
     }
 
     #[cfg(feature = "http-import")]
@@ -2710,7 +2716,19 @@ mod tests {
         };
 
         let err = cli.run().unwrap_err();
-        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
+        assert!(
+            err.to_string().contains("HTTP module imports are disabled"),
+            "error was: {err}"
+        );
+    }
+
+    #[cfg(feature = "http-import")]
+    #[test]
+    fn test_no_lockfile_conflicts_with_frozen() {
+        assert!(
+            Cli::try_parse_from(["mq", "--no-lockfile", "--frozen", "self"]).is_err(),
+            "--no-lockfile should conflict with --frozen"
+        );
     }
 
     #[rstest]

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -334,8 +334,13 @@ struct InputArgs {
     )]
     eval_all: bool,
 
-    /// Allow HTTP imports from additional domain(s) beyond the default.
-    /// By default only `raw.githubusercontent.com/harehare` is permitted.
+    /// Allow `import`/`include` to fetch modules over HTTP(S). Disabled by default
+    #[cfg(feature = "http-import")]
+    #[arg(long = "allow-http-import", default_value_t = false)]
+    allow_http_import: bool,
+
+    /// Allow HTTP imports from additional domain(s) beyond the default. Has no effect
+    /// unless `--allow-http-import` (or `--allow-all`) is also passed.
     /// Use `github.com/{user}/{repo}` to allow a specific repository (expanded automatically),
     /// or a plain domain like `example.com` to allow any path under that host.
     /// Repeat to allow multiple extra domains.
@@ -413,13 +418,14 @@ struct InputArgs {
     #[arg(short = 'E', long = "allow-env", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "NAME")]
     allow_env: Option<Vec<String>>,
 
-    /// Grant every sandboxed permission at once (read/write/net/run/env). Disabled by
-    /// default. Cannot be combined with the individual --allow-* flags above.
+    /// Grant every sandboxed permission at once (read/write/net/run/env), and also enable
+    /// HTTP module imports as if --allow-http-import were passed. Disabled by default.
+    /// Cannot be combined with the individual --allow-* flags above.
     #[arg(
         short = 'a',
         long = "allow-all",
         default_value_t = false,
-        conflicts_with_all = ["allow_net", "allow_read", "allow_write", "allow_run", "allow_env"]
+        conflicts_with_all = ["allow_net", "allow_read", "allow_write", "allow_run", "allow_env", "allow_http_import"]
     )]
     allow_all: bool,
 }
@@ -1051,6 +1057,19 @@ impl Cli {
             "  mq --allow-net=api.example.com 'http(\"get\", \"https://api.example.com/data\")' file.md"
         );
 
+        #[cfg(feature = "http-import")]
+        {
+            let _ = writeln!(out, "\n{}", "HTTP module imports (--allow-http-import):".bold().cyan());
+            let _ = writeln!(
+                out,
+                "  Separate from --allow-net above; disabled by default regardless of it."
+            );
+            let _ = writeln!(
+                out,
+                "  mq --allow-http-import 'import \"github.com/harehare/kdl.mq\"' file.md"
+            );
+        }
+
         let _ = writeln!(out, "\n{}", "Working with multiple files:".bold().cyan());
         let _ = writeln!(
             out,
@@ -1169,6 +1188,19 @@ impl Cli {
             mq --allow-net=api.example.com 'http(\"get\", \"https://api.example.com/data\")' file.md\n```"
         );
 
+        #[cfg(feature = "http-import")]
+        {
+            let _ = writeln!(out, "\n## HTTP module imports (--allow-http-import)\n");
+            let _ = writeln!(
+                out,
+                "Separate from --allow-net above; disabled by default regardless of it.\n"
+            );
+            let _ = writeln!(
+                out,
+                "```sh\nmq --allow-http-import 'import \"github.com/harehare/kdl.mq\"' file.md\n```"
+            );
+        }
+
         let _ = writeln!(out, "\n## Working with multiple files\n");
         let _ = writeln!(
             out,
@@ -1281,11 +1313,12 @@ impl Cli {
     }
 
     fn create_engine(&self) -> miette::Result<DefaultEngine> {
-        // --module-directories/--module-names/include/import resolve modules from
-        // directories the invoker explicitly configured, so module resolution keeps
-        // full native access (unchanged from before this Io existed) — --allow-read/
-        // write/net/run instead gate what a running query's read_file/write_file/http/
-        // system builtins can do at runtime, via the ambient Io set below.
+        // --module-directories/--module-names/include/import resolve local modules from
+        // directories the invoker explicitly configured, so local module resolution keeps
+        // full native access (unchanged from before this Io existed). --allow-read/write/
+        // net/run instead gate what a running query's read_file/write_file/http/system
+        // builtins can do at runtime, via the ambient Io set below. HTTP module imports are
+        // gated separately, by --allow-http-import below, not by this Io.
         let sandboxed_io = mq_lang::SandboxedIo::new(mq_lang::NativeIo::default());
         let sandboxed_io = if self.input.allow_all {
             sandboxed_io.allow_all()
@@ -1402,6 +1435,7 @@ impl Cli {
 
         #[cfg(feature = "http-import")]
         {
+            engine.set_http_import_enabled(self.input.allow_http_import || self.input.allow_all);
             if let Some(domains) = &self.input.allowed_domains {
                 engine.set_http_allowed_domains(domains.clone());
             }
@@ -2630,11 +2664,53 @@ mod tests {
     #[case(&["mq", "--allow-all", "--allow-net=example.com", "self"])]
     #[case(&["mq", "--allow-all", "--allow-run", "self"])]
     #[case(&["mq", "--allow-all", "--allow-env", "self"])]
+    #[case(&["mq", "--allow-all", "--allow-http-import", "self"])]
     fn test_allow_all_conflicts_with_individual_allow_flags(#[case] args: &[&str]) {
         assert!(
             Cli::try_parse_from(args).is_err(),
             "--allow-all should conflict with individual --allow-* flags"
         );
+    }
+
+    #[cfg(feature = "http-import")]
+    #[test]
+    fn test_http_import_disabled_by_default() {
+        // No network call is made: resolution fails on the enabled-check before any
+        // request, so this stays fast and deterministic regardless of connectivity.
+        let cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some(r#"import "github.com/harehare/lisp""#.to_string()),
+            files: None,
+            ..Cli::default()
+        };
+
+        let err = cli.run().unwrap_err();
+        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
+    }
+
+    #[cfg(feature = "http-import")]
+    #[test]
+    fn test_allowed_domain_alone_does_not_enable_http_import() {
+        let cli = Cli {
+            input: InputArgs {
+                input_format: Some(InputFormat::Null),
+                allowed_domains: Some(vec!["example.com".to_string()]),
+                ..Default::default()
+            },
+            output: OutputArgs::default(),
+            commands: None,
+            query: Some(r#"import "https://example.com/mod.mq""#.to_string()),
+            files: None,
+            ..Cli::default()
+        };
+
+        let err = cli.run().unwrap_err();
+        assert!(err.to_string().contains("--allow-http-import"), "error was: {err}");
     }
 
     #[rstest]

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -235,17 +235,6 @@ Fetched modules are cached in `{system_cache_dir}/mq/` as `{md5(url)}.mq` files.
 
 ### Lock file (`mq.lock`)
 
-Every fetched module URL's SHA-256 content hash is recorded in an `mq.lock` file, created in
-the current directory the first time a URL is fetched. This makes HTTP imports reproducible
-across machines and CI: if the same URL is fetched again with different content — from a
-different machine, a fresh (cold) cache, or after `--refresh-modules` clears the disk cache
-— mq fails with an error instead of silently using whatever the remote now serves.
-
-The check also applies to disk-cache hits, not just network fetches. The module cache is
-shared per machine while `mq.lock` is per project, so a project whose lock file expects
-different content than the local cache holds fails the same way, and a project without an
-`mq.lock` yet gets one created even when every module is served from the cache.
-
 - **First use of a URL** (fetched or served from the cache): recorded in `mq.lock`.
 - **Later use, content unchanged**: succeeds silently.
 - **Later use, content changed**: fails with an error explaining the mismatch. Re-run with
@@ -260,6 +249,7 @@ different content than the local cache holds fails the same way, and a project w
 Commit `mq.lock` alongside scripts that use HTTP imports so CI and teammates fetch the exact
 content you locked, the same way `package-lock.json`/`deno.lock` work.
 
+
 ### CLI options
 
 | Flag                        | Description                                                                                                                             |
@@ -268,6 +258,7 @@ content you locked, the same way `package-lock.json`/`deno.lock` work.
 | `--refresh-modules`         | Discard cached mutable-ref modules and re-fetch them, updating their `mq.lock` entries.                                                 |
 | `--allowed-domain <domain>` | Allow HTTP imports from an additional domain beyond the default (`raw.githubusercontent.com/harehare`). Repeat to add multiple domains. Has no effect unless `--allow-http-import` (or `--allow-all`) is also passed. |
 | `--no-lockfile`             | Disable the `mq.lock` integrity check/update.                                                                                           |
+| `--frozen`                  | Fail instead of recording a new `mq.lock` entry. Use in CI once `mq.lock` is committed. Mutually exclusive with `--no-lockfile`.        |
 | `--lockfile <path>`         | Use `<path>` instead of `./mq.lock`.                                                                                                     |
 
 **Examples:**
@@ -290,6 +281,9 @@ mq --allow-http-import --lockfile config/mq.lock 'self' file.md
 
 # Skip the mq.lock check entirely
 mq --no-lockfile 'self' file.md
+
+# CI: fail if a script tries to import a URL not already recorded in the committed mq.lock
+mq --allow-http-import --frozen 'self' file.md
 ```
 
 ## Network and File-Write Capabilities
@@ -318,10 +312,7 @@ bodies in the same order. Each request is a dict with a required `url` and optio
 mq --allow-net 'http_all([{"url": "https://example.com/a"}, {"url": "https://example.com/b", "method": "post", "body": "{}", "headers": {"Content-Type": "application/json"}}])'
 ```
 
-Requests in the batch run concurrently when the runtime supports it, so fanning out to
-multiple endpoints is faster than calling `http()` in a loop. The same URL/domain policy
-applies as for `http()`: HTTPS only, and `--allow-net` (with or without a domain allowlist)
-is required.
+Requests in the batch run concurrently when the runtime supports it, so fanning out to multiple endpoints is faster than calling `http()` in a loop. The same URL/domain policy applies as for `http()`: HTTPS only, and `--allow-net` (with or without a domain allowlist) is required.
 
 > **Security note:** `http` only accepts `https://` URLs and is routed through the same
 > SSRF-hardened client used for HTTP imports — no automatic redirects, and DNS results are
@@ -340,8 +331,7 @@ mq --allow-net 'http_post("https://example.com", "{}", {"Content-Type": "applica
 mq --allow-write 'write_file("out.md", "# Hello")'
 ```
 
-`--allow-net` also accepts a domain allowlist, restricting `http`/`http_*` calls to just those
-domains (and any path under them) instead of granting unrestricted network access:
+`--allow-net` also accepts a domain allowlist, restricting `http`/`http_*` calls to just those domains (and any path under them) instead of granting unrestricted network access:
 
 ```sh
 # Restrict to just example.com

--- a/docs/books/src/reference/modules_and_imports.md
+++ b/docs/books/src/reference/modules_and_imports.md
@@ -191,8 +191,11 @@ import "md"
 When `mq` is built with the `http-import` feature, `import` and `include` accept HTTP/HTTPS URLs
 in addition to local file names.
 
-> **Security note:** By default, only URLs under `github.com/harehare` (resolved to `raw.githubusercontent.com/harehare`) are allowed.
-> Importing from any other domain requires explicitly enabling it with the `--allowed-domain` flag.
+> **Security note:** HTTP imports are disabled by default and must be enabled with
+> `--allow-http-import`. Once enabled, only URLs under `github.com/harehare` (resolved to
+> `raw.githubusercontent.com/harehare`) are allowed; importing from any other domain also
+> requires `--allowed-domain`. This is a separate permission from `--allow-net`, which only
+> gates the `http()`/`http_request()` builtins, not module resolution.
 
 ### Plain URL
 
@@ -218,9 +221,8 @@ github.com/{owner}/{path}[@{version}]
 
 **Example:**
 
-```mq
-import "github.com/harehare/kdl.mq"
-| kdl::kdl_parse("title \"Hello, World!\"")
+```sh
+mq --allow-http-import 'import "github.com/harehare/kdl.mq" | kdl::kdl_parse("title \"Hello, World!\"")'
 ```
 
 ### Caching
@@ -262,25 +264,29 @@ content you locked, the same way `package-lock.json`/`deno.lock` work.
 
 | Flag                        | Description                                                                                                                             |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `--allow-http-import`       | Enable HTTP module imports. Disabled by default; `import`/`include` of a `github.com/...` or `https://...` URL fails without this.      |
 | `--refresh-modules`         | Discard cached mutable-ref modules and re-fetch them, updating their `mq.lock` entries.                                                 |
-| `--allowed-domain <domain>` | Allow HTTP imports from an additional domain beyond the default (`raw.githubusercontent.com/harehare`). Repeat to add multiple domains. |
+| `--allowed-domain <domain>` | Allow HTTP imports from an additional domain beyond the default (`raw.githubusercontent.com/harehare`). Repeat to add multiple domains. Has no effect unless `--allow-http-import` (or `--allow-all`) is also passed. |
 | `--no-lockfile`             | Disable the `mq.lock` integrity check/update.                                                                                           |
 | `--lockfile <path>`         | Use `<path>` instead of `./mq.lock`.                                                                                                     |
 
 **Examples:**
 
 ```sh
-# Force re-fetch of any HEAD/branch modules, accepting new content into mq.lock
-mq --refresh-modules 'self' file.md
+# Enable HTTP imports, restricted to the built-in default domain
+mq --allow-http-import 'self' file.md
 
-# Only allow imports from example.com
-mq --allowed-domain example.com 'self' file.md
+# Force re-fetch of any HEAD/branch modules, accepting new content into mq.lock
+mq --allow-http-import --refresh-modules 'self' file.md
+
+# Only allow imports from example.com (in addition to the built-in default)
+mq --allow-http-import --allowed-domain example.com 'self' file.md
 
 # Allow multiple domains
-mq --allowed-domain example.com --allowed-domain raw.githubusercontent.com 'self' file.md
+mq --allow-http-import --allowed-domain example.com --allowed-domain raw.githubusercontent.com 'self' file.md
 
 # Use a different lock file location
-mq --lockfile config/mq.lock 'self' file.md
+mq --allow-http-import --lockfile config/mq.lock 'self' file.md
 
 # Skip the mq.lock check entirely
 mq --no-lockfile 'self' file.md


### PR DESCRIPTION
## Summary

http-import predates SandboxedIo and was left outside its permission boundary for compatibility, so --allow-net never gated import/include of github.com/... or https://... URLs. Add a new --allow-http-import flag (and --allow-all) required before any HTTP/GitHub import is attempted; --allowed-domain keeps scoping which hosts are reachable once enabled. Library-level defaults (LSP/FFI/WASM embedders) are unchanged.

https://github.com/harehare/mq/issues/2194

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
