### PR TITLE
✨ feat(mq-lang): add depth parameter to section::sections

### DIFF
--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -40,7 +40,8 @@ def _h_level_num(md):
 end
 
 # Returns sections whose title contains the specified pattern.
-# If depth is true, each section spans until the next header at the same or higher level.
+# If depth is true, each section spans until the next header at the same or higher level
+# (delegates to section::sections(md_nodes, depth), see its doc for details).
 #
 # Example:
 # ```
@@ -50,18 +51,40 @@ end
 #
 # Returns: array
 def section(md_nodes, pattern, depth = false):
+  sections(md_nodes, depth) | title_contains(pattern)
+end
+
+# Splits markdown nodes into sections based on headers.
+# If depth is true, each section's body extends to the next heading at the same or higher
+# level as that section's own heading, so nested subheadings' content is included in their
+# parent's body. If depth is false (default), every heading of any level is a boundary, so
+# a heading's body only extends to the very next heading regardless of level.
+#
+# Example:
+# ```
+# import "section" | len(section::sections(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B")))
+# #=> 3
+# ```
+# Example:
+# ```
+# import "section" | len(section::body(first(section::sections(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B"), true))))
+# #=> 3
+# ```
+#
+# Returns: array
+def sections(md_nodes, depth = false):
   let agg_nodes = _ensure_aggregated(md_nodes)
-  | if (depth):
-      if (is_empty(agg_nodes)):
-        []
-      else:
+  | if (is_empty(agg_nodes)):
+      []
+    else:
+      if (depth):
         do
           let n = len(agg_nodes)
-          | let match_indices = do foreach (i, range(n - 1)): if (is_h(agg_nodes[i]) && contains(to_text(agg_nodes[i]), pattern)): i; | compact();
+          | let start_indices = do foreach (i, range(n - 1)): if (is_h(agg_nodes[i])): i; | compact();
           | var result = []
           | var i = 0
-          | while (i < len(match_indices)):
-              let start = match_indices[i]
+          | while (i < len(start_indices)):
+              let start = start_indices[i]
               | let lvl = _h_level_num(agg_nodes[start])
               | let boundaries = do foreach (j, range(n - 1)): if (is_h(agg_nodes[j]) && _h_level_num(agg_nodes[j]) <= lvl): j; | compact();
               | let boundaries_with_end = boundaries + n
@@ -71,41 +94,22 @@ def section(md_nodes, pattern, depth = false):
               | result
             end
         end
-    else:
-      do
-        sections(agg_nodes) | title_contains(pattern)
-      end
-end
-
-# Splits markdown nodes into sections based on headers.
-#
-# Example:
-# ```
-# import "section" | len(section::sections(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B")))
-# #=> 3
-# ```
-#
-# Returns: array
-def sections(md_nodes):
-  let agg_nodes = _ensure_aggregated(md_nodes)
-  | if (is_empty(agg_nodes)):
-      []
-    else:
-      do
-        let indices = do foreach (i, range(len(agg_nodes) - 1)): if (is_h(agg_nodes[i])): i; | compact();
-        | let indices_with_end = indices + len(agg_nodes)
-        | let indices_len = len(indices)
-        | var result = []
-        | var i = 0
-        | while (i < indices_len):
-            let start_node = indices[i]
-            | let end_node = indices_with_end[i + 1]
-            | let children = agg_nodes[start_node + 1:end_node]
-            | result += [{type: :section, header: agg_nodes[start_node], children: children}]
-            | i = i + 1
-            | result
-          end
-      end
+      else:
+        do
+          let indices = do foreach (i, range(len(agg_nodes) - 1)): if (is_h(agg_nodes[i])): i; | compact();
+          | let indices_with_end = indices + len(agg_nodes)
+          | let indices_len = len(indices)
+          | var result = []
+          | var i = 0
+          | while (i < indices_len):
+              let start_node = indices[i]
+              | let end_node = indices_with_end[i + 1]
+              | let children = agg_nodes[start_node + 1:end_node]
+              | result += [{type: :section, header: agg_nodes[start_node], children: children}]
+              | i = i + 1
+              | result
+            end
+        end
 end
 
 # Filters sections based on a given predicate function.

--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -81,9 +81,10 @@ def sections(md_nodes, depth = false):
         do
           let n = len(agg_nodes)
           | let start_indices = do foreach (i, range(n - 1)): if (is_h(agg_nodes[i])): i; | compact();
+          | let start_index_len = len(start_indices)
           | var result = []
           | var i = 0
-          | while (i < len(start_indices)):
+          | while (i < start_index_len):
               let start = start_indices[i]
               | let lvl = _h_level_num(agg_nodes[start])
               | let boundaries = do foreach (j, range(n - 1)): if (is_h(agg_nodes[j]) && _h_level_num(agg_nodes[j]) <= lvl): j; | compact();

--- a/crates/mq-lang/modules/section_test.mq
+++ b/crates/mq-lang/modules/section_test.mq
@@ -103,6 +103,39 @@ def test_section_section_depth_false_unchanged():
   | assert_eq(len(secs_default), len(secs_depth))
 end
 
+def test_section_sections_depth_nested_body():
+  let flat_secs = do test_sections | section::sections();
+  | let nested_secs = do test_sections | section::sections(., true);
+  | let flat_intro = first(flat_secs)
+  | let nested_intro = first(nested_secs)
+  | assert(len(section::body(nested_intro)) > len(section::body(flat_intro)))
+end
+
+def test_section_sections_depth_includes_subheading_text():
+  let secs = do test_sections | section::sections(., true);
+  | let intro = first(secs)
+  | let body_text = to_markdown_string(section::body(intro))
+  | assert(contains(body_text, "Advanced Topics"))
+  | assert(contains(body_text, "This section covers advanced topics."))
+end
+
+# @parametrize([[section_md, 3], ["# test", 1]])
+def test_section_sections_depth_len(markdown, expected_len):
+  let sections = do markdown | to_markdown() | section::sections(., true);
+  | assert_eq(len(sections), expected_len)
+end
+
+def test_section_sections_false_unchanged():
+  let secs = do test_sections | section::sections();
+  | assert_eq(len(secs), 3)
+  | let titles = section::titles(secs)
+  | assert_eq(titles, ["Introduction", "Advanced Topics", "Conclusion"])
+  | let levels = map(secs, section::level)
+  | assert_eq(levels, [1, 2, 1])
+  | let intro_body_text = to_markdown_string(section::body(first(secs)))
+  | assert_eq(intro_body_text, "This is the introduction section.\n")
+end
+
 def test_section_bodies_pipe():
   let body_list = do test_sections | section::section("Introduction") | section::bodies();
   | assert_eq(len(body_list), 1)

--- a/crates/mq-lang/modules/section_test.mq
+++ b/crates/mq-lang/modules/section_test.mq
@@ -103,20 +103,19 @@ def test_section_section_depth_false_unchanged():
   | assert_eq(len(secs_default), len(secs_depth))
 end
 
-def test_section_sections_depth_nested_body():
-  let flat_secs = do test_sections | section::sections();
-  | let nested_secs = do test_sections | section::sections(., true);
-  | let flat_intro = first(flat_secs)
-  | let nested_intro = first(nested_secs)
-  | assert(len(section::body(nested_intro)) > len(section::body(flat_intro)))
+# @parametrize([[false, 1], [true, 3]])
+def test_section_sections_depth_body_len(depth, expected_len):
+  let secs = do test_sections | section::sections(., depth);
+  | let intro = first(secs)
+  | assert_eq(len(section::body(intro)), expected_len)
 end
 
-def test_section_sections_depth_includes_subheading_text():
-  let secs = do test_sections | section::sections(., true);
+# @parametrize([[false, false], [true, true]])
+def test_section_sections_depth_includes_subheading(depth, expected_contains):
+  let secs = do test_sections | section::sections(., depth);
   | let intro = first(secs)
   | let body_text = to_markdown_string(section::body(intro))
-  | assert(contains(body_text, "Advanced Topics"))
-  | assert(contains(body_text, "This section covers advanced topics."))
+  | assert_eq(contains(body_text, "Advanced Topics"), expected_contains)
 end
 
 # @parametrize([[section_md, 3], ["# test", 1]])
@@ -125,15 +124,12 @@ def test_section_sections_depth_len(markdown, expected_len):
   | assert_eq(len(sections), expected_len)
 end
 
-def test_section_sections_false_unchanged():
+# @parametrize([[0, "Introduction", 1], [1, "Advanced Topics", 2], [2, "Conclusion", 1]])
+def test_section_sections_title_level(index, expected_title, expected_level):
   let secs = do test_sections | section::sections();
-  | assert_eq(len(secs), 3)
-  | let titles = section::titles(secs)
-  | assert_eq(titles, ["Introduction", "Advanced Topics", "Conclusion"])
-  | let levels = map(secs, section::level)
-  | assert_eq(levels, [1, 2, 1])
-  | let intro_body_text = to_markdown_string(section::body(first(secs)))
-  | assert_eq(intro_body_text, "This is the introduction section.\n")
+  | let s = get(secs, index)
+  | assert_eq(section::title(s), expected_title)
+  | assert_eq(section::level(s), expected_level)
 end
 
 def test_section_bodies_pipe():


### PR DESCRIPTION
## Summary

sections() previously only supported flat boundaries (every heading of any level ends the previous section), so nested subsection content was unreachable in bulk without calling section() once per known heading name. Add a depth parameter reusing the same same-or-higher-level boundary algorithm section() already had, and simplify section() to delegate to sections(md_nodes, depth) | title_contains(pattern).

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
