### PR TITLE
🐛 fix(neovim): add matchit support so end matches its opening block keyword

### DIFF
--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -5,6 +5,7 @@ Neovim plugin for [mq](https://mqlang.org/) - a jq-like tool for Markdown proces
 ## Features
 
 - 🎨 **Syntax Highlighting** - Full syntax support for `.mq` files
+- 🔗 **Matching Keywords** - `%` jumps between block keywords (`def`, `fn`, `while`, `until`, `loop`, `foreach`, `match`, `module`) and their `end` via matchit
 - 🔧 **LSP Integration** - Code completion, diagnostics, and more via Language Server Protocol
 - 🐛 **DAP Integration** - Debug your mq queries with nvim-dap
 - ⚡  **Commands** - Execute mq queries directly from Neovim

--- a/editors/neovim/ftplugin/mq.vim
+++ b/editors/neovim/ftplugin/mq.vim
@@ -1,0 +1,16 @@
+" ftplugin for mq: matchit/matchparen support for block keywords
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+if !exists("g:loaded_matchit") && findfile("macros/matchit.vim", &runtimepath) !=# ""
+  runtime! macros/matchit.vim
+endif
+
+let b:match_words = '\<\%(def\|fn\|while\|until\|loop\|foreach\|match\|module\)\>:\<end\>'
+
+" Ignore keywords found inside comments or strings.
+let b:match_skip = 's:mqComment\|mqString\|mqStringBytes\|mqStringInterpolate'
+
+let b:undo_ftplugin = "unlet! b:match_words b:match_skip"


### PR DESCRIPTION
## Summary

`.mq` files had no b:match_words, so % / matching-keyword highlighting couldn't tell which end closes match, def, while, until, loop, foreach, or module. if/elif/else/unless/try/catch never own an end themselves (single-expression bodies per the parser), so they're intentionally excluded to avoid miscounting.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
