### PR TITLE
🐛 fix(jetbrains): replace removed-for-removal addBrowseFolderListener overload

### DIFF
--- a/editors/jetbrains/src/main/kotlin/org/mqlang/mq/settings/MqSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/org/mqlang/mq/settings/MqSettingsConfigurable.kt
@@ -16,18 +16,18 @@ class MqSettingsConfigurable : Configurable {
 
     private val lspPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            "mq-lsp Executable",
-            "Path to the mq-lsp language server executable. Leave empty to auto-detect on PATH.",
             null,
-            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor(),
+            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+                .withTitle("mq-lsp Executable")
+                .withDescription("Path to the mq-lsp language server executable. Leave empty to auto-detect on PATH."),
         )
     }
     private val dbgPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            "mq-dbg Executable",
-            "Path to the mq-dbg debug adapter executable. Leave empty to auto-detect on PATH.",
             null,
-            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor(),
+            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+                .withTitle("mq-dbg Executable")
+                .withDescription("Path to the mq-dbg debug adapter executable. Leave empty to auto-detect on PATH."),
         )
     }
     private val showExamplesCheckBox = JBCheckBox("Show examples when creating a new .mq file")


### PR DESCRIPTION
## Summary

Switch MqSettingsConfigurable's browse buttons from the deprecated 4-arg addBrowseFolderListener(title, description, project, descriptor) to the current addBrowseFolderListener(project, descriptor) form, moving title/description onto FileChooserDescriptor.withTitle/withDescription.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
