### PR TITLE
✨ feat(editors,mq-playground,mq-chrome-extension,docs): replace macro/quote/unquote highlighting with until/unless

### DIFF
--- a/assets/mq.sublime-syntax
+++ b/assets/mq.sublime-syntax
@@ -23,7 +23,7 @@ contexts:
       scope: comment.line.number-sign.mq
 
   keywords:
-    - match: '\b(def|do|let|if|elif|else|end|while|foreach|self|nodes|match|fn|break|continue|include|import|module|var|macro|quote|unquote|loop|try|catch|as)\b'
+    - match: '\b(def|do|let|if|elif|else|end|while|until|unless|foreach|self|nodes|match|fn|break|continue|include|import|module|var|loop|try|catch|as)\b'
       scope: keyword.control.mq
     - match: '(//=|<<|>>|<=|>=|==|!=|=~|!~|\|\||&&|\?\?|::|\.\.|\|=|\+=|-=|\*=|/=|%=|->|=|<|>|\||:|;|\?|!|\+|-|\*|/|%|@)'
       scope: keyword.operator.mq

--- a/docs/books/theme/highlight-mq.js
+++ b/docs/books/theme/highlight-mq.js
@@ -6,7 +6,7 @@
   function hljsDefineMq(hljs) {
     const KEYWORDS = {
       keyword:
-        "def do let if elif else end while foreach self nodes match fn break continue include import module var macro quote unquote loop try catch",
+        "def do let if elif else end while until unless foreach self nodes match fn break continue include import module var loop try catch",
       literal: "true false None",
     };
 
@@ -77,7 +77,7 @@
     };
 
     const KEYWORD_ALTERNATION =
-      "def|do|let|if|elif|else|end|while|foreach|self|nodes|match|fn|break|continue|include|import|module|var|macro|quote|unquote|loop|try|catch";
+      "def|do|let|if|elif|else|end|while|until|unless|foreach|self|nodes|match|fn|break|continue|include|import|module|var|loop|try|catch";
 
     const FUNCTION_CALL = {
       className: "title.function.invoke",

--- a/editors/jetbrains/src/main/resources/textmate/Syntaxes/mq.tmLanguage.json
+++ b/editors/jetbrains/src/main/resources/textmate/Syntaxes/mq.tmLanguage.json
@@ -49,7 +49,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.mq",
-                    "match": "\\b(def|do|let|if|elif|else|end|while|foreach|self|nodes|fn|break|continue|include|match|module|import|var|macro|quote|unquote|loop|try|catch|as)\\b"
+                    "match": "\\b(def|do|let|if|elif|else|end|while|until|unless|foreach|self|nodes|fn|break|continue|include|match|module|import|var|loop|try|catch|as)\\b"
                 },
                 {
                     "name": "keyword.operator.mq",

--- a/editors/neovim/syntax/mq.vim
+++ b/editors/neovim/syntax/mq.vim
@@ -7,7 +7,7 @@ syn match mqComment "#.*$" contains=mqTodo
 syn keyword mqTodo contained TODO FIXME XXX NOTE
 
 " Keywords (use \< and \> for word boundaries to avoid partial matches)
-syn match mqKeywordControl "\<\(def\|do\|if\|elif\|else\|end\|while\|foreach\|fn\|break\|continue\|match\|macro\|quote\|unquote\|loop\|try\|catch\|as\)\>"
+syn match mqKeywordControl "\<\(def\|do\|if\|elif\|else\|end\|while\|until\|unless\|foreach\|fn\|break\|continue\|match\|loop\|try\|catch\|as\)\>"
 syn match mqKeywordInclude "\<\(include\|module\|import\)\>"
 syn match mqKeywordSpecial "\<\(self\|nodes\)\>"
 syn match mqKeywordLetVar "\<\(let\|var\)\>" nextgroup=mqVariableDef skipwhite

--- a/editors/vscode/snippets/mq.json
+++ b/editors/vscode/snippets/mq.json
@@ -20,6 +20,20 @@
         ],
         "description": "Loop while condition is true"
     },
+    "until": {
+        "prefix": "until",
+        "body": [
+            "until (${1:condition}): ${0:body};"
+        ],
+        "description": "Loop until condition is true"
+    },
+    "unless": {
+        "prefix": "unless",
+        "body": [
+            "unless (${1:condition}): ${0:body}"
+        ],
+        "description": "Run body when condition is false"
+    },
     "def": {
         "prefix": "def",
         "body": [
@@ -47,26 +61,5 @@
             "module ${1:name}:\n  ${2:body}\nend"
         ],
         "description": "Create a module that contains related functions and variables"
-    },
-    "macro": {
-        "prefix": "macro",
-        "body": [
-            "macro ${1:name}(${2:args}) do\n  ${3:body}\nend"
-        ],
-        "description": "Define a macro"
-    },
-    "quote": {
-        "prefix": "quote",
-        "body": [
-            "quote do\n  ${1:body}\nend"
-        ],
-        "description": "Quote an expression"
-    },
-    "unquote": {
-        "prefix": "unquote",
-        "body": [
-            "unquote(${1:expr})"
-        ],
-        "description": "Unquote an expression"
     }
 }

--- a/editors/vscode/syntaxes/mq.tmLanguage.json
+++ b/editors/vscode/syntaxes/mq.tmLanguage.json
@@ -49,7 +49,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.mq",
-                    "match": "\\b(def|do|let|if|elif|else|end|while|foreach|self|nodes|fn|break|continue|include|match|module|import|var|macro|quote|unquote|loop|try|catch|as)\\b"
+                    "match": "\\b(def|do|let|if|elif|else|end|while|until|unless|foreach|self|nodes|fn|break|continue|include|match|module|import|var|loop|try|catch|as)\\b"
                 },
                 {
                     "name": "keyword.operator.mq",

--- a/editors/zed/languages/mq/highlights.scm
+++ b/editors/zed/languages/mq/highlights.scm
@@ -7,6 +7,8 @@
   "else"
   "end"
   "while"
+  "until"
+  "unless"
   "loop"
   "foreach"
   "include"
@@ -16,7 +18,6 @@
   "fn"
   "do"
   "var"
-  "macro"
   "try"
   "catch"
   "as"
@@ -121,10 +122,6 @@
 ; Function definitions
 (def_expr
   name: (identifier) @function)
-
-; Macro definitions
-(macro_expr
-  name: (identifier) @function.macro)
 
 ; Function calls
 (call_expr

--- a/editors/zed/languages/mq/indents.scm
+++ b/editors/zed/languages/mq/indents.scm
@@ -3,9 +3,10 @@
 (match_expr) @indent
 (foreach_expr) @indent
 (while_expr) @indent
+(until_expr) @indent
+(unless_expr) @indent
 (block_expr) @indent
 (module_expr) @indent
-(macro_expr) @indent
 (loop_expr) @indent
 
 "end" @outdent

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/mqLanguage.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/mqLanguage.ts
@@ -6,7 +6,7 @@ type MqState = {
 };
 
 const KEYWORDS =
-  /^\b(let|def|do|match|while|foreach|if|elif|else|end|self|None|nodes|break|continue|include|import|module|var|macro|quote|unquote|loop)\b/;
+  /^\b(let|def|do|match|while|until|unless|foreach|if|elif|else|end|self|None|nodes|break|continue|include|import|module|var|loop)\b/;
 const OPERATORS =
   /^(\/\/=|<<|>>|\|\||\?\?|<=|>=|==|!=|=~|&&|\+=|-=|\*=|\/=|\|=|=|\||:|;|\?|!|\+|-|\*|\/|%|<|>|@)/;
 const FUNCTION_CALL = /^[a-zA-Z_]\w*(?=\s*\()/;

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -1656,6 +1656,38 @@ export const Playground = () => {
             },
           },
           {
+            label: "until",
+            kind: monaco.languages.CompletionItemKind.Snippet,
+            insertText: "until (${1:condition}): ${0:body};",
+            insertTextRules:
+              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+            detail: "Loop until condition is true",
+            documentation:
+              "Creates an until loop that repeats execution while condition is false, the inverse of while.",
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: wordRange.startColumn,
+              endLineNumber: position.lineNumber,
+              endColumn: wordRange.endColumn,
+            },
+          },
+          {
+            label: "unless",
+            kind: monaco.languages.CompletionItemKind.Snippet,
+            insertText: "unless (${1:condition}): ${0:body}",
+            insertTextRules:
+              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+            detail: "Run body when condition is false",
+            documentation:
+              "Executes the body only when condition is false, the inverse of a single-branch if.",
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: wordRange.startColumn,
+              endLineNumber: position.lineNumber,
+              endColumn: wordRange.endColumn,
+            },
+          },
+          {
             label: "def",
             kind: monaco.languages.CompletionItemKind.Snippet,
             insertText: "def ${0}(${1:args}): ${2:body};",
@@ -1719,54 +1751,6 @@ export const Playground = () => {
               endColumn: wordRange.endColumn,
             },
           },
-          {
-            label: "macro",
-            kind: monaco.languages.CompletionItemKind.Snippet,
-            insertText: "macro ${1:name}(${2:args}) do\n  ${3:body}:\nend",
-            insertTextRules:
-              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-            detail: "Macro declaration",
-            documentation:
-              "Creates a macro that generates code at compile time for reuse.",
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: wordRange.startColumn,
-              endLineNumber: position.lineNumber,
-              endColumn: wordRange.endColumn,
-            },
-          },
-          {
-            label: "quote",
-            kind: monaco.languages.CompletionItemKind.Snippet,
-            insertText: "quote do\n  ${1:body}:\nend",
-            insertTextRules:
-              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-            detail: "Quote block",
-            documentation:
-              "Creates a quote block that treats the code inside as data rather than executing it.",
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: wordRange.startColumn,
-              endLineNumber: position.lineNumber,
-              endColumn: wordRange.endColumn,
-            },
-          },
-          {
-            label: "unquote",
-            kind: monaco.languages.CompletionItemKind.Snippet,
-            insertText: "unquote(${1:expr})",
-            insertTextRules:
-              monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-            detail: "Unquote expression",
-            documentation:
-              "Inserts the result of an expression into a quote block.",
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: wordRange.startColumn,
-              endLineNumber: position.lineNumber,
-              endColumn: wordRange.endColumn,
-            },
-          },
         ];
 
         return { suggestions: [...suggestions, ...snippets] };
@@ -1815,7 +1799,7 @@ export const Playground = () => {
         root: [
           [/#[^\n]*/, "comment"],
           [
-            /\b(let|def|do|match|while|foreach|if|elif|else|end|self|None|nodes|break|continue|include|import|module|var|macro|quote|unquote|loop)\b/,
+            /\b(let|def|do|match|while|until|unless|foreach|if|elif|else|end|self|None|nodes|break|continue|include|import|module|var|loop)\b/,
             "keyword",
           ],
           [/;/, "delimiter"],


### PR DESCRIPTION
## Summary

Editor syntax highlighting, snippets, and completions across Zed, Neovim, VS Code, JetBrains, Sublime Text, the docs highlighter, the playground, and the Chrome extension still referenced the removed macro/quote/unquote syntax. Remove those and add until/unless to match #2209.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
