### PR TITLE
✨ feat(jetbrains): add dedicated file icon for .mq files

### DIFF
--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -17,6 +17,7 @@ the VS Code and Neovim integrations.
 
 - Smart code completion, hover documentation, go to definition, document symbols and formatting for `.mq` files via `mq-lsp`
 - Syntax highlighting (via the same TextMate grammar as the VS Code extension)
+- Dedicated file icon for `.mq` files in the project tree and editor tabs
 - Execute mq queries directly from the editor
 - Debug `.mq` files with `mq-dbg` (Debug Adapter Protocol)
 - One-click installer that downloads `mq-lsp` and `mq-dbg` from GitHub Releases

--- a/editors/jetbrains/src/main/kotlin/org/mqlang/mq/icons/MqFileIconProvider.kt
+++ b/editors/jetbrains/src/main/kotlin/org/mqlang/mq/icons/MqFileIconProvider.kt
@@ -1,0 +1,18 @@
+package org.mqlang.mq.icons
+
+import com.intellij.ide.FileIconProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import javax.swing.Icon
+
+/**
+ * Gives `.mq` files their own icon in the project tree, tabs and elsewhere.
+ *
+ * `.mq` syntax highlighting is registered via a TextMate bundle rather than a dedicated [com.intellij.openapi.fileTypes.FileType]
+ * (see [org.mqlang.mq.textmate.MqTextMateBundleProvider]), which leaves files with the generic TextMate icon.
+ * [FileIconProvider] overrides the icon by file name alone, without needing to own the file type.
+ */
+class MqFileIconProvider : FileIconProvider {
+    override fun getIcon(file: VirtualFile, flags: Int, project: Project?): Icon? =
+        if (file.extension == "mq") MqIcons.FILE else null
+}

--- a/editors/jetbrains/src/main/kotlin/org/mqlang/mq/icons/MqIcons.kt
+++ b/editors/jetbrains/src/main/kotlin/org/mqlang/mq/icons/MqIcons.kt
@@ -1,0 +1,8 @@
+package org.mqlang.mq.icons
+
+import com.intellij.openapi.util.IconLoader
+
+/** Icons bundled with the plugin. [IconLoader] picks the `_dark` variant automatically under dark themes. */
+object MqIcons {
+    val FILE = IconLoader.getIcon("/icons/mqFile.svg", MqIcons::class.java)
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <textmate.bundleProvider implementation="org.mqlang.mq.textmate.MqTextMateBundleProvider"/>
+        <fileIconProvider implementation="org.mqlang.mq.icons.MqFileIconProvider"/>
 
         <notificationGroup id="mq" displayType="BALLOON"/>
 

--- a/editors/jetbrains/src/main/resources/icons/mqFile.svg
+++ b/editors/jetbrains/src/main/resources/icons/mqFile.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M4 11.6 L4 4.4 L8 8.4 L12 4.4 L12 11.6" fill="none" stroke="#2B5773" stroke-width="1.4" stroke-linecap="square" stroke-linejoin="miter"/>
+</svg>

--- a/editors/jetbrains/src/main/resources/icons/mqFile_dark.svg
+++ b/editors/jetbrains/src/main/resources/icons/mqFile_dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M4 11.6 L4 4.4 L8 8.4 L12 4.4 L12 11.6" fill="none" stroke="#61AFEF" stroke-width="1.4" stroke-linecap="square" stroke-linejoin="miter"/>
+</svg>


### PR DESCRIPTION
## Summary

Registers a FileIconProvider so .mq files get their own icon in the project tree and editor tabs instead of the generic TextMate icon, since .mq's syntax highlighting is backed by a TextMate bundle rather than a dedicated FileType.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
