### PR TITLE
✨ feat(mq-playground): bump mq-web to 0.8.3 and add HTTP import toggle

### DIFF
--- a/packages/mq-playground/package.json
+++ b/packages/mq-playground/package.json
@@ -15,7 +15,7 @@
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.56.0",
     "monaco-vim": "^0.4.4",
-    "mq-web": "0.8.2",
+    "mq-web": "0.8.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0"

--- a/packages/mq-playground/pnpm-lock.yaml
+++ b/packages/mq-playground/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(monaco-editor@0.56.0)
       mq-web:
-        specifier: 0.8.2
-        version: 0.8.2
+        specifier: 0.8.3
+        version: 0.8.3
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -974,8 +974,8 @@ packages:
     peerDependencies:
       monaco-editor: '*'
 
-  mq-web@0.8.2:
-    resolution: {integrity: sha512-IEst+4q9gES/aSL3v9aOWaNJ+4f87jevaMZqlTKjRe7ssOG6Pj9md2cXGRHslV8xBkFAuxtXaDBh2I+nfuHvVg==}
+  mq-web@0.8.3:
+    resolution: {integrity: sha512-jyxh1xw/iLUl4O0MArjHHOMwTRpK1Q09R74bzEpihE7c+zy3B79tdoqYznU1zBb974L3/Gl4c85ybvlSR47yug==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1944,7 +1944,7 @@ snapshots:
     dependencies:
       monaco-editor: 0.56.0
 
-  mq-web@0.8.2: {}
+  mq-web@0.8.3: {}
 
   ms@2.1.3: {}
 

--- a/packages/mq-playground/src/Playground.tsx
+++ b/packages/mq-playground/src/Playground.tsx
@@ -88,6 +88,7 @@ type EditorSettings = {
   lineNumbers: "on" | "off";
   tabSize: number;
   shareMode: "current" | "all";
+  allowHttpImport: boolean;
 };
 
 const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
@@ -100,6 +101,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   lineNumbers: "on",
   tabSize: 2,
   shareMode: "current",
+  allowHttpImport: false,
 };
 
 function loadEditorSettings(): EditorSettings {
@@ -247,6 +249,9 @@ export const Playground = () => {
   );
   const [shareMode, setShareMode] = useState<"current" | "all">(
     _initialSettings.shareMode,
+  );
+  const [allowHttpImport, setAllowHttpImport] = useState(
+    _initialSettings.allowHttpImport,
   );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isExamplesOpen, setIsExamplesOpen] = useState(false);
@@ -579,6 +584,7 @@ export const Playground = () => {
         listStyle,
         linkTitleStyle,
         linkUrlStyle,
+        allowHttpImport,
       });
       setResult(output);
 
@@ -607,6 +613,7 @@ export const Playground = () => {
     listStyle,
     linkUrlStyle,
     linkTitleStyle,
+    allowHttpImport,
     isOPFSSupported,
     loadFiles,
   ]);
@@ -1367,6 +1374,7 @@ export const Playground = () => {
       minimapEnabled,
       wordWrap,
       shareMode,
+      allowHttpImport,
     });
 
     if (theme === "system") {
@@ -1408,6 +1416,7 @@ export const Playground = () => {
     minimapEnabled,
     wordWrap,
     shareMode,
+    allowHttpImport,
   ]);
 
   // Add keyboard shortcut for save (Ctrl+S / Cmd+S)
@@ -2638,6 +2647,8 @@ img{max-width:100%}
         shareMode={shareMode}
         onShareModeChange={setShareMode}
         isOPFSSupported={isOPFSSupported}
+        allowHttpImport={allowHttpImport}
+        onAllowHttpImportToggle={setAllowHttpImport}
         onClearHttpCache={async () => {
           await mq.clearHttpCache();
           showToast("HTTP module cache cleared", "success");

--- a/packages/mq-playground/src/components/SettingsDialog.tsx
+++ b/packages/mq-playground/src/components/SettingsDialog.tsx
@@ -21,6 +21,8 @@ type SettingsDialogProps = {
   shareMode: "current" | "all";
   onShareModeChange: (mode: "current" | "all") => void;
   isOPFSSupported: boolean;
+  allowHttpImport: boolean;
+  onAllowHttpImportToggle: (enabled: boolean) => void;
   onClearHttpCache?: () => Promise<void>;
   onClearAllHttpCache?: () => Promise<void>;
 };
@@ -45,6 +47,8 @@ export const SettingsDialog = ({
   shareMode,
   onShareModeChange,
   isOPFSSupported,
+  allowHttpImport,
+  onAllowHttpImportToggle,
   onClearHttpCache,
   onClearAllHttpCache,
 }: SettingsDialogProps) => {
@@ -170,9 +174,18 @@ export const SettingsDialog = ({
               </div>
             </div>
           )}
-          {isOPFSSupported && (onClearHttpCache || onClearAllHttpCache) && (
+          {isOPFSSupported && (
             <div className="settings-section">
-              <h4>Cache</h4>
+              <h4>HTTP Modules</h4>
+              <div className="settings-item">
+                <label htmlFor="allow-http-import">Allow HTTP Imports</label>
+                <input
+                  id="allow-http-import"
+                  type="checkbox"
+                  checked={allowHttpImport}
+                  onChange={(e) => onAllowHttpImportToggle(e.target.checked)}
+                />
+              </div>
               {onClearHttpCache && (
                 <div className="settings-item">
                   <label>HTTP Module Cache</label>


### PR DESCRIPTION
## Summary

Bump the mq-web dependency to 0.8.3, which carries the previously unreleased Options.allowHttpImport wasm binding. Add an "Allow HTTP Imports" checkbox to the Settings dialog's HTTP Modules section so users can opt in to HTTP/GitHub module imports per the same off-by-default policy as the CLI's --allow-http-import.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
