### PR TITLE
✨ feat(mq-lang): add encode/decode builtins for text encoding conversion 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "codspeed-divan-compat",
  "csv",
  "dirs 6.0.0",
+ "encoding_rs",
  "getrandom 0.4.3",
  "glob",
  "html-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ dashmap = "6.2.1"
 dirs = "6.0.0"
 divan = {version = "4.7.0", package = "codspeed-divan-compat"}
 ego-tree = "0.11.0"
+encoding_rs = "0.8.35"
 fantoccini = {version = "0.22.1", default-features = false, features = ["rustls-tls"]}
 futures = "0.3"
 glob = "0.3.3"

--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -1401,6 +1401,12 @@ fn register_bytes(ctx: &mut InferenceContext) {
     register_unary(ctx, "utf8", Type::Bytes, Type::String);
     register_unary(ctx, "utf8", Type::None, Type::None);
 
+    // decode: (bytes, string) -> string
+    register_binary(ctx, "decode", Type::Bytes, Type::String, Type::String);
+
+    // encode: (string, string) -> bytes
+    register_binary(ctx, "encode", Type::String, Type::String, Type::Bytes);
+
     // xor: (bytes, bytes) -> bytes
     register_binary(ctx, "xor", Type::Bytes, Type::Bytes, Type::Bytes);
 

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -16,6 +16,7 @@ mq-macros = {workspace = true}
 base64 = {workspace = true}
 ciborium = {workspace = true}
 csv = {workspace = true}
+encoding_rs = {workspace = true}
 html-escape = "0.2"
 md5 = {workspace = true}
 sha2 = {workspace = true}

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -720,6 +720,30 @@ fn utf8_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> 
     }
 }
 
+#[mq_macros::mq_fn(name = "decode", params = Fixed(2))]
+fn decode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::Bytes(b), RuntimeValue::String(label)] => convert::decode(b, label),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("decode should always receive exactly two arguments"),
+    }
+}
+
+#[mq_macros::mq_fn(name = "encode", params = Fixed(2))]
+fn encode_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(text), RuntimeValue::String(label)] => convert::encode(text, label),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("encode should always receive exactly two arguments"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "xor", params = Fixed(2))]
 fn xor_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -4944,6 +4968,8 @@ mq_macros::builtin_dispatch! {
     FROM_HEX,
     TO_HEX,
     UTF8,
+    DECODE,
+    ENCODE,
     XOR,
     BAND,
     BOR,
@@ -6642,6 +6668,31 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
                 code: r#"utf8(to_bytes("hi"))"#,
                 expected: r#"hi"#,
             }],
+            capability: None,
+        },
+    );
+    map.insert(
+        SmolStr::new("decode"),
+        BuiltinFunctionDoc {
+            description: "Decodes bytes as text using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"). Returns an error if the label is unrecognized or the bytes contain a sequence invalid for that encoding, rather than silently substituting replacement characters.",
+            params: &["bytes", "label"],
+            param_types: &["bytes", "string"],
+            returns: "string",
+            examples: &[BuiltinExample {
+                code: r#"decode(encode("hi", "shift_jis"), "shift_jis")"#,
+                expected: r#"hi"#,
+            }],
+            capability: None,
+        },
+    );
+    map.insert(
+        SmolStr::new("encode"),
+        BuiltinFunctionDoc {
+            description: "Encodes text as bytes using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"). Returns an error if the label is unrecognized or the text contains a character unmappable in that encoding, rather than silently substituting a replacement byte.",
+            params: &["text", "label"],
+            param_types: &["string", "string"],
+            returns: "bytes",
+            examples: &[],
             capability: None,
         },
     );
@@ -11908,6 +11959,103 @@ mod tests {
             &RuntimeValue::None,
             &ident,
             vec![RuntimeValue::Bytes(vec![0xff, 0xfe])],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_shift_jis() {
+        let ident = Ident::new("decode");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![
+                RuntimeValue::Bytes(vec![0x82, 0xa0]),
+                RuntimeValue::String("shift_jis".to_string()),
+            ],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert_eq!(result, Ok(RuntimeValue::String("あ".to_string())));
+    }
+
+    #[test]
+    fn test_decode_unknown_label() {
+        let ident = Ident::new("decode");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![
+                RuntimeValue::Bytes(vec![0x00]),
+                RuntimeValue::String("not-a-real-encoding".to_string()),
+            ],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_invalid_bytes() {
+        let ident = Ident::new("decode");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![
+                RuntimeValue::Bytes(vec![0xff, 0xff]),
+                RuntimeValue::String("shift_jis".to_string()),
+            ],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encode_shift_jis() {
+        let ident = Ident::new("encode");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![
+                RuntimeValue::String("あ".to_string()),
+                RuntimeValue::String("shift_jis".to_string()),
+            ],
+            &Shared::new(SharedCell::new(Env::default())),
+        );
+        assert_eq!(result, Ok(RuntimeValue::Bytes(vec![0x82, 0xa0])));
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let encoded = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("encode"),
+            vec![
+                RuntimeValue::String("こんにちは".to_string()),
+                RuntimeValue::String("euc-jp".to_string()),
+            ],
+            &env,
+        )
+        .unwrap();
+        let decoded = eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("decode"),
+            vec![encoded, RuntimeValue::String("euc-jp".to_string())],
+            &env,
+        );
+        assert_eq!(decoded, Ok(RuntimeValue::String("こんにちは".to_string())));
+    }
+
+    #[test]
+    fn test_encode_unmappable_character() {
+        let ident = Ident::new("encode");
+        let result = eval_builtin(
+            &RuntimeValue::None,
+            &ident,
+            vec![
+                RuntimeValue::String("😀".to_string()),
+                RuntimeValue::String("shift_jis".to_string()),
+            ],
             &Shared::new(SharedCell::new(Env::default())),
         );
         assert!(result.is_err());

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -6674,7 +6674,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("decode"),
         BuiltinFunctionDoc {
-            description: "Decodes bytes as text using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"). Returns an error if the label is unrecognized or the bytes contain a sequence invalid for that encoding, rather than silently substituting replacement characters.",
+            description: "Decodes bytes as text using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"; case-insensitive, and common aliases such as \"latin1\" or \"ascii\" are accepted). Supported encodings: UTF-8, UTF-16BE, UTF-16LE, IBM866, ISO-2022-JP, ISO-8859-2 through ISO-8859-8 (and ISO-8859-8-I), ISO-8859-10, ISO-8859-13 through ISO-8859-16, KOI8-R, KOI8-U, Shift_JIS, EUC-JP, EUC-KR, Big5, GBK, gb18030, macintosh, x-mac-cyrillic, x-user-defined, windows-874, windows-1250 through windows-1258 (see https://encoding.spec.whatwg.org/#names-and-labels for the full label list, including aliases). Returns an error if the label is unrecognized or the bytes contain a sequence invalid for that encoding, rather than silently substituting replacement characters.",
             params: &["bytes", "label"],
             param_types: &["bytes", "string"],
             returns: "string",
@@ -6688,7 +6688,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("encode"),
         BuiltinFunctionDoc {
-            description: "Encodes text as bytes using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"). Returns an error if the label is unrecognized or the text contains a character unmappable in that encoding, rather than silently substituting a replacement byte.",
+            description: "Encodes text as bytes using a WHATWG encoding label (e.g. \"shift_jis\", \"utf-16le\", \"euc-jp\"; case-insensitive, and common aliases such as \"latin1\" or \"ascii\" are accepted). Supported encodings: UTF-8, UTF-16BE, UTF-16LE, IBM866, ISO-2022-JP, ISO-8859-2 through ISO-8859-8 (and ISO-8859-8-I), ISO-8859-10, ISO-8859-13 through ISO-8859-16, KOI8-R, KOI8-U, Shift_JIS, EUC-JP, EUC-KR, Big5, GBK, gb18030, macintosh, x-mac-cyrillic, x-user-defined, windows-874, windows-1250 through windows-1258 (see https://encoding.spec.whatwg.org/#names-and-labels for the full label list, including aliases). Returns an error if the label is unrecognized or the text contains a character unmappable in that encoding, rather than silently substituting a replacement byte.",
             params: &["text", "label"],
             param_types: &["string", "string"],
             returns: "bytes",

--- a/crates/mq-lang/src/eval/builtin/convert.rs
+++ b/crates/mq-lang/src/eval/builtin/convert.rs
@@ -2,6 +2,7 @@ use crate::RuntimeValue;
 use crate::eval::builtin::Error;
 use crate::number::Number;
 use base64::prelude::*;
+use encoding_rs::Encoding;
 use html_escape::decode_html_entities;
 use percent_encoding::{NON_ALPHANUMERIC, percent_decode, utf8_percent_encode};
 use sha2::Digest;
@@ -574,6 +575,36 @@ pub(super) fn utf8(input: &[u8]) -> Result<RuntimeValue, Error> {
 #[inline(always)]
 pub(super) fn to_hex(input: &[u8]) -> Result<RuntimeValue, Error> {
     Ok(RuntimeValue::String(bytes_to_hex(input)))
+}
+
+/// Decode bytes as text using a WHATWG encoding label. Errors on invalid input rather than substituting.
+#[inline(always)]
+pub(super) fn decode(input: &[u8], label: &str) -> Result<RuntimeValue, Error> {
+    let encoding = Encoding::for_label(label.as_bytes())
+        .ok_or_else(|| Error::Runtime(format!("decode: unrecognized encoding label \"{}\"", label)))?;
+    let (decoded, _, had_errors) = encoding.decode(input);
+    if had_errors {
+        return Err(Error::Runtime(format!(
+            "decode: input contains a byte sequence invalid for encoding \"{}\"",
+            encoding.name()
+        )));
+    }
+    Ok(RuntimeValue::String(decoded.into_owned()))
+}
+
+/// Encode text as bytes using a WHATWG encoding label. Errors on unmappable input rather than substituting.
+#[inline(always)]
+pub(super) fn encode(input: &str, label: &str) -> Result<RuntimeValue, Error> {
+    let encoding = Encoding::for_label(label.as_bytes())
+        .ok_or_else(|| Error::Runtime(format!("encode: unrecognized encoding label \"{}\"", label)))?;
+    let (encoded, _, had_unmappable) = encoding.encode(input);
+    if had_unmappable {
+        return Err(Error::Runtime(format!(
+            "encode: input contains a character unmappable in encoding \"{}\"",
+            encoding.name()
+        )));
+    }
+    Ok(RuntimeValue::Bytes(encoded.into_owned()))
 }
 
 #[inline(always)]


### PR DESCRIPTION
## Summary

Adds `decode(bytes, label): string` and `encode(text, label): bytes` builtins backed by encoding_rs, using WHATWG encoding labels (e.g. "shift_jis", "euc-jp", "utf-16le"). Both error on invalid byte sequences / unmappable characters rather than silently substituting, to avoid silent mojibake. Also registers the signatures in mq-check's type checker.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
