### PR TITLE
🐛 fix(jetbrains): fix binary incompatibility in MqSettingsConfigurable browse listeners

### DIFF
--- a/editors/jetbrains/src/main/kotlin/org/mqlang/mq/settings/MqSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/org/mqlang/mq/settings/MqSettingsConfigurable.kt
@@ -1,6 +1,7 @@
 package org.mqlang.mq.settings
 
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.ui.TextBrowseFolderListener
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.ui.components.JBCheckBox
@@ -16,18 +17,20 @@ class MqSettingsConfigurable : Configurable {
 
     private val lspPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            null,
-            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
-                .withTitle("mq-lsp Executable")
-                .withDescription("Path to the mq-lsp language server executable. Leave empty to auto-detect on PATH."),
+            TextBrowseFolderListener(
+                FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+                    .withTitle("mq-lsp Executable")
+                    .withDescription("Path to the mq-lsp language server executable. Leave empty to auto-detect on PATH."),
+            ),
         )
     }
     private val dbgPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            null,
-            FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
-                .withTitle("mq-dbg Executable")
-                .withDescription("Path to the mq-dbg debug adapter executable. Leave empty to auto-detect on PATH."),
+            TextBrowseFolderListener(
+                FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+                    .withTitle("mq-dbg Executable")
+                    .withDescription("Path to the mq-dbg debug adapter executable. Leave empty to auto-detect on PATH."),
+            ),
         )
     }
     private val showExamplesCheckBox = JBCheckBox("Show examples when creating a new .mq file")


### PR DESCRIPTION
## Summary

TextFieldWithBrowseButton.addBrowseFolderListener(Project, FileChooserDescriptor) isn't present in early 242.x builds (e.g. IU-242.26775.15), causing a NoSuchMethodError at runtime despite pluginSinceBuild = 242. Switch to addBrowseFolderListener(TextBrowseFolderListener), which is stable across the whole supported build range.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
