### PR TITLE
✨ feat(mq-repl): support multiple files and globs for REPL input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,7 @@ dependencies = [
  "arboard",
  "colored 3.1.1",
  "dirs 6.0.0",
+ "glob",
  "miette",
  "mq-hir",
  "mq-lang",

--- a/crates/mq-repl/Cargo.toml
+++ b/crates/mq-repl/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.8.3"
 [dependencies]
 colored = {workspace = true}
 dirs = {workspace = true}
+glob = {workspace = true}
 miette = {workspace = true}
 mq-hir = {workspace = true}
 mq-lang = {workspace = true, features = ["http"]}

--- a/crates/mq-repl/src/command_context.rs
+++ b/crates/mq-repl/src/command_context.rs
@@ -1,4 +1,4 @@
-use std::{fmt, fs, io::Write, process::Command as ProcessCommand};
+use std::{fmt, fs, io::Write, path::PathBuf, process::Command as ProcessCommand};
 
 #[cfg(all(feature = "clipboard", not(target_os = "android")))]
 use arboard::Clipboard;
@@ -31,7 +31,7 @@ pub enum Command {
     Eval(String),
     Help,
     History,
-    LoadFile(String),
+    LoadFile(Vec<String>),
     NotFound(String),
     Quit,
     Reset,
@@ -81,7 +81,12 @@ impl Command {
             Command::Help => format!("{:<12}{}", "/help", "Print command help"),
             Command::History => format!("{:<12}{}", "/history", "Show command history"),
             Command::Quit => format!("{:<12}{}", "/quit", "Quit evaluation and exit"),
-            Command::LoadFile(_) => format!("{:<12}{}", "/load", "Load a markdown file"),
+            Command::LoadFile(_) => {
+                format!(
+                    "{:<12}{}",
+                    "/load", "Load one or more markdown files (supports globs, e.g. /load *.md)"
+                )
+            }
             Command::SaveFile(_) => format!("{:<12}{}", "/save", "Save a current result to a file"),
             Command::Reset => format!("{:<12}{}", "/reset", "Reset REPL state (clear variables and input)"),
             Command::Vars => format!("{:<12}{}", "/vars", "List bound variables"),
@@ -102,7 +107,9 @@ impl From<String> for Command {
             ["/help"] => Command::Help,
             ["/history"] => Command::History,
             ["/quit"] => Command::Quit,
-            ["/load", file_path] => Command::LoadFile(file_path.to_string()),
+            ["/load", first, rest @ ..] => {
+                Command::LoadFile(std::iter::once(first).chain(rest).map(|s| s.to_string()).collect())
+            }
             ["/save", file_path] => Command::SaveFile(file_path.to_string()),
             ["/reset"] => Command::Reset,
             ["/vars"] => Command::Vars,
@@ -502,17 +509,37 @@ impl CommandContext {
                 std::process::exit(0);
             }
             Command::NotFound(s) => Err(miette!(format!("Command not found: {}", s))),
-            Command::LoadFile(file_path) => {
-                fs::read_to_string(file_path)
-                    .into_diagnostic()
-                    .and_then(|markdown_content| {
-                        let markdown: mq_markdown::Markdown =
-                            mq_markdown::Markdown::from_markdown_str(&markdown_content)?;
+            Command::LoadFile(paths) => {
+                let mut resolved_paths: Vec<PathBuf> = Vec::new();
 
-                        self.input = markdown.nodes.into_iter().map(mq_lang::RuntimeValue::from).collect();
-                        self.reindex_document();
-                        Ok(CommandOutput::None)
-                    })
+                for pattern in paths {
+                    if pattern.contains(['*', '?', '[']) {
+                        let matches: Vec<PathBuf> = glob::glob(&pattern)
+                            .into_diagnostic()?
+                            .collect::<Result<Vec<_>, _>>()
+                            .into_diagnostic()?;
+
+                        if matches.is_empty() {
+                            return Err(miette!("No files matched pattern: {}", pattern));
+                        }
+
+                        resolved_paths.extend(matches);
+                    } else {
+                        resolved_paths.push(PathBuf::from(pattern));
+                    }
+                }
+
+                let mut combined_input = Vec::new();
+
+                for path in &resolved_paths {
+                    let markdown_content = fs::read_to_string(path).into_diagnostic()?;
+                    let markdown = mq_markdown::Markdown::from_markdown_str(&markdown_content)?;
+                    combined_input.extend(markdown.nodes.into_iter().map(mq_lang::RuntimeValue::from));
+                }
+
+                self.input = combined_input;
+                self.reindex_document();
+                Ok(CommandOutput::None)
             }
             Command::SaveFile(file_path) => {
                 let content = self.input.iter().map(|v| v.to_string()).collect::<Vec<_>>().join("\n");
@@ -626,8 +653,14 @@ mod tests {
             panic!("Expected Env command");
         }
 
-        if let Command::LoadFile(path) = Command::from("/load test.md".to_string()) {
-            assert_eq!(path, "test.md");
+        if let Command::LoadFile(paths) = Command::from("/load test.md".to_string()) {
+            assert_eq!(paths, vec!["test.md".to_string()]);
+        } else {
+            panic!("Expected LoadFile command");
+        }
+
+        if let Command::LoadFile(paths) = Command::from("/load a.md b.md".to_string()) {
+            assert_eq!(paths, vec!["a.md".to_string(), "b.md".to_string()]);
         } else {
             panic!("Expected LoadFile command");
         }
@@ -644,7 +677,7 @@ mod tests {
         assert_eq!(format!("{}", Command::Reset), "/reset");
         assert_eq!(format!("{}", Command::Vars), "/vars");
         assert_eq!(format!("{}", Command::Version), "/version");
-        assert_eq!(format!("{}", Command::LoadFile("test.md".to_string())), "/load");
+        assert_eq!(format!("{}", Command::LoadFile(vec!["test.md".to_string()])), "/load");
         assert_eq!(
             format!("{}", Command::Env("key".to_string(), "value".to_string())),
             "/env"
@@ -821,6 +854,111 @@ mod tests {
 
         let list_items = ctx.input.iter().filter(|v| v.to_string().contains("List item")).count();
         assert_eq!(list_items, 2);
+    }
+
+    #[test]
+    fn test_execute_load_file_multiple() {
+        let engine = mq_lang::DefaultEngine::default();
+        let mut ctx = CommandContext::new(engine, vec!["".to_string().into()]);
+        let (_, path_a) = create_file("test_execute_load_file_multiple_a.md", "# Header A");
+        let (_, path_b) = create_file("test_execute_load_file_multiple_b.md", "# Header B");
+        let path_a_clone = path_a.clone();
+        let path_b_clone = path_b.clone();
+
+        defer! {
+            if path_a_clone.exists() {
+                std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+            }
+            if path_b_clone.exists() {
+                std::fs::remove_file(&path_b_clone).expect("Failed to delete temp file");
+            }
+        }
+
+        let result = ctx.execute(&format!(
+            "/load {} {}",
+            path_a.to_str().unwrap(),
+            path_b.to_str().unwrap()
+        ));
+        assert!(matches!(result, Ok(CommandOutput::None)));
+
+        let headings: Vec<String> = ctx.input.iter().map(|v| v.to_string()).collect();
+        assert!(headings.iter().any(|h| h.contains("Header A")));
+        assert!(headings.iter().any(|h| h.contains("Header B")));
+        assert!(
+            headings.iter().position(|h| h.contains("Header A")) < headings.iter().position(|h| h.contains("Header B"))
+        );
+    }
+
+    #[test]
+    fn test_execute_load_file_glob() {
+        let engine = mq_lang::DefaultEngine::default();
+        let mut ctx = CommandContext::new(engine, vec!["".to_string().into()]);
+        let (temp_dir, path_a) = create_file("test_glob_load_a.md", "# Glob Header A");
+        let (_, path_b) = create_file("test_glob_load_b.md", "# Glob Header B");
+        let path_a_clone = path_a.clone();
+        let path_b_clone = path_b.clone();
+
+        defer! {
+            if path_a_clone.exists() {
+                std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+            }
+            if path_b_clone.exists() {
+                std::fs::remove_file(&path_b_clone).expect("Failed to delete temp file");
+            }
+        }
+
+        let pattern = temp_dir.join("test_glob_load_*.md");
+        let result = ctx.execute(&format!("/load {}", pattern.to_str().unwrap()));
+        assert!(matches!(result, Ok(CommandOutput::None)));
+
+        let headings: Vec<String> = ctx.input.iter().map(|v| v.to_string()).collect();
+        assert!(headings.iter().any(|h| h.contains("Glob Header A")));
+        assert!(headings.iter().any(|h| h.contains("Glob Header B")));
+    }
+
+    #[test]
+    fn test_execute_load_file_glob_no_matches() {
+        let engine = mq_lang::DefaultEngine::default();
+        let mut ctx = CommandContext::new(engine, vec!["".to_string().into()]);
+        let temp_dir = std::env::temp_dir();
+        let pattern = temp_dir.join("test_execute_load_file_no_such_glob_*.md");
+
+        let result = ctx.execute(&format!("/load {}", pattern.to_str().unwrap()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_execute_load_file_nonexistent_literal() {
+        let engine = mq_lang::DefaultEngine::default();
+        let mut ctx = CommandContext::new(engine, vec!["".to_string().into()]);
+
+        let result = ctx.execute("/load /definitely/does/not/exist.md");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_execute_load_file_failure_preserves_existing_input() {
+        let (_, path_a) = create_file("test_load_preserve_a.md", "# Preserved Header");
+        let path_a_clone = path_a.clone();
+
+        defer! {
+            if path_a_clone.exists() {
+                std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+            }
+        }
+
+        let mut ctx = CommandContext::new(mq_lang::DefaultEngine::default(), vec!["".to_string().into()]);
+        ctx.execute(&format!("/load {}", path_a.to_str().unwrap()))
+            .expect("initial load should succeed");
+
+        let result = ctx.execute(&format!(
+            "/load {} /definitely/does/not/exist.md",
+            path_a.to_str().unwrap()
+        ));
+        assert!(result.is_err());
+
+        let headings: Vec<String> = ctx.input.iter().map(|v| v.to_string()).collect();
+        assert!(headings.iter().any(|h| h.contains("Preserved Header")));
     }
 
     #[rstest]

--- a/crates/mq-repl/src/repl.rs
+++ b/crates/mq-repl/src/repl.rs
@@ -319,7 +319,7 @@ impl Completer for MqLineHelper {
             })
             .collect::<Vec<_>>();
 
-        if line.starts_with(Command::LoadFile("".to_string()).to_string().as_str()) {
+        if line.starts_with(Command::LoadFile(vec![]).to_string().as_str()) {
             let (_, file_completions) = self.file_completer.complete_path(line, pos)?;
             completions.extend(file_completions);
         }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -543,8 +543,12 @@ impl OutputArgs {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Start a REPL session for interactive query execution
-    Repl,
+    /// Start a REPL session for interactive query execution. Optional FILES are
+    /// combined as the initial input (same file/format handling as `mq QUERY FILES...`).
+    Repl {
+        /// Markdown (or other supported format) files to load as the REPL's initial input
+        files: Option<Vec<PathBuf>>,
+    },
     /// Start a debug adapter for mq
     #[cfg(feature = "debugger")]
     Dap,
@@ -556,15 +560,6 @@ enum Commands {
     },
     /// Show documentation for a builtin function, selector, standard module, standard-module
     /// function, or the `examples` topic.
-    ///
-    /// Looks up NAME among native builtin functions, selectors (with or without a leading
-    /// `.`), `builtin.mq` functions, standard module names (e.g. `section`, `table`), and
-    /// every standard module's functions, and prints its signature, parameter/return types,
-    /// description, examples, required capability (Cargo feature), and the module it belongs
-    /// to (if any). Use `module::function` (e.g. `section::section`) to disambiguate a
-    /// function whose name collides with its own module. Run `mq help examples` for CLI usage
-    /// examples (basic queries, ARGS passing, auto-parsing by file extension). Run with no NAME
-    /// to list everything.
     Help {
         /// Name of a function, selector, module, or `examples`, e.g. `map`, `.h1`, `csv_parse`,
         /// `section`, `examples`
@@ -1303,9 +1298,20 @@ impl Cli {
         }
 
         match &self.commands {
-            Some(Commands::Repl) => {
+            Some(Commands::Repl { files }) => {
                 let engine = self.create_engine()?;
-                mq_repl::Repl::with_engine(engine, vec![mq_lang::RuntimeValue::String("".to_string())]).run()
+                let input = match files {
+                    Some(files) if !files.is_empty() => {
+                        let contents = self.read_files_content(files)?;
+                        let mut combined = Vec::new();
+                        for (file, content) in &contents {
+                            combined.extend(self.resolve_input(file, content)?);
+                        }
+                        combined
+                    }
+                    _ => vec![mq_lang::RuntimeValue::String("".to_string())],
+                };
+                mq_repl::Repl::with_engine(engine, input).run()
             }
             None if self.query.is_none() => {
                 let engine = self.create_engine()?;
@@ -2067,6 +2073,22 @@ impl Cli {
             })
     }
 
+    /// Reads each file's raw content, choosing binary or text mode per-file based on its
+    /// detected format. Shared by `read_contents` and the `repl` subcommand's file-seeding.
+    fn read_files_content(&self, files: &[PathBuf]) -> miette::Result<Vec<(Option<PathBuf>, ContentData)>> {
+        files
+            .iter()
+            .map(|file| {
+                let content: ContentData = if self.needs_binary_read_for_file(file) {
+                    fs::read(file).map(Into::into).into_diagnostic()?
+                } else {
+                    fs::read_to_string(file).map(Into::into).into_diagnostic()?
+                };
+                Ok((Some(file.clone()), content))
+            })
+            .collect()
+    }
+
     fn read_contents(&self) -> miette::Result<Vec<(Option<PathBuf>, ContentData)>> {
         if matches!(self.input.input_format, Some(InputFormat::Null)) {
             return Ok(vec![(None, ContentData::empty())]);
@@ -2074,25 +2096,7 @@ impl Cli {
 
         self.files
             .clone()
-            .map(|files| {
-                let load_contents: miette::Result<Vec<ContentData>> = files
-                    .iter()
-                    .map(|file| {
-                        if self.needs_binary_read_for_file(file) {
-                            fs::read(file).map(Into::into).into_diagnostic()
-                        } else {
-                            fs::read_to_string(file).map(Into::into).into_diagnostic()
-                        }
-                    })
-                    .collect();
-                load_contents.map(move |contents| {
-                    files
-                        .into_iter()
-                        .zip(contents)
-                        .map(|(file, content)| (Some(file), content))
-                        .collect::<Vec<_>>()
-                })
-            })
+            .map(|files| self.read_files_content(&files))
             .unwrap_or_else(|| {
                 if io::stdin().is_terminal() {
                     return Ok(vec![(None, ContentData::empty())]);
@@ -4713,8 +4717,6 @@ mod tests {
     fn test_content_data_as_bytes(#[case] input: ContentData, #[case] expected: &[u8]) {
         assert_eq!(input.as_bytes(), expected);
     }
-
-    // --- ContentData::from (Into conversions) ---
 
     #[rstest]
     #[case("hello".to_string(), Some("hello"))]

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -866,6 +866,123 @@ fn test_repl_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
+fn test_repl_with_file_arg_loads_content() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_repl_file_arg.md", "# Repl File Heading");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd.arg("repl").arg(&temp_file_path).write_stdin("self\n").assert();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("Repl File Heading"),
+        "expected repl output to contain file contents, got: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_repl_with_multiple_file_args_combines_content() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, path_a) = create_file("test_repl_multi_file_a.md", "# Multi File Heading A");
+    let (_, path_b) = create_file("test_repl_multi_file_b.md", "# Multi File Heading B");
+    let path_a_clone = path_a.clone();
+    let path_b_clone = path_b.clone();
+
+    defer! {
+        if path_a_clone.exists() {
+            std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+        }
+        if path_b_clone.exists() {
+            std::fs::remove_file(&path_b_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd.arg("repl").arg(&path_a).arg(&path_b).write_stdin("self\n").assert();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(stdout.contains("Multi File Heading A"), "got: {stdout}");
+    assert!(stdout.contains("Multi File Heading B"), "got: {stdout}");
+    Ok(())
+}
+
+#[test]
+fn test_repl_no_files_still_seeds_empty() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd.arg("repl").write_stdin("self\n").assert();
+
+    assert.success();
+    Ok(())
+}
+
+#[test]
+fn test_repl_load_command_multiple_files() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, path_a) = create_file("test_repl_load_multi_a.md", "# Load Multi Heading A");
+    let (_, path_b) = create_file("test_repl_load_multi_b.md", "# Load Multi Heading B");
+    let path_a_clone = path_a.clone();
+    let path_b_clone = path_b.clone();
+
+    defer! {
+        if path_a_clone.exists() {
+            std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+        }
+        if path_b_clone.exists() {
+            std::fs::remove_file(&path_b_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("repl")
+        .write_stdin(format!(
+            "/load {} {}\nself\n",
+            path_a.to_string_lossy(),
+            path_b.to_string_lossy()
+        ))
+        .assert();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(stdout.contains("Load Multi Heading A"), "got: {stdout}");
+    assert!(stdout.contains("Load Multi Heading B"), "got: {stdout}");
+    Ok(())
+}
+
+#[test]
+fn test_repl_load_command_glob() -> Result<(), Box<dyn std::error::Error>> {
+    let (temp_dir, path_a) = create_file("test_repl_load_glob_a.md", "# Load Glob Heading A");
+    let (_, path_b) = create_file("test_repl_load_glob_b.md", "# Load Glob Heading B");
+    let path_a_clone = path_a.clone();
+    let path_b_clone = path_b.clone();
+
+    defer! {
+        if path_a_clone.exists() {
+            std::fs::remove_file(&path_a_clone).expect("Failed to delete temp file");
+        }
+        if path_b_clone.exists() {
+            std::fs::remove_file(&path_b_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let pattern = temp_dir.join("test_repl_load_glob_*.md");
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("repl")
+        .write_stdin(format!("/load {}\nself\n", pattern.to_string_lossy()))
+        .assert();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(stdout.contains("Load Glob Heading A"), "got: {stdout}");
+    assert!(stdout.contains("Load Glob Heading B"), "got: {stdout}");
+    Ok(())
+}
+
+#[test]
 fn test_collection() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     std::fs::write(temp_dir.path().join("a.md"), "# Hello\n")?;


### PR DESCRIPTION
## Summary

`mq repl <files...>` now combines multiple files as the initial input (reusing the same format-aware resolution as `mq QUERY FILES...`), and `/load` now accepts multiple paths and glob patterns in one call instead of only a single literal file. A failed multi-file `/load` leaves the previous input untouched rather than partially overwriting it.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
