### PR TITLE
✨ feat(mq-lang): add html-to-markdown feature flag

### DIFF
--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -26,7 +26,7 @@ glob = {workspace = true}
 ignore = {workspace = true, optional = true}
 itertools = {workspace = true}
 miette = {workspace = true}
-mq-markdown = {workspace = true, features = ["html-to-markdown", "json", "obsidian"]}
+mq-markdown = {workspace = true, features = ["json", "obsidian"]}
 nom = {workspace = true}
 nom_locate = {workspace = true}
 percent-encoding = {workspace = true}
@@ -65,8 +65,9 @@ ast-json = ["smallvec/serde", "smol_str/serde"]
 cst = ["dep:ropey"]
 css-selector = ["dep:scraper"]
 debugger = ["sync"]
-default = ["std"]
+default = ["std", "html-to-markdown"]
 file-io = ["dep:ignore"]
+html-to-markdown = ["mq-markdown/html-to-markdown"]
 process-io = []
 std = []
 sync = []

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -876,6 +876,7 @@ fn max_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> R
     }
 }
 
+#[cfg(feature = "html-to-markdown")]
 #[mq_macros::mq_fn(name = "from_html", params = Fixed(1))]
 fn from_html_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
@@ -5010,6 +5011,7 @@ mq_macros::builtin_dispatch! {
     SAMPLE,
     MIN,
     MAX,
+    #[cfg(feature = "html-to-markdown")]
     FROM_HTML,
     TO_HTML,
     HTML_ESCAPE,
@@ -6510,6 +6512,7 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
             capability: None,
         },
     );
+    #[cfg(feature = "html-to-markdown")]
     map.insert(
         SmolStr::new("from_html"),
         BuiltinFunctionDoc {

--- a/crates/mq-lang/src/lib.rs
+++ b/crates/mq-lang/src/lib.rs
@@ -199,11 +199,13 @@ pub fn parse_mdx_input(input: &str) -> miette::Result<Vec<RuntimeValue>> {
     Ok(mdx.nodes.into_iter().map(RuntimeValue::from).collect())
 }
 
+#[cfg(feature = "html-to-markdown")]
 pub fn parse_html_input(input: &str) -> miette::Result<Vec<RuntimeValue>> {
     let html = mq_markdown::Markdown::from_html_str(input)?;
     Ok(html.nodes.into_iter().map(RuntimeValue::from).collect())
 }
 
+#[cfg(feature = "html-to-markdown")]
 pub fn parse_html_input_with_options(
     input: &str,
     options: mq_markdown::ConversionOptions,
@@ -372,6 +374,7 @@ mod tests {
         assert_eq!(values.len(), 3);
     }
 
+    #[cfg(feature = "html-to-markdown")]
     #[test]
     fn test_parse_html_input() {
         let input = "<h1>Heading</h1><p>Some text.</p>";
@@ -381,6 +384,7 @@ mod tests {
         assert!(!values.is_empty());
     }
 
+    #[cfg(feature = "html-to-markdown")]
     #[test]
     fn test_parse_html_input_with_options() {
         let input = r#"<html>


### PR DESCRIPTION
## Summary

Make HTML-to-Markdown conversion (from_html builtin, parse_html_input) opt-out via a new html-to-markdown Cargo feature, included in default so existing behavior is unchanged.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
