### PR TITLE
fix(table): stop directly-adjacent tables from merging

### DIFF
--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -38,16 +38,29 @@ def tables(md_nodes):
       | let nodes_len = len(md_nodes)
       | while (i < nodes_len):
           let node = md_nodes[i]
-          | if (is_table_cell(node)):
-              if (node.row != current_row_index) do
-                  if (!is_empty(current_row)):
-                    current_rows += [current_row]
-                  | current_row = []
-                  | current_row_index = node.row
-                  | current_row = [node]
-                end
-              else:
-                current_row += node
+          | if (is_table_cell(node)): do
+                if (node.row == 0 && node.column == 0 && !is_empty(current_align)) do
+                    if (!is_empty(current_row)) do
+                        current_rows += [current_row]
+                        | current_row = []
+                      end
+                    | if (!is_empty(current_rows)) do
+                        tables += [{type: :table, align: current_align, header: current_rows[0], rows: current_rows[1:]}]
+                      end
+                    | current_align = []
+                    | current_rows = []
+                    | current_row_index = -1
+                  end
+                | if (node.row != current_row_index) do
+                    if (!is_empty(current_row)):
+                      current_rows += [current_row]
+                    | current_row = []
+                    | current_row_index = node.row
+                    | current_row = [node]
+                  end
+                else:
+                  current_row += node
+              end
             elif (is_table_align(node)): current_align = node
             else: do
                 if (!is_empty(current_row)) do

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -21,6 +21,43 @@ def test_table_tables_empty():
   | assert_eq(result, [])
 end
 
+def test_table_tables_adjacent():
+  let md_nodes = to_markdown("| A | B |\n| - | - |\n| 1 | 2 |\n\n| C | D |\n|---|---|\n| 3 | 4 |\n")
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 2)
+  | assert_eq(to_string(result[0][:header][0]), "A")
+  | assert_eq(len(result[0][:rows]), 1)
+  | assert_eq(to_string(result[1][:header][0]), "C")
+  | assert_eq(len(result[1][:rows]), 1)
+  | assert_eq(to_string(result[1][:rows][0][0]), "3")
+end
+
+def test_table_tables_three_adjacent():
+  let md_nodes = to_markdown("| A |\n| - |\n| 1 |\n\n| B |\n| - |\n| 2 |\n\n| C |\n| - |\n| 3 |\n")
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 3)
+  | assert_eq(to_string(result[0][:header][0]), "A")
+  | assert_eq(to_string(result[1][:header][0]), "B")
+  | assert_eq(to_string(result[2][:header][0]), "C")
+end
+
+def test_table_tables_adjacent_different_widths():
+  let md_nodes = to_markdown("| A | B |\n| - | - |\n| 1 | 2 |\n\n| C |\n| - |\n| 3 |\n")
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 2)
+  | assert_eq(len(result[0][:header]), 2)
+  | assert_eq(len(result[1][:header]), 1)
+  | assert_eq(len(result[1][:rows][0]), 1)
+end
+
+def test_table_tables_adjacent_header_only():
+  let md_nodes = to_markdown("| A | B |\n| - | - |\n\n| C | D |\n| - | - |\n| 1 | 2 |\n")
+  | let result = table::tables(md_nodes)
+  | assert_eq(len(result), 2)
+  | assert_eq(len(result[0][:rows]), 0)
+  | assert_eq(len(result[1][:rows]), 1)
+end
+
 # @parametrize([[table_md_followed_by_paragraph], [table_md_followed_by_heading], [table_md_followed_by_break]])
 def test_table_tables_followed_by(markdown):
   let md_nodes = to_markdown(markdown)

--- a/crates/mq-markdown/src/markdown.rs
+++ b/crates/mq-markdown/src/markdown.rs
@@ -74,7 +74,8 @@ impl Markdown {
                 row, column, values, ..
             }) = node
             {
-                if current_table.as_ref().is_none_or(|t| i >= t.end) {
+                let is_new_table = current_table.as_ref().is_none_or(|t| i >= t.end);
+                if is_new_table {
                     current_table = Some(TableLayout::compute(&self.nodes, &self.options, i));
                 }
                 let table = current_table.as_ref().unwrap();
@@ -90,15 +91,21 @@ impl Markdown {
                 if is_new_row {
                     if current_table_row.is_some() {
                         buffer.push_str(" |\n");
-                    } else if !in_table && let Some(pos) = node.position() {
-                        // Insert newlines before the first row of a table
-                        let new_line_count = pre_position
-                            .as_ref()
-                            .map(|p| pos.start.line.saturating_sub(p.end.line))
-                            .unwrap_or_else(|| if is_first { 0 } else { 1 })
-                            .min(2);
-                        for _ in 0..new_line_count {
+                    }
+                    if is_new_table {
+                        if in_table {
+                            // Adjacent table: restore the blank line GFM needs to keep them separate.
                             buffer.push('\n');
+                        } else if let Some(pos) = node.position() {
+                            // Insert newlines before the first row of a table
+                            let new_line_count = pre_position
+                                .as_ref()
+                                .map(|p| pos.start.line.saturating_sub(p.end.line))
+                                .unwrap_or_else(|| if is_first { 0 } else { 1 })
+                                .min(2);
+                            for _ in 0..new_line_count {
+                                buffer.push('\n');
+                            }
                         }
                     }
                     current_table_row = Some(*row);
@@ -556,6 +563,19 @@ mod tests {
     // A data row with fewer cells than the header must render only the
     // cells present, without panicking or misaligning later rows.
     #[case::table_ragged_row("| A | B |\n|---|---|\n| 1 |\n", 4, "| A | B |\n| - | - |\n| 1 |\n")]
+    // adjacent tables have no separator node between them; the renderer must still
+    // keep the blank line, or re-parsing merges them into one table.
+    #[case::tables_adjacent(
+        "| A | B |\n|---|---|\n| 1 | 2 |\n\n| C | D |\n|---|---|\n| 3 | 4 |\n",
+        10,
+        "| A | B |\n| - | - |\n| 1 | 2 |\n\n| C | D |\n| - | - |\n| 3 | 4 |\n"
+    )]
+    // adjacent tables of different widths must not share column layout.
+    #[case::tables_adjacent_different_widths(
+        "| A | B |\n|---|---|\n| 1 | 2 |\n\n| C |\n|---|\n| 3 |\n",
+        8,
+        "| A | B |\n| - | - |\n| 1 | 2 |\n\n| C |\n| - |\n| 3 |\n"
+    )]
     #[case::excessive_blank_lines("# Title\n\n\n\nParagraph", 2, "# Title\n\nParagraph\n")]
     #[case::three_blank_lines("Para 1\n\n\n\n\nPara 2", 2, "Para 1\n\nPara 2\n")]
     // GFM autolink literal: link text is the same URL — must not nest on round-trip

--- a/crates/mq-markdown/src/markdown/table_layout.rs
+++ b/crates/mq-markdown/src/markdown/table_layout.rs
@@ -28,6 +28,10 @@ impl TableLayout {
                 Node::TableCell(TableCell {
                     row, column, values, ..
                 }) => {
+                    // row 0 after an align row means an adjacent next table, not a continuation.
+                    if *row == 0 && *column == 0 && !align.is_empty() {
+                        break;
+                    }
                     let width = cell_display_width(values, options);
                     cell_widths.insert((*row, *column), width);
                     if *column >= widths.len() {


### PR DESCRIPTION
## Summary

table::tables() only flushed a table when it hit a non-table node, so two tables separated by nothing but a blank line had no signal to split on: the second header was swallowed as a data row and the table count came out short. Detect the boundary instead whenever a header cell (row 0, column 0) shows up after an align row was already captured for the table in progress.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
