### PR TITLE
fix(mq-lang): escape special characters in json_stringify and csv_to_json

### DIFF
--- a/crates/mq-lang/modules/csv.mq
+++ b/crates/mq-lang/modules/csv.mq
@@ -138,16 +138,25 @@ end
 # import "csv" | csv::csv_to_json([{"name": "Alice", "age": 30}])
 # #=> [{"name":"Alice","age":30}]
 # ```
+# Example:
+# ```
+# import "csv" | csv::csv_to_json([{"name": "back\\slash"}])
+# #=> [{"name":"back\\slash"}]
+# ```
 #
 # Returns: string
 def csv_to_json(data):
+  def _escape_json_string(str):
+    replace(replace(replace(replace(str, "\\", "\\\\"), "\"", "\\\""), "\n", "\\n"), "\t", "\\t")
+  end
+
   def _to_json(value):
     if (is_dict(value)):
-      "{" + join(map(keys(value), fn(k): "\"" + k + "\":" + _to_json(value[k]);), ",") + "}"
+      "{" + join(map(keys(value), fn(k): "\"" + _escape_json_string(k) + "\":" + _to_json(value[k]);), ",") + "}"
     elif (is_array(value)):
       "[" + join(map(value, _to_json), ",") + "]"
     elif (is_string(value)):
-      "\"" + replace(replace(value, "\"", "\\\""), "\n", "\\n") + "\""
+      "\"" + _escape_json_string(value) + "\""
     elif (is_number(value)):
       to_string(value)
     elif (is_bool(value)):
@@ -155,7 +164,7 @@ def csv_to_json(data):
     elif (is_none(value)):
       "null"
     else:
-      "\"" + to_string(value) + "\""
+      "\"" + _escape_json_string(to_string(value)) + "\""
   end
 
   | if (is_array(data) && len(data) > 0 && is_dict(first(data))):

--- a/crates/mq-lang/modules/csv_test.mq
+++ b/crates/mq-lang/modules/csv_test.mq
@@ -1,4 +1,5 @@
 import "csv"
+| import "json"
 | include "test"
 
 # -- CSV and PSV Tests --
@@ -27,6 +28,18 @@ def test_csv_stringify_roundtrip_with_quotes():
   let original = [{"a": "he said \"hi\"", "b": "x,y"}]
   | let result = csv::csv_parse(csv::csv_stringify(original, ","), true)
   | assert_eq(result, original)
+end
+
+def test_csv_to_json_escapes_special_characters():
+  let original = [{"a": "back\\slash and \"quote\" and\nnewline\tend"}]
+  | let result = csv::csv_to_json(original)
+  | assert_eq(json::json_parse(result), original)
+end
+
+def test_csv_to_json_escapes_key():
+  let original = [{"a\"b": "1"}]
+  | let result = csv::csv_to_json(original)
+  | assert_eq(json::json_parse(result), original)
 end
 
 | let psv_input = "a|b|c\n\"1,2\"|\"2,3\"|\"3,4\"\n4|5|6\n\"multi\nline\"|7|8\n9|10|\"quoted,comma\"\n\"\"|11|12\n13|14|15\n" |

--- a/crates/mq-lang/modules/json.mq
+++ b/crates/mq-lang/modules/json.mq
@@ -20,11 +20,20 @@ end
 # import "json" | json::json_stringify({"a": 1})
 # #=> {"a": 1}
 # ```
+# Example:
+# ```
+# import "json" | json::json_stringify({"a": "he said \"hi\"\nbye"})
+# #=> {"a": "he said \"hi\"\nbye"}
+# ```
 #
 # Returns: string
 def json_stringify(data):
+  def _escape_string(str):
+    replace(str, "\\", "\\\\") | replace("\"", "\\\"") | replace("\n", "\\n") | replace("\t", "\\t")
+  end
+
   def _format_json_stringify(data):
-    "\"" + data + "\""
+    "\"" + _escape_string(data) + "\""
   end
 
   def _json_array_stringify(data):
@@ -34,7 +43,7 @@ def json_stringify(data):
   def _json_object_stringify(data):
     "{" + join(
       map(entries(data),
-        fn(entry): "\"" + first(entry) + "\": " + json_stringify(last(entry));), ", ") + "}"
+        fn(entry): "\"" + _escape_string(first(entry)) + "\": " + json_stringify(last(entry));), ", ") + "}"
   end
 
   | if (is_string(data)):

--- a/crates/mq-lang/modules/json_test.mq
+++ b/crates/mq-lang/modules/json_test.mq
@@ -15,6 +15,18 @@ def test_json_stringify():
   | assert_snapshot("json_stringify", result)
 end
 
+def test_json_stringify_escapes_special_characters():
+  let original = {"a": "he said \"hi\"\nline2\tend\\slash"}
+  | let result = json::json_stringify(original)
+  | assert_eq(json::json_parse(result), original)
+end
+
+def test_json_stringify_escapes_key():
+  let original = {"a\"b": 1}
+  | let result = json::json_stringify(original)
+  | assert_eq(json::json_parse(result), original)
+end
+
 def test_json_to_markdown_table():
   let result = json::json_parse(json_input)
   | let result = json::json_to_markdown_table(result["users"])


### PR DESCRIPTION
## Summary

json::json_stringify wrapped string values/keys in quotes without any escaping, producing invalid JSON for strings containing quotes, backslashes, newlines, or tabs. csv::csv_to_json escaped quotes and newlines but not backslashes. Both now use the same escape order as yaml.mq/toml.mq's _escape_string (backslash, quote, newline, tab).

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
