### PR TITLE
✨ feat(mq-lang): add column and heading-level helpers to table/section modules

### DIFF
--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -433,6 +433,37 @@ def has_content(section):
   has_body(section)
 end
 
+# Shifts the heading level of a section and all of its descendant headings
+# by `delta` (positive demotes, e.g. h1 -> h2; negative promotes), keeping
+# their relative depths intact. Depth is clamped to the valid 1-6 range.
+#
+# Example:
+# ```
+# import "section" | let s = first(section::sections(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A"), true)) | section::level(section::shift_level(s, 1))
+# #=> 2
+# ```
+#
+# Returns: dict
+def shift_level(section, delta):
+  if (!_is_section(section)):
+    section
+  else:
+    do
+      let shift_node = fn(node):
+            if (is_h(node)):
+              if (delta >= 0):
+                shift_right(node, delta)
+              else:
+                shift_left(node, 0 - delta)
+            else:
+              node
+          end
+      | let new_header = shift_node(section[:header])
+      | let new_children = map(section[:children], shift_node)
+      | set(set(section, :header, new_header), :children, new_children)
+    end
+end
+
 # Flattens sections back to markdown nodes for output.
 # This converts section objects back to their original markdown node arrays.
 #

--- a/crates/mq-lang/modules/section_test.mq
+++ b/crates/mq-lang/modules/section_test.mq
@@ -156,6 +156,42 @@ def test_section_by_level_empty():
   | assert_eq(secs, [])
 end
 
+def test_section_shift_level_demotes_header_and_descendants():
+  let secs = do test_sections | section::sections(., true);
+  | let intro = first(secs)
+  | let shifted = section::shift_level(intro, 1)
+  | assert_eq(section::level(shifted), 2)
+  | let sub_heading = first(filter(shifted[:children], is_h))
+  | assert(is_h3(sub_heading))
+end
+
+def test_section_shift_level_promotes():
+  let secs = do test_sections | section::sections(., true);
+  | let intro = first(secs)
+  | let demoted = section::shift_level(intro, 1)
+  | let promoted = section::shift_level(demoted, -1)
+  | assert_eq(section::level(promoted), 1)
+end
+
+def test_section_shift_level_promote_clamps_at_min():
+  let secs = do test_sections | section::sections();
+  | let intro = first(secs)
+  | let shifted = section::shift_level(intro, -5)
+  | assert_eq(section::level(shifted), 1)
+end
+
+def test_section_shift_level_preserves_children_count():
+  let secs = do test_sections | section::sections(., true);
+  | let intro = first(secs)
+  | let shifted = section::shift_level(intro, 1)
+  | assert_eq(len(shifted[:children]), len(intro[:children]))
+end
+
+def test_section_shift_level_non_section_returns_unchanged():
+  let result = section::shift_level("not a section", 1)
+  | assert_eq(result, "not a section")
+end
+
 # A single node (not wrapped in an array) means the caller forgot to aggregate
 # input (missing `-A`/`nodes |`). This should be normalized to a one-element
 # array instead of silently producing meaningless results.

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -89,6 +89,20 @@ def tables(md_nodes):
     end
 end
 
+# Returns the index of the column whose header matches `name` (compared as
+# text), or -1 if no column has that header.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |")) | first(self) | table::column_index(self, "b")
+# #=> 1
+# ```
+#
+# Returns: number
+def column_index(table, name):
+  index(map(table[:header], to_string), name)
+end
+
 # Set the alignment for a table.
 #
 # Example:
@@ -172,6 +186,58 @@ def remove_row(table, row_index):
   set(table, :rows, del(table[:rows], row_index))
 end
 
+# Returns a new table containing only the given column indices, in the
+# order given, so this can also reorder columns. Column numbers on the
+# resulting header/row cells are renumbered to match their new positions.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b | c |\n| --- | --- | --- |\n| 1 | 2 | 3 |")) | first(self) | table::select_columns(self, [2, 0]) | table::to_csv(self)
+# #=> c,a
+# 3,1
+# ```
+#
+# Returns: dict
+def select_columns(table, indices):
+  let align_tokens = split(attr(table[:align], "align"), ",")
+  | var col = 0
+  | let new_header = foreach (i, indices):
+        let cell = to_md_table_cell(to_string(table[:header][i]), 0, col)
+        | col += 1
+        | cell
+      end
+  | let new_align_tokens = foreach (i, indices):
+        align_tokens[i]
+      end
+  | let new_align = to_md_table_align(new_align_tokens)
+  | var row_num = 0
+  | let new_rows = foreach (row, table[:rows]):
+        row_num += 1
+        | var c = 0
+        | let cells = foreach (i, indices):
+              let cell = to_md_table_cell(to_string(row[i]), row_num, c)
+              | c += 1
+              | cell
+            end
+        | cells
+      end
+  | {type: :table, align: new_align, header: new_header, rows: new_rows}
+end
+
+# Returns a new table with the header text at `index` replaced by `name`.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |")) | first(self) | table::rename_column(self, 0, "x") | table::to_csv(self)
+# #=> x,b
+# 1,2
+# ```
+#
+# Returns: dict
+def rename_column(table, index, name):
+  set(table, :header, set(table[:header], index, to_md_table_cell(name, 0, index)))
+end
+
 # Remove a column from a table at the specified index.
 #
 # Example:
@@ -182,10 +248,8 @@ end
 #
 # Returns: dict
 def remove_column(table, col_index):
-  let rows = foreach (row, table[:rows]):
-      del(row, col_index)
-    end
-  | set(table, :rows, rows)
+  let indices = filter(range(0, len(table[:header]) - 1), fn(i): i != col_index;)
+  | select_columns(table, indices)
 end
 
 # Map a function over each row in the table.
@@ -296,6 +360,47 @@ def to_array(table)
   | map(table[:rows], fn(row):
         fold(range(0, len(headers) - 1), dict(), fn(acc, i): set(acc, headers[i], to_string(row[i])););
       )
+end
+
+# Builds a table structure from an array of dict records keyed by column
+# name (the inverse of `to_array`). Column order follows the keys of the
+# first record; a key missing from a later record renders as an empty cell.
+#
+# Example:
+# ```
+# import "table" | table::from_array([{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]) | table::to_csv(self)
+# #=> a,b
+# 1,2
+# 3,4
+# ```
+#
+# Returns: dict
+def from_array(records):
+  if (is_empty(records)):
+    {type: :table, align: to_md_table_align([]), header: [], rows: []}
+  else:
+    do
+      let headers = map(keys(first(records)), to_string)
+      | var col = 0
+      | let header_cells = foreach (h, headers):
+            let cell = to_md_table_cell(h, 0, col)
+            | col += 1
+            | cell
+          end
+      | let align = to_md_table_align(map(headers, fn(_): "none";))
+      | var row_num = 0
+      | let rows = foreach (record, records):
+            row_num += 1
+            | var c = 0
+            | let cells = foreach (h, headers):
+                  let cell = to_md_table_cell(to_string(get_or(record, h, "")), row_num, c)
+                  | c += 1
+                  | cell
+                end
+            | cells
+          end
+      | {type: :table, align: align, header: header_cells, rows: rows}
+    end
 end
 
 # Reshape a table from wide format to long format (a.k.a. melt/unpivot).

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -112,8 +112,57 @@ end
 
 def test_table_remove_column():
   let t = first(table::tables(table_nodes))
-  | let t = table::remove_column(t, 0)
+  | let t = table::remove_column(t, 1)
+  | assert_eq(len(t[:header]), 2)
+  | assert_eq(to_string(t[:header][0]), "Name")
+  | assert_eq(to_string(t[:header][1]), "City")
   | assert_eq(len(t[:rows][0]), 2)
+  | let new_header_cell = t[:header][1]
+  | assert_eq(new_header_cell.column, 1)
+  | assert_eq(table::to_csv(t), "Name,City\nAlice,Tokyo\nBob,Osaka")
+end
+
+def test_table_column_index():
+  let t = first(table::tables(table_nodes))
+  | assert_eq(table::column_index(t, "City"), 2)
+  | assert_eq(table::column_index(t, "Missing"), -1)
+end
+
+def test_table_select_columns():
+  let t = first(table::tables(table_nodes))
+  | let result = table::select_columns(t, [2, 0])
+  | assert_eq(len(result[:header]), 2)
+  | assert_eq(to_string(result[:header][0]), "City")
+  | assert_eq(to_string(result[:header][1]), "Name")
+  | let second_header_cell = result[:header][1]
+  | assert_eq(second_header_cell.column, 1)
+  | assert_eq(table::to_csv(result), "City,Name\nTokyo,Alice\nOsaka,Bob")
+end
+
+def test_table_rename_column():
+  let t = first(table::tables(table_nodes))
+  | let result = table::rename_column(t, 0, "FullName")
+  | assert_eq(to_string(result[:header][0]), "FullName")
+  | assert_eq(to_string(result[:header][1]), "Age")
+  | assert_eq(len(result[:rows]), 2)
+end
+
+def test_table_from_array():
+  let records = [{"Name": "Alice", "Age": "30"}, {"Name": "Bob", "Age": "25"}]
+  | let result = table::from_array(records)
+  | assert_eq(table::to_csv(result), "Name,Age\nAlice,30\nBob,25")
+end
+
+def test_table_from_array_empty():
+  let result = table::from_array([])
+  | assert_eq(result[:header], [])
+  | assert_eq(result[:rows], [])
+end
+
+def test_table_from_array_round_trips_with_to_array():
+  let t = first(table::tables(table_nodes))
+  | let result = table::from_array(table::to_array(t))
+  | assert_eq(table::to_csv(result), table::to_csv(t))
 end
 
 def test_table_to_markdown():


### PR DESCRIPTION
## Summary

- table::column_index(table, name): look up a column index by header text
- table::from_array(records): build a table from an array of dict records (inverse of table::to_array)
- table::select_columns(table, indices) / table::rename_column(table, index, name): extract/reorder columns and rename a header
- section::shift_level(section, delta): shift a section's heading and all of its descendant headings by delta while keeping relative depths intact

Also fixes table::remove_column, which previously left the header cell in place and never renumbered the remaining cells' column indices, producing a header/body column-count mismatch in the rendered Markdown. It now reuses select_columns so header, align, and row cells stay consistent.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
