### PR TITLE
✨ feat(mq-lang): extend table/section/gron modules, add frontmatter/JSON parity

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -965,7 +965,7 @@ def unique_by(arr, f):
           let item = get(arr, i)
           | let key = to_string(f(item))
           | let already_seen = get(seen, key)
-          | result = if (is_none(already_seen)): result + item else: result
+          | result = if (is_none(already_seen)): result + [item] else: result
           | seen = if (is_none(already_seen)): set(seen, key, true) else: seen
           | i += 1
           | result

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -273,7 +273,10 @@ def test_fold(value, init, f, expected):
   | assert_eq(result, expected)
 end
 
-# @parametrize([[[1, 2, 3, 2, 1, 4], fn(x): x;, [1, 2, 3, 4]], [[{"id": 1}, {"id": 2}, {"id": 1}], fn(x): x["id"];, [{"id": 1}, {"id": 2}]], [[], fn(x): x;, []]])
+# Elements that are themselves arrays (e.g. [[1, 2], [3, 4], [1, 2]]) must be
+# kept as single elements, not concatenated/flattened into the result (`+`
+# on two arrays concatenates, so appending must wrap the element in [item]).
+# @parametrize([[[1, 2, 3, 2, 1, 4], fn(x): x;, [1, 2, 3, 4]], [[{"id": 1}, {"id": 2}, {"id": 1}], fn(x): x["id"];, [{"id": 1}, {"id": 2}]], [[], fn(x): x;, []], [[[1, 2], [3, 4], [1, 2]], fn(row): row;, [[1, 2], [3, 4]]]])
 def test_unique_by(value, f, expected):
   let result = unique_by(value, f)
   | assert_eq(result, expected)

--- a/crates/mq-lang/modules/__snapshots__/toon_test/toon_stringify.snap
+++ b/crates/mq-lang/modules/__snapshots__/toon_test/toon_stringify.snap
@@ -1,3 +1,7 @@
+items[3]:
+  - 1
+  - a: 1
+  - text
 context:
   task: Our favorite hikes together
   location: Boulder
@@ -7,10 +11,6 @@ hikes[3]{name,id,distanceKm,elevationGain,companion,wasSunny}:
   Blue Lake Trail,1,7.5,320,ana,true
   Ridge Overlook,2,9.2,540,luis,false
   Wildflower Loop,3,5.1,180,sam,true
-items[3]:
-  - 1
-  - a: 1
-  - text
 items2[2]{name,price}:
   Laptop,999
   Mouse,29

--- a/crates/mq-lang/modules/gron.mq
+++ b/crates/mq-lang/modules/gron.mq
@@ -1,5 +1,35 @@
 # gron Implementation in mq.
 
+import "json" |
+
+# Returns true if `key` can be written as a bare `path.key` segment (matching
+# the `gron` tool's own escaping rules); otherwise it needs bracket notation.
+def _is_bare_ident(key): test(key, "^[A-Za-z_][A-Za-z0-9_]*$");
+
+# Joins a gron path with the next key, using dot notation (`path.key`) when
+# `key` is a bare identifier, and bracket notation (`path["key"]`) otherwise.
+def _join_key(path, key):
+  if (_is_bare_ident(key)):
+    path + "." + key
+  else:
+    path + "[" + json::json_stringify(key) + "]"
+end
+
+def _gron_lines(path, value):
+  if (is_dict(value)):
+    if (is_empty(keys(value))):
+      [path + " = {};"]
+    else:
+      [path + " = {};"] + flat_map(sort(keys(value)), fn(k): _gron_lines(_join_key(path, k), value[k]);)
+  elif (is_array(value)):
+    if (is_empty(value)):
+      [path + " = [];"]
+    else:
+      [path + " = [];"] + flat_map(range(0, len(value) - 1), fn(i): _gron_lines(path + "[" + to_string(i) + "]", value[i]);)
+  else:
+    [path + " = " + json::json_stringify(value) + ";"]
+end
+
 # Parses gron-style `path = value;` assignment statements (as produced by `mq -F gron`)
 # and returns the corresponding data structure.
 #
@@ -12,4 +42,23 @@
 # Returns: dynamic
 def gron_parse(input):
   _gron_parse(to_string(input))
+end
+
+# Converts a data structure into gron-style `path = value;` assignment
+# statements (the inverse of `gron_parse`, and matching `mq -F gron`'s
+# output), so a value can be flattened, grepped, and reconstructed without
+# leaving a single query. Paths are rooted at `json`, following the `gron`
+# tool's own convention.
+#
+# Example:
+# ```
+# import "gron" | gron::gron_stringify({"a": 1, "b": 2})
+# #=> json = {};
+# json.a = 1;
+# json.b = 2;
+# ```
+#
+# Returns: string
+def gron_stringify(data):
+  join(_gron_lines("json", data), "\n")
 end

--- a/crates/mq-lang/modules/gron_test.mq
+++ b/crates/mq-lang/modules/gron_test.mq
@@ -18,3 +18,14 @@ def test_gron_parse_array():
   let result = gron::gron_parse("json = [];\njson[0] = \"x\";\njson[1] = \"y\";")
   | assert_eq(result, ["x", "y"])
 end
+
+# @parametrize([["hello", "json = \"hello\";"], [{"a": {"b": "deep"}}, "json = {};\njson.a = {};\njson.a.b = \"deep\";"], [["x", "y"], "json = [];\njson[0] = \"x\";\njson[1] = \"y\";"], [{}, "json = {};"], [[], "json = [];"], [{"weird key": "v"}, "json = {};\njson[\"weird key\"] = \"v\";"], [{"b": 1, "a": 2}, "json = {};\njson.a = 2;\njson.b = 1;"]])
+def test_gron_stringify(value, expected):
+  assert_eq(gron::gron_stringify(value), expected)
+end
+
+# @parametrize([[{"a": 1, "b": [2, 3]}], [["x", {"y": 1}]], [{"a": {"b": {"c": 1}}}]])
+def test_gron_stringify_round_trips_with_parse(value):
+  let result = gron::gron_stringify(value)
+  | assert_eq(gron::gron_parse(result), value)
+end

--- a/crates/mq-lang/modules/json.mq
+++ b/crates/mq-lang/modules/json.mq
@@ -107,3 +107,23 @@ def json_to_markdown_table(data):
     else:
       _create_simple_markdown_table(data)
 end
+
+# Converts a data structure to a JSON front matter string, delimited with
+# `;;;` (the convention used by e.g. Hexo). Unlike YAML (`---`) and TOML
+# (`+++`) front matter, mq's Markdown parser does not recognize `;;;` blocks
+# as a distinct front matter node, so this output won't round-trip through
+# `frontmatter`/`is_yaml`/`is_toml`-style selectors — it's meant for
+# generating files for tools that do support this convention.
+#
+# Example:
+# ```
+# import "json" | json::to_frontmatter({"key": 1})
+# #=> ;;;
+# {"key": 1}
+# ;;;
+# ```
+#
+# Returns: string
+def to_frontmatter(data):
+  ";;;\n" + json_stringify(data) + "\n;;;"
+end

--- a/crates/mq-lang/modules/json_test.mq
+++ b/crates/mq-lang/modules/json_test.mq
@@ -32,3 +32,12 @@ def test_json_to_markdown_table():
   | let result = json::json_to_markdown_table(result["users"])
   | assert_snapshot("json_to_markdown_table", result)
 end
+
+# @parametrize([[{"title": "title", "draft": false}], [{}], [{"tags": ["a", "b"]}]])
+def test_json_to_frontmatter(input):
+  let result = json::to_frontmatter(input)
+  | assert(starts_with(result, ";;;\n"))
+  | assert(ends_with(result, "\n;;;"))
+  | let body = result[4:len(result) - 4]
+  | assert_eq(json::json_parse(body), input)
+end

--- a/crates/mq-lang/modules/section.mq
+++ b/crates/mq-lang/modules/section.mq
@@ -113,6 +113,56 @@ def sections(md_nodes, depth = false):
         end
 end
 
+def _tree_from_nodes(items):
+  if (is_empty(items)):
+    []
+  else:
+    do
+      let h_idxs = do foreach (i, range(0, len(items) - 1)): if (is_h(items[i])): i; | compact();
+      | if (is_empty(h_idxs)):
+          []
+        else:
+          do
+            let min_level = first(sort(map(h_idxs, fn(i): _h_level_num(items[i]);)))
+            | let top_idxs = filter(h_idxs, fn(i): _h_level_num(items[i]) == min_level;)
+            | let top_idxs_with_end = top_idxs + [len(items)]
+            | let n = len(top_idxs)
+            | var result = []
+            | var k = 0
+            | while (k != n):
+                let start = top_idxs[k]
+                | let end_idx = top_idxs_with_end[k + 1]
+                | let span = items[start + 1:end_idx]
+                | let sub_h_idxs = do foreach (j, range(0, len(span) - 1)): if (is_h(span[j])): j; | compact();
+                | let first_sub = first(sub_h_idxs)
+                | let own_body = if (is_none(first_sub)): span else: span[0:first_sub]
+                | let rest = if (is_none(first_sub)): [] else: span[first_sub:len(span)]
+                | result += [{type: :section, header: items[start], children: own_body, subsections: _tree_from_nodes(rest)}]
+                | k += 1
+                | result
+              end
+          end
+    end
+end
+
+# Groups sections into a nested tree by heading level: each section dict
+# gets a `subsections` field holding the sections whose heading sits
+# directly beneath it (recursively nested the same way). A section's own
+# `children` stays exactly what `section::sections` would give it: the
+# section's own body up to its next heading of any level, not including the
+# content of its subsections.
+#
+# Example:
+# ```
+# import "section" | len(section::subsections(first(section::tree(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B")))))
+# #=> 1
+# ```
+#
+# Returns: array
+def tree(md_nodes):
+  _tree_from_nodes(_ensure_aggregated(md_nodes))
+end
+
 # Filters sections based on a given predicate function.
 #
 # Example:
@@ -272,6 +322,23 @@ def all_nodes(section):
     []
 end
 
+# Returns the direct child sections of a section built by `section::tree`
+# (an empty array for a leaf section, or for a section not built by `tree`).
+#
+# Example:
+# ```
+# import "section" | len(section::subsections(first(section::tree(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B")))))
+# #=> 1
+# ```
+#
+# Returns: array
+def subsections(section):
+  if (_is_section(section)):
+    get_or(section, :subsections, [])
+  else:
+    []
+end
+
 # Filters sections by heading level. l can be a number (exact level) or a range array (e.g. 1..2).
 #
 # Example:
@@ -398,6 +465,44 @@ def toc(sections):
                 ""
             end
       | map(sections, create_toc_entry)
+    end
+end
+
+# Generates a Markdown table-of-contents with links to each section's
+# heading anchor (`[title](#slug)`), indented by heading level. Anchors come
+# from `slugify`; a repeated anchor gets a numeric suffix (`-1`, `-2`, ...)
+# the same way GitHub disambiguates duplicate headings. Note the slug is only
+# an approximation of GitHub's own anchor algorithm.
+#
+# Example:
+# ```
+# import "section" | section::toc_markdown(section::sections(to_markdown("# A\n\nBody A\n\n## A1\n\nSub A\n\n# B\n\nBody B")))
+# #=> ["  - [A](#a)", "    - [A1](#a1)", "  - [B](#b)"]
+# ```
+#
+# Returns: array
+def toc_markdown(sections):
+  if (is_empty(sections)):
+    []
+  else:
+    do
+      var seen = dict()
+      | var result = []
+      | foreach (section, sections):
+            if (_is_section(section)) do
+                let lvl = level(section)
+                | let indent = join(map(range(0, lvl - 1), fn(_): "  ";), "")
+                | let title_text = title(section)
+                | let base_slug = slugify(title_text)
+                | let count = get_or(seen, base_slug, -1)
+                | let slug = if (count < 0): base_slug else: base_slug + "-" + to_string(count + 1)
+                | seen = set(seen, base_slug, count + 1)
+                | result += [indent + "- [" + title_text + "](#" + slug + ")"]
+              end
+            else:
+              None
+          end
+      | result
     end
 end
 

--- a/crates/mq-lang/modules/section_test.mq
+++ b/crates/mq-lang/modules/section_test.mq
@@ -2,7 +2,9 @@ import "section"
 | include "test"
 
 | let section_md = "# Introduction\nThis is the introduction section.\n\n## Advanced Topics\nThis section covers advanced topics.\n\n# Conclusion\nThis is the conclusion section.\n"
-| let test_sections = to_markdown(section_md) |
+| let test_sections = to_markdown(section_md)
+| let nested_md = "# A\n\nBody A\n\n## A1\n\nSub A\n\n### A1a\n\nDeep\n\n## A2\n\nSub A2\n\n# B\n\nBody B\n"
+| let nested_sections = to_markdown(nested_md) |
 
 # @parametrize([[section_md, 3], ["# test", 1]])
 def test_section_sections(markdown, expected_len):
@@ -212,4 +214,49 @@ def test_section_split_single_node_normalized():
   let single = first(test_sections)
   | let secs = section::split(single, 1)
   | assert_eq(len(secs), 1)
+end
+
+def test_section_tree_top_level():
+  let roots = section::tree(nested_sections)
+  | assert_eq(len(roots), 2)
+  | assert_eq(section::title(roots[0]), "A")
+  | assert_eq(section::title(roots[1]), "B")
+end
+
+def test_section_tree_nested_subsections():
+  let roots = section::tree(nested_sections)
+  | let a = roots[0]
+  | let a_subs = section::subsections(a)
+  | assert_eq(len(a_subs), 2)
+  | assert_eq(section::title(a_subs[0]), "A1")
+  | assert_eq(section::title(a_subs[1]), "A2")
+  | let a1_subs = section::subsections(a_subs[0])
+  | assert_eq(len(a1_subs), 1)
+  | assert_eq(section::title(a1_subs[0]), "A1a")
+  | assert_eq(section::subsections(a_subs[1]), [])
+end
+
+def test_section_tree_children_excludes_subsection_content():
+  let roots = section::tree(nested_sections)
+  | let a = roots[0]
+  | assert_eq(to_markdown_string(section::body(a)), "Body A\n")
+end
+
+def test_section_tree_leaf_has_no_subsections():
+  let roots = section::tree(nested_sections)
+  | assert_eq(section::subsections(roots[1]), [])
+end
+
+def test_section_subsections_non_section():
+  assert_eq(section::subsections("not a section"), [])
+end
+
+# @parametrize([[section_md, ["  - [Introduction](#introduction)", "    - [Advanced Topics](#advanced-topics)", "  - [Conclusion](#conclusion)"]], ["# Notes\n\nA\n\n# Notes\n\nB\n", ["  - [Notes](#notes)", "  - [Notes](#notes-1)"]]])
+def test_section_toc_markdown(markdown, expected):
+  let secs = section::sections(to_markdown(markdown))
+  | assert_eq(section::toc_markdown(secs), expected)
+end
+
+def test_section_toc_markdown_empty():
+  assert_eq(section::toc_markdown([]), [])
 end

--- a/crates/mq-lang/modules/table.mq
+++ b/crates/mq-lang/modules/table.mq
@@ -103,6 +103,82 @@ def column_index(table, name):
   index(map(table[:header], to_string), name)
 end
 
+# Returns the number of data rows in the table (excludes the header).
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::num_rows(self)
+# #=> 2
+# ```
+#
+# Returns: number
+def num_rows(table): len(table[:rows]);
+
+# Returns the number of columns in the table.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |")) | first(self) | table::num_cols(self)
+# #=> 2
+# ```
+#
+# Returns: number
+def num_cols(table): len(table[:header]);
+
+# Returns the string value of the data cell at `row_index`, `col_index`
+# (0-indexed, excluding the header row), or None if either index is out of
+# range.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::get_cell(self, 1, 0)
+# #=> 3
+# ```
+#
+# Returns: dynamic
+def get_cell(table, row_index, col_index):
+  if (row_index < 0 || row_index >= len(table[:rows]) || col_index < 0 || col_index >= len(table[:header])):
+    None
+  else:
+    to_string(table[:rows][row_index][col_index])
+end
+
+# Returns a new table with the data cell at `row_index`, `col_index`
+# (0-indexed, excluding the header row) replaced by `value`.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::set_cell(self, 0, 1, "9") | table::to_csv(self)
+# #=> a,b
+# 1,9
+# 3,4
+# ```
+#
+# Returns: dict
+def set_cell(table, row_index, col_index, value):
+  if (row_index < 0 || row_index >= len(table[:rows]) || col_index < 0 || col_index >= len(table[:header])):
+    error("Row or column index out of range.")
+  else: do
+      let old_cell = table[:rows][row_index][col_index]
+      | let new_cell = to_md_table_cell(to_string(value), old_cell.row, old_cell.column)
+      | let new_row = set(table[:rows][row_index], col_index, new_cell)
+      | set(table, :rows, set(table[:rows], row_index, new_row))
+    end
+end
+
+# Returns the data values (as strings) of column `col_index`, one per row.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::column_values(self, 1)
+# #=> ["2", "4"]
+# ```
+#
+# Returns: array
+def column_values(table, col_index):
+  map(table[:rows], fn(row): to_string(row[col_index]);)
+end
+
 # Set the alignment for a table.
 #
 # Example:
@@ -143,6 +219,40 @@ def add_row(table, row):
     end
 end
 
+# Insert a new row into the table at data-row index `index` (0-indexed),
+# shifting subsequent rows down. Row numbers on every row are renumbered so
+# they stay consistent.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::insert_row(self, 1, ["5", "6"]) | table::to_csv(self)
+# #=> a,b
+# 1,2
+# 5,6
+# 3,4
+# ```
+#
+# Returns: dict
+def insert_row(table, index, row):
+  if (len(row) != len(table[:header])):
+    error("Row length does not match table header length.")
+  else: do
+      let new_rows_raw = insert(table[:rows], index, row)
+      | var row_num = 0
+      | let new_rows = foreach (r, new_rows_raw):
+            row_num += 1
+            | var c = 0
+            | let cells = foreach (v, r):
+                  let cell = to_md_table_cell(to_string(v), row_num, c)
+                  | c += 1
+                  | cell
+                end
+            | cells
+          end
+      | set(table, :rows, new_rows)
+    end
+end
+
 # Add a new column to a table.
 #
 # Example:
@@ -169,6 +279,82 @@ def add_column(table, col):
             end
       | let table_with_header = set(table, :header, new_header)
       | set(table_with_header, :rows, new_rows)
+    end
+end
+
+# Insert a new column into the table at `index` (0-indexed), shifting
+# existing columns right. `col` is `[header_value, row0_value, row1_value,
+# ...]`, like `add_column`'s argument. Column numbers on every cell are
+# renumbered so they stay consistent; the new column's alignment is "none".
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::insert_column(self, 1, ["c", "9", "10"]) | table::to_csv(self)
+# #=> a,c,b
+# 1,9,2
+# 3,10,4
+# ```
+#
+# Returns: dict
+def insert_column(table, index, col):
+  if (len(col) != len(table[:rows]) + 1):
+    error("Column length does not match table row count.")
+  else: do
+      let new_header_values = insert(map(table[:header], to_string), index, to_string(col[0]))
+      | var c = 0
+      | let new_header = foreach (h, new_header_values):
+            let cell = to_md_table_cell(h, 0, c)
+            | c += 1
+            | cell
+          end
+      | let align_tokens = split(attr(table[:align], "align"), ",")
+      | let new_align = to_md_table_align(insert(align_tokens, index, "none"))
+      | var row_num = 0
+      | let new_rows = foreach (row, table[:rows]):
+            row_num += 1
+            | let values = insert(map(row, to_string), index, to_string(col[row_num]))
+            | var c = 0
+            | let cells = foreach (v, values):
+                  let cell = to_md_table_cell(v, row_num, c)
+                  | c += 1
+                  | cell
+                end
+            | cells
+          end
+      | set(set(set(table, :header, new_header), :rows, new_rows), :align, new_align)
+    end
+end
+
+# Concatenates the data rows of `table_b` onto `table_a`. Errors if the two
+# tables don't have the same number of columns. `table_a`'s header and
+# alignment are kept; row numbers on the appended cells are renumbered to
+# continue after `table_a`'s existing rows.
+#
+# Example:
+# ```
+# import "table" | let a = first(table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |"))) | let b = first(table::tables(to_markdown("| a | b |\n| --- | --- |\n| 3 | 4 |"))) | table::to_csv(table::union(a, b))
+# #=> a,b
+# 1,2
+# 3,4
+# ```
+#
+# Returns: dict
+def union(table_a, table_b):
+  if (len(table_a[:header]) != len(table_b[:header])):
+    error("Tables must have the same number of columns.")
+  else: do
+      var row_num = len(table_a[:rows])
+      | let appended_rows = foreach (row, table_b[:rows]):
+            row_num += 1
+            | var c = 0
+            | let cells = foreach (v, row):
+                  let cell = to_md_table_cell(to_string(v), row_num, c)
+                  | c += 1
+                  | cell
+                end
+            | cells
+          end
+      | set(table_a, :rows, table_a[:rows] + appended_rows)
     end
 end
 
@@ -267,6 +453,24 @@ def map_rows(table, f):
   set(table, :rows, map(table[:rows], f))
 end
 
+# Applies `f` to the string value of every data cell in the table (the
+# header is untouched). Row/column numbers are preserved.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| x | y |")) | first(self) | table::map_cells(self, upcase) | table::to_csv(self)
+# #=> a,b
+# X,Y
+# ```
+#
+# Returns: dict
+def map_cells(table, f):
+  let new_rows = map(table[:rows], fn(row):
+        map(row, fn(cell): to_md_table_cell(f(to_string(cell)), cell.row, cell.column););
+      )
+  | set(table, :rows, new_rows)
+end
+
 # Filter tables from markdown nodes based on a predicate function.
 #
 # Example:
@@ -311,6 +515,35 @@ def sort_rows(table, column_index = None):
     sort(table[:rows])
   else:
     sort_by(table[:rows], fn(row): row[column_index];)
+  | set(table, :rows, new_rows)
+end
+
+# Removes data rows that are exact duplicates of an earlier row (compared by
+# cell text), keeping the first occurrence. Row numbers are renumbered so
+# they stay consistent.
+#
+# Example:
+# ```
+# import "table" | table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n| 1 | 2 |\n| 3 | 4 |")) | first(self) | table::dedupe_rows(self) | table::to_csv(self)
+# #=> a,b
+# 1,2
+# 3,4
+# ```
+#
+# Returns: dict
+def dedupe_rows(table):
+  let unique_rows = unique_by(table[:rows], fn(row): map(row, to_string);)
+  | var row_num = 0
+  | let new_rows = foreach (row, unique_rows):
+        row_num += 1
+        | var c = 0
+        | let cells = foreach (v, row):
+              let cell = to_md_table_cell(to_string(v), row_num, c)
+              | c += 1
+              | cell
+            end
+        | cells
+      end
   | set(table, :rows, new_rows)
 end
 

--- a/crates/mq-lang/modules/table_test.mq
+++ b/crates/mq-lang/modules/table_test.mq
@@ -104,6 +104,56 @@ def test_table_add_column():
   | assert_eq(row1_new_cell.row, row1_first_cell.row)
 end
 
+def test_table_insert_row():
+  let t = first(table::tables(table_nodes))
+  | let result = table::insert_row(t, 1, ["Carol", "40", "Nagoya"])
+  | assert_eq(table::to_csv(result), "Name,Age,City\nAlice,30,Tokyo\nCarol,40,Nagoya\nBob,25,Osaka")
+end
+
+def test_table_insert_column():
+  let t = first(table::tables(table_nodes))
+  | let result = table::insert_column(t, 1, ["Country", "Japan", "Japan"])
+  | assert_eq(table::to_csv(result), "Name,Country,Age,City\nAlice,Japan,30,Tokyo\nBob,Japan,25,Osaka")
+end
+
+def test_table_union():
+  let a = first(table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |")))
+  | let b = first(table::tables(to_markdown("| a | b |\n| --- | --- |\n| 3 | 4 |")))
+  | let result = table::union(a, b)
+  | assert_eq(table::to_csv(result), "a,b\n1,2\n3,4")
+end
+
+def test_table_union_mismatched_columns():
+  let a = first(table::tables(to_markdown("| a | b |\n| --- | --- |\n| 1 | 2 |")))
+  | let b = first(table::tables(to_markdown("| a |\n| --- |\n| 3 |")))
+  | let result = try: table::union(a, b) catch: "error"
+  | assert_eq(result, "error")
+end
+
+# Every one of these ops validates the shape of its input against the
+# table's existing header/rows and should error rather than silently
+# producing a header/row column-count mismatch.
+# @parametrize([[fn(table): table::add_row(table, ["x"]);], [fn(table): table::add_column(table, ["c", "x"]);], [fn(table): table::insert_row(table, 0, ["x"]);], [fn(table): table::insert_column(table, 0, ["c", "x"]);], [fn(table): table::set_cell(table, 99, 0, "x");], [fn(table): table::set_cell(table, 0, 99, "x");]])
+def test_table_shape_mismatch_errors(op):
+  let t = first(table::tables(table_nodes))
+  | let result = try: op(t) catch: "error"
+  | assert_eq(result, "error")
+end
+
+def test_table_map_cells():
+  let t = first(table::tables(table_nodes))
+  | let result = table::map_cells(t, upcase)
+  | assert_eq(table::to_csv(result), "Name,Age,City\nALICE,30,TOKYO\nBOB,25,OSAKA")
+end
+
+# @parametrize([["| a | b |\n| --- | --- |\n| 1 | 2 |\n| 1 | 2 |\n| 3 | 4 |", "a,b\n1,2\n3,4"], ["| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |", "a,b\n1,2\n3,4"], ["| a | b |\n| --- | --- |\n| 1 | 2 |\n| 1 | 2 |\n| 1 | 2 |", "a,b\n1,2"]])
+def test_table_dedupe_rows(markdown, expected_csv):
+  let md_nodes = to_markdown(markdown)
+  | let t = first(table::tables(md_nodes))
+  | let result = table::dedupe_rows(t)
+  | assert_eq(table::to_csv(result), expected_csv)
+end
+
 def test_table_remove_row():
   let t = first(table::tables(table_nodes))
   | let t = table::remove_row(t, 0)
@@ -120,6 +170,34 @@ def test_table_remove_column():
   | let new_header_cell = t[:header][1]
   | assert_eq(new_header_cell.column, 1)
   | assert_eq(table::to_csv(t), "Name,City\nAlice,Tokyo\nBob,Osaka")
+end
+
+def test_table_num_rows():
+  let t = first(table::tables(table_nodes))
+  | assert_eq(table::num_rows(t), 2)
+end
+
+def test_table_num_cols():
+  let t = first(table::tables(table_nodes))
+  | assert_eq(table::num_cols(t), 3)
+end
+
+# @parametrize([[0, 0, "Alice"], [1, 2, "Osaka"], [5, 0, None], [0, 5, None], [-1, 0, None]])
+def test_table_get_cell(row_index, col_index, expected):
+  let t = first(table::tables(table_nodes))
+  | assert_eq(table::get_cell(t, row_index, col_index), expected)
+end
+
+def test_table_set_cell():
+  let t = first(table::tables(table_nodes))
+  | let result = table::set_cell(t, 0, 1, "31")
+  | assert_eq(table::to_csv(result), "Name,Age,City\nAlice,31,Tokyo\nBob,25,Osaka")
+end
+
+# @parametrize([[0, ["Alice", "Bob"]], [1, ["30", "25"]], [2, ["Tokyo", "Osaka"]]])
+def test_table_column_values(col_index, expected):
+  let t = first(table::tables(table_nodes))
+  | assert_eq(table::column_values(t, col_index), expected)
 end
 
 def test_table_column_index():

--- a/crates/mq-lang/modules/toml.mq
+++ b/crates/mq-lang/modules/toml.mq
@@ -14,7 +14,10 @@ def _add_toml_lines(lines, key, value):
       | lines + ["[" + key + "]"] + body_lines[0:len(body_lines) - 1] + last_line
     end
   elif (is_array(value)):
-    lines + ["[[" + key + "]]"] + if (len(value) == 0): _toml_stringify_value(first(value)) else: map(value, fn(v): _toml_stringify_value(v) + ", ";)
+    if (is_empty(value) || !is_dict(first(value))):
+      lines + [key + " = " + _toml_stringify_value(value)]
+    else:
+      lines + flat_map(value, fn(entry): ["[[" + key + "]]"] + map(keys(entry), fn(k): k + " = " + _toml_stringify_value(entry[k]););)
   else: lines + [key + " = " + _toml_stringify_value(value)]
 end
 
@@ -141,4 +144,19 @@ def toml_to_markdown_table(data):
     _create_dict_markdown_table(data)
   else:
     _create_simple_markdown_table(data)
+end
+
+# Converts a data structure to a TOML front matter string.
+#
+# Example:
+# ```
+# import "toml" | toml::to_frontmatter({"key": 1})
+# #=> +++
+# key = 1
+# +++
+# ```
+#
+# Returns: string
+def to_frontmatter(data):
+  "+++\n" + toml_stringify(data) + "\n+++"
 end

--- a/crates/mq-lang/modules/toml_test.mq
+++ b/crates/mq-lang/modules/toml_test.mq
@@ -16,3 +16,23 @@ def test_toml_to_json():
   | let result = toml::toml_to_json(parsed)
   | assert_eq(json::json_parse(result), parsed)
 end
+
+# Regression test: an array value must round-trip through toml_stringify.
+# A scalar array used to be rendered as an invalid `[[key]]` array-of-tables
+# block containing bare trailing-comma lines instead of `key = [...]`; an
+# array of dicts used to dump each entry as an inline table (`{...}`) on its
+# own trailing-comma line instead of proper `[[key]]` sections.
+# @parametrize([[{"tags": ["a", "b"]}], [{"tags": []}], [{"nums": [1, 2, 3]}], [{"users": [{"name": "a"}, {"name": "b"}]}]])
+def test_toml_stringify_array_round_trips(input):
+  let result = toml::toml_stringify(input)
+  | assert_eq(toml::toml_parse(result), input)
+end
+
+# @parametrize([[{"title": "title", "draft": false}], [{"count": 3}]])
+def test_toml_to_frontmatter(input):
+  let result = toml::to_frontmatter(input)
+  | assert(starts_with(result, "+++\n"))
+  | assert(ends_with(result, "\n+++"))
+  | let body = result[4:len(result) - 4]
+  | assert_eq(toml::toml_parse(body), input)
+end

--- a/crates/mq-lang/modules/xml.mq
+++ b/crates/mq-lang/modules/xml.mq
@@ -1,5 +1,9 @@
 # XML Implementation in mq
 
+def _escape_string(str):
+  replace(str, "\\", "\\\\") | replace("\"", "\\\"") | replace("\n", "\\n") | replace("\t", "\\t")
+end
+
 # Parses an XML string and returns the corresponding data structure.
 #
 # Example:
@@ -141,4 +145,31 @@ end
 # Returns: string
 def xml_to_markdown_table(data):
   _xml_to_markdown_table(data, 1)
+end
+
+# Converts a data structure (typically the `{tag, attributes, children,
+# text}` shape returned by `xml_parse`) to a JSON string representation.
+#
+# Example:
+# ```
+# import "xml" | xml::xml_to_json({"tag": "a"})
+# #=> {"tag": "a"}
+# ```
+#
+# Returns: string
+def xml_to_json(data):
+  if (is_dict(data)):
+    "{" + join(map(keys(data), fn(k): "\"" + k + "\": " + xml_to_json(data[k]);), ", ") + "}"
+  elif (is_array(data)):
+    "[" + join(map(data, xml_to_json), ", ") + "]"
+  elif (is_string(data)):
+    "\"" + _escape_string(data) + "\""
+  elif (is_number(data)):
+    to_string(data)
+  elif (is_bool(data)):
+    if (data): "true" else: "false"
+  elif (is_none(data)):
+    "null"
+  else:
+    "\"" + to_string(data) + "\""
 end

--- a/crates/mq-lang/modules/xml_test.mq
+++ b/crates/mq-lang/modules/xml_test.mq
@@ -1,4 +1,5 @@
 import "xml"
+| import "json"
 | include "test"
 
 # -- XML Tests --
@@ -18,4 +19,14 @@ end
 def test_xml_to_markdown_table():
   let result = xml::xml_to_markdown_table(xml::xml_parse(xml_input))
   | assert_snapshot("xml_to_markdown_table", result)
+end
+
+def test_xml_to_json():
+  let parsed = xml::xml_parse(xml_input)
+  | let result = xml::xml_to_json(parsed)
+  | assert_eq(json::json_parse(result), parsed)
+end
+
+def test_xml_to_json_simple():
+  assert_eq(xml::xml_to_json({"tag": "a"}), "{\"tag\": \"a\"}")
 end


### PR DESCRIPTION
## Summary

- table: add cell access (get_cell/set_cell), insert_row/insert_column, union, map_cells, dedupe_rows, num_rows/num_cols, column_values
- section: add tree/subsections (nested heading hierarchy) and toc_markdown (linked table of contents with GitHub-style anchors)
- gron: add gron_stringify, the inverse of gron_parse, matching `mq -F gron`'s output so a value can be flattened/grepped/reconstructed without leaving a query
- json/toml: add to_frontmatter, matching yaml::to_frontmatter
- xml: add xml_to_json, matching yaml_to_json/toml_to_json

Also fixes two bugs found while building the above:
- unique_by flattened array elements into the result instead of keeping them as single items, because `+` concatenates when the appended value is itself an array
- toml_stringify rendered every array (including plain scalar arrays) as an invalid `[[key]]` array-of-tables block with bare trailing-comma lines; scalar arrays now render as inline `key = [...]` and dict arrays render as proper `[[key]]` sections

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
