### PR TITLE
✨ feat(mq-lang): add optional seed argument to random builtins

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -290,9 +290,11 @@ fn register_math(ctx: &mut InferenceContext) {
     register_unary(ctx, "human_bytes", Type::Number, Type::String);
     register_unary(ctx, "human_size", Type::Number, Type::String);
 
-    // Randomness
+    // Randomness. `seed` is optional; the trailing overloads accept it.
     register_nullary(ctx, "rand", Type::Number);
+    register_unary(ctx, "rand", Type::Number, Type::Number);
     register_binary(ctx, "rand_int", Type::Number, Type::Number, Type::Number);
+    register_ternary(ctx, "rand_int", Type::Number, Type::Number, Type::Number, Type::Number);
 }
 
 /// String functions: downcase, upcase, trim, starts_with, ends_with, etc.
@@ -455,8 +457,17 @@ fn register_string(ctx: &mut InferenceContext) {
     register_nullary(ctx, "uuid_v4", Type::String);
     register_nullary(ctx, "uuid_v7", Type::String);
 
-    // random_string: (number, string) -> string
+    // random_string: (number, string) -> string. `seed` is optional; the ternary overload
+    // accepts it.
     register_binary(ctx, "random_string", Type::Number, Type::String, Type::String);
+    register_ternary(
+        ctx,
+        "random_string",
+        Type::Number,
+        Type::String,
+        Type::Number,
+        Type::String,
+    );
 }
 
 /// Array functions: flatten, reverse, sort, uniq, compact, len, slice, insert, range, repeat
@@ -467,12 +478,32 @@ fn register_array(ctx: &mut InferenceContext) {
         register_unary(ctx, name, Type::array(Type::Var(a)), Type::array(Type::Var(a)));
     }
 
+    // shuffle: ([a], seed: number) -> [a]. `seed` is optional; this overload accepts it.
+    let a = ctx.fresh_var();
+    register_binary(
+        ctx,
+        "shuffle",
+        Type::array(Type::Var(a)),
+        Type::Number,
+        Type::array(Type::Var(a)),
+    );
+
     // sample: ([a], number) -> [a]
     let a = ctx.fresh_var();
     register_binary(
         ctx,
         "sample",
         Type::array(Type::Var(a)),
+        Type::Number,
+        Type::array(Type::Var(a)),
+    );
+    // sample: ([a], number, seed: number) -> [a]. `seed` is optional; this overload accepts it.
+    let a = ctx.fresh_var();
+    register_ternary(
+        ctx,
+        "sample",
+        Type::array(Type::Var(a)),
+        Type::Number,
         Type::Number,
         Type::array(Type::Var(a)),
     );
@@ -1582,7 +1613,9 @@ mod tests {
     #[case::infinite("infinite()", true)]
     #[case::is_nan("is_nan(1.0)", true)]
     #[case::rand("rand()", true)]
+    #[case::rand_seeded("rand(42)", true)]
     #[case::rand_int("rand_int(1, 10)", true)]
+    #[case::rand_int_seeded("rand_int(1, 10, 42)", true)]
     #[case::ln("ln(2.0)", true)]
     #[case::log10("log10(100)", true)]
     #[case::log("log(2.0)", true)]
@@ -1723,7 +1756,11 @@ mod tests {
     #[case::uuid_v4("uuid_v4()", true)]
     #[case::uuid_v7("uuid_v7()", true)]
     #[case::random_string("random_string(10, \"abc\")", true)]
-    #[case::random_string_wrong_types("random_string(\"10\", 1)", false)] // Should fail: wrong types
+    #[case::random_string_seeded("random_string(10, \"abc\", 42)", true)]
+    // Should fail: wrong types. Uses non-numeric/non-string args so it can't accidentally
+    // satisfy the seeded ternary overload via the implicit-piped-input fallback (a bare
+    // `(String, Number)` pair would coincidentally match that overload's charset/seed slots).
+    #[case::random_string_wrong_types("random_string(true, false)", false)]
     fn test_string_encoding_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(
@@ -1744,7 +1781,9 @@ mod tests {
     #[case::uniq("uniq([1, 2, 2, 3])", true)]
     #[case::compact("compact([1, none, 2])", true)]
     #[case::shuffle("shuffle([1, 2, 3])", true)]
+    #[case::shuffle_seeded("shuffle([1, 2, 3], 42)", true)]
     #[case::sample("sample([1, 2, 3], 2)", true)]
+    #[case::sample_seeded("sample([1, 2, 3], 2, 42)", true)]
     fn test_array_manipulation_functions(#[case] code: &str, #[case] should_succeed: bool) {
         let result = check_types(code);
         assert_eq!(

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -606,19 +606,39 @@ fn uuid_v4_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<R
     Ok(RuntimeValue::String(uuid::Uuid::new_v4().to_string()))
 }
 
-/// Generates a pseudo-random `f64` in `[0, 1)`. Not cryptographically secure.
-#[mq_macros::mq_fn(name = "rand", params = None)]
-fn rand_impl(_: &Ident, _: &RuntimeValue, _: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
-    Ok(RuntimeValue::Number(random::next_f64().into()))
+/// Generates a pseudo-random `f64` in `[0, 1)`. Not cryptographically secure. If `seed` is
+/// given, the result is a deterministic function of it instead of the OS entropy source.
+#[mq_macros::mq_fn(name = "rand", params = Range(0, 1))]
+fn rand_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [] => Ok(RuntimeValue::Number(random::next_f64(None).into())),
+        [RuntimeValue::Number(seed)] if seed.is_int() => Ok(RuntimeValue::Number(
+            random::next_f64(Some(seed.to_int() as u64)).into(),
+        )),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("rand should always receive zero or one arguments"),
+    }
 }
 
-/// Generates a pseudo-random integer uniformly distributed in `[min, max]` (inclusive).
-#[mq_macros::mq_fn(name = "rand_int", params = Fixed(2))]
+/// Generates a pseudo-random integer uniformly distributed in `[min, max]` (inclusive). If
+/// `seed` is given, the result is a deterministic function of it instead of the OS entropy
+/// source.
+#[mq_macros::mq_fn(name = "rand_int", params = Range(2, 3))]
 fn rand_int_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::Number(min), RuntimeValue::Number(max)] if min.is_int() && max.is_int() => {
             let (min_i, max_i) = (min.to_int(), max.to_int());
-            random::next_range_i64(min_i, max_i)
+            random::next_range_i64(min_i, max_i, None)
+                .map(|n| RuntimeValue::Number(n.into()))
+                .ok_or_else(|| Error::Runtime(format!("rand_int: min ({min_i}) must be <= max ({max_i})")))
+        }
+        [
+            RuntimeValue::Number(min),
+            RuntimeValue::Number(max),
+            RuntimeValue::Number(seed),
+        ] if min.is_int() && max.is_int() && seed.is_int() => {
+            let (min_i, max_i) = (min.to_int(), max.to_int());
+            random::next_range_i64(min_i, max_i, Some(seed.to_int() as u64))
                 .map(|n| RuntimeValue::Number(n.into()))
                 .ok_or_else(|| Error::Runtime(format!("rand_int: min ({min_i}) must be <= max ({max_i})")))
         }
@@ -626,26 +646,42 @@ fn rand_int_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv)
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
         )),
-        _ => unreachable!("rand_int should always receive exactly two arguments"),
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("rand_int should always receive two or three arguments"),
     }
 }
 
-/// Returns a new array containing the same elements as `arr` in a uniformly random order.
-#[mq_macros::mq_fn(name = "shuffle", params = Fixed(1))]
+/// Returns a new array containing the same elements as `arr` in a uniformly random order. If
+/// `seed` is given, the permutation is a deterministic function of it instead of the OS entropy
+/// source.
+#[mq_macros::mq_fn(name = "shuffle", params = Range(1, 2))]
 fn shuffle_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::Array(arr)] => {
             let mut arr = std::mem::take(arr);
-            random::shuffle(runtime_value::array_mut(&mut arr));
+            random::shuffle(runtime_value::array_mut(&mut arr), None);
+            Ok(RuntimeValue::Array(arr))
+        }
+        [RuntimeValue::Array(arr), RuntimeValue::Number(seed)] if seed.is_int() => {
+            let mut arr = std::mem::take(arr);
+            random::shuffle(runtime_value::array_mut(&mut arr), Some(seed.to_int() as u64));
             Ok(RuntimeValue::Array(arr))
         }
         [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
-        _ => unreachable!("shuffle should always receive exactly one argument"),
+        [a, b] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b)],
+        )),
+        _ => unreachable!("shuffle should always receive one or two arguments"),
     }
 }
 
-/// Returns `n` elements sampled from `arr` without replacement, in random order.
-#[mq_macros::mq_fn(name = "sample", params = Fixed(2))]
+/// Returns `n` elements sampled from `arr` without replacement, in random order. If `seed` is
+/// given, the sample is a deterministic function of it instead of the OS entropy source.
+#[mq_macros::mq_fn(name = "sample", params = Range(2, 3))]
 fn sample_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::Array(arr), RuntimeValue::Number(n)] if n.is_int() && n.value() >= 0.0 => {
@@ -656,25 +692,59 @@ fn sample_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -
                     arr.len()
                 )));
             }
-            Ok(RuntimeValue::Array(Shared::new(random::sample(arr, n))))
+            Ok(RuntimeValue::Array(Shared::new(random::sample(arr, n, None))))
+        }
+        [
+            RuntimeValue::Array(arr),
+            RuntimeValue::Number(n),
+            RuntimeValue::Number(seed),
+        ] if n.is_int() && n.value() >= 0.0 && seed.is_int() => {
+            let n = n.to_int() as usize;
+            if n > arr.len() {
+                return Err(Error::Runtime(format!(
+                    "sample: n ({n}) must not exceed the array length ({})",
+                    arr.len()
+                )));
+            }
+            Ok(RuntimeValue::Array(Shared::new(random::sample(
+                arr,
+                n,
+                Some(seed.to_int() as u64),
+            ))))
         }
         [a, b] => Err(Error::InvalidTypes(
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
         )),
-        _ => unreachable!("sample should always receive exactly two arguments"),
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("sample should always receive two or three arguments"),
     }
 }
 
 /// Returns a random string of `len` characters, each independently chosen (with
-/// replacement) from `charset`.
-#[mq_macros::mq_fn(name = "random_string", params = Fixed(2))]
+/// replacement) from `charset`. If `seed` is given, the result is a deterministic function of
+/// it instead of the OS entropy source.
+#[mq_macros::mq_fn(name = "random_string", params = Range(2, 3))]
 fn random_string_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
     match args.as_mut_slice() {
         [RuntimeValue::Number(len), RuntimeValue::String(charset)] if len.is_int() && len.value() >= 0.0 => {
             let len = len.to_int() as usize;
             let charset: Vec<char> = charset.chars().collect();
-            random::next_string(len, &charset)
+            random::next_string(len, &charset, None)
+                .map(RuntimeValue::String)
+                .ok_or_else(|| Error::Runtime("random_string: charset must not be empty".to_string()))
+        }
+        [
+            RuntimeValue::Number(len),
+            RuntimeValue::String(charset),
+            RuntimeValue::Number(seed),
+        ] if len.is_int() && len.value() >= 0.0 && seed.is_int() => {
+            let len = len.to_int() as usize;
+            let charset: Vec<char> = charset.chars().collect();
+            random::next_string(len, &charset, Some(seed.to_int() as u64))
                 .map(RuntimeValue::String)
                 .ok_or_else(|| Error::Runtime("random_string: charset must not be empty".to_string()))
         }
@@ -682,7 +752,11 @@ fn random_string_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &Share
             ident.to_string(),
             vec![std::mem::take(a), std::mem::take(b)],
         )),
-        _ => unreachable!("random_string should always receive exactly two arguments"),
+        [a, b, c] => Err(Error::InvalidTypes(
+            ident.to_string(),
+            vec![std::mem::take(a), std::mem::take(b), std::mem::take(c)],
+        )),
+        _ => unreachable!("random_string should always receive two or three arguments"),
     }
 }
 
@@ -6985,9 +7059,9 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("rand"),
         BuiltinFunctionDoc {
-            description: "Generates a pseudo-random number in the range [0, 1). Not cryptographically secure.",
-            params: &[],
-            param_types: &[],
+            description: "Generates a pseudo-random number in the range [0, 1). Not cryptographically secure. `seed` is optional; when given, the result is a deterministic function of it instead of OS entropy.",
+            params: &["seed?"],
+            param_types: &["number"],
             returns: "number",
             examples: &[],
             capability: None,
@@ -6996,9 +7070,9 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("rand_int"),
         BuiltinFunctionDoc {
-            description: "Generates a pseudo-random integer uniformly distributed in [min, max] (inclusive). Not cryptographically secure.",
-            params: &["min", "max"],
-            param_types: &["number", "number"],
+            description: "Generates a pseudo-random integer uniformly distributed in [min, max] (inclusive). Not cryptographically secure. `seed` is optional; when given, the result is a deterministic function of it instead of OS entropy.",
+            params: &["min", "max", "seed?"],
+            param_types: &["number", "number", "number"],
             returns: "number",
             examples: &[],
             capability: None,
@@ -7007,9 +7081,9 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("random_string"),
         BuiltinFunctionDoc {
-            description: "Generates a random string of `len` characters, each independently chosen (with replacement) from `charset`. Not cryptographically secure.",
-            params: &["len", "charset"],
-            param_types: &["number", "string"],
+            description: "Generates a random string of `len` characters, each independently chosen (with replacement) from `charset`. Not cryptographically secure. `seed` is optional; when given, the result is a deterministic function of it instead of OS entropy.",
+            params: &["len", "charset", "seed?"],
+            param_types: &["number", "string", "number"],
             returns: "string",
             examples: &[],
             capability: None,
@@ -7018,9 +7092,9 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("shuffle"),
         BuiltinFunctionDoc {
-            description: "Returns a new array containing the same elements as the input, in a uniformly random order.",
-            params: &["array"],
-            param_types: &["array"],
+            description: "Returns a new array containing the same elements as the input, in a uniformly random order. `seed` is optional; when given, the permutation is a deterministic function of it instead of OS entropy.",
+            params: &["array", "seed?"],
+            param_types: &["array", "number"],
             returns: "array",
             examples: &[],
             capability: None,
@@ -7029,9 +7103,9 @@ pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>
     map.insert(
         SmolStr::new("sample"),
         BuiltinFunctionDoc {
-            description: "Returns n elements sampled from the array without replacement, in random order. Errors if n exceeds the array length.",
-            params: &["array", "n"],
-            param_types: &["array", "number"],
+            description: "Returns n elements sampled from the array without replacement, in random order. Errors if n exceeds the array length. `seed` is optional; when given, the sample is a deterministic function of it instead of OS entropy.",
+            params: &["array", "n", "seed?"],
+            param_types: &["array", "number", "number"],
             returns: "array",
             examples: &[],
             capability: None,
@@ -9808,6 +9882,52 @@ mod tests {
     }
 
     #[test]
+    fn test_rand_seeded_is_deterministic_and_in_unit_range() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let call = |seed: i64| match eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("rand"),
+            vec![RuntimeValue::Number(seed.into())],
+            &env,
+        )
+        .unwrap()
+        {
+            RuntimeValue::Number(n) => n.value(),
+            other => panic!("rand(seed) should return a number, got {other:?}"),
+        };
+        let v = call(42);
+        assert!((0.0..1.0).contains(&v), "rand(42) out of [0, 1)");
+        assert_eq!(v, call(42), "rand(seed) should be deterministic for a fixed seed");
+    }
+
+    #[test]
+    fn test_rand_int_seeded_is_deterministic_and_within_bounds() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let call = |seed: i64| match eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("rand_int"),
+            vec![
+                RuntimeValue::Number(1.into()),
+                RuntimeValue::Number(10.into()),
+                RuntimeValue::Number(seed.into()),
+            ],
+            &env,
+        )
+        .unwrap()
+        {
+            RuntimeValue::Number(n) => n.to_int(),
+            other => panic!("rand_int(min, max, seed) should return a number, got {other:?}"),
+        };
+        let v = call(7);
+        assert!((1..=10).contains(&v), "rand_int(1, 10, 7) produced {v}");
+        assert_eq!(
+            v,
+            call(7),
+            "rand_int(min, max, seed) should be deterministic for a fixed seed"
+        );
+    }
+
+    #[test]
     fn test_rand_int_invalid_range_errors() {
         let env = Shared::new(SharedCell::new(Env::default()));
         let result = eval_builtin(
@@ -9867,6 +9987,31 @@ mod tests {
     }
 
     #[test]
+    fn test_random_string_seeded_is_deterministic() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let call = |seed: i64| match eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("random_string"),
+            vec![
+                RuntimeValue::Number(16.into()),
+                RuntimeValue::String("abcdefghijklmnopqrstuvwxyz0123456789".into()),
+                RuntimeValue::Number(seed.into()),
+            ],
+            &env,
+        )
+        .unwrap()
+        {
+            RuntimeValue::String(s) => s.to_string(),
+            other => panic!("random_string should return a string, got {other:?}"),
+        };
+        assert_eq!(
+            call(7),
+            call(7),
+            "random_string(len, charset, seed) should be deterministic for a fixed seed"
+        );
+    }
+
+    #[test]
     fn test_random_string_calls_are_unique() {
         let env = Shared::new(SharedCell::new(Env::default()));
         let values: std::collections::HashSet<String> = (0..200)
@@ -9919,6 +10064,31 @@ mod tests {
     }
 
     #[test]
+    fn test_shuffle_seeded_is_deterministic() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let input: Vec<RuntimeValue> = (1..=10).map(|n| RuntimeValue::Number(n.into())).collect();
+        let call = |seed: i64| match eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("shuffle"),
+            vec![
+                RuntimeValue::Array(Shared::new(input.clone())),
+                RuntimeValue::Number(seed.into()),
+            ],
+            &env,
+        )
+        .unwrap()
+        {
+            RuntimeValue::Array(shuffled) => (*shuffled).clone(),
+            other => panic!("shuffle should return an array, got {other:?}"),
+        };
+        assert_eq!(
+            call(3),
+            call(3),
+            "shuffle(arr, seed) should be deterministic for a fixed seed"
+        );
+    }
+
+    #[test]
     fn test_sample_returns_subset_without_duplicates() {
         let env = Shared::new(SharedCell::new(Env::default()));
         let input: Vec<RuntimeValue> = (1..=10).map(|n| RuntimeValue::Number(n.into())).collect();
@@ -9945,6 +10115,32 @@ mod tests {
             }
             other => panic!("sample should return an array, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_sample_seeded_is_deterministic() {
+        let env = Shared::new(SharedCell::new(Env::default()));
+        let input: Vec<RuntimeValue> = (1..=10).map(|n| RuntimeValue::Number(n.into())).collect();
+        let call = |seed: i64| match eval_builtin(
+            &RuntimeValue::None,
+            &Ident::new("sample"),
+            vec![
+                RuntimeValue::Array(Shared::new(input.clone())),
+                RuntimeValue::Number(4.into()),
+                RuntimeValue::Number(seed.into()),
+            ],
+            &env,
+        )
+        .unwrap()
+        {
+            RuntimeValue::Array(sampled) => (*sampled).clone(),
+            other => panic!("sample should return an array, got {other:?}"),
+        };
+        assert_eq!(
+            call(11),
+            call(11),
+            "sample(arr, n, seed) should be deterministic for a fixed seed"
+        );
     }
 
     #[test]

--- a/crates/mq-lang/src/eval/builtin/random.rs
+++ b/crates/mq-lang/src/eval/builtin/random.rs
@@ -1,4 +1,4 @@
-//! Randomness backing `rand`, `rand_int`, `shuffle`, and `sample`.
+//! Randomness backing `rand`, `rand_int`, `shuffle`, `sample`, and `random_string`.
 //!
 //! Delegates to the [`rand`] crate (OS-seeded via `getrandom`, exposed through
 //! `rand::rng()`/`ThreadRng`) rather than a hand-rolled generator, so output is backed by a
@@ -6,51 +6,66 @@
 //! this requires the `getrandom` crate's `wasm_js` feature (see `Cargo.toml`), which sources
 //! entropy from the browser's `crypto.getRandomValues`.
 //!
+//! Every function takes an optional `seed`: when given, output is drawn from a fresh
+//! `StdRng::seed_from_u64(seed)` instead, making the call a pure, reproducible function of its
+//! arguments (no hidden global RNG state, safe under parallel evaluation). This backs
+//! property-based tests in `mq-test`, where a failing case's seed can be reported and replayed.
+//!
 //! These functions are still **not** intended for generating secrets or authentication tokens —
 //! use a purpose-built secret-generation API for that.
 
 use crate::RuntimeValue;
-use rand::RngExt;
+use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
+use rand::{Rng, RngExt, SeedableRng};
+
+/// Runs `f` against a seeded `StdRng` when `seed` is given, or the OS-seeded thread RNG otherwise.
+fn with_rng<T>(seed: Option<u64>, f: impl FnOnce(&mut dyn Rng) -> T) -> T {
+    match seed {
+        Some(seed) => f(&mut StdRng::seed_from_u64(seed)),
+        None => f(&mut rand::rng()),
+    }
+}
 
 /// Returns a pseudo-random `f64` uniformly distributed in `[0, 1)`.
-pub(super) fn next_f64() -> f64 {
-    rand::rng().random::<f64>()
+pub(super) fn next_f64(seed: Option<u64>) -> f64 {
+    with_rng(seed, |rng| rng.random::<f64>())
 }
 
 /// Returns a pseudo-random integer uniformly distributed in `[min, max]` (inclusive).
 /// Returns `None` if `min > max`.
-pub(super) fn next_range_i64(min: i64, max: i64) -> Option<i64> {
+pub(super) fn next_range_i64(min: i64, max: i64, seed: Option<u64>) -> Option<i64> {
     if min > max {
         return None;
     }
-    Some(rand::rng().random_range(min..=max))
+    Some(with_rng(seed, |rng| rng.random_range(min..=max)))
 }
 
 /// Shuffles `items` in place using a uniformly random permutation (Fisher-Yates).
-pub(super) fn shuffle(items: &mut [RuntimeValue]) {
-    items.shuffle(&mut rand::rng());
+pub(super) fn shuffle(items: &mut [RuntimeValue], seed: Option<u64>) {
+    with_rng(seed, |rng| items.shuffle(rng));
 }
 
 /// Returns `n` elements sampled from `items` without replacement, in random order.
 ///
 /// Panics if `n > items.len()`; callers must validate the bound first.
-pub(super) fn sample(items: &[RuntimeValue], n: usize) -> Vec<RuntimeValue> {
+pub(super) fn sample(items: &[RuntimeValue], n: usize, seed: Option<u64>) -> Vec<RuntimeValue> {
     let mut items = items.to_vec();
-    shuffle(&mut items);
+    shuffle(&mut items, seed);
     items.truncate(n);
     items
 }
 
 /// Returns a random string of `len` characters, each chosen uniformly at random
 /// (with replacement) from `charset`. Returns `None` if `charset` is empty.
-pub(super) fn next_string(len: usize, charset: &[char]) -> Option<String> {
+pub(super) fn next_string(len: usize, charset: &[char], seed: Option<u64>) -> Option<String> {
     if charset.is_empty() {
         return None;
     }
 
-    let mut rng = rand::rng();
-    Some((0..len).map(|_| charset[rng.random_range(0..charset.len())]).collect())
+    Some(with_rng(seed, |rng| {
+        (0..len).map(|_| charset[rng.random_range(0..charset.len())]).collect()
+    }))
 }
 
 #[cfg(test)]
@@ -60,15 +75,20 @@ mod tests {
     #[test]
     fn test_next_f64_in_unit_range() {
         for _ in 0..1000 {
-            let v = next_f64();
+            let v = next_f64(None);
             assert!((0.0..1.0).contains(&v), "value {v} out of [0, 1)");
         }
     }
 
     #[test]
+    fn test_next_f64_seeded_is_deterministic() {
+        assert_eq!(next_f64(Some(42)), next_f64(Some(42)));
+    }
+
+    #[test]
     fn test_next_range_i64_within_bounds() {
         for _ in 0..1000 {
-            let v = next_range_i64(-5, 5).unwrap();
+            let v = next_range_i64(-5, 5, None).unwrap();
             assert!((-5..=5).contains(&v), "value {v} out of [-5, 5]");
         }
     }
@@ -76,13 +96,21 @@ mod tests {
     #[test]
     fn test_next_range_i64_single_value_range() {
         for _ in 0..10 {
-            assert_eq!(next_range_i64(7, 7), Some(7));
+            assert_eq!(next_range_i64(7, 7, None), Some(7));
         }
     }
 
     #[test]
     fn test_next_range_i64_invalid_range() {
-        assert_eq!(next_range_i64(5, 1), None);
+        assert_eq!(next_range_i64(5, 1, None), None);
+    }
+
+    #[test]
+    fn test_next_range_i64_seeded_is_deterministic() {
+        assert_eq!(
+            next_range_i64(0, 1_000_000, Some(7)),
+            next_range_i64(0, 1_000_000, Some(7))
+        );
     }
 
     fn nums(vals: &[i64]) -> Vec<RuntimeValue> {
@@ -93,7 +121,7 @@ mod tests {
     fn test_shuffle_preserves_multiset() {
         let mut items = nums(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let original = items.clone();
-        shuffle(&mut items);
+        shuffle(&mut items, None);
         assert_eq!(items.len(), original.len());
 
         let mut sorted_original = original.clone();
@@ -106,14 +134,23 @@ mod tests {
     #[test]
     fn test_shuffle_empty_array() {
         let mut items: Vec<RuntimeValue> = vec![];
-        shuffle(&mut items);
+        shuffle(&mut items, None);
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_shuffle_seeded_is_deterministic() {
+        let mut a = nums(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let mut b = a.clone();
+        shuffle(&mut a, Some(123));
+        shuffle(&mut b, Some(123));
+        assert_eq!(a, b);
     }
 
     #[test]
     fn test_sample_returns_requested_count_without_duplicates() {
         let items = nums(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let sampled = sample(&items, 4);
+        let sampled = sample(&items, 4, None);
         assert_eq!(sampled.len(), 4);
 
         for v in &sampled {
@@ -128,7 +165,7 @@ mod tests {
     #[test]
     fn test_sample_full_length_is_a_permutation() {
         let items = nums(&[1, 2, 3, 4, 5]);
-        let sampled = sample(&items, items.len());
+        let sampled = sample(&items, items.len(), None);
         let mut sorted_original = items.clone();
         let mut sorted_sampled = sampled.clone();
         sorted_original.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -139,13 +176,19 @@ mod tests {
     #[test]
     fn test_sample_zero() {
         let items = nums(&[1, 2, 3]);
-        assert_eq!(sample(&items, 0), Vec::<RuntimeValue>::new());
+        assert_eq!(sample(&items, 0, None), Vec::<RuntimeValue>::new());
+    }
+
+    #[test]
+    fn test_sample_seeded_is_deterministic() {
+        let items = nums(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(sample(&items, 4, Some(99)), sample(&items, 4, Some(99)));
     }
 
     #[test]
     fn test_next_string_uses_only_charset_chars() {
         let charset: Vec<char> = "abc".chars().collect();
-        let s = next_string(20, &charset).unwrap();
+        let s = next_string(20, &charset, None).unwrap();
         assert_eq!(s.chars().count(), 20);
         assert!(s.chars().all(|c| charset.contains(&c)));
     }
@@ -153,11 +196,17 @@ mod tests {
     #[test]
     fn test_next_string_zero_length() {
         let charset: Vec<char> = "abc".chars().collect();
-        assert_eq!(next_string(0, &charset), Some(String::new()));
+        assert_eq!(next_string(0, &charset, None), Some(String::new()));
     }
 
     #[test]
     fn test_next_string_empty_charset() {
-        assert_eq!(next_string(5, &[]), None);
+        assert_eq!(next_string(5, &[], None), None);
+    }
+
+    #[test]
+    fn test_next_string_seeded_is_deterministic() {
+        let charset: Vec<char> = "abcdefghijklmnopqrstuvwxyz0123456789".chars().collect();
+        assert_eq!(next_string(16, &charset, Some(7)), next_string(16, &charset, Some(7)));
     }
 }


### PR DESCRIPTION
## Summary

rand, rand_int, shuffle, sample, and random_string now accept an optional trailing seed argument. When given, output is drawn from a fresh seeded RNG instead of OS entropy, making the call a pure, reproducible function of its arguments (no global RNG state). This lays the groundwork for property-based testing in mq-test, where a failing case's seed can be reported and replayed.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
