### PR TITLE
✨ feat(mq-lang): add html standard module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "codspeed-divan-compat",
  "csv",
  "dirs 6.0.0",
+ "ego-tree",
  "encoding_rs",
  "getrandom 0.4.3",
  "glob",

--- a/crates/mq-lang/Cargo.toml
+++ b/crates/mq-lang/Cargo.toml
@@ -34,6 +34,7 @@ rand = {workspace = true}
 regex = {workspace = true}
 ropey = {workspace = true, optional = true}
 rustc-hash = {workspace = true}
+ego-tree = {workspace = true, optional = true}
 scraper = {workspace = true, optional = true}
 serde = {workspace = true, features = ["derive", "rc"]}
 serde_json = {workspace = true}
@@ -63,7 +64,7 @@ web-time = {workspace = true}
 [features]
 ast-json = ["smallvec/serde", "smol_str/serde"]
 cst = ["dep:ropey"]
-css-selector = ["dep:scraper"]
+css-selector = ["dep:ego-tree", "dep:scraper"]
 debugger = ["sync"]
 default = ["std", "html-to-markdown"]
 file-io = ["dep:ignore"]

--- a/crates/mq-lang/modules/html.mq
+++ b/crates/mq-lang/modules/html.mq
@@ -76,3 +76,100 @@ end
 def html_stringify(data):
   _html_stringify(data)
 end
+
+def _html_find_all(data, tag):
+  let matches = if (data["tag"] == tag): [data] else: []
+  | matches + flat_map(data["children"], fn(child): _html_find_all(child, tag);)
+end
+
+# Recursively finds every element (including `data` itself) whose tag matches
+# `tag`, in document order.
+#
+# Example:
+# ```
+# import "html" | len(html::html_find_all(html::html_parse("<div><p>a</p><p>b</p></div>"), "p"))
+# #=> 2
+# ```
+#
+# Returns: array
+def html_find_all(data, tag):
+  _html_find_all(data, tag)
+end
+
+# Recursively finds the first element (including `data` itself) whose tag
+# matches `tag`, or `None` if there's no match.
+#
+# Example:
+# ```
+# import "html" | html::html_find(html::html_parse("<div><p>hi</p></div>"), "p")["text"]
+# #=> hi
+# ```
+#
+# Returns: dict
+def html_find(data, tag):
+  first(_html_find_all(data, tag))
+end
+
+# Returns the value of attribute `name` on element `data`, or `None` if the
+# attribute isn't set.
+#
+# Example:
+# ```
+# import "html" | html::html_attr(html::html_find(html::html_parse("<a href=\"https://example.com\">x</a>"), "a"), "href")
+# #=> https://example.com
+# ```
+#
+# Returns: string
+def html_attr(data, name):
+  data["attributes"][name]
+end
+
+def _html_text_parts(data):
+  let own = if (is_empty(data["text"])): [] else: [data["text"]]
+  | own + flat_map(data["children"], _html_text_parts)
+end
+
+# Returns the concatenated text content of `data` and all its descendants, in
+# document order.
+#
+# Example:
+# ```
+# import "html" | html::html_text(html::html_parse("<p>hi <b>there</b></p>"))
+# #=> hi there
+# ```
+#
+# Returns: string
+def html_text(data):
+  join(_html_text_parts(data), " ")
+end
+
+def _html_escape_json_string(str):
+  replace(str, "\\", "\\\\") | replace("\"", "\\\"") | replace("\n", "\\n") | replace("\t", "\\t")
+end
+
+# Converts a data structure (typically the `{tag, attributes, children,
+# text}` shape returned by `html_parse`) to a JSON string representation.
+#
+# Example:
+# ```
+# import "html" | html::html_to_json({"tag": "a"})
+# #=> {"tag": "a"}
+# ```
+#
+# Returns: string
+def html_to_json(data):
+  if (is_dict(data)):
+    "{" + join(map(keys(data), fn(k): "\"" + k + "\": " + html_to_json(data[k]);), ", ") + "}"
+  elif (is_array(data)):
+    "[" + join(map(data, html_to_json), ", ") + "]"
+  elif (is_string(data)):
+    "\"" + _html_escape_json_string(data) + "\""
+  elif (is_number(data)):
+    to_string(data)
+  elif (is_bool(data)):
+    if (data): "true" else: "false"
+  elif (is_none(data)):
+    "null"
+  else:
+    "\"" + to_string(data) + "\""
+end

--- a/crates/mq-lang/modules/html.mq
+++ b/crates/mq-lang/modules/html.mq
@@ -1,0 +1,78 @@
+# HTML Implementation in mq
+
+let _void_tags = ["area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"]
+
+| def _escape_text(str):
+  replace(replace(replace(str, "&", "&amp;"), "<", "&lt;"), ">", "&gt;")
+end
+
+| def _escape_attr(str):
+  replace(_escape_text(str), "\"", "&quot;")
+end
+
+| def _format_attributes(attributes):
+  if (is_empty(keys(attributes))):
+    ""
+  else:
+    " " + join(map(entries(attributes), fn(entry): first(entry) + "=\"" + _escape_attr(last(entry)) + "\"";), " ")
+end
+
+# Parses an HTML string into the `{tag, attributes, children, text}` tree rooted at `<html>`,
+# the same shape `xml::xml_parse` produces.
+#
+# Example:
+# ```
+# import "html" | html::html_parse("<p>hi</p>")["tag"]
+# #=> html
+# ```
+#
+# Returns: dynamic
+def html_parse(input):
+  _html_parse(to_string(input))
+end
+
+def _html_stringify(data):
+  def _format_element(element):
+    let tag = element["tag"]
+    | let attributes = element["attributes"]
+    | let children = element["children"]
+    | let text = element["text"]
+    | let attr_str = _format_attributes(attributes)
+    | if (index(_void_tags, tag) != -1):
+        "<" + tag + attr_str + ">"
+      else:
+        _format_element_with_content(tag, attr_str, children, text)
+  end
+
+  def _format_element_with_content(tag, attr_str, children, text):
+    let content = if (!is_none(text)):
+      _escape_text(text)
+    else:
+      ""
+    | let child_content = if (!is_empty(children)):
+          join(map(children, _html_stringify), "")
+        else:
+          ""
+    | let all_content = content + child_content
+    | "<" + tag + attr_str + ">" + all_content + "</" + tag + ">"
+  end
+
+  | if (is_dict(data) && !is_none(data["tag"])):
+      _format_element(data)
+    else:
+      to_string(data)
+end
+
+# Serializes a `{tag, attributes, children, text}` value back to an HTML string.
+# Void elements (`br`, `img`, ...) get no closing tag.
+#
+# Example:
+# ```
+# import "html" | html::html_stringify({"tag": "p", "attributes": {}, "children": [], "text": "hi"})
+# #=> <p>hi</p>
+# ```
+#
+# Returns: string
+def html_stringify(data):
+  _html_stringify(data)
+end

--- a/crates/mq-lang/modules/html_test.mq
+++ b/crates/mq-lang/modules/html_test.mq
@@ -1,4 +1,5 @@
 import "html"
+| import "json"
 | include "test"
 
 # -- HTML Tests --
@@ -51,4 +52,46 @@ def test_html_stringify_escapes_text_and_attributes():
   assert_eq(
     html::html_stringify({"tag": "p", "attributes": {"title": "a \"quote\""}, "children": [], "text": "<b> & </b>"}),
     "<p title=\"a &quot;quote&quot;\">&lt;b&gt; &amp; &lt;/b&gt;</p>")
+end
+
+# @parametrize([["p", 1], ["img", 1], ["div", 1], ["nope", 0]])
+def test_html_find_all(tag, expected_len):
+  let result = html::html_find_all(html::html_parse(html_input), tag)
+  | assert_eq(len(result), expected_len)
+end
+
+# @parametrize([["img", "img"], ["div", "div"], ["nope", None]])
+def test_html_find(tag, expected_tag):
+  let result = html::html_find(html::html_parse(html_input), tag)
+  | let actual_tag = if (is_none(result)): None else: result["tag"]
+  | assert_eq(actual_tag, expected_tag)
+end
+
+# @parametrize([["src", "x.png"], ["alt", None]])
+def test_html_attr(name, expected):
+  let img = html::html_find(html::html_parse(html_input), "img")
+  | assert_eq(html::html_attr(img, name), expected)
+end
+
+# @parametrize([
+#   ["<p>hi <b>there</b></p>", "hi there"],
+#   ["<p><span></span></p>", ""],
+#   ["<div><p>a</p><p>b</p></div>", "a b"],
+# ])
+def test_html_text(input, expected):
+  assert_eq(html::html_text(html::html_parse(input)), expected)
+end
+
+def test_html_to_json_roundtrips():
+  let parsed = html::html_parse(html_input)
+  | let result = html::html_to_json(parsed)
+  | assert_eq(json::json_parse(result), parsed)
+end
+
+# @parametrize([
+#   [{"tag": "a"}, "{\"tag\": \"a\"}"],
+#   [{"tag": "br", "attributes": {}, "children": [], "text": None}, "{\"text\": null, \"tag\": \"br\", \"attributes\": {}, \"children\": []}"],
+# ])
+def test_html_to_json_simple(data, expected):
+  assert_eq(html::html_to_json(data), expected)
 end

--- a/crates/mq-lang/modules/html_test.mq
+++ b/crates/mq-lang/modules/html_test.mq
@@ -1,0 +1,54 @@
+import "html"
+| include "test"
+
+# -- HTML Tests --
+
+| let html_input = "<!DOCTYPE html><html><body><div class=\"a\"><p>hi <b>there</b></p><img src=\"x.png\"></div></body></html>" |
+
+def test_html_parse_root_tag():
+  let result = html::html_parse(html_input)
+  | assert_eq(result["tag"], "html")
+end
+
+def test_html_parse_nested_element():
+  let result = html::html_parse(html_input)
+  | let div = first(result["children"][1]["children"])
+  | assert_eq(div["tag"], "div")
+  | assert_eq(div["attributes"]["class"], "a")
+end
+
+def test_html_parse_collapses_text_around_inline_elements():
+  let result = html::html_parse(html_input)
+  | let div = first(result["children"][1]["children"])
+  | let p = first(div["children"])
+  | assert_eq(p["text"], "hi")
+end
+
+def test_html_parse_void_element_has_no_children_or_text():
+  let result = html::html_parse(html_input)
+  | let div = first(result["children"][1]["children"])
+  | let img = last(div["children"])
+  | assert_eq(img["tag"], "img")
+  | assert_eq(img["attributes"]["src"], "x.png")
+  | assert_true(is_empty(img["children"]))
+  | assert_true(is_none(img["text"]))
+end
+
+def test_html_stringify_void_element():
+  assert_eq(
+    html::html_stringify({"tag": "br", "attributes": {}, "children": [], "text": None}),
+    "<br>")
+end
+
+def test_html_stringify_roundtrip():
+  let parsed = html::html_parse("<p class=\"a\">hi &amp; bye</p>")
+  | let body = last(parsed["children"])
+  | let p = first(body["children"])
+  | assert_eq(html::html_stringify(p), "<p class=\"a\">hi &amp; bye</p>")
+end
+
+def test_html_stringify_escapes_text_and_attributes():
+  assert_eq(
+    html::html_stringify({"tag": "p", "attributes": {"title": "a \"quote\""}, "children": [], "text": "<b> & </b>"}),
+    "<p title=\"a &quot;quote&quot;\">&lt;b&gt; &amp; &lt;/b&gt;</p>")
+end

--- a/crates/mq-lang/src/eval/builtin.rs
+++ b/crates/mq-lang/src/eval/builtin.rs
@@ -4062,6 +4062,16 @@ fn _xml_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEn
     }
 }
 
+#[cfg(feature = "css-selector")]
+#[mq_macros::mq_fn(name = "_html_parse", params = Fixed(1))]
+fn _html_parse_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(html_str)] => Ok(css::parse_html(html_str)),
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("_html_parse should always receive exactly one argument"),
+    }
+}
+
 #[mq_macros::mq_fn(name = "set_variable", params = Fixed(2))]
 fn set_variable_impl(
     ident: &Ident,
@@ -5325,6 +5335,8 @@ mq_macros::builtin_dispatch! {
     CSS_TEXT,
     #[cfg(feature = "css-selector")]
     CSS_ATTR,
+    #[cfg(feature = "css-selector")]
+    _HTML_PARSE,
 }
 
 /// A single runnable, verified example shown by `mq help`.
@@ -6168,6 +6180,18 @@ pub static INTERNAL_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc
             returns: "dynamic",
             examples: &[],
             capability: None,
+        },
+    );
+    #[cfg(feature = "css-selector")]
+    map.insert(
+        SmolStr::new("_html_parse"),
+        BuiltinFunctionDoc {
+            description: "Parses an HTML string and returns the corresponding data structure.",
+            params: &["html_string"],
+            param_types: &[],
+            returns: "dynamic",
+            examples: &[],
+            capability: Some("css-selector"),
         },
     );
     map.insert(

--- a/crates/mq-lang/src/eval/builtin/css.rs
+++ b/crates/mq-lang/src/eval/builtin/css.rs
@@ -10,12 +10,67 @@
 //!
 //! Gated at compile time by the `css-selector` feature.
 
-use scraper::{Html, Selector};
+use std::collections::BTreeMap;
+
+use ego_tree::NodeRef;
+use scraper::{Html, Node, Selector};
+
+use crate::eval::runtime_value::RuntimeValue;
+use crate::{Ident, Shared};
 
 use super::Error;
 
 fn err(msg: impl std::fmt::Display) -> Error {
     Error::Runtime(format!("css: {msg}"))
+}
+
+// Same `{tag, attributes, children, text}` shape as `_xml_parse`; whitespace-only text is dropped.
+fn build_element(node: NodeRef<'_, Node>) -> RuntimeValue {
+    let element = node.value().as_element().expect("node is an element");
+    let mut attributes = BTreeMap::new();
+
+    for (name, value) in element.attrs() {
+        attributes.insert(Ident::new(name), RuntimeValue::String(value.to_string()));
+    }
+
+    let mut children = Vec::new();
+    let mut text: Option<String> = None;
+
+    for child in node.children() {
+        match child.value() {
+            Node::Element(_) => children.push(build_element(child)),
+            Node::Text(t) => {
+                let trimmed = t.trim();
+                if !trimmed.is_empty() {
+                    match &mut text {
+                        Some(existing) => {
+                            existing.push(' ');
+                            existing.push_str(trimmed);
+                        }
+                        None => text = Some(trimmed.to_string()),
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut dict = BTreeMap::new();
+    dict.insert(Ident::new("tag"), RuntimeValue::String(element.name().to_string()));
+    dict.insert(Ident::new("attributes"), RuntimeValue::Dict(Shared::new(attributes)));
+    dict.insert(Ident::new("children"), RuntimeValue::Array(Shared::new(children)));
+    dict.insert(
+        Ident::new("text"),
+        text.map(RuntimeValue::String).unwrap_or(RuntimeValue::NONE),
+    );
+    RuntimeValue::Dict(Shared::new(dict))
+}
+
+/// Parses `html` into the `{tag, attributes, children, text}` tree rooted at `<html>`;
+/// comments, doctypes, and processing instructions are dropped.
+pub(super) fn parse_html(html: &str) -> RuntimeValue {
+    let document = Html::parse_document(html);
+    build_element(*document.root_element())
 }
 
 fn parse_selector(selector: &str) -> Result<Selector, Error> {

--- a/crates/mq-lang/src/module.rs
+++ b/crates/mq-lang/src/module.rs
@@ -43,6 +43,7 @@ fn get_module_name(name: &str) -> Cow<'static, str> {
         "csv" => Cow::Borrowed("csv.mq"),
         "fuzzy" => Cow::Borrowed("fuzzy.mq"),
         "gron" => Cow::Borrowed("gron.mq"),
+        "html" => Cow::Borrowed("html.mq"),
         "json" => Cow::Borrowed("json.mq"),
         "md" => Cow::Borrowed("md.mq"),
         "section" => Cow::Borrowed("section.mq"),
@@ -99,6 +100,8 @@ pub static STANDARD_MODULES: LazyLock<StandardModules> = LazyLock::new(|| {
     std_module!(csv);
     std_module!(fuzzy);
     std_module!(gron);
+    #[cfg(feature = "css-selector")]
+    std_module!(html);
     std_module!(json);
     std_module!(md);
     std_module!(section);

--- a/crates/mq-lang/src/module/resolver/std_resolver.rs
+++ b/crates/mq-lang/src/module/resolver/std_resolver.rs
@@ -60,6 +60,22 @@ mod tests {
         assert!(matches!(resolver.resolve(name), Err(ModuleError::NotFound(_))));
     }
 
+    #[cfg(feature = "css-selector")]
+    #[test]
+    fn test_resolve_html_module() {
+        let resolver = StdModuleResolver;
+        let result = resolver.resolve("html");
+        assert!(result.is_ok(), "expected Ok for std module 'html', got {result:?}");
+        assert!(!result.unwrap().is_empty());
+    }
+
+    #[cfg(not(feature = "css-selector"))]
+    #[test]
+    fn test_resolve_html_module_not_found_without_css_selector() {
+        let resolver = StdModuleResolver;
+        assert!(matches!(resolver.resolve("html"), Err(ModuleError::NotFound(_))));
+    }
+
     #[rstest]
     #[case("csv", "csv")]
     #[case("json", "json")]

--- a/crates/mq-test/Cargo.toml
+++ b/crates/mq-test/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.8.3"
 clap = {workspace = true, features = ["derive"]}
 glob = {workspace = true}
 miette = {workspace = true, features = ["fancy"]}
-mq-lang = {workspace = true, features = ["cst", "debugger", "file-io", "http", "mock-io"]}
+mq-lang = {workspace = true, features = ["cst", "css-selector", "debugger", "file-io", "http", "mock-io"]}
 rayon = {workspace = true}
 rustc-hash = {workspace = true}
 serde_json = {workspace = true}

--- a/docs/books/src/start/modules.md
+++ b/docs/books/src/start/modules.md
@@ -10,6 +10,7 @@ Standard modules are built into `mq` — use them with `include` or `import`, no
 | `yaml` | YAML 1.2 parser and formatter |
 | `toml` | TOML parser and formatter |
 | `xml` | XML parser and formatter |
+| `html` | HTML parser and formatter (requires the `css-selector` build feature) |
 | `csv` | CSV / TSV parser and formatter |
 | `cbor` | CBOR binary format support |
 | `semver` | Semantic versioning (SemVer) utilities |


### PR DESCRIPTION
## Summary

Adds html::html_parse/html_stringify, mirroring xml.mq's {tag, attributes, children, text} tree shape. html_parse is backed by a new _html_parse builtin that walks scraper's html5ever-based parse tree (already linked in by the css-selector feature, which mq-run enables by default.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
