### PR TITLE
✨ feat(mq-web-api): add opt-in API key auth with scopes and per-key rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,6 +2904,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.20",
  "tokio",
  "tower",

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -34,6 +34,7 @@ mq-markdown = {workspace = true, features = ["json"]}
 rayon = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
+sha2 = {workspace = true}
 thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tower = {workspace = true}

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -213,6 +213,34 @@ cached.
 | `RATE_LIMIT_WINDOW_SIZE_SECONDS` | `3600` | Window size in seconds |
 | `RATE_LIMIT_CLEANUP_INTERVAL_SECONDS` | `3600` | Expired-entry cleanup interval |
 
+### Authentication
+
+Disabled by default. When `AUTH_ENABLED=true`, every endpoint except `/health`, `/docs`, and the OpenAPI spec requires `Authorization: Bearer <key>`. Keys carry a scope (`read`: `functions`/`selectors`/`check`/`format`/`lint`, `query`: `/api/v1/query`, `/api/v1/batch`, `/{query}`) and an optional rate limit override enforced independently of the IP-based limit above.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_ENABLED` | `false` | Require an API key on protected endpoints |
+| `API_KEYS` | — | Comma-separated keys; each gets both scopes and no rate limit override |
+| `API_KEYS_FILE` | — | Path to a JSON file for per-key name/scopes/rate limit (takes precedence over `API_KEYS`) |
+
+`API_KEYS_FILE` format:
+
+```json
+[
+  { "key": "sk_live_...", "name": "acme-corp", "scopes": ["read", "query"], "rate_limit_per_window": 5000 },
+  { "key": "sk_live_...", "name": "acme-readonly", "scopes": ["read"] }
+]
+```
+
+`scopes` defaults to `["read", "query"]` when omitted; `rate_limit_per_window` defaults to the server-wide `RATE_LIMIT_REQUESTS_PER_WINDOW`.
+
+```bash
+curl -H "Authorization: Bearer sk_live_..." \
+  -X POST http://localhost:8080/api/v1/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": ".h1", "input": "# Title"}'
+```
+
 ### OpenTelemetry (requires `otel` feature)
 
 | Variable | Default | Description |

--- a/crates/mq-web-api/src/auth.rs
+++ b/crates/mq-web-api/src/auth.rs
@@ -1,0 +1,208 @@
+//! API key authentication and scope-based authorization.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{collections::HashMap, collections::HashSet, fmt::Write as _};
+
+use crate::config::AuthConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Scope {
+    Read,
+    Query,
+}
+
+impl std::fmt::Display for Scope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Scope::Read => "read",
+            Scope::Query => "query",
+        })
+    }
+}
+
+fn default_scopes() -> Vec<Scope> {
+    vec![Scope::Read, Scope::Query]
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiKeyDef {
+    key: String,
+    name: String,
+    #[serde(default = "default_scopes")]
+    scopes: Vec<Scope>,
+    rate_limit_per_window: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiKeyRecord {
+    pub name: String,
+    pub scopes: HashSet<Scope>,
+    pub rate_limit_per_window: Option<i64>,
+}
+
+impl ApiKeyRecord {
+    pub fn has_scope(&self, scope: Scope) -> bool {
+        self.scopes.contains(&scope)
+    }
+}
+
+#[derive(Debug)]
+pub struct ApiKeyStore {
+    by_hash: HashMap<String, ApiKeyRecord>,
+}
+
+impl ApiKeyStore {
+    fn from_defs(defs: Vec<ApiKeyDef>) -> Self {
+        let by_hash = defs
+            .into_iter()
+            .map(|def| {
+                (
+                    hash_key(&def.key),
+                    ApiKeyRecord {
+                        name: def.name,
+                        scopes: def.scopes.into_iter().collect(),
+                        rate_limit_per_window: def.rate_limit_per_window,
+                    },
+                )
+            })
+            .collect();
+        Self { by_hash }
+    }
+
+    fn from_raw_keys(keys: Vec<String>) -> Self {
+        let by_hash = keys
+            .into_iter()
+            .enumerate()
+            .map(|(i, key)| {
+                (
+                    hash_key(&key),
+                    ApiKeyRecord {
+                        name: format!("key-{}", i + 1),
+                        scopes: default_scopes().into_iter().collect(),
+                        rate_limit_per_window: None,
+                    },
+                )
+            })
+            .collect();
+        Self { by_hash }
+    }
+
+    pub fn from_config(config: &AuthConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        let store = if let Some(path) = &config.keys_file {
+            let content = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("Failed to read API_KEYS_FILE '{}': {}", path, e));
+            let defs: Vec<ApiKeyDef> = serde_json::from_str(&content)
+                .unwrap_or_else(|e| panic!("Failed to parse API_KEYS_FILE '{}': {}", path, e));
+            Self::from_defs(defs)
+        } else {
+            Self::from_raw_keys(config.keys.clone())
+        };
+
+        assert!(
+            !store.by_hash.is_empty(),
+            "AUTH_ENABLED=true but no API keys were configured (set API_KEYS or API_KEYS_FILE)"
+        );
+
+        Some(store)
+    }
+
+    pub fn authenticate(&self, presented: &str) -> Option<&ApiKeyRecord> {
+        self.by_hash.get(&hash_key(presented))
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_hash.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_hash.is_empty()
+    }
+}
+
+fn hash_key(raw: &str) -> String {
+    let digest = Sha256::digest(raw.as_bytes());
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(hex, "{:02x}", byte).expect("writing to a String never fails");
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raw_keys_get_both_scopes_and_no_override() {
+        let store = ApiKeyStore::from_raw_keys(vec!["secret-1".to_string(), "secret-2".to_string()]);
+        assert_eq!(store.len(), 2);
+
+        let record = store.authenticate("secret-1").unwrap();
+        assert!(record.has_scope(Scope::Read));
+        assert!(record.has_scope(Scope::Query));
+        assert_eq!(record.rate_limit_per_window, None);
+    }
+
+    #[test]
+    fn test_unknown_key_is_rejected() {
+        let store = ApiKeyStore::from_raw_keys(vec!["secret-1".to_string()]);
+        assert!(store.authenticate("not-a-key").is_none());
+    }
+
+    #[test]
+    fn test_defs_carry_scopes_and_rate_limit_override() {
+        let defs: Vec<ApiKeyDef> = serde_json::from_str(
+            r#"[
+                {"key": "readonly-key", "name": "acme-readonly", "scopes": ["read"]},
+                {"key": "full-key", "name": "acme-full", "rate_limit_per_window": 5000}
+            ]"#,
+        )
+        .unwrap();
+        let store = ApiKeyStore::from_defs(defs);
+
+        let readonly = store.authenticate("readonly-key").unwrap();
+        assert_eq!(readonly.name, "acme-readonly");
+        assert!(readonly.has_scope(Scope::Read));
+        assert!(!readonly.has_scope(Scope::Query));
+        assert_eq!(readonly.rate_limit_per_window, None);
+
+        let full = store.authenticate("full-key").unwrap();
+        assert_eq!(full.name, "acme-full");
+        assert!(full.has_scope(Scope::Read));
+        assert!(full.has_scope(Scope::Query));
+        assert_eq!(full.rate_limit_per_window, Some(5000));
+    }
+
+    #[test]
+    fn test_from_config_disabled_returns_none() {
+        let config = AuthConfig {
+            enabled: false,
+            keys: vec!["secret".to_string()],
+            keys_file: None,
+        };
+        assert!(ApiKeyStore::from_config(&config).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "no API keys were configured")]
+    fn test_from_config_enabled_without_keys_panics() {
+        let config = AuthConfig {
+            enabled: true,
+            keys: vec![],
+            keys_file: None,
+        };
+        ApiKeyStore::from_config(&config);
+    }
+
+    #[test]
+    fn test_hash_key_is_deterministic_and_distinct() {
+        assert_eq!(hash_key("same"), hash_key("same"));
+        assert_ne!(hash_key("a"), hash_key("b"));
+    }
+}

--- a/crates/mq-web-api/src/config.rs
+++ b/crates/mq-web-api/src/config.rs
@@ -18,6 +18,14 @@ pub struct Config {
     pub query_timeout: Duration,
     /// Short-lived cache for repeated `{query, input, input_format, args}` combinations.
     pub query_cache: QueryCacheConfig,
+    pub auth: AuthConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AuthConfig {
+    pub enabled: bool,
+    pub keys: Vec<String>,
+    pub keys_file: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +47,7 @@ impl Default for Config {
             otel_service_name: "mq-web-api".to_string(),
             query_timeout: Duration::from_secs(10),
             query_cache: QueryCacheConfig::default(),
+            auth: AuthConfig::default(),
         }
     }
 }
@@ -175,6 +184,30 @@ impl Config {
                     max_entries_str, config.query_cache.max_entries
                 );
             }
+        }
+
+        if let Ok(enabled_str) = env::var("AUTH_ENABLED") {
+            match enabled_str.parse::<bool>() {
+                Ok(enabled) => config.auth.enabled = enabled,
+                Err(_) => eprintln!(
+                    "Warning: Invalid AUTH_ENABLED value '{}', using default {}",
+                    enabled_str, config.auth.enabled
+                ),
+            }
+        }
+
+        if let Ok(keys) = env::var("API_KEYS") {
+            config.auth.keys = keys
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+
+        if let Ok(keys_file) = env::var("API_KEYS_FILE")
+            && !keys_file.is_empty()
+        {
+            config.auth.keys_file = Some(keys_file);
         }
 
         config

--- a/crates/mq-web-api/src/handlers.rs
+++ b/crates/mq-web-api/src/handlers.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::{debug, error, info};
-use utoipa::{OpenApi, ToSchema};
+use utoipa::{
+    Modify, OpenApi, ToSchema,
+    openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
+};
 
 use crate::{
     api::{
@@ -149,9 +152,23 @@ pub async fn health_check() -> Json<HealthResponse> {
     ),
     tags(
         (name = "mq-api", description = "Markdown Query API")
-    )
+    ),
+    modifiers(&SecurityAddon)
 )]
 pub struct ApiDoc;
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(components) = openapi.components.as_mut() {
+            components.add_security_scheme(
+                "api_key",
+                SecurityScheme::Http(HttpBuilder::new().scheme(HttpAuthScheme::Bearer).build()),
+            );
+        }
+    }
+}
 
 #[utoipa::path(
     get,
@@ -164,7 +181,8 @@ pub struct ApiDoc;
         ("query" = String, Query, description = "mq query string to execute"),
         ("input" = String, Query, description = "Input content to process"),
         ("input_format" = Option<String>, Query, description = "Input format: markdown, mdx, text, html, raw, null, csv, tsv, psv, json, yaml, toml, xml, or toon")
-    )
+    ),
+    security(("api_key" = []))
 )]
 pub async fn get_query_api(
     ValidatedQuery(params): ValidatedQuery<QueryParams>,
@@ -219,7 +237,8 @@ pub async fn get_query_api(
         (status = 200, description = "Query executed successfully", body = QueryApiResponse),
         (status = 400, description = "Invalid request parameters"),
     ),
-    request_body = ApiRequest
+    request_body = ApiRequest,
+    security(("api_key" = []))
 )]
 pub async fn post_query_api(
     State(state): State<AppState>,
@@ -259,7 +278,8 @@ pub async fn post_query_api(
         (status = 200, description = "Batch processed (see per-item `error` fields for per-document failures)", body = BatchApiResponse),
         (status = 400, description = "Invalid request parameters, or `inputs` exceeds the batch size limit"),
     ),
-    request_body = BatchApiRequest
+    request_body = BatchApiRequest,
+    security(("api_key" = []))
 )]
 pub async fn post_batch_api(
     State(state): State<AppState>,
@@ -337,7 +357,8 @@ fn sniff_input_format(body: &str) -> Option<InputFormat> {
     responses(
         (status = 200, description = "Query executed successfully", body = QueryApiResponse),
         (status = 400, description = "Invalid query or request"),
-    )
+    ),
+    security(("api_key" = []))
 )]
 pub async fn post_shorthand_query_api(
     State(state): State<AppState>,

--- a/crates/mq-web-api/src/lib.rs
+++ b/crates/mq-web-api/src/lib.rs
@@ -46,6 +46,10 @@
 //! - Configurable request windows
 //! - Automatic cleanup of expired entries
 //!
+//! # Authentication
+//!
+//! Opt-in via `AUTH_ENABLED=true`, `API_KEYS`/`API_KEYS_FILE`, and `Authorization: Bearer <key>`.
+//!
 //! # Configuration
 //!
 //! Configure the server using environment variables:
@@ -54,8 +58,10 @@
 //! - `HOST` - Bind address (default: 0.0.0.0)
 //! - `RATE_LIMIT_REQUESTS` - Max requests per window
 //! - `RATE_LIMIT_WINDOW` - Time window in seconds
+//! - `AUTH_ENABLED` - Require an API key (default: false)
 //!
 pub mod api;
+pub mod auth;
 pub mod banner;
 pub mod cleanup;
 pub mod config;
@@ -68,6 +74,7 @@ pub mod routes;
 pub mod server;
 
 pub use api::{ApiRequest, InputFormat, query};
+pub use auth::{ApiKeyStore, Scope};
 pub use cleanup::CleanupService;
 pub use config::Config;
 pub use query_cache::{QueryCache, QueryCacheConfig};

--- a/crates/mq-web-api/src/middleware.rs
+++ b/crates/mq-web-api/src/middleware.rs
@@ -1,3 +1,5 @@
+pub mod auth;
 pub mod rate_limit;
 
+pub use auth::{AuthContext, AuthState, auth_middleware};
 pub use rate_limit::rate_limit_middleware;

--- a/crates/mq-web-api/src/middleware/auth.rs
+++ b/crates/mq-web-api/src/middleware/auth.rs
@@ -1,0 +1,202 @@
+use axum::{
+    extract::{Request, State},
+    http::{HeaderValue, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::{
+    auth::{ApiKeyRecord, ApiKeyStore, Scope},
+    problem::ProblemDetails,
+    rate_limiter::{RateLimitError, RateLimiter},
+};
+
+#[derive(Clone)]
+pub struct AuthState {
+    pub store: Arc<ApiKeyStore>,
+    pub rate_limiter: Arc<RateLimiter>,
+}
+
+#[derive(Clone)]
+pub struct AuthContext {
+    pub key_name: String,
+}
+
+fn required_scope(path: &str) -> Option<Scope> {
+    if path == "/health"
+        || path.starts_with("/docs")
+        || path == "/api/v1/openapi.json"
+        || path == "/openapi.json"
+        || path == "/api/query"
+        || path == "/api/check"
+        || path == "/api/format"
+    {
+        return None;
+    }
+
+    if path == "/api/v1/query" || path == "/api/v1/batch" {
+        return Some(Scope::Query);
+    }
+
+    if path.starts_with("/api/v1/") {
+        return Some(Scope::Read);
+    }
+
+    Some(Scope::Query)
+}
+
+fn extract_bearer(request: &Request) -> Option<&str> {
+    request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+}
+
+pub async fn auth_middleware(State(auth): State<AuthState>, mut request: Request, next: Next) -> Response {
+    let Some(required) = required_scope(request.uri().path()) else {
+        return next.run(request).await;
+    };
+
+    let Some(presented) = extract_bearer(&request) else {
+        return unauthorized("Missing API key");
+    };
+
+    let Some(record) = auth.store.authenticate(presented) else {
+        warn!("Auth failed: unknown API key presented for {}", request.uri().path());
+        return unauthorized("Invalid API key");
+    };
+
+    if !record.has_scope(required) {
+        warn!(
+            "Auth failed: key '{}' lacks scope {:?} for {}",
+            record.name,
+            required,
+            request.uri().path()
+        );
+        return forbidden(&record.name, required);
+    }
+
+    if let Some(response) = check_key_quota(&auth.rate_limiter, record).await {
+        return response;
+    }
+
+    debug!("Authenticated request as '{}'", record.name);
+    request.extensions_mut().insert(AuthContext {
+        key_name: record.name.clone(),
+    });
+
+    next.run(request).await
+}
+
+async fn check_key_quota(rate_limiter: &RateLimiter, record: &ApiKeyRecord) -> Option<Response> {
+    let identifier = format!("key:{}", record.name);
+
+    match rate_limiter
+        .check_and_increment_with_limit(&identifier, record.rate_limit_per_window)
+        .await
+    {
+        Ok(()) => None,
+        Err(RateLimitError::LimitExceeded { requests, limit }) => {
+            warn!(
+                "Per-key rate limit exceeded for '{}': {}/{}",
+                record.name, requests, limit
+            );
+            Some(key_rate_limited(requests, limit))
+        }
+        Err(err) => {
+            warn!("Rate limiter error for key '{}': {}", record.name, err);
+            None
+        }
+    }
+}
+
+fn unauthorized(detail: &str) -> Response {
+    let mut response = ProblemDetails::new(StatusCode::UNAUTHORIZED)
+        .with_title("Unauthorized")
+        .with_detail("error", detail)
+        .into_response();
+    response
+        .headers_mut()
+        .insert(axum::http::header::WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+    response
+}
+
+fn forbidden(key_name: &str, required: Scope) -> Response {
+    ProblemDetails::new(StatusCode::FORBIDDEN)
+        .with_title("Insufficient scope")
+        .with_detail("key", key_name)
+        .with_detail("required_scope", &required.to_string())
+        .into_response()
+}
+
+fn key_rate_limited(requests: i64, limit: i64) -> Response {
+    let mut response = ProblemDetails::new(StatusCode::TOO_MANY_REQUESTS)
+        .with_title("API key rate limit exceeded")
+        .with_detail("requests", &requests.to_string())
+        .with_detail("limit", &limit.to_string())
+        .into_response();
+    let headers = response.headers_mut();
+    if let Ok(v) = HeaderValue::from_str(&limit.to_string()) {
+        headers.insert("X-RateLimit-Key-Limit", v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&requests.to_string()) {
+        headers.insert("X-RateLimit-Key-Used", v);
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_required_scope_public_paths() {
+        for path in ["/health", "/docs", "/docs/", "/api/v1/openapi.json", "/openapi.json"] {
+            assert_eq!(required_scope(path), None, "path: {}", path);
+        }
+    }
+
+    #[test]
+    fn test_required_scope_query_paths() {
+        for path in ["/api/v1/query", "/api/v1/batch", "/.h1", "/upcase"] {
+            assert_eq!(required_scope(path), Some(Scope::Query), "path: {}", path);
+        }
+    }
+
+    #[test]
+    fn test_required_scope_read_paths() {
+        for path in [
+            "/api/v1/functions",
+            "/api/v1/functions/map",
+            "/api/v1/selectors",
+            "/api/v1/check",
+            "/api/v1/format",
+            "/api/v1/lint",
+        ] {
+            assert_eq!(required_scope(path), Some(Scope::Read), "path: {}", path);
+        }
+    }
+
+    #[test]
+    fn test_extract_bearer() {
+        let request = Request::builder()
+            .header("authorization", "Bearer my-key")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_bearer(&request), Some("my-key"));
+
+        let missing = Request::builder().body(axum::body::Body::empty()).unwrap();
+        assert_eq!(extract_bearer(&missing), None);
+
+        let wrong_scheme = Request::builder()
+            .header("authorization", "Basic dXNlcjpwYXNz")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_bearer(&wrong_scheme), None);
+    }
+}

--- a/crates/mq-web-api/src/rate_limiter.rs
+++ b/crates/mq-web-api/src/rate_limiter.rs
@@ -51,6 +51,15 @@ impl RateLimiter {
     }
 
     pub async fn check_and_increment(&self, identifier: &str) -> Result<(), RateLimitError> {
+        self.check_and_increment_with_limit(identifier, None).await
+    }
+
+    pub async fn check_and_increment_with_limit(
+        &self,
+        identifier: &str,
+        limit_override: Option<i64>,
+    ) -> Result<(), RateLimitError> {
+        let limit = limit_override.unwrap_or(self.config.requests_per_window);
         let now = current_timestamp();
         let window_start = self.get_window_start(now);
         let expires_at = window_start + self.config.window_size_seconds;
@@ -73,14 +82,11 @@ impl RateLimiter {
 
         debug!(
             "Rate limit check for '{}': {}/{} requests in current window",
-            identifier, count, self.config.requests_per_window
+            identifier, count, limit
         );
 
-        if count > self.config.requests_per_window {
-            return Err(RateLimitError::LimitExceeded {
-                requests: count,
-                limit: self.config.requests_per_window,
-            });
+        if count > limit {
+            return Err(RateLimitError::LimitExceeded { requests: count, limit });
         }
 
         Ok(())
@@ -232,6 +238,28 @@ mod tests {
 
         let result = limiter.check_and_increment(identifier).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_and_increment_with_limit_override() {
+        let limiter = RateLimiter::new(RateLimitConfig {
+            requests_per_window: 100,
+            ..RateLimitConfig::default()
+        });
+        let identifier = "key:acme";
+
+        for _ in 1..=3 {
+            limiter
+                .check_and_increment_with_limit(identifier, Some(3))
+                .await
+                .unwrap();
+        }
+
+        let result = limiter.check_and_increment_with_limit(identifier, Some(3)).await;
+        assert!(matches!(
+            result,
+            Err(RateLimitError::LimitExceeded { requests: 4, limit: 3 })
+        ));
     }
 
     #[tokio::test]

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -16,18 +16,23 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::{
+    auth::ApiKeyStore,
     config::Config,
     handlers::{
         ApiDoc, AppState, get_function_api, get_functions_api, get_query_api, get_selector_api, get_selectors_api,
         health_check, post_batch_api, post_check_api, post_format_api, post_lint_api, post_query_api,
         post_shorthand_query_api,
     },
-    middleware::rate_limit_middleware,
+    middleware::{AuthState, auth_middleware, rate_limit_middleware},
     query_cache::QueryCache,
     rate_limiter::RateLimiter,
 };
 
-pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router {
+pub fn create_router(
+    config: &Config,
+    rate_limiter: Arc<RateLimiter>,
+    api_key_store: Option<Arc<ApiKeyStore>>,
+) -> Router {
     let state = AppState {
         query_timeout: config.query_timeout,
         query_cache: Arc::new(QueryCache::new(config.query_cache.clone())),
@@ -67,7 +72,7 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
         .route("/selectors/{name}", get(get_selector_api))
         .route("/lint", post(post_lint_api));
 
-    Router::new()
+    let router = Router::new()
         .merge(SwaggerUi::new("/docs").url("/api/v1/openapi.json", ApiDoc::openapi()))
         .route("/health", get(health_check))
         .nest("/api/v1", v1_routes)
@@ -91,7 +96,21 @@ pub fn create_router(config: &Config, rate_limiter: Arc<RateLimiter>) -> Router 
                 .layer(CompressionLayer::new())
                 .layer(TraceLayer::new_for_http())
                 .layer(cors),
-        )
+        );
+
+    let router = if let Some(store) = api_key_store {
+        router.layer(middleware::from_fn_with_state(
+            AuthState {
+                store,
+                rate_limiter: rate_limiter.clone(),
+            },
+            auth_middleware,
+        ))
+    } else {
+        router
+    };
+
+    router
         .layer(middleware::from_fn_with_state(rate_limiter, rate_limit_middleware))
         .with_state(state)
 }

--- a/crates/mq-web-api/src/server.rs
+++ b/crates/mq-web-api/src/server.rs
@@ -8,6 +8,7 @@ use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberI
 static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> = std::sync::OnceLock::new();
 
 use crate::{
+    auth::ApiKeyStore,
     cleanup::CleanupService,
     config::{Config, LogFormat},
     rate_limiter::RateLimiter,
@@ -115,12 +116,19 @@ pub async fn start_server(config: Config) -> Result<(), Box<dyn std::error::Erro
     let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit.clone()));
     info!("Rate limiter initialized successfully");
 
-    let app = create_router(&config, rate_limiter.clone()).layer(TraceLayer::new_for_http().on_response(
-        |response: &axum::response::Response, latency: Duration, _span: &tracing::Span| {
-            let ms = latency.as_secs_f64() * 1000.0;
-            info!("response latency: {:.2}ms, status: {}", ms, response.status());
-        },
-    ));
+    let api_key_store = ApiKeyStore::from_config(&config.auth).map(Arc::new);
+    match &api_key_store {
+        Some(store) => info!("API key authentication enabled with {} key(s)", store.len()),
+        None => info!("API key authentication disabled"),
+    }
+
+    let app =
+        create_router(&config, rate_limiter.clone(), api_key_store).layer(TraceLayer::new_for_http().on_response(
+            |response: &axum::response::Response, latency: Duration, _span: &tracing::Span| {
+                let ms = latency.as_secs_f64() * 1000.0;
+                info!("response latency: {:.2}ms, status: {}", ms, response.status());
+            },
+        ));
 
     let bind_address = config.bind_address();
     let listener = tokio::net::TcpListener::bind(&bind_address)
@@ -145,6 +153,9 @@ pub async fn start_server(config: Config) -> Result<(), Box<dyn std::error::Erro
     info!("  QUERY_CACHE_ENABLED: Cache repeated query/input combinations (default: true)");
     info!("  QUERY_CACHE_TTL_SECONDS: How long a cached result stays fresh (default: 30)");
     info!("  QUERY_CACHE_MAX_ENTRIES: Max number of cached query results (default: 1000)");
+    info!("  AUTH_ENABLED: Require an API key on protected endpoints (default: false)");
+    info!("  API_KEYS: Comma-separated API keys (all get read+query scope, no rate limit override)");
+    info!("  API_KEYS_FILE: Path to a JSON file of {{key, name, scopes, rate_limit_per_window}} entries");
 
     // Start cleanup service
     let mut cleanup_service = CleanupService::new(

--- a/docs/books/src/start/web_api.md
+++ b/docs/books/src/start/web_api.md
@@ -48,6 +48,27 @@ All settings are controlled through environment variables.
 | `RATE_LIMIT_WINDOW_SIZE_SECONDS` | `3600` | Window size in seconds |
 | `RATE_LIMIT_CLEANUP_INTERVAL_SECONDS` | `3600` | Expired-entry cleanup interval |
 
+### Authentication
+
+Disabled by default. When `AUTH_ENABLED=true`, every endpoint except `/health`, `/docs`, and the OpenAPI spec requires `Authorization: Bearer <key>`. Keys carry a scope (`read`: `functions`/`selectors`/`check`/`format`/`lint`, `query`: `/api/v1/query`, `/api/v1/batch`, `/{query}`) and an optional rate limit override enforced independently of the IP-based limit above.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_ENABLED` | `false` | Require an API key on protected endpoints |
+| `API_KEYS` | — | Comma-separated keys; each gets both scopes and no rate limit override |
+| `API_KEYS_FILE` | — | Path to a JSON file for per-key name/scopes/rate limit (takes precedence over `API_KEYS`) |
+
+`API_KEYS_FILE` format:
+
+```json
+[
+  { "key": "sk_live_...", "name": "acme-corp", "scopes": ["read", "query"], "rate_limit_per_window": 5000 },
+  { "key": "sk_live_...", "name": "acme-readonly", "scopes": ["read"] }
+]
+```
+
+`scopes` defaults to `["read", "query"]` when omitted; `rate_limit_per_window` defaults to the server-wide `RATE_LIMIT_REQUESTS_PER_WINDOW`.
+
 ### OpenTelemetry (requires `otel` feature)
 
 | Variable | Default | Description |
@@ -171,6 +192,15 @@ curl -X POST http://localhost:8080/api/v1/format \
 curl -X POST http://localhost:8080/api/v1/lint \
   -H "Content-Type: application/json" \
   -d '{"query": "let x = .h1 | .text"}'
+```
+
+### Authenticated request (when `AUTH_ENABLED=true`)
+
+```bash
+curl -H "Authorization: Bearer sk_live_..." \
+  -X POST http://localhost:8080/api/v1/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": ".h1", "input": "# Title"}'
 ```
 
 ### List builtin functions and selectors


### PR DESCRIPTION
## Summary

Adds Authorization: Bearer <key> authentication (AUTH_ENABLED, API_KEYS/API_KEYS_FILE), read/query scopes per endpoint, and per-key rate limit overrides enforced alongside the existing IP-based limiter.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
