### PR TITLE
✨ feat(mq-chrome-extension): auto-run queries with copy/download and shortcuts

### DIFF
--- a/docs/books/src/start/install.md
+++ b/docs/books/src/start/install.md
@@ -139,8 +139,10 @@ You can install the VSCode extension from the [Visual Studio Marketplace](https:
 ### Chrome Extension
 
 The mq Chrome extension converts the page you're viewing to Markdown and
-runs mq queries against it from the toolbar popup. It isn't on the Chrome
-Web Store yet, so install it unpacked:
+runs mq queries against it from the toolbar popup. Queries run automatically
+after editing, or immediately with Cmd/Ctrl+Enter; results can be copied or
+downloaded as Markdown. It isn't on the Chrome Web Store yet, so install it
+unpacked:
 
 ```sh
 git clone https://github.com/harehare/mq.git

--- a/packages/mq-chrome-extension/README.md
+++ b/packages/mq-chrome-extension/README.md
@@ -10,11 +10,14 @@ nothing is sent to a server.
 
 ## What it does
 
-1. **Extract page** — grabs the current tab's raw HTML and converts it to
-   Markdown in the source pane, which you can also edit or paste your own
-   content into.
-2. **Run a query** — filters the source Markdown and shows the result,
-   with a Copy button.
+1. **Extract page** — when you open the popup, it grabs the current tab's raw
+   HTML and converts it to Markdown in the source pane. You can also edit or
+   paste your own content into it.
+2. **Run a query** — filters the source Markdown and shows the result.
+   Queries run automatically shortly after you stop typing, or immediately
+   with **Cmd/Ctrl+Enter** or the Run button.
+3. **Reuse the result** — copy it or download it as `mq-result.md`; the
+   result pane also shows the output size and execution time.
 
 ## Install (unpacked, not yet on the Chrome Web Store)
 

--- a/packages/mq-chrome-extension/entrypoints/popup/App.tsx
+++ b/packages/mq-chrome-extension/entrypoints/popup/App.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { htmlToMarkdown, run } from "./lib/mq";
+import { diagnostics, htmlToMarkdown, run } from "./lib/mq";
 import { extractActivePageHtml } from "./lib/activeTab";
-import { queryStorage } from "./lib/queryStorage";
+import { DEFAULT_QUERY, queryStorage } from "./lib/queryStorage";
+import { downloadText } from "./lib/download";
+import { formatDiagnostics } from "./lib/diagnostics";
 import { SourcePane } from "./components/SourcePane";
 import { QueryEditor } from "./components/QueryEditor";
 import { ResultPane } from "./components/ResultPane";
@@ -15,19 +17,20 @@ const DEFAULT_OPTIONS: RunOptions = {
 
 export function App() {
   const [markdown, setMarkdown] = useState("");
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(DEFAULT_QUERY);
   const [result, setResult] = useState("");
   const [options, setOptions] = useState<RunOptions>(DEFAULT_OPTIONS);
-  const [isExtracting, setIsExtracting] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [lastRun, setLastRun] = useState<{ durationMs: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoRunTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const queryLoadedRef = useRef(false);
+  const runIdRef = useRef(0);
 
   const handleExtract = async (): Promise<string | undefined> => {
     setError(null);
-    setIsExtracting(true);
     try {
       const extracted = await extractActivePageHtml();
       if (!extracted.ok) {
@@ -37,25 +40,44 @@ export function App() {
       const md = await htmlToMarkdown(extracted.value);
       setMarkdown(md);
       setResult("");
+      setLastRun(null);
       return md;
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       return undefined;
-    } finally {
-      setIsExtracting(false);
     }
   };
 
   const runQuery = async (q: string, src: string, opts: RunOptions) => {
+    const runId = ++runIdRef.current;
+    if (autoRunTimeoutRef.current) {
+      clearTimeout(autoRunTimeoutRef.current);
+      autoRunTimeoutRef.current = null;
+    }
     setError(null);
     setIsRunning(true);
+    const startedAt = performance.now();
     try {
       const filtered = await run(q, src, opts);
+      if (runId !== runIdRef.current) return;
       setResult(filtered);
+      setLastRun({ durationMs: Math.round(performance.now() - startedAt) });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const fallback = err instanceof Error ? err.message : String(err);
+      try {
+        const queryDiagnostics = await diagnostics(q);
+        if (runId !== runIdRef.current) return;
+        setError(
+          queryDiagnostics.length > 0
+            ? formatDiagnostics(queryDiagnostics)
+            : fallback,
+        );
+      } catch {
+        if (runId !== runIdRef.current) return;
+        setError(fallback);
+      }
     } finally {
-      setIsRunning(false);
+      if (runId === runIdRef.current) setIsRunning(false);
     }
   };
 
@@ -69,16 +91,13 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [extractedMarkdown, storedQuery] = await Promise.all([
+      const [, storedQuery] = await Promise.all([
         handleExtract(),
         queryStorage.getValue(),
       ]);
       if (cancelled) return;
       setQuery(storedQuery);
       queryLoadedRef.current = true;
-      if (storedQuery.trim() && extractedMarkdown) {
-        await runQuery(storedQuery, extractedMarkdown, options);
-      }
     })();
     return () => {
       cancelled = true;
@@ -90,6 +109,19 @@ export function App() {
     if (!queryLoadedRef.current) return;
     queryStorage.setValue(query);
   }, [query]);
+
+  useEffect(() => {
+    if (!queryLoadedRef.current || !query.trim() || !markdown) return;
+    autoRunTimeoutRef.current = setTimeout(() => {
+      void runQuery(query, markdown, options);
+    }, 400);
+    return () => {
+      if (autoRunTimeoutRef.current) {
+        clearTimeout(autoRunTimeoutRef.current);
+        autoRunTimeoutRef.current = null;
+      }
+    };
+  }, [markdown, options, query]);
 
   const handleCopy = () => {
     navigator.clipboard
@@ -104,9 +136,14 @@ export function App() {
       });
   };
 
+  const handleDownload = () => {
+    downloadText("mq-result.md", result);
+  };
+
   useEffect(() => {
     return () => {
       if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      if (autoRunTimeoutRef.current) clearTimeout(autoRunTimeoutRef.current);
     };
   }, []);
 
@@ -117,9 +154,7 @@ export function App() {
 
         <SourcePane
           markdown={markdown}
-          isExtracting={isExtracting}
           onMarkdownChange={setMarkdown}
-          onExtract={handleExtract}
         />
 
         <QueryEditor
@@ -133,7 +168,13 @@ export function App() {
 
         <OptionsPanel options={options} onChange={setOptions} />
 
-        <ResultPane result={result} copied={copied} onCopy={handleCopy} />
+        <ResultPane
+          result={result}
+          copied={copied}
+          lastRun={lastRun}
+          onCopy={handleCopy}
+          onDownload={handleDownload}
+        />
       </div>
     </div>
   );

--- a/packages/mq-chrome-extension/entrypoints/popup/components/CodeEditor.tsx
+++ b/packages/mq-chrome-extension/entrypoints/popup/components/CodeEditor.tsx
@@ -3,6 +3,7 @@ import { syntaxHighlighting } from "@codemirror/language";
 import { markdown } from "@codemirror/lang-markdown";
 import { mqLanguage } from "../lib/mqLanguage";
 import { editorHighlightStyle } from "../lib/editorHighlight";
+import type { KeyboardEventHandler } from "react";
 
 export type EditorLanguage = "markdown" | "mq";
 
@@ -14,6 +15,7 @@ type CodeEditorProps = {
   highlightActiveLine?: boolean;
   className?: string;
   onChange?: (value: string) => void;
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
 };
 
 const languageExtension = (language: EditorLanguage) => {
@@ -71,6 +73,7 @@ export function CodeEditor({
   highlightActiveLine = !readOnly,
   className,
   onChange,
+  onKeyDown,
 }: CodeEditorProps) {
   return (
     <CodeMirror
@@ -89,6 +92,7 @@ export function CodeEditor({
       theme={editorTheme}
       extensions={[languageExtension(language), syntaxHighlighting(editorHighlightStyle)]}
       onChange={onChange}
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/mq-chrome-extension/entrypoints/popup/components/QueryEditor.tsx
+++ b/packages/mq-chrome-extension/entrypoints/popup/components/QueryEditor.tsx
@@ -1,4 +1,5 @@
 import { EXAMPLE_CATEGORIES } from "../lib/examples";
+import { isRunShortcut } from "../lib/shortcuts";
 import { CodeEditor } from "./CodeEditor";
 
 type QueryEditorProps = {
@@ -49,15 +50,16 @@ export function QueryEditor({
         value={query}
         highlightActiveLine={false}
         onChange={onChange}
+        onKeyDown={(event) => {
+          if (isRunShortcut(event)) {
+            event.preventDefault();
+            if (!disabled && !isRunning) onRun();
+          }
+        }}
       />
-      <button
-        type="button"
-        className="run-button"
-        onClick={onRun}
-        disabled={disabled || isRunning}
-      >
-        {isRunning ? "Running…" : "Run"}
-      </button>
+      <span className="keyboard-hint">
+        {isRunning ? "Running…" : "Auto-run enabled · ⌘/Ctrl + Enter to run now"}
+      </span>
     </section>
   );
 }

--- a/packages/mq-chrome-extension/entrypoints/popup/components/ResultPane.tsx
+++ b/packages/mq-chrome-extension/entrypoints/popup/components/ResultPane.tsx
@@ -3,22 +3,35 @@ import { CodeEditor } from "./CodeEditor";
 type ResultPaneProps = {
   result: string;
   copied: boolean;
+  lastRun: { durationMs: number } | null;
   onCopy: () => void;
+  onDownload: () => void;
 };
 
-export function ResultPane({ result, copied, onCopy }: ResultPaneProps) {
+export function ResultPane({
+  result,
+  copied,
+  lastRun,
+  onCopy,
+  onDownload,
+}: ResultPaneProps) {
   return (
     <section className="pane pane-result">
       <div className="pane-header">
         <h2>Result</h2>
-        <button
-          type="button"
-          className={copied ? "copied" : ""}
-          onClick={onCopy}
-          disabled={!result}
-        >
-          {copied ? "Copied!" : "Copy"}
-        </button>
+        <div className="pane-actions">
+          <button
+            type="button"
+            className={copied ? "copied" : ""}
+            onClick={onCopy}
+            disabled={!result}
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+          <button type="button" onClick={onDownload} disabled={!result}>
+            Download
+          </button>
+        </div>
       </div>
       <CodeEditor
         className="pane-textarea"
@@ -27,6 +40,11 @@ export function ResultPane({ result, copied, onCopy }: ResultPaneProps) {
         value={result}
         placeholder="Run a query to see the filtered Markdown here."
       />
+      {lastRun && (
+        <div className="result-meta">
+          {result.length.toLocaleString()} characters · {lastRun.durationMs} ms
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/mq-chrome-extension/entrypoints/popup/components/SourcePane.tsx
+++ b/packages/mq-chrome-extension/entrypoints/popup/components/SourcePane.tsx
@@ -2,34 +2,22 @@ import { CodeEditor } from "./CodeEditor";
 
 type SourcePaneProps = {
   markdown: string;
-  isExtracting: boolean;
   onMarkdownChange: (value: string) => void;
-  onExtract: () => void;
 };
 
 export function SourcePane({
   markdown,
-  isExtracting,
   onMarkdownChange,
-  onExtract,
 }: SourcePaneProps) {
   return (
     <section className="pane pane-source">
       <div className="pane-header">
         <h2>Source</h2>
-        <button
-          type="button"
-          className="primary"
-          onClick={onExtract}
-          disabled={isExtracting}
-        >
-          {isExtracting ? "Extracting…" : "Extract page"}
-        </button>
       </div>
       <CodeEditor
         className="pane-textarea"
         language="markdown"
-        placeholder="Click “Extract page” to convert the current page to Markdown, or paste your own."
+        placeholder="The current page is converted to Markdown automatically. You can also paste your own content."
         value={markdown}
         onChange={onMarkdownChange}
       />

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/diagnostics.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/diagnostics.ts
@@ -1,0 +1,11 @@
+import type { Diagnostic } from "./mq";
+
+/** Formats mq diagnostics into a concise message suitable for the popup UI. */
+export function formatDiagnostics(diagnostics: ReadonlyArray<Diagnostic>): string {
+  return diagnostics
+    .map(
+      ({ startLine, startColumn, message }) =>
+        `Line ${startLine}, column ${startColumn}: ${message}`,
+    )
+    .join("\n");
+}

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/download.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/download.ts
@@ -1,0 +1,10 @@
+/** Downloads text from the popup without requiring an additional permission. */
+export function downloadText(filename: string, text: string): void {
+  const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/mq.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/mq.ts
@@ -1,2 +1,2 @@
-export { run, htmlToMarkdown } from "mq-web";
-export type { Options } from "mq-web";
+export { diagnostics, htmlToMarkdown, run } from "mq-web";
+export type { Diagnostic, Options } from "mq-web";

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/queryStorage.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/queryStorage.ts
@@ -1,9 +1,12 @@
 import { storage } from "wxt/utils/storage";
 
+/** Query used when the user has not saved a query yet. */
+export const DEFAULT_QUERY = ".";
+
 /**
  * Persists the last entered query so it survives the popup being closed
  * and reopened (the popup's React tree is torn down on close).
  */
 export const queryStorage = storage.defineItem<string>("local:query", {
-  fallback: "",
+  fallback: DEFAULT_QUERY,
 });

--- a/packages/mq-chrome-extension/entrypoints/popup/lib/shortcuts.ts
+++ b/packages/mq-chrome-extension/entrypoints/popup/lib/shortcuts.ts
@@ -1,0 +1,4 @@
+/** Returns whether a keyboard event should run the current mq query. */
+export function isRunShortcut(event: Pick<KeyboardEvent, "ctrlKey" | "key" | "metaKey">): boolean {
+  return (event.metaKey || event.ctrlKey) && event.key === "Enter";
+}

--- a/packages/mq-chrome-extension/entrypoints/popup/style.css
+++ b/packages/mq-chrome-extension/entrypoints/popup/style.css
@@ -126,6 +126,13 @@ body {
   padding-left: 7px;
 }
 
+.pane-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
 .pane-textarea {
   display: flex;
   width: 100%;
@@ -139,6 +146,15 @@ body {
 
 .query-textarea {
   min-height: 0;
+}
+
+.keyboard-hint,
+.result-meta {
+  padding: 5px 10px;
+  color: var(--muted);
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  font-size: 11px;
 }
 
 .pane-footer {
@@ -176,15 +192,13 @@ button:disabled {
   cursor: not-allowed;
 }
 
-button.primary,
-button.run-button {
+button.primary {
   background: var(--accent);
   color: var(--accent-fg);
   border-color: var(--accent);
 }
 
-button.primary:hover:not(:disabled),
-button.run-button:hover:not(:disabled) {
+button.primary:hover:not(:disabled) {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
   color: var(--accent-fg);

--- a/packages/mq-chrome-extension/package.json
+++ b/packages/mq-chrome-extension/package.json
@@ -32,7 +32,7 @@
     "@lezer/highlight": "^1.2.3",
     "@uiw/react-codemirror": "^4.25.11",
     "codemirror": "^6.0.2",
-    "mq-web": "0.8.3",
+    "mq-web": "0.8.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/packages/mq-chrome-extension/pnpm-lock.yaml
+++ b/packages/mq-chrome-extension/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       mq-web:
-        specifier: 0.8.3
-        version: 0.8.3
+        specifier: 0.8.4
+        version: 0.8.4
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1262,8 +1262,8 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mq-web@0.8.3:
-    resolution: {integrity: sha512-jyxh1xw/iLUl4O0MArjHHOMwTRpK1Q09R74bzEpihE7c+zy3B79tdoqYznU1zBb974L3/Gl4c85ybvlSR47yug==}
+  mq-web@0.8.4:
+    resolution: {integrity: sha512-FIISCftrBMEXVs0r56najswbv+QhAWDkU0xqDKbN/srHyGdoImjOcBGj/LVjpJUN0D2BNVxXg1PrIIbjJy6fVg==}
 
   nano-spawn@2.1.0:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
@@ -2693,7 +2693,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
-  mq-web@0.8.3: {}
+  mq-web@0.8.4: {}
 
   nano-spawn@2.1.0: {}
 

--- a/packages/mq-chrome-extension/tests/activeTab.test.ts
+++ b/packages/mq-chrome-extension/tests/activeTab.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeScript: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    scripting: { executeScript: mocks.executeScript },
+    tabs: { query: mocks.query },
+  },
+}));
+
+import {
+  extractActivePageHtml,
+  PERMISSION_MESSAGE,
+} from "../entrypoints/popup/lib/activeTab";
+
+describe("extractActivePageHtml", () => {
+  beforeEach(() => {
+    mocks.query.mockReset();
+    mocks.executeScript.mockReset();
+  });
+
+  it("returns an error when no active tab exists", async () => {
+    mocks.query.mockResolvedValue([]);
+
+    await expect(extractActivePageHtml()).resolves.toEqual({
+      ok: false,
+      message: "No active tab found.",
+    });
+  });
+
+  it("returns the HTML produced by the injected function", async () => {
+    mocks.query.mockResolvedValue([{ id: 42 }]);
+    mocks.executeScript.mockResolvedValue([{ result: "<main>Article</main>" }]);
+
+    await expect(extractActivePageHtml()).resolves.toEqual({
+      ok: true,
+      value: "<main>Article</main>",
+    });
+    expect(mocks.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 42 }, args: [] }),
+    );
+  });
+
+  it("explains restricted-page failures", async () => {
+    mocks.query.mockResolvedValue([{ id: 42 }]);
+    mocks.executeScript.mockRejectedValue(
+      new Error("Cannot access a chrome:// URL"),
+    );
+
+    await expect(extractActivePageHtml()).resolves.toEqual({
+      ok: false,
+      message: `${PERMISSION_MESSAGE} (Cannot access a chrome:// URL)`,
+    });
+  });
+});

--- a/packages/mq-chrome-extension/tests/popup-utils.test.ts
+++ b/packages/mq-chrome-extension/tests/popup-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatDiagnostics } from "../entrypoints/popup/lib/diagnostics";
+import { downloadText } from "../entrypoints/popup/lib/download";
+import { isRunShortcut } from "../entrypoints/popup/lib/shortcuts";
+
+describe("formatDiagnostics", () => {
+  it("includes the source position for every diagnostic", () => {
+    expect(
+      formatDiagnostics([
+        {
+          startLine: 2,
+          startColumn: 4,
+          endLine: 2,
+          endColumn: 5,
+          message: "expected expression",
+        },
+      ]),
+    ).toBe("Line 2, column 4: expected expression");
+  });
+});
+
+describe("isRunShortcut", () => {
+  it.each([
+    [{ key: "Enter", metaKey: true, ctrlKey: false }, true],
+    [{ key: "Enter", metaKey: false, ctrlKey: true }, true],
+    [{ key: "Enter", metaKey: false, ctrlKey: false }, false],
+    [{ key: "a", metaKey: true, ctrlKey: false }, false],
+  ])("recognizes %o as %s", (event, expected) => {
+    expect(isRunShortcut(event)).toBe(expected);
+  });
+});
+
+describe("downloadText", () => {
+  it("downloads the Markdown and releases the temporary object URL", () => {
+    const createObjectUrl = vi.fn(() => "blob:result");
+    const revokeObjectUrl = vi.fn();
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    Object.assign(URL, { createObjectURL: createObjectUrl, revokeObjectURL: revokeObjectUrl });
+
+    downloadText("result.md", "# Result");
+
+    expect(createObjectUrl).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:result");
+  });
+});


### PR DESCRIPTION
## Summary

Queries now run automatically after editing (with Cmd/Ctrl+Enter to run immediately), and results can be copied or downloaded as Markdown.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
