### PR TITLE
✨ feat(mq-run): add --compact flag for single-line JSON output

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -546,6 +546,10 @@ struct OutputArgs {
     /// when source line/column spans aren't needed.
     #[arg(long, default_value_t = false)]
     no_position: bool,
+
+    /// Print JSON on a single line, without pretty-printing. Only valid with -F json.
+    #[arg(long, default_value_t = false)]
+    compact: bool,
 }
 
 impl OutputArgs {
@@ -1326,6 +1330,10 @@ impl Cli {
 
         if self.output.diff && matches!(self.output.output_format, OutputFormat::Grep) {
             return Err(miette!("--diff is not supported with -F grep"));
+        }
+
+        if self.output.compact && !matches!(self.output.output_format, OutputFormat::Json) {
+            return Err(miette!("--compact is only valid with -F json"));
         }
 
         if (self.input.csv_delimiter.is_some() || self.input.no_header)
@@ -2356,7 +2364,8 @@ impl Cli {
             }
             OutputFormat::Json => {
                 let theme = colorize.then(mq_markdown::ColorTheme::from_env);
-                let json_str = crate::output::json::runtime_values_to_json(runtime_values, theme.as_ref())?;
+                let json_str =
+                    crate::output::json::runtime_values_to_json(runtime_values, theme.as_ref(), self.output.compact)?;
                 buf.extend_from_slice(json_str.as_bytes());
             }
             OutputFormat::Html => {

--- a/crates/mq-run/src/output/json.rs
+++ b/crates/mq-run/src/output/json.rs
@@ -88,18 +88,52 @@ pub(crate) fn runtime_values_to_json_value(runtime_values: &[mq_lang::RuntimeVal
     }
 }
 
+fn colorize_json_value_compact(value: &serde_json::Value, theme: &ColorTheme<'_>) -> String {
+    let reset = &theme.code.1;
+
+    match value {
+        serde_json::Value::Null => format!("{}null{}", theme.blockquote_marker.0, reset),
+        serde_json::Value::Bool(b) => format!("{}{}{}", theme.heading.0, b, reset),
+        serde_json::Value::Number(n) => format!("{}{}{}", theme.emphasis.0, n, reset),
+        serde_json::Value::String(s) => format!("{}{}{}", theme.code.0, json_quote(s), reset),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(|v| colorize_json_value_compact(v, theme)).collect();
+            format!("[{}]", items.join(","))
+        }
+        serde_json::Value::Object(map) => {
+            let items: Vec<String> = map
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}{}{}:{}",
+                        theme.link_url.0,
+                        json_quote(k),
+                        reset,
+                        colorize_json_value_compact(v, theme)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
 /// Converts a list of [`mq_lang::RuntimeValue`]s into a JSON string.
-/// Pass `Some(theme)` to enable ANSI color output.
+/// `theme` enables ANSI color; `compact` renders a single line.
 pub(crate) fn runtime_values_to_json(
     runtime_values: &[mq_lang::RuntimeValue],
     theme: Option<&ColorTheme<'_>>,
+    compact: bool,
 ) -> miette::Result<String> {
     let result = runtime_values_to_json_value(runtime_values);
 
-    if let Some(theme) = theme {
-        Ok(colorize_json_value(&result, 0, theme))
-    } else {
-        serde_json::to_string_pretty(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
+    match (theme, compact) {
+        (Some(theme), true) => Ok(colorize_json_value_compact(&result, theme)),
+        (Some(theme), false) => Ok(colorize_json_value(&result, 0, theme)),
+        (None, true) => serde_json::to_string(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e)),
+        (None, false) => {
+            serde_json::to_string_pretty(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
+        }
     }
 }
 
@@ -119,7 +153,7 @@ mod tests {
     #[case(vec![RuntimeValue::Boolean(false)], "false")]
     #[case(vec![RuntimeValue::None], "null")]
     fn test_single_non_markdown_no_theme(#[case] values: Vec<RuntimeValue>, #[case] expected: &str) {
-        let result = runtime_values_to_json(&values, None).unwrap();
+        let result = runtime_values_to_json(&values, None, false).unwrap();
         assert_eq!(result, expected);
     }
 
@@ -129,7 +163,7 @@ mod tests {
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
         ];
-        let result = runtime_values_to_json(&values, None).unwrap();
+        let result = runtime_values_to_json(&values, None, false).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 2);
@@ -139,7 +173,7 @@ mod tests {
     fn test_empty_markdown_filtered_out() {
         let empty_node = mq_markdown::Node::Empty;
         let values = vec![RuntimeValue::Markdown(Box::new(empty_node), None)];
-        let result = runtime_values_to_json(&values, None).unwrap();
+        let result = runtime_values_to_json(&values, None, false).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.is_array());
         assert!(parsed.as_array().unwrap().is_empty());
@@ -149,7 +183,7 @@ mod tests {
     fn test_with_plain_theme_null() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::None];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains("null"));
     }
 
@@ -157,7 +191,7 @@ mod tests {
     fn test_with_plain_theme_bool() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Boolean(true)];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains("true"));
     }
 
@@ -166,7 +200,7 @@ mod tests {
         let theme = plain_theme();
         // Build a Number RuntimeValue via From<usize>
         let values = vec![RuntimeValue::from(42usize)];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains("42"));
     }
 
@@ -174,7 +208,7 @@ mod tests {
     fn test_with_plain_theme_string() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::String("hi".to_string())];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains("hi"));
     }
 
@@ -182,7 +216,7 @@ mod tests {
     fn test_colorize_array_empty() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Array(Shared::new(vec![]))];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert_eq!(result, "[]");
     }
 
@@ -193,7 +227,7 @@ mod tests {
             RuntimeValue::String("x".to_string()),
             RuntimeValue::String("y".to_string()),
         ]))];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains('[') && result.contains(']'));
         assert!(result.contains("\"x\"") && result.contains("\"y\""));
     }
@@ -202,7 +236,7 @@ mod tests {
     fn test_colorize_object_empty() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::new()))];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert_eq!(result, "{}");
     }
 
@@ -212,7 +246,28 @@ mod tests {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("key"), RuntimeValue::String("val".to_string()));
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_json(&values, Some(&theme)).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
         assert!(result.contains("key") && result.contains("val"));
+    }
+
+    #[test]
+    fn test_compact_no_theme() {
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(mq_lang::Ident::new("a"), RuntimeValue::from(1usize));
+        map.insert(mq_lang::Ident::new("b"), RuntimeValue::from(2usize));
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
+        let result = runtime_values_to_json(&values, None, true).unwrap();
+        assert_eq!(result, r#"{"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn test_compact_with_theme() {
+        let theme = plain_theme();
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(mq_lang::Ident::new("a"), RuntimeValue::from(1usize));
+        map.insert(mq_lang::Ident::new("b"), RuntimeValue::from(2usize));
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
+        let result = runtime_values_to_json(&values, Some(&theme), true).unwrap();
+        assert_eq!(result, r#"{"a":1,"b":2}"#);
     }
 }

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -151,6 +151,19 @@ fn update_does_not_accept_misleading_in_place_aliases(#[case] alias: &str) {
     cmd.arg(alias).arg("self").write_stdin("# Title\n").assert().failure();
 }
 
+#[test]
+fn test_compact_rejected_without_json_format() {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+
+    cmd.arg("--compact")
+        .arg("-F")
+        .arg("yaml")
+        .arg("self")
+        .write_stdin("# Title\n")
+        .assert()
+        .failure();
+}
+
 #[rstest]
 #[case::json(
     vec!["--unbuffered", "-F", "json", ".code_inline"],
@@ -382,6 +395,11 @@ In {year}, the snowfall was above average.
     vec!["--unbuffered", "-I", "xml", "self"],
     "<root>text</root>",
     Some("{\"text\": \"text\", \"attributes\": {}, \"tag\": \"root\", \"children\": []}\n")
+)]
+#[case::output_format_json_compact(
+    vec!["--unbuffered", "-I", "json", "-F", "json", "--compact", "self"],
+    r#"{"name": "Alice", "age": 30}"#,
+    Some("{\"name\":\"Alice\",\"age\":30}")
 )]
 #[case::output_format_yaml(
     vec!["--unbuffered", "-I", "json", "-F", "yaml", "self"],


### PR DESCRIPTION
## Summary

Mirrors jq's -c/--compact-output. Only valid with -F json; errors otherwise.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [ ] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass
- [ ] I added or updated tests covering this change
- [ ] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [ ] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
