### PR TITLE
✅ test(mq-run): fix wrap-dependent assertion in blocked-read repl test

### DIFF
--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -892,8 +892,13 @@ fn test_repl_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::E
         .assert();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    let normalized = stderr
+        .replace('│', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
     assert!(
-        stderr.contains("filesystem reads are disabled"),
+        normalized.contains("filesystem reads are disabled"),
         "expected repl output to report reads are disabled, got: {stderr}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

miette's graphical handler hard-wraps rendered error output at ~78 columns and prefixes continuation lines with "│ ". The assertion in test_repl_without_allow_read_is_blocked checked for the literal phrase "filesystem reads are disabled" in stderr, so whether it passed depended on the temp file path length pushing the wrap point across the phrase.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [x] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
