### PR TITLE
✨ feat(mq-web-api): add request body size limit and HTTP request timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5075,6 +5075,7 @@ dependencies = [
  "futures-core",
  "http 1.5.0",
  "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "tokio",

--- a/crates/mq-web-api/Cargo.toml
+++ b/crates/mq-web-api/Cargo.toml
@@ -38,7 +38,7 @@ sha2 = {workspace = true}
 thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tower = {workspace = true}
-tower-http = {workspace = true, features = ["cors", "trace", "compression-gzip"]}
+tower-http = {workspace = true, features = ["cors", "trace", "compression-gzip", "limit", "timeout"]}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter", "json"]}
 utoipa = {workspace = true, features = ["preserve_order"]}

--- a/crates/mq-web-api/README.md
+++ b/crates/mq-web-api/README.md
@@ -189,6 +189,8 @@ All settings are controlled through environment variables.
 | `LOG_FORMAT` | `json` | Log format: `json` or `text` |
 | `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
 | `QUERY_TIMEOUT_SECONDS` | `10` | Max seconds a single query may run before it's aborted |
+| `MAX_REQUEST_BODY_SIZE` | `10485760` | Max accepted HTTP request body size, in bytes. Larger requests get `413 Payload Too Large` |
+| `REQUEST_TIMEOUT_SECONDS` | `30` | Max seconds a single HTTP request may take end-to-end (routing, auth, rate limiting, handler). Exceeding it returns `408 Request Timeout` |
 
 ### Query Cache
 

--- a/crates/mq-web-api/src/config.rs
+++ b/crates/mq-web-api/src/config.rs
@@ -19,6 +19,15 @@ pub struct Config {
     /// Short-lived cache for repeated `{query, input, input_format, args}` combinations.
     pub query_cache: QueryCacheConfig,
     pub auth: AuthConfig,
+    /// Maximum accepted size of an HTTP request body, in bytes. Requests whose
+    /// `Content-Length` (or actual streamed size) exceeds this are rejected with
+    /// `413 Payload Too Large` before a handler runs.
+    pub max_request_body_size: usize,
+    /// Maximum duration allowed to process a single HTTP request end-to-end
+    /// (routing, auth, rate limiting, handler, response). Distinct from
+    /// `query_timeout`, which only bounds query evaluation itself; a request
+    /// that exceeds this is aborted with `408 Request Timeout`.
+    pub request_timeout: Duration,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -48,6 +57,8 @@ impl Default for Config {
             query_timeout: Duration::from_secs(10),
             query_cache: QueryCacheConfig::default(),
             auth: AuthConfig::default(),
+            max_request_body_size: 10 * 1024 * 1024,
+            request_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -210,6 +221,28 @@ impl Config {
             config.auth.keys_file = Some(keys_file);
         }
 
+        if let Ok(size_str) = env::var("MAX_REQUEST_BODY_SIZE") {
+            if let Ok(size) = size_str.parse::<usize>() {
+                config.max_request_body_size = size;
+            } else {
+                eprintln!(
+                    "Warning: Invalid MAX_REQUEST_BODY_SIZE value '{}', using default {}",
+                    size_str, config.max_request_body_size
+                );
+            }
+        }
+
+        if let Ok(timeout_str) = env::var("REQUEST_TIMEOUT_SECONDS") {
+            if let Ok(timeout) = timeout_str.parse::<u64>() {
+                config.request_timeout = Duration::from_secs(timeout);
+            } else {
+                eprintln!(
+                    "Warning: Invalid REQUEST_TIMEOUT_SECONDS value '{}', using default {:?}",
+                    timeout_str, config.request_timeout
+                );
+            }
+        }
+
         config
     }
 
@@ -264,5 +297,12 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config_443.server_url(), "https://example.com");
+    }
+
+    #[test]
+    fn test_default_request_limits() {
+        let config = Config::default();
+        assert_eq!(config.max_request_body_size, 10 * 1024 * 1024);
+        assert_eq!(config.request_timeout, Duration::from_secs(30));
     }
 }

--- a/crates/mq-web-api/src/routes.rs
+++ b/crates/mq-web-api/src/routes.rs
@@ -1,6 +1,6 @@
 use axum::{
     Router,
-    http::Method,
+    http::{Method, StatusCode},
     middleware,
     response::Redirect,
     routing::{get, post},
@@ -10,6 +10,8 @@ use tower::ServiceBuilder;
 use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},
+    limit::RequestBodyLimitLayer,
+    timeout::TimeoutLayer,
     trace::TraceLayer,
 };
 use utoipa::OpenApi;
@@ -93,9 +95,14 @@ pub fn create_router(
         .route("/{query}", post(post_shorthand_query_api))
         .layer(
             ServiceBuilder::new()
+                .layer(RequestBodyLimitLayer::new(config.max_request_body_size))
                 .layer(CompressionLayer::new())
                 .layer(TraceLayer::new_for_http())
-                .layer(cors),
+                .layer(cors)
+                .layer(TimeoutLayer::with_status_code(
+                    StatusCode::REQUEST_TIMEOUT,
+                    config.request_timeout,
+                )),
         );
 
     let router = if let Some(store) = api_key_store {
@@ -113,4 +120,50 @@ pub fn create_router(
     router
         .layer(middleware::from_fn_with_state(rate_limiter, rate_limit_middleware))
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rate_limiter::RateLimiter;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_oversized_request_body_is_rejected() {
+        let config = Config {
+            max_request_body_size: 16,
+            ..Config::default()
+        };
+        let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit.clone()));
+        let router = create_router(&config, rate_limiter, None);
+
+        let body = "x".repeat(64);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/format")
+            .header("content-length", body.len())
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_request_within_body_limit_is_not_rejected() {
+        let config = Config::default();
+        let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit.clone()));
+        let router = create_router(&config, rate_limiter, None);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/crates/mq-web-api/src/server.rs
+++ b/crates/mq-web-api/src/server.rs
@@ -150,6 +150,8 @@ pub async fn start_server(config: Config) -> Result<(), Box<dyn std::error::Erro
     info!("  RATE_LIMIT_WINDOW_SIZE_SECONDS: Window size in seconds (default: 3600)");
     info!("  RATE_LIMIT_CLEANUP_INTERVAL_SECONDS: Cleanup interval in seconds (default: 3600)");
     info!("  QUERY_TIMEOUT_SECONDS: Max seconds a single query may run before it's aborted (default: 10)");
+    info!("  MAX_REQUEST_BODY_SIZE: Max accepted HTTP request body size in bytes (default: 10485760)");
+    info!("  REQUEST_TIMEOUT_SECONDS: Max seconds a single HTTP request may take end-to-end (default: 30)");
     info!("  QUERY_CACHE_ENABLED: Cache repeated query/input combinations (default: true)");
     info!("  QUERY_CACHE_TTL_SECONDS: How long a cached result stays fresh (default: 30)");
     info!("  QUERY_CACHE_MAX_ENTRIES: Max number of cached query results (default: 1000)");

--- a/docs/books/src/start/web_api.md
+++ b/docs/books/src/start/web_api.md
@@ -39,6 +39,8 @@ All settings are controlled through environment variables.
 | `LOG_FORMAT` | `json` | Log format: `json` or `text` |
 | `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
 | `QUERY_TIMEOUT_SECONDS` | `10` | Max seconds a single query may run before it's aborted |
+| `MAX_REQUEST_BODY_SIZE` | `10485760` | Max accepted HTTP request body size, in bytes. Larger requests get `413 Payload Too Large` |
+| `REQUEST_TIMEOUT_SECONDS` | `30` | Max seconds a single HTTP request may take end-to-end (routing, auth, rate limiting, handler). Exceeding it returns `408 Request Timeout` |
 
 ### Rate Limiting
 


### PR DESCRIPTION
## Summary

Requests were unbounded in size and had no server-side timeout beyond the per-query evaluation limit, leaving the API exposed to memory exhaustion from large payloads and connection-pool exhaustion from stalled requests.

Add MAX_REQUEST_BODY_SIZE (default 10MiB) enforced via tower_http::limit::RequestBodyLimitLayer, returning 413 Payload Too Large when exceeded, and REQUEST_TIMEOUT_SECONDS (default 30s) enforced via tower_http::timeout::TimeoutLayer, returning 408 Request Timeout for the whole request lifecycle (routing, auth, rate limiting, handler).

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
