### PR TITLE
✨ feat(mq-run): add --indent/--tab options for JSON and XML output

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -631,6 +631,21 @@ struct OutputArgs {
     /// Print JSON on a single line, without pretty-printing. Only valid with -F json.
     #[arg(long, default_value_t = false)]
     compact: bool,
+
+    /// Number of spaces per indent level in pretty-printed output (0-7), jq's
+    /// `--indent`. Only valid with -F json or -F xml; default is 2.
+    #[arg(
+        long,
+        value_name = "N",
+        value_parser = clap::value_parser!(u8).range(0..=7),
+        conflicts_with_all = ["tab", "compact"]
+    )]
+    indent: Option<u8>,
+
+    /// Indent pretty-printed output with tabs instead of spaces, jq's `--tab`.
+    /// Only valid with -F json or -F xml.
+    #[arg(long, default_value_t = false, conflicts_with_all = ["indent", "compact"])]
+    tab: bool,
 }
 
 impl OutputArgs {
@@ -653,6 +668,24 @@ impl OutputArgs {
             values.into_iter().take(limit).collect()
         } else {
             values
+        }
+    }
+
+    /// The per-level indent string for pretty-printed JSON output, honoring `--tab`/`--indent`.
+    fn json_indent_unit(&self) -> String {
+        if self.tab {
+            "\t".to_string()
+        } else {
+            " ".repeat(self.indent.unwrap_or(2) as usize)
+        }
+    }
+
+    /// The `(indent_char, indent_size)` pair for pretty-printed XML output, honoring `--tab`/`--indent`.
+    fn xml_indent(&self) -> (u8, usize) {
+        if self.tab {
+            (b'\t', 1)
+        } else {
+            (b' ', self.indent.unwrap_or(2) as usize)
         }
     }
 }
@@ -1425,6 +1458,12 @@ impl Cli {
 
         if self.output.compact && !matches!(self.resolved_output_format(), OutputFormat::Json) {
             return Err(miette!("--compact is only valid with -F json"));
+        }
+
+        if (self.output.indent.is_some() || self.output.tab)
+            && !matches!(self.resolved_output_format(), OutputFormat::Json | OutputFormat::Xml)
+        {
+            return Err(miette!("--indent/--tab are only valid with -F json or -F xml"));
         }
 
         if (self.input.csv_delimiter.is_some() || self.input.no_header)
@@ -2505,8 +2544,12 @@ impl Cli {
             }
             OutputFormat::Json => {
                 let theme = colorize.then(mq_markdown::ColorTheme::from_env);
-                let json_str =
-                    crate::output::json::runtime_values_to_json(runtime_values, theme.as_ref(), self.output.compact)?;
+                let json_str = crate::output::json::runtime_values_to_json(
+                    runtime_values,
+                    theme.as_ref(),
+                    self.output.compact,
+                    &self.output.json_indent_unit(),
+                )?;
                 buf.extend_from_slice(json_str.as_bytes());
             }
             OutputFormat::Html => {
@@ -2552,7 +2595,8 @@ impl Cli {
                 buf.extend_from_slice(toon_str.as_bytes());
             }
             OutputFormat::Xml => {
-                let xml_str = crate::output::xml::runtime_values_to_xml(runtime_values)?;
+                let (indent_char, indent_size) = self.output.xml_indent();
+                let xml_str = crate::output::xml::runtime_values_to_xml(runtime_values, indent_char, indent_size)?;
                 buf.extend_from_slice(xml_str.as_bytes());
             }
             OutputFormat::Yaml => {

--- a/crates/mq-run/src/output/json.rs
+++ b/crates/mq-run/src/output/json.rs
@@ -12,7 +12,7 @@ fn json_quote(s: &str) -> String {
     serde_json::to_string(s).unwrap()
 }
 
-fn colorize_json_value(value: &serde_json::Value, indent: usize, theme: &ColorTheme<'_>) -> String {
+fn colorize_json_value(value: &serde_json::Value, indent: usize, indent_unit: &str, theme: &ColorTheme<'_>) -> String {
     let reset = &theme.code.1;
 
     match value {
@@ -24,11 +24,17 @@ fn colorize_json_value(value: &serde_json::Value, indent: usize, theme: &ColorTh
             if arr.is_empty() {
                 return "[]".to_string();
             }
-            let indent_str = "  ".repeat(indent);
-            let inner_indent = "  ".repeat(indent + 1);
+            let indent_str = indent_unit.repeat(indent);
+            let inner_indent = indent_unit.repeat(indent + 1);
             let items: Vec<String> = arr
                 .iter()
-                .map(|v| format!("{}{}", inner_indent, colorize_json_value(v, indent + 1, theme)))
+                .map(|v| {
+                    format!(
+                        "{}{}",
+                        inner_indent,
+                        colorize_json_value(v, indent + 1, indent_unit, theme)
+                    )
+                })
                 .collect();
             format!("[\n{}\n{}]", items.join(",\n"), indent_str)
         }
@@ -36,8 +42,8 @@ fn colorize_json_value(value: &serde_json::Value, indent: usize, theme: &ColorTh
             if map.is_empty() {
                 return "{}".to_string();
             }
-            let indent_str = "  ".repeat(indent);
-            let inner_indent = "  ".repeat(indent + 1);
+            let indent_str = indent_unit.repeat(indent);
+            let inner_indent = indent_unit.repeat(indent + 1);
             let items: Vec<String> = map
                 .iter()
                 .map(|(k, v)| {
@@ -47,7 +53,7 @@ fn colorize_json_value(value: &serde_json::Value, indent: usize, theme: &ColorTh
                         theme.link_url.0,
                         json_quote(k),
                         reset,
-                        colorize_json_value(v, indent + 1, theme)
+                        colorize_json_value(v, indent + 1, indent_unit, theme)
                     )
                 })
                 .collect();
@@ -119,21 +125,21 @@ fn colorize_json_value_compact(value: &serde_json::Value, theme: &ColorTheme<'_>
 }
 
 /// Converts a list of [`mq_lang::RuntimeValue`]s into a JSON string.
-/// `theme` enables ANSI color; `compact` renders a single line.
+/// `theme` enables ANSI color; `compact` renders a single line; `indent_unit`
+/// (e.g. `"  "` or `"\t"`) sets the per-level indent for pretty output.
 pub(crate) fn runtime_values_to_json(
     runtime_values: &[mq_lang::RuntimeValue],
     theme: Option<&ColorTheme<'_>>,
     compact: bool,
+    indent_unit: &str,
 ) -> miette::Result<String> {
     let result = runtime_values_to_json_value(runtime_values);
 
     match (theme, compact) {
         (Some(theme), true) => Ok(colorize_json_value_compact(&result, theme)),
-        (Some(theme), false) => Ok(colorize_json_value(&result, 0, theme)),
+        (Some(theme), false) => Ok(colorize_json_value(&result, 0, indent_unit, theme)),
         (None, true) => serde_json::to_string(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e)),
-        (None, false) => {
-            serde_json::to_string_pretty(&result).map_err(|e| miette!("Failed to serialize to JSON: {}", e))
-        }
+        (None, false) => Ok(colorize_json_value(&result, 0, indent_unit, &ColorTheme::PLAIN)),
     }
 }
 
@@ -153,7 +159,7 @@ mod tests {
     #[case(vec![RuntimeValue::Boolean(false)], "false")]
     #[case(vec![RuntimeValue::None], "null")]
     fn test_single_non_markdown_no_theme(#[case] values: Vec<RuntimeValue>, #[case] expected: &str) {
-        let result = runtime_values_to_json(&values, None, false).unwrap();
+        let result = runtime_values_to_json(&values, None, false, "  ").unwrap();
         assert_eq!(result, expected);
     }
 
@@ -163,7 +169,7 @@ mod tests {
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
         ];
-        let result = runtime_values_to_json(&values, None, false).unwrap();
+        let result = runtime_values_to_json(&values, None, false, "  ").unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 2);
@@ -173,7 +179,7 @@ mod tests {
     fn test_empty_markdown_filtered_out() {
         let empty_node = mq_markdown::Node::Empty;
         let values = vec![RuntimeValue::Markdown(Box::new(empty_node), None)];
-        let result = runtime_values_to_json(&values, None, false).unwrap();
+        let result = runtime_values_to_json(&values, None, false, "  ").unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.is_array());
         assert!(parsed.as_array().unwrap().is_empty());
@@ -183,7 +189,7 @@ mod tests {
     fn test_with_plain_theme_null() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::None];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains("null"));
     }
 
@@ -191,7 +197,7 @@ mod tests {
     fn test_with_plain_theme_bool() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Boolean(true)];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains("true"));
     }
 
@@ -200,7 +206,7 @@ mod tests {
         let theme = plain_theme();
         // Build a Number RuntimeValue via From<usize>
         let values = vec![RuntimeValue::from(42usize)];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains("42"));
     }
 
@@ -208,7 +214,7 @@ mod tests {
     fn test_with_plain_theme_string() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::String("hi".to_string())];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains("hi"));
     }
 
@@ -216,7 +222,7 @@ mod tests {
     fn test_colorize_array_empty() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Array(Shared::new(vec![]))];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert_eq!(result, "[]");
     }
 
@@ -227,7 +233,7 @@ mod tests {
             RuntimeValue::String("x".to_string()),
             RuntimeValue::String("y".to_string()),
         ]))];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains('[') && result.contains(']'));
         assert!(result.contains("\"x\"") && result.contains("\"y\""));
     }
@@ -236,7 +242,7 @@ mod tests {
     fn test_colorize_object_empty() {
         let theme = plain_theme();
         let values = vec![RuntimeValue::Dict(Shared::new(std::collections::BTreeMap::new()))];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert_eq!(result, "{}");
     }
 
@@ -246,7 +252,7 @@ mod tests {
         let mut map = std::collections::BTreeMap::new();
         map.insert(mq_lang::Ident::new("key"), RuntimeValue::String("val".to_string()));
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_json(&values, Some(&theme), false).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), false, "  ").unwrap();
         assert!(result.contains("key") && result.contains("val"));
     }
 
@@ -256,7 +262,7 @@ mod tests {
         map.insert(mq_lang::Ident::new("a"), RuntimeValue::from(1usize));
         map.insert(mq_lang::Ident::new("b"), RuntimeValue::from(2usize));
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_json(&values, None, true).unwrap();
+        let result = runtime_values_to_json(&values, None, true, "  ").unwrap();
         assert_eq!(result, r#"{"a":1,"b":2}"#);
     }
 
@@ -267,7 +273,22 @@ mod tests {
         map.insert(mq_lang::Ident::new("a"), RuntimeValue::from(1usize));
         map.insert(mq_lang::Ident::new("b"), RuntimeValue::from(2usize));
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_json(&values, Some(&theme), true).unwrap();
+        let result = runtime_values_to_json(&values, Some(&theme), true, "  ").unwrap();
         assert_eq!(result, r#"{"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn test_custom_indent_width_no_theme() {
+        let values = vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::from(1usize)]))];
+        let result = runtime_values_to_json(&values, None, false, "    ").unwrap();
+        assert_eq!(result, "[\n    1\n]");
+    }
+
+    #[test]
+    fn test_tab_indent_with_theme() {
+        let theme = plain_theme();
+        let values = vec![RuntimeValue::Array(Shared::new(vec![RuntimeValue::from(1usize)]))];
+        let result = runtime_values_to_json(&values, Some(&theme), false, "\t").unwrap();
+        assert_eq!(result, "[\n\t1\n]");
     }
 }

--- a/crates/mq-run/src/output/xml.rs
+++ b/crates/mq-run/src/output/xml.rs
@@ -109,12 +109,16 @@ fn write_json_as_xml(writer: &mut Writer<&mut Vec<u8>>, tag: &str, value: &serde
     Ok(())
 }
 
-/// Converts a list of [`RuntimeValue`]s into an XML string.
-pub(crate) fn runtime_values_to_xml(runtime_values: &[RuntimeValue]) -> miette::Result<String> {
+/// Converts a list of [`RuntimeValue`]s into an XML string, indented with `indent_size` repetitions of `indent_char` per nesting level.
+pub(crate) fn runtime_values_to_xml(
+    runtime_values: &[RuntimeValue],
+    indent_char: u8,
+    indent_size: usize,
+) -> miette::Result<String> {
     let non_none: Vec<&RuntimeValue> = runtime_values.iter().filter(|v| !v.is_none()).collect();
 
     let mut buf = Vec::new();
-    let mut writer = Writer::new_with_indent(&mut buf, b' ', 2);
+    let mut writer = Writer::new_with_indent(&mut buf, indent_char, indent_size);
     writer
         .write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))
         .map_err(xml_err)?;
@@ -148,7 +152,7 @@ mod tests {
         map.insert(Ident::new("text"), RuntimeValue::String("hello".to_string()));
 
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_xml(&values).unwrap();
+        let result = runtime_values_to_xml(&values, b' ', 2).unwrap();
         assert!(result.contains("<root id=\"1\">hello</root>"));
     }
 
@@ -157,7 +161,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
         let values = vec![RuntimeValue::Dict(Shared::new(map))];
-        let result = runtime_values_to_xml(&values).unwrap();
+        let result = runtime_values_to_xml(&values, b' ', 2).unwrap();
         assert!(result.contains("<root>"));
         assert!(result.contains("<name>Alice</name>"));
     }
@@ -168,7 +172,7 @@ mod tests {
             RuntimeValue::String("a".to_string()),
             RuntimeValue::String("b".to_string()),
         ]))];
-        let result = runtime_values_to_xml(&values).unwrap();
+        let result = runtime_values_to_xml(&values, b' ', 2).unwrap();
         assert!(result.contains("<item>a</item>"));
         assert!(result.contains("<item>b</item>"));
     }
@@ -176,14 +180,32 @@ mod tests {
     #[test]
     fn test_text_escaping() {
         let values = vec![RuntimeValue::String("<tag> & \"quote\"".to_string())];
-        let result = runtime_values_to_xml(&values).unwrap();
+        let result = runtime_values_to_xml(&values, b' ', 2).unwrap();
         assert!(result.contains("&lt;tag&gt; &amp;"));
     }
 
     #[test]
     fn test_empty_dict() {
         let values = vec![RuntimeValue::Dict(Shared::new(BTreeMap::new()))];
-        let result = runtime_values_to_xml(&values).unwrap();
+        let result = runtime_values_to_xml(&values, b' ', 2).unwrap();
         assert!(result.contains("<root/>"));
+    }
+
+    #[test]
+    fn test_custom_indent_width() {
+        let mut map = BTreeMap::new();
+        map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
+        let result = runtime_values_to_xml(&values, b' ', 4).unwrap();
+        assert!(result.contains("\n    <name>Alice</name>"));
+    }
+
+    #[test]
+    fn test_tab_indent() {
+        let mut map = BTreeMap::new();
+        map.insert(Ident::new("name"), RuntimeValue::String("Alice".to_string()));
+        let values = vec![RuntimeValue::Dict(Shared::new(map))];
+        let result = runtime_values_to_xml(&values, b'\t', 1).unwrap();
+        assert!(result.contains("\n\t<name>Alice</name>"));
     }
 }


### PR DESCRIPTION
## Summary

Mirrors jq's --indent (0-7 spaces) and --tab flags for pretty-printed JSON and XML output. Mutually exclusive with --compact and each other, and only valid with -F json or -F xml.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
