### PR TITLE
✨ feat(mq-lang): add strip_ansi builtin function

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -168,6 +168,17 @@ end
 # Returns: bool
 def test(s, pattern): is_regex_match(s, pattern);
 
+# Removes ANSI escape sequences (e.g. color codes) from a string
+#
+# Example:
+# ```
+# strip_ansi("\x1b[31mred\x1b[0m")
+# #=> red
+# ```
+#
+# Returns: string
+def strip_ansi(s): gsub(s, "\x1b\\[[0-9;]*[a-zA-Z]", "");
+
 # Returns value if condition is true, None otherwise
 #
 # Example:

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -88,6 +88,18 @@ def test_rtrimstr(value, suffix, expected):
   | assert_eq(result, expected)
 end
 
+# @parametrize([
+#   ["\x1b[31mred\x1b[0m", "red"],
+#   ["\x1b[1;32mgreen\x1b[0m plain", "green plain"],
+#   ["\x1b[2J\x1b[H", ""],
+#   ["no ansi here", "no ansi here"],
+#   ["", ""],
+# ])
+def test_strip_ansi(value, expected):
+  let result = strip_ansi(value)
+  | assert_eq(result, expected)
+end
+
 # Collection tests
 # @parametrize([
 #   [[], true],


### PR DESCRIPTION
## Summary

Adds strip_ansi(str) to strip ANSI CSI escape sequences (e.g. SGR color codes) from strings, useful when embedding captured terminal or log output into Markdown.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
