### PR TITLE
✨ feat(mq-lang): add shell_quote builtin for POSIX shell escaping

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1521,6 +1521,24 @@ def slugify(s, separator = "-"):
   | gsub("^-+|-+$", "")
 end
 
+# Quotes a string for safe use as a POSIX shell argument (like jq's `@sh` format).
+#
+# Example:
+# ```
+# shell_quote("it's a test")
+# #=> 'it'"'"'s a test'
+# ```
+#
+# Returns: string
+def shell_quote(s):
+  if (is_empty(s)):
+    ""
+  elif (test(s, "^[A-Za-z0-9_@%+=:,./-]+$")):
+    s
+  else:
+    "'" + replace(s, "'", "'\"'\"'") + "'"
+end
+
 # Calculates the p-th percentile of an array of numbers using linear interpolation between closest ranks.
 #
 # Example:

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -100,6 +100,17 @@ def test_strip_ansi(value, expected):
   | assert_eq(result, expected)
 end
 
+# @parametrize([
+#   ["hello", "hello"],
+#   ["hello world", "'hello world'"],
+#   ["", ""],
+#   ["it's a test", "'it'\"'\"'s a test'"],
+# ])
+def test_shell_quote(value, expected):
+  let result = shell_quote(value)
+  | assert_eq(result, expected)
+end
+
 # Collection tests
 # @parametrize([
 #   [[], true],


### PR DESCRIPTION
## Summary

Exposes the existing `-F shell` quoting logic as a public mq-lang builtin (similar to jq's `@sh`), usable directly in queries or via string interpolation, e.g. s"rm ${shell_quote(file)}".

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
