### PR TITLE
fix(cli): correct the -U help example's in-place and untouched claims

### DIFF
--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1190,11 +1190,16 @@ impl Cli {
             "  mq -T json 'self' file.txt       # sets both -I and -F at once (-I/-F still override)"
         );
 
-        let _ = writeln!(out, "\n{}", "Updating markdown in place (-U):".bold().cyan());
+        let _ = writeln!(out, "\n{}", "Updating markdown (-U):".bold().cyan());
         let _ = writeln!(
             out,
-            "  mq -U '.h1 | update(\"New title\")' file.md  # rewrite the h1, leave everything else untouched"
+            "  mq -U '.h1 | update(\"New title\")' file.md         # whole document to stdout; the file is not touched"
         );
+        let _ = writeln!(
+            out,
+            "  mq -U --diff '.h1 | update(\"New title\")' file.md  # preview the change as a unified diff"
+        );
+        let _ = writeln!(out, "  (-U never edits in place; unmatched content is reformatted too)");
 
         let _ = writeln!(out, "\n{}", "Filtering with context (-F grep):".bold().cyan());
         let _ = writeln!(
@@ -1331,10 +1336,12 @@ impl Cli {
             mq -T json 'self' file.txt       # sets both -I and -F at once (-I/-F still override)\n```"
         );
 
-        let _ = writeln!(out, "\n## Updating markdown in place (-U)\n");
+        let _ = writeln!(out, "\n## Updating markdown (-U)\n");
         let _ = writeln!(
             out,
-            "```sh\nmq -U '.h1 | update(\"New title\")' file.md  # rewrite the h1, leave everything else untouched\n```"
+            "```sh\nmq -U '.h1 | update(\"New title\")' file.md         # whole document to stdout; the file is not touched\n\
+            mq -U --diff '.h1 | update(\"New title\")' file.md  # preview the change as a unified diff\n```\n\n\
+            `-U` never edits in place; unmatched content is reformatted too."
         );
 
         let _ = writeln!(out, "\n## Filtering with context (-F grep)\n");


### PR DESCRIPTION
## Summary

`mq help examples` made two claims about `-U` that the binary doesn't match:

1. The topic was headed **"Updating markdown in place (-U)"**. `-U` writes to stdout and leaves the file alone. This is the same wording that made `-i`/`--in-place` misleading in #2063 — those aliases were removed in #2064, but this help topic kept the phrasing.
2. The example comment said **"leave everything else untouched"**. `-U` re-serializes the whole document, so unmatched content is normalized, not preserved.

`mq --help` already words it correctly (*"Update matching Markdown nodes and write the result to stdout"*); only the examples topic was out of step.

This retitles the topic, replaces the example comment with what `-U` actually does, and adds the `--diff` form — the topic previously had no way to discover that you can preview a rewrite before committing to it, which is the direct remedy for the misconception. Both the plain-text and `--markdown` renderings are updated.

Closes #2295.

### Before

```
Updating markdown in place (-U):
  mq -U '.h1 | update("New title")' file.md  # rewrite the h1, leave everything else untouched
```

### After

```
Updating markdown (-U):
  mq -U '.h1 | update("New title")' file.md         # whole document to stdout; the file is not touched
  mq -U --diff '.h1 | update("New title")' file.md  # preview the change as a unified diff
  (-U never edits in place; unmatched content is reformatted too)
```

### Why the second claim is false

Given `u.md`, deliberately not in mq's canonical form:

```markdown
Old title
=========

Body *em* and __strong__.

* item one
```

```console
$ mq -U --diff '.h1 | update("New title")' u.md
-Old title
-=========
+# New title
-Body *em* and __strong__.
+Body *em* and **strong**.
-* item one
+- item one
```

The query matches only the `h1`, but two of the three changes land outside it.

## Type of Change

- [x] 📝 Documentation

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [ ] I ran `just test-all` and all tests pass — see note below
- [ ] I added or updated tests covering this change — no test asserts this help text; happy to add one if you'd like
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed — no other copies of this wording exist
- [ ] I added a changelog entry if this is a user-facing change — the repo has no CHANGELOG; let me know if one is expected

## Additional Context

Verified the rendered output of both variants, and that the `--markdown` form still parses with mq itself (`mq help examples --markdown | mq '.code'` returns both example lines inside the code block).

**On tests:** `cargo test -p mq-run` has 3 pre-existing failures on `main` — `test_repl_load_command_glob`, `test_repl_load_command_multiple_files`, `test_repl_no_files_still_seeds_empty`. They fail identically on a clean checkout of `476b8d9` with this change stashed, so they're unrelated to this PR. All other 141 pass.

If you'd prefer a more minimal change — just the two string corrections without the added `--diff` line — I'm glad to trim it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
