### PR TITLE
✨ feat(mq-lang): add unzip builtin function

### DIFF
--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -2048,6 +2048,22 @@ def zip(arr1, arr2):
     end
 end
 
+# Splits an array of pairs into an array of two arrays: one with the first elements of each pair and one with the second elements. This is the inverse of `zip`.
+#
+# Example:
+# ```
+# unzip([[1, "a"], [2, "b"]])
+# #=> [[1, 2], ["a", "b"]]
+# ```
+#
+# Returns: array
+def unzip(pairs):
+  if (not(is_array(pairs))):
+    error("argument must be an array")
+  else:
+    fold(pairs, [[], []], fn(acc, pair): [acc[0] + [pair[0]], acc[1] + [pair[1]]];)
+end
+
 # Returns the minimum element in an array based on a provided function that extracts a comparable value from each element.
 #
 # Example:

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -926,6 +926,22 @@ def test_zip(value1, value2, expected):
 end
 
 # @parametrize([
+#   [[[1, "a"], [2, "b"], [3, "c"]], [[1, 2, 3], ["a", "b", "c"]]],
+#   [[[1, "x"], [2, "y"]], [[1, 2], ["x", "y"]]],
+#   [[], [[], []]],
+# ])
+def test_unzip(value, expected):
+  let result = unzip(value)
+  | assert_eq(result, expected)
+end
+
+def test_unzip_is_inverse_of_zip():
+  let a = [1, 2, 3]
+  | let b = ["a", "b", "c"]
+  | assert_eq(unzip(zip(a, b)), [a, b])
+end
+
+# @parametrize([
 #   [[{"value": 3}, {"value": 1}, {"value": 2}], fn(x): x["value"];, {"value": 1}],
 #   [[], fn(x): x;, None],
 #   [[{"score": 10}, {"score": 5}], fn(x): x["score"];, {"score": 5}],


### PR DESCRIPTION
## Summary

Adds unzip(pairs) as the inverse of zip: splits an array of pairs into an array of two arrays, one holding the first elements and one holding the second elements.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
