### PR TITLE
✨ feat(cli): add atomic writes for -o via --atomic-output

### DIFF
--- a/crates/mq-run/src/atomic_output.rs
+++ b/crates/mq-run/src/atomic_output.rs
@@ -1,0 +1,325 @@
+//! Atomic writes for `-o`/`--output`: write to a temp file next to the
+//! target, then `fsync` + `rename` in [`OutputSink::finish`], so a crash or
+//! full disk mid-write can't leave a truncated file at the destination.
+
+use miette::IntoDiagnostic;
+use miette::miette;
+use std::fs;
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum AtomicOutput {
+    /// Atomic for a missing or regular-file target; direct write for pipes/devices.
+    #[default]
+    Auto,
+    /// Always write atomically, even over pipes/devices.
+    Always,
+    /// Always write directly to the target path, truncating it up front.
+    Never,
+}
+
+/// Call [`OutputSink::finish`] once done writing.
+pub(crate) enum OutputSink {
+    Stdout(io::StdoutLock<'static>),
+    BufferedStdout(BufWriter<io::StdoutLock<'static>>),
+    Direct(BufWriter<fs::File>),
+    Atomic {
+        writer: BufWriter<fs::File>,
+        temp_path: PathBuf,
+        target_path: PathBuf,
+    },
+}
+
+impl Write for OutputSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            OutputSink::Stdout(w) => w.write(buf),
+            OutputSink::BufferedStdout(w) => w.write(buf),
+            OutputSink::Direct(w) => w.write(buf),
+            OutputSink::Atomic { writer, .. } => writer.write(buf),
+        }
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        match self {
+            OutputSink::Stdout(w) => w.write_all(buf),
+            OutputSink::BufferedStdout(w) => w.write_all(buf),
+            OutputSink::Direct(w) => w.write_all(buf),
+            OutputSink::Atomic { writer, .. } => writer.write_all(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            OutputSink::Stdout(w) => w.flush(),
+            OutputSink::BufferedStdout(w) => w.flush(),
+            OutputSink::Direct(w) => w.flush(),
+            OutputSink::Atomic { writer, .. } => writer.flush(),
+        }
+    }
+}
+
+impl OutputSink {
+    pub(crate) fn open(output_file: &Option<PathBuf>, atomic: AtomicOutput, unbuffered: bool) -> miette::Result<Self> {
+        match output_file {
+            Some(path) => Self::open_file(path, atomic),
+            None if unbuffered => Ok(OutputSink::Stdout(io::stdout().lock())),
+            None => Ok(OutputSink::BufferedStdout(BufWriter::new(io::stdout().lock()))),
+        }
+    }
+
+    fn open_file(path: &Path, atomic: AtomicOutput) -> miette::Result<Self> {
+        let use_atomic = match atomic {
+            AtomicOutput::Never => false,
+            AtomicOutput::Always => true,
+            AtomicOutput::Auto => Self::target_supports_atomic(path)?,
+        };
+
+        if !use_atomic {
+            let file = fs::File::create(path).into_diagnostic()?;
+            return Ok(OutputSink::Direct(BufWriter::new(file)));
+        }
+
+        let (file, temp_path) = Self::create_temp_file(path)?;
+        Ok(OutputSink::Atomic {
+            writer: BufWriter::new(file),
+            temp_path,
+            target_path: path.to_path_buf(),
+        })
+    }
+
+    /// FIFOs, sockets, and device files can't safely be replaced via `rename`.
+    fn target_supports_atomic(path: &Path) -> miette::Result<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(meta) => {
+                let file_type = meta.file_type();
+                Ok(file_type.is_file() || file_type.is_symlink())
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(true),
+            Err(e) => Err(miette!(e)),
+        }
+    }
+
+    /// Same directory as `target`, so the later `rename` stays on one filesystem.
+    fn create_temp_file(target: &Path) -> miette::Result<(fs::File, PathBuf)> {
+        let dir = match target.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => parent,
+            _ => Path::new("."),
+        };
+        let file_name = target
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "output".to_string());
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let pid = std::process::id();
+
+        for _ in 0..64 {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default();
+            let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let candidate = dir.join(format!(".{file_name}.mq-tmp-{pid:x}-{nanos:x}-{unique:x}"));
+
+            match fs::OpenOptions::new().write(true).create_new(true).open(&candidate) {
+                Ok(file) => return Ok((file, candidate)),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => {
+                    return Err(miette!(
+                        "failed to create a temporary file for atomic write in {}: {e}",
+                        dir.display()
+                    ));
+                }
+            }
+        }
+
+        Err(miette!(
+            "failed to create a unique temporary file for atomic write in {}",
+            dir.display()
+        ))
+    }
+
+    pub(crate) fn finish(self) -> miette::Result<()> {
+        match self {
+            OutputSink::Stdout(_) => Ok(()),
+            OutputSink::BufferedStdout(mut w) => Self::ignore_broken_pipe(w.flush()),
+            OutputSink::Direct(mut w) => Self::ignore_broken_pipe(w.flush()),
+            OutputSink::Atomic {
+                writer,
+                temp_path,
+                target_path,
+            } => {
+                let result = Self::publish_atomic(writer, &temp_path, &target_path);
+                if result.is_err() {
+                    let _ = fs::remove_file(&temp_path);
+                }
+                result
+            }
+        }
+    }
+
+    fn publish_atomic(mut writer: BufWriter<fs::File>, temp_path: &Path, target_path: &Path) -> miette::Result<()> {
+        writer.flush().into_diagnostic()?;
+        let file = writer
+            .into_inner()
+            .map_err(|e| miette!("failed to flush temporary output file: {}", e.error()))?;
+        file.sync_all().into_diagnostic()?;
+        drop(file);
+
+        if let Ok(meta) = fs::metadata(target_path) {
+            let _ = fs::set_permissions(temp_path, meta.permissions());
+        }
+
+        fs::rename(temp_path, target_path).into_diagnostic()?;
+        Ok(())
+    }
+
+    fn ignore_broken_pipe(result: io::Result<()>) -> miette::Result<()> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+            Err(e) => Err(miette!(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use scopeguard::defer;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "mq-atomic-output-test-{name}-{}-{unique:x}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("failed to create test directory");
+        dir
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    fn test_atomic_write_new_file(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("new-file");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+
+        let mut sink = OutputSink::open(&Some(target.clone()), mode, false).unwrap();
+        sink.write_all(b"hello").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hello");
+        let entries: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_atomic_write_overwrites_existing_file() {
+        let dir = temp_dir("overwrite");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+        fs::write(&target, "old content that is longer than new").unwrap();
+
+        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
+        sink.write_all(b"new").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+    }
+
+    #[test]
+    fn test_never_mode_writes_directly() {
+        let dir = temp_dir("never");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+
+        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Never, false).unwrap();
+        sink.write_all(b"direct").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "direct");
+        let entries: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_finish_error_cleans_up_temp_file() {
+        let dir = temp_dir("cleanup");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        // Rename onto a directory fails.
+        let target = dir.join("out_dir");
+        fs::create_dir(&target).unwrap();
+
+        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
+        sink.write_all(b"data").unwrap();
+        assert!(sink.finish().is_err());
+
+        let leftover: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter(|e| e.as_ref().unwrap().file_name() != "out_dir")
+            .collect();
+        assert!(leftover.is_empty(), "temp file should be cleaned up on failure");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("permissions");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+        fs::write(&target, "old").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o640)).unwrap();
+
+        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
+        sink.write_all(b"new").unwrap();
+        sink.finish().unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o640);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_auto_mode_falls_back_to_direct_write_for_socket() {
+        use std::os::unix::fs::FileTypeExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = temp_dir("socket");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.sock");
+
+        let _listener = UnixListener::bind(&target).expect("failed to bind unix socket");
+        assert!(fs::symlink_metadata(&target).unwrap().file_type().is_socket());
+        assert!(!OutputSink::target_supports_atomic(&target).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_always_mode_skips_special_file_check() {
+        use std::os::unix::fs::FileTypeExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = temp_dir("socket-always");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.sock");
+        let _listener = UnixListener::bind(&target).expect("failed to bind unix socket");
+
+        // `always` skips the special-file check.
+        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
+        sink.write_all(b"data").unwrap();
+        sink.finish().unwrap();
+
+        assert!(!fs::symlink_metadata(&target).unwrap().file_type().is_socket());
+        assert_eq!(fs::read_to_string(&target).unwrap(), "data");
+    }
+}

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -29,6 +29,7 @@ static HAD_TRUTHY_OUTPUT: AtomicBool = AtomicBool::new(false);
 // Tracks whether --diff found any changed input, for the exit-code-1 CI check below.
 static HAD_DIFF: AtomicBool = AtomicBool::new(false);
 
+use crate::atomic_output::{AtomicOutput, OutputSink};
 use crate::grep;
 use mq_help as help;
 
@@ -587,6 +588,11 @@ struct OutputArgs {
     /// Output to the specified file
     #[clap(short = 'o', long = "output", value_name = "FILE")]
     output_file: Option<PathBuf>,
+
+    /// Write `-o`/`--output` atomically via a same-directory temp file + fsync
+    /// + rename, so a crash or full disk mid-write can't truncate the target.
+    #[clap(long, value_enum, default_value_t = AtomicOutput::Auto, requires = "output_file")]
+    atomic_output: AtomicOutput,
 
     /// Colorize markdown output
     #[arg(short = 'C', long = "color-output", default_value_t = false)]
@@ -1848,15 +1854,12 @@ impl Cli {
 
         if let Some(input) = grep_input {
             let (before, after) = self.output.context_counts();
-            grep::print_grep(
-                runtime_values,
-                &input,
-                file,
+            let handle = OutputSink::open(
                 &self.output.output_file,
+                self.output.atomic_output,
                 self.output.unbuffered,
-                before,
-                after,
-            )
+            )?;
+            grep::print_grep(runtime_values, &input, file, handle, before, after)
         } else {
             self.print(runtime_values)
         }
@@ -2197,15 +2200,11 @@ impl Cli {
         let mut total = 0usize;
         let mut engine = self.create_engine()?;
 
-        let stdout = io::stdout();
-        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
-            let file = fs::File::create(output_file).into_diagnostic()?;
-            Box::new(BufWriter::new(file))
-        } else if self.output.unbuffered {
-            Box::new(stdout.lock())
-        } else {
-            Box::new(BufWriter::new(stdout.lock()))
-        };
+        let mut handle = OutputSink::open(
+            &self.output.output_file,
+            self.output.atomic_output,
+            self.output.unbuffered,
+        )?;
 
         for (file, content) in files {
             let count = self.count_file(&mut engine, query, file, content)?;
@@ -2225,12 +2224,7 @@ impl Cli {
             Self::write_ignore_pipe(&mut handle, format!("{}\n", total).as_bytes())?;
         }
 
-        if !self.output.unbuffered
-            && let Err(e) = handle.flush()
-            && e.kind() != std::io::ErrorKind::BrokenPipe
-        {
-            return Err(miette!(e));
-        }
+        handle.finish()?;
 
         Ok(())
     }
@@ -2621,15 +2615,11 @@ impl Cli {
     }
 
     fn print(&self, runtime_values: mq_lang::RuntimeValues) -> miette::Result<()> {
-        let stdout = io::stdout();
-        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
-            let file = fs::File::create(output_file).into_diagnostic()?;
-            Box::new(BufWriter::new(file))
-        } else if self.output.unbuffered {
-            Box::new(stdout.lock())
-        } else {
-            Box::new(BufWriter::new(stdout.lock()))
-        };
+        let mut handle = OutputSink::open(
+            &self.output.output_file,
+            self.output.atomic_output,
+            self.output.unbuffered,
+        )?;
         let stripped_values: Option<Vec<mq_lang::RuntimeValue>> = self.output.no_position.then(|| {
             runtime_values
                 .values()
@@ -2648,13 +2638,7 @@ impl Cli {
         let colorize = self.output.color_output && !Self::is_no_color();
         let buf = self.render(runtime_values, colorize)?;
         Self::write_ignore_pipe(&mut handle, &buf)?;
-
-        if !self.output.unbuffered
-            && let Err(e) = handle.flush()
-            && e.kind() != std::io::ErrorKind::BrokenPipe
-        {
-            return Err(miette!(e));
-        }
+        handle.finish()?;
 
         Ok(())
     }
@@ -2682,15 +2666,11 @@ impl Cli {
     /// by the file path (or `<stdin>` when there is none). Colorizes `+`/`-`/`@@`
     /// lines when `-C`/`--color-output` is set and `NO_COLOR` isn't.
     fn print_unified_diff(&self, original: &str, rendered: &str, file: &Option<PathBuf>) -> miette::Result<()> {
-        let stdout = io::stdout();
-        let mut handle: Box<dyn Write> = if let Some(output_file) = &self.output.output_file {
-            let file = fs::File::create(output_file).into_diagnostic()?;
-            Box::new(BufWriter::new(file))
-        } else if self.output.unbuffered {
-            Box::new(stdout.lock())
-        } else {
-            Box::new(BufWriter::new(stdout.lock()))
-        };
+        let mut handle = OutputSink::open(
+            &self.output.output_file,
+            self.output.atomic_output,
+            self.output.unbuffered,
+        )?;
 
         let label = file
             .as_ref()
@@ -2725,13 +2705,7 @@ impl Cli {
         }
 
         Self::write_ignore_pipe(&mut handle, out.as_bytes())?;
-
-        if !self.output.unbuffered
-            && let Err(e) = handle.flush()
-            && e.kind() != std::io::ErrorKind::BrokenPipe
-        {
-            return Err(miette!(e));
-        }
+        handle.finish()?;
 
         Ok(())
     }

--- a/crates/mq-run/src/grep.rs
+++ b/crates/mq-run/src/grep.rs
@@ -5,12 +5,12 @@
 //! `--context`). Groups of context nodes are separated by `--`, matching the
 //! behaviour of `grep -A/-B/-C`.
 
-use miette::IntoDiagnostic;
+use crate::atomic_output::OutputSink;
 use miette::miette;
 #[cfg(test)]
 use mq_lang::Shared;
 use std::collections::HashSet;
-use std::io::{self, BufWriter, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 /// Prints query results in grep-like format.
@@ -18,21 +18,10 @@ pub(crate) fn print_grep(
     runtime_values: mq_lang::RuntimeValues,
     original_input: &[mq_lang::RuntimeValue],
     file: &Option<PathBuf>,
-    output_file: &Option<PathBuf>,
-    unbuffered: bool,
+    mut handle: OutputSink,
     before: usize,
     after: usize,
 ) -> miette::Result<()> {
-    let stdout = io::stdout();
-    let mut handle: Box<dyn Write> = if let Some(path) = output_file {
-        let f = std::fs::File::create(path).into_diagnostic()?;
-        Box::new(BufWriter::new(f))
-    } else if unbuffered {
-        Box::new(stdout.lock())
-    } else {
-        Box::new(BufWriter::new(stdout.lock()))
-    };
-
     let filename = file.as_ref().map(|p| p.to_string_lossy().into_owned());
 
     // Collect start lines of matched nodes for quick lookup.
@@ -113,14 +102,7 @@ pub(crate) fn print_grep(
         }
     }
 
-    if !unbuffered
-        && let Err(e) = handle.flush()
-        && e.kind() != std::io::ErrorKind::BrokenPipe
-    {
-        return Err(miette!(e));
-    }
-
-    Ok(())
+    handle.finish()
 }
 
 fn format_line(filename: &Option<String>, line_num: Option<usize>, content: &str, sep: &str) -> String {

--- a/crates/mq-run/src/lib.rs
+++ b/crates/mq-run/src/lib.rs
@@ -42,6 +42,7 @@
 //! mq --repl
 //! ```
 
+pub(crate) mod atomic_output;
 pub mod cli;
 pub(crate) mod grep;
 pub(crate) mod output;

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -1805,6 +1805,127 @@ fn test_output_format_auto_detected_from_output_file_extension() {
 }
 
 #[test]
+fn test_atomic_output_requires_output_file() {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--atomic-output")
+        .arg("always")
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+}
+
+#[rstest]
+#[case::auto("auto")]
+#[case::always("always")]
+#[case::never("never")]
+fn test_atomic_output_modes_overwrite_existing_file(#[case] mode: &str) {
+    let (_, output_file) = create_file(&format!("cli_atomic_output_{mode}.md"), "old content");
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--atomic-output")
+        .arg(mode)
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert!(content.contains("hello"));
+
+    // Scope the check to this target's own temp file; the OS temp dir is shared.
+    let target_name = output_file.file_name().unwrap().to_string_lossy().into_owned();
+    let dir = output_file.parent().unwrap();
+    let stray_temp_files: Vec<_> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.contains("mq-tmp") && name.contains(&target_name)
+        })
+        .collect();
+    assert!(
+        stray_temp_files.is_empty(),
+        "expected no leftover temp files, found {stray_temp_files:?}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_atomic_output_preserves_existing_file_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_, output_file) = create_file("cli_atomic_output_perms.md", "old content");
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+    std::fs::set_permissions(&output_file, std::fs::Permissions::from_mode(0o640)).expect("failed to set permissions");
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .success();
+
+    let mode = std::fs::metadata(&output_file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o640,
+        "atomic write should preserve the target's existing permissions"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_atomic_output_failure_leaves_existing_file_untouched() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("mq-atomic-output-failure-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("failed to create test directory");
+    defer! {
+        // Restore write access before cleanup, or remove_dir_all fails.
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    let output_file = dir.join("out.md");
+    std::fs::write(&output_file, "ORIGINAL").expect("failed to write original file");
+
+    // Read-only dir: the temp file can't be created, so the write must fail.
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).expect("failed to set permissions");
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--atomic-output")
+        .arg("always")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("failed to restore permissions");
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert_eq!(
+        content, "ORIGINAL",
+        "a failed atomic write must not modify the existing file"
+    );
+}
+
+#[test]
 fn test_format_flag_sets_input_and_output() {
     let mut cmd = cargo::cargo_bin_cmd!("mq");
     let result = cmd


### PR DESCRIPTION
## Summary

Direct File::create truncates the target immediately, so a crash or a full disk mid-write can leave an empty or partial file. -o now writes to a same-directory temp file and fsync+renames it into place instead.

--atomic-output controls this: auto (default) is atomic for missing or regular-file targets and falls back to a direct write for pipes/ devices/sockets; always forces atomic even for those; never restores the old direct-write behavior. Existing file permissions are preserved across the rename, and a failed write leaves the original file intact.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
