### PR TITLE
🐛 fix(help): register `nodes` keyword so `mq help nodes` resolves

### DIFF
--- a/crates/mq-help/src/catalog.rs
+++ b/crates/mq-help/src/catalog.rs
@@ -71,9 +71,10 @@ pub fn all_entries() -> Vec<HelpEntry> {
     results
 }
 
-/// Native builtin functions, selectors, and `builtin.mq` functions — everything in
-/// [`all_entries`] except standard-module functions. Cheap: unlike `all_entries`/`all_modules`,
-/// it never parses a standard module's source.
+/// Native builtin functions, selectors, `builtin.mq` functions, and language keywords with
+/// their own help topic (currently just `nodes`) — everything in [`all_entries`] except
+/// standard-module functions. Cheap: unlike `all_entries`/`all_modules`, it never parses a
+/// standard module's source.
 pub fn top_level_entries() -> Vec<HelpEntry> {
     let mut results = Vec::new();
 
@@ -126,6 +127,24 @@ pub fn top_level_entries() -> Vec<HelpEntry> {
     for fdoc in reference::extract_functions_from_cst(BUILTIN_MODULE_FILE, true) {
         results.push(from_mq_fn_doc(fdoc, None));
     }
+
+    results.push(HelpEntry {
+        name: "nodes".to_string(),
+        kind: "keyword",
+        params: Vec::new(),
+        returns: "array".to_string(),
+        description: "Collects every input node into a single array assigned to `self`, so the \
+            rest of the pipeline runs once over the whole input instead of once per node. \
+            Equivalent to prefixing a query with the `-A`/`--aggregate` CLI flag. Only valid at \
+            the top level of a program, not inside a `def`/`fn` body."
+            .to_string(),
+        examples: vec![HelpExample {
+            code: "nodes | type(self)".to_string(),
+            expected: "array".to_string(),
+        }],
+        capability: None,
+        related_module: None,
+    });
 
     results
 }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -1015,9 +1015,9 @@ impl Cli {
         handle.flush().into_diagnostic()
     }
 
-    /// Sorted, deduped selector and top-level function names for the `mq help` index.
-    /// Cheap: uses `top_level_entries`, which never parses standard-module sources.
-    fn help_index_names() -> (Vec<String>, Vec<String>) {
+    /// Sorted, deduped selector, top-level function, and keyword names for the `mq help`
+    /// index. Cheap: uses `top_level_entries`, which never parses standard-module sources.
+    fn help_index_names() -> (Vec<String>, Vec<String>, Vec<String>) {
         let entries = help::top_level_entries();
 
         let mut selectors: Vec<String> = entries
@@ -1036,13 +1036,21 @@ impl Cli {
         functions.sort_unstable();
         functions.dedup();
 
-        (selectors, functions)
+        let mut keywords: Vec<String> = entries
+            .iter()
+            .filter(|e| e.kind == "keyword")
+            .map(|e| e.name.clone())
+            .collect();
+        keywords.sort_unstable();
+        keywords.dedup();
+
+        (selectors, functions, keywords)
     }
 
     /// Builds the grouped `mq help` index text: selectors, top-level functions, and modules
     /// (each with a one-line summary), for a name-less human-readable lookup.
     fn help_index_text() -> String {
-        let (selectors, functions) = Self::help_index_names();
+        let (selectors, functions, keywords) = Self::help_index_names();
         let mut out = String::new();
 
         let _ = writeln!(out, "{}", "Selectors:".bold().cyan());
@@ -1053,6 +1061,11 @@ impl Cli {
         let _ = writeln!(out, "\n{}", "Functions:".bold().cyan());
         for f in functions {
             let _ = writeln!(out, "  {f}");
+        }
+
+        let _ = writeln!(out, "\n{}", "Keywords:".bold().cyan());
+        for k in keywords {
+            let _ = writeln!(out, "  {k}");
         }
 
         let _ = writeln!(out, "\n{}", "Modules:".bold().cyan());
@@ -1073,7 +1086,7 @@ impl Cli {
 
     /// Same content as [`Self::help_index_text`], as Markdown — queryable with mq itself.
     fn help_index_markdown() -> String {
-        let (selectors, functions) = Self::help_index_names();
+        let (selectors, functions, keywords) = Self::help_index_names();
         let mut out = String::new();
 
         let _ = writeln!(out, "# mq help");
@@ -1086,6 +1099,11 @@ impl Cli {
         let _ = writeln!(out, "\n## Functions\n");
         for f in functions {
             let _ = writeln!(out, "- `{f}`");
+        }
+
+        let _ = writeln!(out, "\n## Keywords\n");
+        for k in keywords {
+            let _ = writeln!(out, "- `{k}`");
         }
 
         let _ = writeln!(out, "\n## Modules\n");


### PR DESCRIPTION
## Summary

`nodes` is a parser-level keyword (not a registered function/selector), so `mq help` treated it as unknown and even suggested the unrelated `nones` — despite `section`/`table` module warnings and the cookbook recommending it as the `-A` substitute.

Add `nodes` as a `keyword`-kind HelpEntry in mq-help's catalog so it resolves via `mq help nodes` (text/markdown/json), appears in the `mq help` index under a new "Keywords" section, and is a candidate for "did you mean" suggestions.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
