### PR TITLE
✨ feat(cli): add --no-clobber/--append for -o output

### DIFF
--- a/crates/mq-run/src/atomic_output.rs
+++ b/crates/mq-run/src/atomic_output.rs
@@ -1,13 +1,18 @@
 //! Atomic writes for `-o`/`--output`: write to a temp file next to the
 //! target, then `fsync` + `rename` in [`OutputSink::finish`], so a crash or
 //! full disk mid-write can't leave a truncated file at the destination.
+//!
+//! [`ClobberMode`] adds `--no-clobber` (fail if the target already existed)
+//! and `--append`. Atomic append is crash-safe but not concurrency-safe
+//! (read-modify-rename can race); use `--atomic-output never` for
+//! concurrent-safe appends across processes.
 
 use miette::IntoDiagnostic;
 use miette::miette;
 use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub(crate) enum AtomicOutput {
@@ -18,6 +23,18 @@ pub(crate) enum AtomicOutput {
     Always,
     /// Always write directly to the target path, truncating it up front.
     Never,
+}
+
+/// How `-o`/`--output` treats a pre-existing target, for the current process.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum ClobberMode {
+    /// Truncate (direct) or replace (atomic) the target, as today.
+    #[default]
+    Overwrite,
+    /// Fail if the target already existed the first time this process opened it.
+    NoClobber,
+    /// Add to whatever is already at the target instead of replacing it.
+    Append,
 }
 
 /// Call [`OutputSink::finish`] once done writing.
@@ -62,15 +79,34 @@ impl Write for OutputSink {
 }
 
 impl OutputSink {
-    pub(crate) fn open(output_file: &Option<PathBuf>, atomic: AtomicOutput, unbuffered: bool) -> miette::Result<Self> {
+    /// `claimed` marks whether this process already opened `output_file`, so
+    /// `--no-clobber` only checks existence once per run.
+    pub(crate) fn open(
+        output_file: &Option<PathBuf>,
+        atomic: AtomicOutput,
+        unbuffered: bool,
+        clobber: ClobberMode,
+        claimed: &AtomicBool,
+    ) -> miette::Result<Self> {
         match output_file {
-            Some(path) => Self::open_file(path, atomic),
+            Some(path) => Self::open_file(path, atomic, clobber, claimed),
             None if unbuffered => Ok(OutputSink::Stdout(io::stdout().lock())),
             None => Ok(OutputSink::BufferedStdout(BufWriter::new(io::stdout().lock()))),
         }
     }
 
-    fn open_file(path: &Path, atomic: AtomicOutput) -> miette::Result<Self> {
+    fn open_file(
+        path: &Path,
+        atomic: AtomicOutput,
+        clobber: ClobberMode,
+        claimed: &AtomicBool,
+    ) -> miette::Result<Self> {
+        let is_first_open = !claimed.swap(true, Ordering::SeqCst);
+
+        if clobber == ClobberMode::NoClobber && is_first_open && Self::target_exists(path)? {
+            return Err(Self::no_clobber_error(path));
+        }
+
         let use_atomic = match atomic {
             AtomicOutput::Never => false,
             AtomicOutput::Always => true,
@@ -78,16 +114,55 @@ impl OutputSink {
         };
 
         if !use_atomic {
-            let file = fs::File::create(path).into_diagnostic()?;
+            let file = if clobber == ClobberMode::Append {
+                fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .into_diagnostic()?
+            } else if clobber == ClobberMode::NoClobber && is_first_open {
+                // create_new closes the TOCTOU gap left by the check above.
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(path)
+                    .map_err(|e| match e.kind() {
+                        io::ErrorKind::AlreadyExists => Self::no_clobber_error(path),
+                        _ => miette!(e),
+                    })?
+            } else {
+                fs::File::create(path).into_diagnostic()?
+            };
             return Ok(OutputSink::Direct(BufWriter::new(file)));
         }
 
         let (file, temp_path) = Self::create_temp_file(path)?;
+        let mut writer = BufWriter::new(file);
+        if clobber == ClobberMode::Append
+            && let Ok(existing) = fs::read(path)
+        {
+            writer.write_all(&existing).into_diagnostic()?;
+        }
         Ok(OutputSink::Atomic {
-            writer: BufWriter::new(file),
+            writer,
             temp_path,
             target_path: path.to_path_buf(),
         })
+    }
+
+    fn no_clobber_error(path: &Path) -> miette::Report {
+        miette!(
+            "output file already exists: {} (use --append to add to it, or drop --no-clobber to overwrite)",
+            path.display()
+        )
+    }
+
+    fn target_exists(path: &Path) -> miette::Result<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(_) => Ok(true),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(miette!(e)),
+        }
     }
 
     /// FIFOs, sockets, and device files can't safely be replaced via `rename`.
@@ -192,6 +267,18 @@ mod tests {
     use rstest::rstest;
     use scopeguard::defer;
 
+    /// Overwrite-mode open with a fresh `claimed` flag, for tests that don't
+    /// care about no-clobber/append.
+    fn open_overwrite(target: &Option<PathBuf>, atomic: AtomicOutput, unbuffered: bool) -> miette::Result<OutputSink> {
+        OutputSink::open(
+            target,
+            atomic,
+            unbuffered,
+            ClobberMode::Overwrite,
+            &AtomicBool::new(false),
+        )
+    }
+
     fn temp_dir(name: &str) -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -212,7 +299,7 @@ mod tests {
         defer! { let _ = fs::remove_dir_all(&dir); }
         let target = dir.join("out.md");
 
-        let mut sink = OutputSink::open(&Some(target.clone()), mode, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), mode, false).unwrap();
         sink.write_all(b"hello").unwrap();
         sink.finish().unwrap();
 
@@ -228,7 +315,7 @@ mod tests {
         let target = dir.join("out.md");
         fs::write(&target, "old content that is longer than new").unwrap();
 
-        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
         sink.write_all(b"new").unwrap();
         sink.finish().unwrap();
 
@@ -241,7 +328,7 @@ mod tests {
         defer! { let _ = fs::remove_dir_all(&dir); }
         let target = dir.join("out.md");
 
-        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Never, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), AtomicOutput::Never, false).unwrap();
         sink.write_all(b"direct").unwrap();
         sink.finish().unwrap();
 
@@ -258,7 +345,7 @@ mod tests {
         let target = dir.join("out_dir");
         fs::create_dir(&target).unwrap();
 
-        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
         sink.write_all(b"data").unwrap();
         assert!(sink.finish().is_err());
 
@@ -280,7 +367,7 @@ mod tests {
         fs::write(&target, "old").unwrap();
         fs::set_permissions(&target, fs::Permissions::from_mode(0o640)).unwrap();
 
-        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), AtomicOutput::Auto, false).unwrap();
         sink.write_all(b"new").unwrap();
         sink.finish().unwrap();
 
@@ -315,11 +402,158 @@ mod tests {
         let _listener = UnixListener::bind(&target).expect("failed to bind unix socket");
 
         // `always` skips the special-file check.
-        let mut sink = OutputSink::open(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
+        let mut sink = open_overwrite(&Some(target.clone()), AtomicOutput::Always, false).unwrap();
         sink.write_all(b"data").unwrap();
         sink.finish().unwrap();
 
         assert!(!fs::symlink_metadata(&target).unwrap().file_type().is_socket());
         assert_eq!(fs::read_to_string(&target).unwrap(), "data");
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    #[case::never(AtomicOutput::Never)]
+    fn test_no_clobber_fails_when_target_exists(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("no-clobber-exists");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+        fs::write(&target, "original").unwrap();
+
+        let claimed = AtomicBool::new(false);
+        let result = OutputSink::open(&Some(target.clone()), mode, false, ClobberMode::NoClobber, &claimed);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected --no-clobber to reject an existing target"),
+        };
+
+        assert!(err.to_string().contains("already exists"));
+        assert_eq!(fs::read_to_string(&target).unwrap(), "original");
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    #[case::never(AtomicOutput::Never)]
+    fn test_no_clobber_succeeds_when_target_missing(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("no-clobber-missing");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+
+        let claimed = AtomicBool::new(false);
+        let mut sink = OutputSink::open(&Some(target.clone()), mode, false, ClobberMode::NoClobber, &claimed).unwrap();
+        sink.write_all(b"fresh").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "fresh");
+    }
+
+    #[test]
+    fn test_no_clobber_allows_a_second_open_in_the_same_run() {
+        let dir = temp_dir("no-clobber-second-open");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.md");
+        let claimed = AtomicBool::new(false);
+
+        let mut first = OutputSink::open(
+            &Some(target.clone()),
+            AtomicOutput::Auto,
+            false,
+            ClobberMode::NoClobber,
+            &claimed,
+        )
+        .unwrap();
+        first.write_all(b"first").unwrap();
+        first.finish().unwrap();
+
+        let mut second = OutputSink::open(
+            &Some(target.clone()),
+            AtomicOutput::Auto,
+            false,
+            ClobberMode::NoClobber,
+            &claimed,
+        )
+        .unwrap();
+        second.write_all(b"second").unwrap();
+        second.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "second");
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    #[case::never(AtomicOutput::Never)]
+    fn test_append_creates_target_when_missing(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("append-missing");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.ndjson");
+
+        let claimed = AtomicBool::new(false);
+        let mut sink = OutputSink::open(&Some(target.clone()), mode, false, ClobberMode::Append, &claimed).unwrap();
+        sink.write_all(b"{\"a\":1}\n").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "{\"a\":1}\n");
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    #[case::never(AtomicOutput::Never)]
+    fn test_append_preserves_existing_content(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("append-existing");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.ndjson");
+        fs::write(&target, "{\"a\":1}\n").unwrap();
+
+        let claimed = AtomicBool::new(false);
+        let mut sink = OutputSink::open(&Some(target.clone()), mode, false, ClobberMode::Append, &claimed).unwrap();
+        sink.write_all(b"{\"a\":2}\n").unwrap();
+        sink.finish().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "{\"a\":1}\n{\"a\":2}\n");
+    }
+
+    #[rstest]
+    #[case::auto(AtomicOutput::Auto)]
+    #[case::always(AtomicOutput::Always)]
+    #[case::never(AtomicOutput::Never)]
+    fn test_append_accumulates_across_multiple_opens_in_one_run(#[case] mode: AtomicOutput) {
+        let dir = temp_dir("append-multi-open");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.ndjson");
+        let claimed = AtomicBool::new(false);
+
+        for line in ["one\n", "two\n", "three\n"] {
+            let mut sink = OutputSink::open(&Some(target.clone()), mode, false, ClobberMode::Append, &claimed).unwrap();
+            sink.write_all(line.as_bytes()).unwrap();
+            sink.finish().unwrap();
+        }
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "one\ntwo\nthree\n");
+    }
+
+    #[test]
+    fn test_append_atomic_leaves_no_stray_temp_files() {
+        let dir = temp_dir("append-atomic-cleanup");
+        defer! { let _ = fs::remove_dir_all(&dir); }
+        let target = dir.join("out.ndjson");
+        fs::write(&target, "old\n").unwrap();
+
+        let claimed = AtomicBool::new(false);
+        let mut sink = OutputSink::open(
+            &Some(target.clone()),
+            AtomicOutput::Always,
+            false,
+            ClobberMode::Append,
+            &claimed,
+        )
+        .unwrap();
+        sink.write_all(b"new\n").unwrap();
+        sink.finish().unwrap();
+
+        let entries: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(entries.len(), 1, "only the target file should remain");
     }
 }

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -29,7 +29,7 @@ static HAD_TRUTHY_OUTPUT: AtomicBool = AtomicBool::new(false);
 // Tracks whether --diff found any changed input, for the exit-code-1 CI check below.
 static HAD_DIFF: AtomicBool = AtomicBool::new(false);
 
-use crate::atomic_output::{AtomicOutput, OutputSink};
+use crate::atomic_output::{AtomicOutput, ClobberMode, OutputSink};
 use crate::grep;
 use mq_help as help;
 
@@ -603,6 +603,24 @@ struct OutputArgs {
     /// + rename, so a crash or full disk mid-write can't truncate the target.
     #[clap(long, value_enum, default_value_t = AtomicOutput::Auto, requires = "output_file")]
     atomic_output: AtomicOutput,
+
+    /// Fail instead of overwriting `-o`/`--output` if the target already exists.
+    #[clap(long, default_value_t = false, requires = "output_file", conflicts_with = "append")]
+    no_clobber: bool,
+
+    /// Add to `-o`/`--output` instead of replacing it, creating it if missing.
+    /// Use `--atomic-output never` for concurrent-safe appends across processes.
+    #[clap(
+        long,
+        default_value_t = false,
+        requires = "output_file",
+        conflicts_with = "no_clobber"
+    )]
+    append: bool,
+
+    /// Whether this process has already opened `output_file` once.
+    #[clap(skip)]
+    output_claimed: std::sync::Arc<AtomicBool>,
 
     /// Colorize markdown output
     #[arg(short = 'C', long = "color-output", default_value_t = false)]
@@ -1769,6 +1787,16 @@ impl Cli {
             })
     }
 
+    fn clobber_mode(&self) -> ClobberMode {
+        if self.output.append {
+            ClobberMode::Append
+        } else if self.output.no_clobber {
+            ClobberMode::NoClobber
+        } else {
+            ClobberMode::Overwrite
+        }
+    }
+
     fn auto_query_prefix(&self, file: &Option<PathBuf>) -> Option<String> {
         let fmt = match self.explicit_input_format() {
             Some(fmt) => fmt,
@@ -1894,6 +1922,8 @@ impl Cli {
                 &self.output.output_file,
                 self.output.atomic_output,
                 self.output.unbuffered,
+                self.clobber_mode(),
+                &self.output.output_claimed,
             )?;
             grep::print_grep(runtime_values, &input, file, handle, before, after)
         } else {
@@ -2214,7 +2244,9 @@ impl Cli {
             return self.execute_eval_all(&query, &files);
         }
 
-        if files.len() > self.parallel_threshold {
+        // Keep --append sequential: parallel files racing the same read-then-rename
+        // append could clobber each other.
+        if files.len() > self.parallel_threshold && !self.output.append {
             files.par_iter().try_for_each(|(file, content)| {
                 let mut engine = self.create_engine()?;
                 self.execute(&mut engine, &query, file, content)
@@ -2358,6 +2390,8 @@ impl Cli {
             &self.output.output_file,
             self.output.atomic_output,
             self.output.unbuffered,
+            self.clobber_mode(),
+            &self.output.output_claimed,
         )?;
 
         for (file, content) in files {
@@ -2804,6 +2838,8 @@ impl Cli {
             &self.output.output_file,
             self.output.atomic_output,
             self.output.unbuffered,
+            self.clobber_mode(),
+            &self.output.output_claimed,
         )?;
         let stripped_values: Option<Vec<mq_lang::RuntimeValue>> = self.output.no_position.then(|| {
             runtime_values
@@ -2855,6 +2891,8 @@ impl Cli {
             &self.output.output_file,
             self.output.atomic_output,
             self.output.unbuffered,
+            self.clobber_mode(),
+            &self.output.output_claimed,
         )?;
 
         let label = file

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -1926,6 +1926,189 @@ fn test_atomic_output_failure_leaves_existing_file_untouched() {
 }
 
 #[test]
+fn test_no_clobber_requires_output_file() {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--no-clobber")
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_append_requires_output_file() {
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--append")
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_no_clobber_and_append_conflict() {
+    let (_, output_file) = create_file("cli_no_clobber_append_conflict.md", "");
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--no-clobber")
+        .arg("--append")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+}
+
+#[rstest]
+#[case::auto("auto")]
+#[case::always("always")]
+#[case::never("never")]
+fn test_no_clobber_rejects_an_existing_output_file(#[case] mode: &str) {
+    let (_, output_file) = create_file(&format!("cli_no_clobber_exists_{mode}.md"), "original content");
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--atomic-output")
+        .arg(mode)
+        .arg("--no-clobber")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .failure();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert_eq!(
+        content, "original content",
+        "--no-clobber must not touch an existing file"
+    );
+}
+
+#[test]
+fn test_no_clobber_writes_when_output_file_is_missing() {
+    let output_file = std::env::temp_dir().join("cli_no_clobber_missing.md");
+    let _ = std::fs::remove_file(&output_file);
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--no-clobber")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("# hello")
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert!(content.contains("hello"));
+}
+
+#[rstest]
+#[case::auto("auto")]
+#[case::always("always")]
+#[case::never("never")]
+fn test_append_adds_after_existing_output_content(#[case] mode: &str) {
+    let (_, output_file) = create_file(&format!("cli_append_existing_{mode}.md"), "# existing\n");
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--atomic-output")
+        .arg(mode)
+        .arg("--append")
+        .arg("-F")
+        .arg("text")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("appended")
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert_eq!(content, "# existing\nappended\n");
+}
+
+#[test]
+fn test_append_creates_output_file_when_missing() {
+    let output_file = std::env::temp_dir().join("cli_append_missing.md");
+    let _ = std::fs::remove_file(&output_file);
+    let output_file_clone = output_file.clone();
+    defer! {
+        if output_file_clone.exists() {
+            std::fs::remove_file(&output_file_clone).ok();
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--append")
+        .arg("-F")
+        .arg("text")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .write_stdin("first")
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert_eq!(content, "first\n");
+}
+
+#[test]
+fn test_append_keeps_multiple_input_files_in_order() {
+    let (_, file_a) = create_file("cli_append_order_a.md", "alpha");
+    let (_, file_b) = create_file("cli_append_order_b.md", "beta");
+    let output_file = std::env::temp_dir().join("cli_append_order_out.md");
+    let _ = std::fs::remove_file(&output_file);
+    let file_a_clone = file_a.clone();
+    let file_b_clone = file_b.clone();
+    let output_file_clone = output_file.clone();
+    defer! {
+        if file_a_clone.exists() { std::fs::remove_file(&file_a_clone).ok(); }
+        if file_b_clone.exists() { std::fs::remove_file(&file_b_clone).ok(); }
+        if output_file_clone.exists() { std::fs::remove_file(&output_file_clone).ok(); }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    cmd.arg("--append")
+        .arg("-F")
+        .arg("text")
+        .arg("-o")
+        .arg(&output_file)
+        .arg("self")
+        .arg(&file_a)
+        .arg(&file_b)
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&output_file).expect("Failed to read output");
+    assert_eq!(content, "alpha\nbeta\n");
+}
+
+#[test]
 fn test_format_flag_sets_input_and_output() {
     let mut cmd = cargo::cargo_bin_cmd!("mq");
     let result = cmd


### PR DESCRIPTION
## Summary

Add --no-clobber (fail if the -o target already exists) and --append (add to it instead of replacing it), both mutually exclusive and requiring -o. --append composes with --atomic-output by copying the target's existing bytes into the temp file before renaming, and forces sequential (in-order) file processing instead of the rayon parallel path so concurrent appends within one run can't race.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
