### PR TITLE
fix(editors/neovim): auto-start LSP server on demand for Mq commands

### DIFF
--- a/editors/neovim/lua/mq/lsp.lua
+++ b/editors/neovim/lua/mq/lsp.lua
@@ -9,10 +9,15 @@ function M.is_running()
   return client_id ~= nil
 end
 
--- Start LSP server
-function M.start()
+-- Start LSP server.
+-- on_ready, if given, is called once the client has finished the
+-- initialize handshake (or immediately if the server is already running).
+function M.start(on_ready)
   if M.is_running() then
     utils.info("LSP server is already running")
+    if on_ready then
+      on_ready()
+    end
     return
   end
 
@@ -67,6 +72,12 @@ function M.start()
     on_attach = lsp_config.on_attach,
     capabilities = config.get_capabilities(),
     settings = lsp_config.settings,
+    on_init = function(...)
+      utils.info("LSP server started")
+      if on_ready then
+        on_ready()
+      end
+    end,
   }
 
   client_id = vim.lsp.start_client(client_config)
@@ -81,8 +92,6 @@ function M.start()
   if vim.bo[bufnr].filetype == "mq" then
     vim.lsp.buf_attach_client(bufnr, client_id)
   end
-
-  utils.info("LSP server started")
 end
 
 -- Stop LSP server
@@ -105,8 +114,16 @@ function M.restart()
 end
 
 function M.execute_command(command, script, input, input_format)
+  -- Auto-start the LSP server on demand instead of erroring out. Commands
+  -- like MqExecuteQuery/MqRunSelected/MqExecuteFile run against markdown/html
+  -- buffers, which never trigger the FileType=mq autostart autocmd in
+  -- setup_autostart(), so without this the server would never be running
+  -- when they're invoked from a non-mq buffer.
   if not M.is_running() then
-    utils.error("LSP server is not running")
+    utils.info("mq LSP server not running, starting it...")
+    M.start(function()
+      M.execute_command(command, script, input, input_format)
+    end)
     return
   end
 


### PR DESCRIPTION
## Problem

`:MqExecuteQuery`, `:MqRunSelected`, and `:MqExecuteFile` all run against markdown/html/mdx buffers, not `.mq` buffers. The LSP server, however, only auto-starts via the `FileType == "mq"` autocmd registered in `setup_autostart()`.

Since these three commands never open an `.mq` buffer, that autocmd never fires, `M.is_running()` stays false, and `execute_command()` immediately bails out with:

```
mq: LSP server is not running
```

on every first invocation of these commands in a session — unless the user happens to have separately opened an `.mq` file, or manually run `:MqStartLSP`, beforehand. This isn't mentioned anywhere in the docs and isn't part of the documented workflow for these commands (README's "Usage Examples" section shows them working standalone).

## Fix

Make `lsp.execute_command()` start the server on demand instead of erroring out:

- `M.start()` now accepts an optional `on_ready` callback. It's invoked once the client's `initialize` handshake actually completes (via the client's `on_init`), not just once the process is spawned — or immediately if the server is already running.
- `execute_command()` now checks `is_running()` and, if false, calls `M.start()` with a callback that re-invokes `execute_command()` with the same arguments once the server is ready, then returns.

This is scoped to `editors/neovim` (Lua only), no Rust code touched.

## Testing

Verified headlessly with a scripted repro:

```
running before: false
running after call: true
RESULT: Hello
```

i.e. cold start (`is_running() == false`) → `execute_command("mq/run", ".h1 | to_text()", ...)` → server auto-starts, `on_init` fires, request is sent, and the correct result (`Hello`) comes back — with the console showing:

```
mq: mq LSP server not running, starting it...
mq: LSP server started
```

Also confirmed `nvim --headless +qa` still exits cleanly and `MqStartLSP`/`MqStopLSP`/`MqRestartLSP` behavior is unchanged (still idempotent, still print the same info messages).