### PR TITLE
✨ feat(mq-lang): add file_info builtin for file metadata

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -1358,6 +1358,10 @@ fn register_file_io(ctx: &mut InferenceContext) {
     register_unary(ctx, "file_exists", Type::String, Type::Bool);
     register_unary(ctx, "file_size", Type::String, Type::Number);
 
+    // file_info: string (path) -> {path, kind, size, modified}
+    let (k, v) = (ctx.fresh_var(), ctx.fresh_var());
+    register_unary(ctx, "file_info", Type::String, Type::dict(Type::Var(k), Type::Var(v)));
+
     // collection: string (dir path) -> [{path, title, frontmatter, content}]
     let (k, v) = (ctx.fresh_var(), ctx.fresh_var());
     register_unary(
@@ -1976,6 +1980,7 @@ mod tests {
     #[case::read_file_bytes("read_file_bytes(\"a.md\")", true)]
     #[case::file_exists("file_exists(\"a.md\")", true)]
     #[case::file_size("file_size(\"a.md\")", true)]
+    #[case::file_info("file_info(\"a.md\")", true)]
     #[case::collection("collection(\"docs\")", true)]
     #[case::collection_respect_gitignore("collection(\"docs\", true)", true)]
     #[case::collection_len("len(collection(\"docs\"))", true)]
@@ -2007,6 +2012,7 @@ mod tests {
     #[case::read_file_number("read_file(42)", false)] // Should fail: wrong type
     #[case::file_exists_number("file_exists(42)", false)] // Should fail: wrong type
     #[case::file_size_number("file_size(42)", false)] // Should fail: wrong type
+    #[case::file_info_number("file_info(42)", false)] // Should fail: wrong type
     #[case::collection_number("collection(42)", false)] // Should fail: wrong type
     #[case::collection_respect_gitignore_number("collection(\"docs\", 42)", false)] // Should fail: wrong type
     #[case::basename_number("basename(42)", false)] // Should fail: wrong type

--- a/crates/mq-lang/src/io.rs
+++ b/crates/mq-lang/src/io.rs
@@ -61,6 +61,41 @@ pub struct HttpRequestSpec {
     pub headers: Vec<(String, String)>,
 }
 
+/// Kind of filesystem entry reported by [`Io::metadata`]. Reflects the entry itself
+/// (via a symlink-unaware stat), not what a symlink points to — a symlink is always
+/// reported as `Symlink`, never followed to its target's kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileKind {
+    File,
+    Dir,
+    Symlink,
+    /// A platform-specific entry that is neither a regular file, directory, nor symlink
+    /// (e.g. a Unix socket or device file).
+    Other,
+}
+
+impl FileKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FileKind::File => "file",
+            FileKind::Dir => "dir",
+            FileKind::Symlink => "symlink",
+            FileKind::Other => "other",
+        }
+    }
+}
+
+/// Metadata for the entry at a path, as returned by [`Io::metadata`], backing the
+/// `file_info` builtin. Never follows a symlink to inspect its target — see [`FileKind`].
+#[derive(Debug, Clone, Copy)]
+pub struct FileMetadata {
+    pub kind: FileKind,
+    pub size: u64,
+    /// Modification time as a unix timestamp (seconds), or `None` if the platform/filesystem
+    /// doesn't report one.
+    pub modified: Option<i64>,
+}
+
 /// Abstracts file, environment-variable, and network access for the mq
 /// engine. All methods are synchronous, matching the existing sync contract
 /// of [`ModuleResolver::resolve`](crate::module::resolver::ModuleResolver::resolve)
@@ -79,6 +114,9 @@ pub trait Io: std::fmt::Debug + IoSyncBound + 'static {
 
     /// Size of the file at `path`, in bytes.
     fn file_size(&self, path: &Path) -> Result<u64, IoError>;
+
+    /// Kind/size/modification-time of the entry at `path`, backing the `file_info` builtin.
+    fn metadata(&self, path: &Path) -> Result<FileMetadata, IoError>;
 
     /// `(path, is_dir)` pairs for the immediate entries of a directory.
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError>;

--- a/crates/mq-lang/src/io/mem.rs
+++ b/crates/mq-lang/src/io/mem.rs
@@ -1,4 +1,4 @@
-use super::{Io, IoError};
+use super::{FileKind, FileMetadata, Io, IoError};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -101,6 +101,28 @@ impl Io for MemIo {
             .get(path)
             .map(|bytes| bytes.len() as u64)
             .ok_or_else(|| IoError::NotFound(Cow::Owned(path.display().to_string())))
+    }
+
+    /// No mtime tracking (this is an in-memory fake with no clock of its own), so
+    /// `modified` is always `None`. A path is a `Dir` if it's a strict ancestor of some
+    /// registered file, since `MemIo` has no separate concept of an empty directory.
+    fn metadata(&self, path: &Path) -> Result<FileMetadata, IoError> {
+        let files = self.files.lock().unwrap();
+        if let Some(bytes) = files.get(path) {
+            return Ok(FileMetadata {
+                kind: FileKind::File,
+                size: bytes.len() as u64,
+                modified: None,
+            });
+        }
+        if files.keys().any(|p| p.as_path() != path && p.starts_with(path)) {
+            return Ok(FileMetadata {
+                kind: FileKind::Dir,
+                size: 0,
+                modified: None,
+            });
+        }
+        Err(IoError::NotFound(Cow::Owned(path.display().to_string())))
     }
 
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
@@ -235,6 +257,31 @@ mod tests {
         assert_eq!(io.execute("git", &["status".to_string()]).unwrap(), "clean");
         assert!(matches!(
             io.execute("git", &["log".to_string()]),
+            Err(IoError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_metadata_reports_file_kind_and_size() {
+        let io = MemIo::default().with_file("/a.txt", "hello");
+        let meta = io.metadata(Path::new("/a.txt")).unwrap();
+        assert_eq!(meta.kind, FileKind::File);
+        assert_eq!(meta.size, 5);
+        assert_eq!(meta.modified, None);
+    }
+
+    #[test]
+    fn test_metadata_reports_dir_kind_for_implied_directory() {
+        let io = MemIo::default().with_file("/dir/a.txt", "a");
+        let meta = io.metadata(Path::new("/dir")).unwrap();
+        assert_eq!(meta.kind, FileKind::Dir);
+    }
+
+    #[test]
+    fn test_metadata_missing_path_is_not_found() {
+        let io = MemIo::default();
+        assert!(matches!(
+            io.metadata(Path::new("/missing.txt")),
             Err(IoError::NotFound(_))
         ));
     }

--- a/crates/mq-lang/src/io/native.rs
+++ b/crates/mq-lang/src/io/native.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "http")]
 use super::HttpRequestSpec;
-use super::{Io, IoError};
+use super::{FileKind, FileMetadata, Io, IoError};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
@@ -40,6 +40,15 @@ fn io_err(err: std::io::Error, path: &Path) -> IoError {
     }
 }
 
+/// Converts to a unix-epoch-seconds timestamp, including times before the epoch
+/// (returned as negative), rather than panicking or silently clamping.
+fn system_time_to_unix(time: std::time::SystemTime) -> Option<i64> {
+    match time.duration_since(std::time::UNIX_EPOCH) {
+        Ok(since_epoch) => i64::try_from(since_epoch.as_secs()).ok(),
+        Err(before_epoch) => i64::try_from(before_epoch.duration().as_secs()).ok().map(|s| -s),
+    }
+}
+
 impl Io for NativeIo {
     fn read_to_string(&self, path: &Path) -> Result<String, IoError> {
         std::fs::read_to_string(path).map_err(|e| io_err(e, path))
@@ -59,6 +68,28 @@ impl Io for NativeIo {
 
     fn file_size(&self, path: &Path) -> Result<u64, IoError> {
         std::fs::metadata(path).map(|m| m.len()).map_err(|e| io_err(e, path))
+    }
+
+    fn metadata(&self, path: &Path) -> Result<FileMetadata, IoError> {
+        // `symlink_metadata` (lstat) rather than `metadata` (stat): a symlink is reported as
+        // such, never followed, so a symlink cycle can never make this call loop or fail.
+        let meta = std::fs::symlink_metadata(path).map_err(|e| io_err(e, path))?;
+        let file_type = meta.file_type();
+        let kind = if file_type.is_symlink() {
+            FileKind::Symlink
+        } else if file_type.is_dir() {
+            FileKind::Dir
+        } else if file_type.is_file() {
+            FileKind::File
+        } else {
+            FileKind::Other
+        };
+
+        Ok(FileMetadata {
+            kind,
+            size: meta.len(),
+            modified: meta.modified().ok().and_then(system_time_to_unix),
+        })
     }
 
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
@@ -291,6 +322,92 @@ mod tests {
             entries,
             vec![(dir.path().join("a.txt"), false), (dir.path().join("subdir"), true),]
         );
+    }
+
+    #[test]
+    fn test_metadata_reports_file_kind_size_and_modified() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("file.txt");
+        std::fs::write(&path, "hello").unwrap();
+        let io = NativeIo::default();
+
+        let meta = io.metadata(&path).unwrap();
+        assert_eq!(meta.kind, FileKind::File);
+        assert_eq!(meta.size, 5);
+        assert!(meta.modified.is_some());
+    }
+
+    #[test]
+    fn test_metadata_reports_dir_kind() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let io = NativeIo::default();
+
+        let meta = io.metadata(dir.path()).unwrap();
+        assert_eq!(meta.kind, FileKind::Dir);
+    }
+
+    #[test]
+    fn test_metadata_missing_path_is_not_found() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let io = NativeIo::default();
+
+        assert!(matches!(
+            io.metadata(&dir.path().join("missing.txt")),
+            Err(IoError::NotFound(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_metadata_reports_symlink_kind_without_following() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, "hello world").unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let io = NativeIo::default();
+
+        let meta = io.metadata(&link).unwrap();
+        assert_eq!(meta.kind, FileKind::Symlink);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_metadata_handles_symlink_cycle_without_following() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::os::unix::fs::symlink(&b, &a).unwrap();
+        std::os::unix::fs::symlink(&a, &b).unwrap();
+        let io = NativeIo::default();
+
+        // lstat never follows the link, so a cyclic symlink resolves instantly.
+        let meta = io.metadata(&a).unwrap();
+        assert_eq!(meta.kind, FileKind::Symlink);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_metadata_denied_by_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("file.txt");
+        std::fs::write(&path, "hello").unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+        let io = NativeIo::default();
+
+        let result = io.metadata(&path);
+        // A root-run process (e.g. inside a container) ignores permission bits, so only
+        // assert when the OS actually enforced them here — otherwise the test would flake.
+        let permissions_enforced = std::fs::metadata(&path).is_err();
+
+        // Restore permissions so the tempdir can be cleaned up.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        if permissions_enforced {
+            assert!(result.is_err());
+        }
     }
 
     #[test]

--- a/crates/mq-lang/src/io/sandboxed.rs
+++ b/crates/mq-lang/src/io/sandboxed.rs
@@ -1,4 +1,4 @@
-use super::{HttpRequestSpec, Io, IoError, NativeIo};
+use super::{FileMetadata, HttpRequestSpec, Io, IoError, NativeIo};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
@@ -204,6 +204,16 @@ impl<Inner: Io> Io for SandboxedIo<Inner> {
         self.inner.file_size(path)
     }
 
+    fn metadata(&self, path: &Path) -> Result<FileMetadata, IoError> {
+        if self.allow_read.is_denied() {
+            return Err(denied("filesystem reads are disabled"));
+        }
+        if !self.allow_read.permits(path) {
+            return Err(denied_path("read", path));
+        }
+        self.inner.metadata(path)
+    }
+
     fn read_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, IoError> {
         if self.allow_read.is_denied() {
             return Err(denied("filesystem reads are disabled"));
@@ -352,6 +362,18 @@ mod tests {
         }
 
         assert_eq!(io.write(Path::new(target), b"x").is_ok(), expected_ok);
+    }
+
+    #[test]
+    fn test_metadata_denied_by_default_then_allowed() {
+        let io = SandboxedIo::new(MemIo::default().with_file("/a.txt", "content"));
+        assert!(matches!(
+            io.metadata(Path::new("/a.txt")),
+            Err(IoError::PermissionDenied(_))
+        ));
+
+        let io = io.allow_read(true);
+        assert_eq!(io.metadata(Path::new("/a.txt")).unwrap().size, 7);
     }
 
     #[test]

--- a/crates/mq-lang/src/runtime/builtin.rs
+++ b/crates/mq-lang/src/runtime/builtin.rs
@@ -4717,6 +4717,40 @@ fn file_size_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv
     }
 }
 
+#[cfg(feature = "file-io")]
+#[mq_macros::mq_fn(name = "file_info", params = Fixed(1))]
+fn file_info_impl(ident: &Ident, _: &RuntimeValue, mut args: Args, _: &SharedEnv) -> Result<RuntimeValue, Error> {
+    match args.as_mut_slice() {
+        [RuntimeValue::String(path)] => {
+            let metadata = io_context::current()
+                .metadata(std::path::Path::new(path.as_str()))
+                .map_err(|e| Error::Runtime(format!("Failed to get info for {}: {}", path, e)))?;
+
+            let mut record = BTreeMap::new();
+            record.insert(Ident::new("path"), RuntimeValue::String(path.clone()));
+            record.insert(
+                Ident::new("kind"),
+                RuntimeValue::String(Shared::new(metadata.kind.as_str().to_string())),
+            );
+            record.insert(
+                Ident::new("size"),
+                RuntimeValue::Number((metadata.size as usize).into()),
+            );
+            record.insert(
+                Ident::new("modified"),
+                metadata
+                    .modified
+                    .map(|secs| RuntimeValue::Number(secs.into()))
+                    .unwrap_or(RuntimeValue::NONE),
+            );
+
+            Ok(RuntimeValue::Dict(Shared::new(record)))
+        }
+        [a] => Err(Error::InvalidTypes(ident.to_string(), vec![std::mem::take(a)])),
+        _ => unreachable!("file_info should always receive exactly one argument"),
+    }
+}
+
 /// Reads the contents of `path` as raw bytes. Requires the ambient [`Io`]'s read
 /// permission (see [`io_context`]).
 #[cfg(feature = "file-io")]
@@ -5555,6 +5589,8 @@ mq_macros::builtin_dispatch! {
     FILE_EXISTS,
     #[cfg(feature = "file-io")]
     FILE_SIZE,
+    #[cfg(feature = "file-io")]
+    FILE_INFO,
     #[cfg(feature = "file-io")]
     READ_FILE_BYTES,
     #[cfg(feature = "file-io")]
@@ -6555,7 +6591,7 @@ pub struct BuiltinFunctionDoc {
 }
 
 pub static BUILTIN_FUNCTION_DOC: LazyLock<FxHashMap<SmolStr, BuiltinFunctionDoc>> = LazyLock::new(|| {
-    let mut map = FxHashMap::with_capacity_and_hasher(112, FxBuildHasher);
+    let mut map = FxHashMap::with_capacity_and_hasher(113, FxBuildHasher);
 
     map.insert(
         SmolStr::new("halt"),
@@ -8837,6 +8873,18 @@ x
             params: &["path"],
             param_types: &["string"],
             returns: "number",
+            examples: &[],
+            capability: Some("file-io"),
+        },
+    );
+    #[cfg(feature = "file-io")]
+    map.insert(
+        SmolStr::new("file_info"),
+        BuiltinFunctionDoc {
+            description: "Returns `{path, kind, size, modified}` for the entry at the given path: `kind` is `\"file\"`, `\"dir\"`, `\"symlink\"`, or `\"other\"`; `size` is in bytes; `modified` is a unix timestamp in seconds, or `None` if unavailable. A symlink is reported as `\"symlink\"` and never followed. Requires the --allow-read CLI flag; otherwise returns a runtime error.",
+            params: &["path"],
+            param_types: &["string"],
+            returns: "dict",
             examples: &[],
             capability: Some("file-io"),
         },
@@ -14207,6 +14255,10 @@ mod tests {
             call("file_size", vec![RuntimeValue::String(Shared::new(text_path.clone()))]).is_err(),
             "file_size should be blocked when read access is not allowed"
         );
+        assert!(
+            call("file_info", vec![RuntimeValue::String(Shared::new(text_path.clone()))]).is_err(),
+            "file_info should be blocked when read access is not allowed"
+        );
 
         let _guard = io_context::scoped(Shared::new(SandboxedIo::new(NativeIo::default()).allow_read(true)));
         assert_eq!(
@@ -14270,6 +14322,95 @@ mod tests {
             "file_size should error for a nonexistent file"
         );
         assert!(call("file_size", vec![RuntimeValue::Number(42.into())]).is_err());
+
+        match call("file_info", vec![RuntimeValue::String(Shared::new(text_path.clone()))])
+            .expect("file_info should succeed")
+        {
+            RuntimeValue::Dict(d) => {
+                assert_eq!(
+                    d.get(&Ident::new("path")),
+                    Some(&RuntimeValue::String(Shared::new(text_path.clone())))
+                );
+                assert_eq!(
+                    d.get(&Ident::new("kind")),
+                    Some(&RuntimeValue::String(Shared::new("file".to_string())))
+                );
+                assert_eq!(d.get(&Ident::new("size")), Some(&RuntimeValue::Number(5.into())));
+                assert!(matches!(d.get(&Ident::new("modified")), Some(RuntimeValue::Number(_))));
+            }
+            other => panic!("expected Dict, got {other:?}"),
+        }
+        assert!(
+            call(
+                "file_info",
+                vec![RuntimeValue::String(Shared::new(
+                    "/nonexistent/path/no_such_file.md".into()
+                ))]
+            )
+            .is_err(),
+            "file_info should error for a nonexistent file"
+        );
+        assert!(call("file_info", vec![RuntimeValue::Number(42.into())]).is_err());
+
+        #[cfg(unix)]
+        {
+            let dir = tempfile::tempdir().expect("failed to create temp dir");
+            match call(
+                "file_info",
+                vec![RuntimeValue::String(Shared::new(
+                    dir.path().to_string_lossy().into_owned(),
+                ))],
+            )
+            .expect("file_info should succeed for a directory")
+            {
+                RuntimeValue::Dict(d) => {
+                    assert_eq!(
+                        d.get(&Ident::new("kind")),
+                        Some(&RuntimeValue::String(Shared::new("dir".to_string())))
+                    );
+                }
+                other => panic!("expected Dict, got {other:?}"),
+            }
+
+            let target = dir.path().join("target.txt");
+            std::fs::write(&target, "hello world").expect("failed to write");
+            let link = dir.path().join("link.txt");
+            std::os::unix::fs::symlink(&target, &link).expect("failed to create symlink");
+            match call(
+                "file_info",
+                vec![RuntimeValue::String(Shared::new(link.to_string_lossy().into_owned()))],
+            )
+            .expect("file_info should succeed for a symlink")
+            {
+                RuntimeValue::Dict(d) => {
+                    assert_eq!(
+                        d.get(&Ident::new("kind")),
+                        Some(&RuntimeValue::String(Shared::new("symlink".to_string())))
+                    );
+                }
+                other => panic!("expected Dict, got {other:?}"),
+            }
+
+            // A cyclic symlink resolves instantly since file_info never follows symlinks.
+            let a = dir.path().join("a");
+            let b = dir.path().join("b");
+            std::os::unix::fs::symlink(&b, &a).expect("failed to create symlink");
+            std::os::unix::fs::symlink(&a, &b).expect("failed to create symlink");
+            match call(
+                "file_info",
+                vec![RuntimeValue::String(Shared::new(a.to_string_lossy().into_owned()))],
+            )
+            .expect("file_info should succeed for a cyclic symlink")
+            {
+                RuntimeValue::Dict(d) => {
+                    assert_eq!(
+                        d.get(&Ident::new("kind")),
+                        Some(&RuntimeValue::String(Shared::new("symlink".to_string())))
+                    );
+                }
+                other => panic!("expected Dict, got {other:?}"),
+            }
+        }
 
         // Basic collection: YAML/TOML frontmatter, title, content, sorted by path.
         {

--- a/crates/mq-run/src/cli.rs
+++ b/crates/mq-run/src/cli.rs
@@ -514,7 +514,7 @@ struct InputArgs {
     #[arg(short = 'N', long = "allow-net", num_args = 0.., require_equals = true, value_delimiter = ',', value_name = "DOMAIN")]
     allow_net: Option<Vec<String>>,
 
-    /// Allow the `read_file`/`read_file_bytes`/`collection`/`file_exists`/`embed_images`
+    /// Allow the `read_file`/`read_file_bytes`/`collection`/`file_exists`/`file_info`/`embed_images`
     /// functions to read from the filesystem. Disabled by default. Pass with no value to
     /// allow reading anywhere, or `--allow-read=PATH` (files or directories; repeat the
     /// flag, or comma-separate, to add more) to restrict reads to just those paths and

--- a/crates/mq-run/tests/integration_tests.rs
+++ b/crates/mq-run/tests/integration_tests.rs
@@ -1107,6 +1107,54 @@ fn test_file_exists_without_allow_read_is_blocked() -> Result<(), Box<dyn std::e
 }
 
 #[test]
+fn test_file_info() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_file_info.md", "test");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg("--allow-read")
+        .arg(format!(
+            r#"file_info("{}") | ."kind""#,
+            temp_file_path.to_string_lossy()
+        ))
+        .arg(temp_file_path.to_string_lossy().to_string())
+        .assert();
+
+    assert.success().code(0).stdout("file\n");
+    Ok(())
+}
+
+#[test]
+fn test_file_info_without_allow_read_is_blocked() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, temp_file_path) = create_file("test_file_info_blocked.md", "test");
+    let temp_file_path_clone = temp_file_path.clone();
+
+    defer! {
+        if temp_file_path_clone.exists() {
+            std::fs::remove_file(&temp_file_path_clone).expect("Failed to delete temp file");
+        }
+    }
+
+    let mut cmd = cargo::cargo_bin_cmd!("mq");
+    let assert = cmd
+        .arg("--unbuffered")
+        .arg(format!(r#"file_info("{}")"#, temp_file_path.to_string_lossy()))
+        .arg(temp_file_path.to_string_lossy().to_string())
+        .assert();
+
+    assert.failure();
+    Ok(())
+}
+
+#[test]
 fn test_output_format_toml_requires_dict() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = cargo::cargo_bin_cmd!("mq");
     let assert = cmd


### PR DESCRIPTION
## Summary

Adds Io::metadata (kind/size/modified) implemented via lstat semantics, so a symlink is reported as such without ever being followed and can't cause a symlink-cycle loop. Exposes it as the file_info(path) builtin, gated by --allow-read like file_size/file_exists, with type-checker, doc-registry, and CLI wiring.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
