### PR TITLE
✨ feat(mq-lang): add dedent and common_indent builtins

### DIFF
--- a/crates/mq-check/src/builtin.rs
+++ b/crates/mq-check/src/builtin.rs
@@ -437,6 +437,12 @@ fn register_string(ctx: &mut InferenceContext) {
     register_unary(ctx, "unlines", Type::array(Type::String), Type::String);
     register_unary(ctx, "unlines", Type::None, Type::None);
 
+    // common_indent/dedent: (string) -> string
+    register_unary(ctx, "common_indent", Type::String, Type::String);
+    register_unary(ctx, "common_indent", Type::None, Type::None);
+    register_unary(ctx, "dedent", Type::String, Type::String);
+    register_unary(ctx, "dedent", Type::None, Type::None);
+
     // slugify: (string, string) -> string
     register_unary(ctx, "slugify", Type::String, Type::String);
     // slugify: (string) -> string

--- a/crates/mq-check/src/lib.rs
+++ b/crates/mq-check/src/lib.rs
@@ -295,6 +295,9 @@ impl TypeChecker {
         // Solve constraints through unification (collects errors internally)
         unify::solve_constraints(&mut ctx);
 
+        // Resolve user-defined call return types before narrowing so `y != None` can narrow `let y = f(x)`.
+        deferred::propagate_user_call_returns(&mut ctx);
+
         // Apply type narrowings from type predicate conditions (e.g., is_string(x))
         // in if/elif branches. This overrides Ref types within narrowed branches.
         // Returns dead branch ranges for unreachable code detection.

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -1247,37 +1247,36 @@ def join_by(left, right, left_key, right_key, kind = "inner"):
     do
       let schema_of = fn(records): unique_by(flat_map(records, keys), identity);
       | let fill_missing = fn(record, schema):
-          fold(schema, record, fn(acc, k): if (in(keys(acc), k)): acc else: set(acc, k, None););
+              fold(schema, record, fn(acc, k): if (in(keys(acc), k)): acc else: set(acc, k, None););
       | let right_matchable = filter(right, fn(r): !is_none(get(r, right_key));)
       | let right_unmatchable = filter(right, fn(r): is_none(get(r, right_key));)
       | let right_by_key = group_by(right_matchable, fn(r): get(r, right_key);)
       | let right_schema = if (kind == "left" || kind == "full"): schema_of(right) else: []
       | let left_schema = if (kind == "right" || kind == "full"): schema_of(left) else: []
       | let left_keys_str = map(left, fn(l):
-            let k = get(l, left_key)
-            | if (is_none(k)): None else: to_string(k);
-          )
+              let k = get(l, left_key)
+              | if (is_none(k)): None else: to_string(k);
+      )
       | let matched_group_keys = unique_by(
-          filter(left_keys_str, fn(k): !is_none(k) && !is_none(get(right_by_key, k));),
-          identity
-        )
+        filter(left_keys_str, fn(k): !is_none(k) && !is_none(get(right_by_key, k));),
+        identity
+      )
       | let left_side = flat_map(left, fn(l):
-            let k = get(l, left_key)
-            | let group = if (is_none(k)): None else: get(right_by_key, to_string(k))
-            | if (is_none(group)):
-                if (kind == "left" || kind == "full"): [fill_missing(l, right_schema)] else: []
-              else:
-                map(group, fn(r): l + r;)
-            ;
-          )
+              let k = get(l, left_key)
+              | let group = if (is_none(k)): None else: get(right_by_key, to_string(k))
+              | if (is_none(group)):
+                  if (kind == "left" || kind == "full"): [fill_missing(l, right_schema)] else: []
+                else:
+                  map(group, fn(r): l + r;);
+      )
       | let right_unmatched_grouped = flat_map(
-          filter(entries(right_by_key), fn(e): !in(matched_group_keys, e[0]);),
-          fn(e): e[1];
-        )
+        filter(entries(right_by_key), fn(e): !in(matched_group_keys, e[0]);),
+        fn(e): e[1];
+      )
       | let right_side = if (kind == "right" || kind == "full"):
-            map(right_unmatched_grouped + right_unmatchable, fn(r): fill_missing(r, left_schema);)
-          else:
-            []
+              map(right_unmatched_grouped + right_unmatchable, fn(r): fill_missing(r, left_schema);)
+            else:
+              []
       | left_side + right_side
     end
 end
@@ -1901,7 +1900,7 @@ def describe(arr):
         median: percentile(arr, 0.5),
         stddev: stddev(arr),
         variance: variance(arr),
-        count: len(arr),
+        count: len(arr)
       }
     end
 end
@@ -1926,15 +1925,15 @@ def stats_by(arr, group_f, value_f, aggs = ["sum", "mean", "min", "max", "stddev
     map(entries(group_by(arr, group_f)), fn(e):
       let values = map(e[1], value_f)
       | fold(aggs, {group: e[0], count: len(values)}, fn(acc, agg):
-          if (agg == "sum"): set(acc, "sum", sum(values))
-          elif (agg == "mean"): set(acc, "mean", mean(values))
-          elif (agg == "min"): set(acc, "min", first(sort(values)))
-          elif (agg == "max"): set(acc, "max", last(sort(values)))
-          elif (agg == "stddev"): set(acc, "stddev", stddev(values))
-          elif (agg == "median"): set(acc, "median", median(values))
-          elif (agg == "variance"): set(acc, "variance", variance(values))
-          else: error("stats_by: unknown agg \"" + agg + "\"");
-        );
+        if (agg == "sum"): set(acc, "sum", sum(values))
+        elif (agg == "mean"): set(acc, "mean", mean(values))
+        elif (agg == "min"): set(acc, "min", first(sort(values)))
+        elif (agg == "max"): set(acc, "max", last(sort(values)))
+        elif (agg == "stddev"): set(acc, "stddev", stddev(values))
+        elif (agg == "median"): set(acc, "median", median(values))
+        elif (agg == "variance"): set(acc, "variance", variance(values))
+        else: error("stats_by: unknown agg \"" + agg + "\"");
+      );
     )
 end
 
@@ -1965,11 +1964,11 @@ def histogram(arr, buckets = 10):
       | let span = if (hi == lo): 1 else: hi - lo
       | let width = span / buckets
       | let bucket_of = fn(x):
-          let idx = floor((x - lo) / width)
-          | if (idx >= buckets): buckets - 1 else: idx;
+              let idx = floor((x - lo) / width)
+              | if (idx >= buckets): buckets - 1 else: idx;
       | let counts = fold(arr, foreach (i, range(0, buckets - 1)): 0;, fn(acc, x):
-          set(acc, bucket_of(x), acc[bucket_of(x)] + 1);
-        )
+              set(acc, bucket_of(x), acc[bucket_of(x)] + 1);
+      )
       | let max_count = max_by(counts, identity)
       | foreach (i, range(0, buckets - 1)):
           let count = counts[i]
@@ -1977,7 +1976,7 @@ def histogram(arr, buckets = 10):
           | {
             range: to_string(round(100 * (lo + i * width)) / 100) + "-" + to_string(round(100 * (lo + (i + 1) * width)) / 100),
             count: count,
-            bar: repeat("█", bar_len),
+            bar: repeat("█", bar_len)
           }
         end
     end
@@ -2156,6 +2155,70 @@ def unlines(arr): if (is_none(arr)): None else: join(arr, "\n");
 #
 # Returns: string
 def indent(s, prefix): s | lines | map(fn(line): prefix + line;) | unlines;
+
+# Returns the longest run of leading spaces/tabs shared by every non-blank line
+# of a string. Blank (empty or whitespace-only) lines are ignored when computing
+# the margin. Lines indented with a mix of tabs and spaces that don't agree on
+# the same prefix yield no common indent.
+#
+# Example:
+# ```
+# common_indent("  a\n    b\n  c") == "  "
+# #=> true
+# ```
+#
+# Returns: string
+def common_indent(s):
+  if (is_none(s)):
+    None
+  else:
+    do
+      let significant = filter(lines(s), fn(line): !is_empty(trim(line));)
+      | if (is_empty(significant)):
+          ""
+        else:
+          do
+            let indents = map(significant, fn(line): first(regex_match(line, "^[ \t]*"));)
+            | let base = first(indents)
+            | let min_len = first(sort(map(indents, len)))
+            | var n = 0
+            | while (n < min_len && all(indents, fn(ind): slice(ind, n, n + 1) == slice(base, n, n + 1);)):
+                n += 1
+              end
+            | slice(base, 0, n)
+          end
+    end
+end
+
+# Removes the common leading whitespace (see `common_indent`) from every line
+# of a string. Blank lines are normalized to empty; the string is returned
+# unchanged when there is no common indent to strip.
+#
+# Example:
+# ```
+# dedent("  a\n  b") == "a\nb"
+# #=> true
+# ```
+#
+# Returns: string
+def dedent(s):
+  if (is_none(s)):
+    None
+  else:
+    do
+      let prefix = common_indent(s)
+      | if (is_empty(prefix)):
+          s
+        else:
+          do
+            s
+            | lines
+            | map(fn(line): if (is_empty(trim(line))): "" else: slice(line, len(prefix), len(line));)
+            | unlines
+          end
+    end
+end
+
 
 # Returns a new dictionary containing only the specified keys from the original dictionary, if they exist.
 #
@@ -2388,8 +2451,7 @@ def merge_with(a, b, policy):
       elif (has(b, key)):
         set(acc, key, b[key])
       else:
-        set(acc, key, a[key])
-    ;)
+        set(acc, key, a[key]);)
   elif (is_array(a) && is_array(b)):
     if (policy == "append"):
       a + b

--- a/crates/mq-lang/builtin.mq
+++ b/crates/mq-lang/builtin.mq
@@ -2207,15 +2207,15 @@ def dedent(s):
   else:
     do
       let prefix = common_indent(s)
-      | if (is_empty(prefix)):
-          s
-        else:
+      | if (prefix != None && !is_empty(prefix)):
           do
             s
             | lines
             | map(fn(line): if (is_empty(trim(line))): "" else: slice(line, len(prefix), len(line));)
             | unlines
           end
+        else:
+          s
     end
 end
 

--- a/crates/mq-lang/builtin_tests.mq
+++ b/crates/mq-lang/builtin_tests.mq
@@ -980,6 +980,37 @@ def test_indent(value, prefix, expected):
 end
 
 # @parametrize([
+#   ["  a\n    b\n  c", "  "],
+#   ["a\nb", ""],
+#   ["  a\n\n  b", "  "],
+#   ["  a\n   \n  b", "  "],
+#   ["\ta\n  b", ""],
+#   ["\ta\n\t\tb", "\t"],
+#   ["  ```\n    code\n  ```", "  "],
+#   ["", ""],
+#   ["   ", ""],
+# ])
+def test_common_indent(value, expected):
+  let result = common_indent(value)
+  | assert_eq(result, expected)
+end
+
+# @parametrize([
+#   ["  a\n    b\n  c", "a\n  b\nc"],
+#   ["a\nb", "a\nb"],
+#   ["  a\n\n  b", "a\n\nb"],
+#   ["  a\n   \n  b", "a\n\nb"],
+#   ["\ta\n  b", "\ta\n  b"],
+#   ["\ta\n\t\tb", "a\n\tb"],
+#   ["  ```\n    code\n  ```", "```\n  code\n```"],
+#   ["", ""],
+# ])
+def test_dedent(value, expected):
+  let result = dedent(value)
+  | assert_eq(result, expected)
+end
+
+# @parametrize([
 #   [{"a": 1, "b": 2, "c": 3}, ["a", "c"], {"a": 1, "c": 3}],
 #   [{"x": 10, "y": 20}, ["y"], {"y": 20}],
 #   [{"key": "value"}, ["nonexistent"], dict()],


### PR DESCRIPTION
## Summary

Adds common_indent(s) to compute the longest shared leading whitespace across a string's non-blank lines, and dedent(s) to strip it, normalizing blank lines to empty. Makes generating templates, quoted text, and code blocks easier to write.

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 📦 Build / dependencies
- [ ] 👷 CI

## Checklist

- [x] I ran `cargo fmt` and `cargo clippy` and addressed any warnings
- [x] I ran `just test-all` and all tests pass
- [x] I added or updated tests covering this change
- [x] I updated relevant documentation (`/docs`, crate `README.md`) if needed
- [x] I added a changelog entry if this is a user-facing change

## Additional Context

<!-- Anything else reviewers should know: screenshots, example queries, breaking changes, etc. -->
